### PR TITLE
fixes for windows build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 debug*log
 plugins/hello_go/hello_go.wasm
 plugins/hello_c/hello_c.wasm
+f4.exe

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtui"
 	"github.com/unxed/vtinput"
-	"golang.org/x/term"
 )
 
 func main() {
@@ -77,7 +76,7 @@ func main() {
 func InitCore() *vtui.ScreenBuf {
 	vtui.DebugLog("=== F4 STARTUP [%s] PID:%d ===", vtui.GetVersionInfo(), os.Getpid())
 	vtui.ConfigDiskLogging(true)
-	width, height, err := term.GetSize(0)
+	width, height, err := vtui.GetTerminalSize()
 	if err != nil {
 		vtui.DebugLog("CORE: term.GetSize(0) failed: %v", err)
 	}

--- a/pty_windows.go
+++ b/pty_windows.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"sync"
 	"unsafe"
@@ -90,11 +89,11 @@ func (p *PTY) Run(name string, args ...string) error {
 			Cb:    uint32(unsafe.Sizeof(windows.StartupInfoEx{})),
 			Flags: windows.STARTF_USESTDHANDLES,
 		},
-		AttributeList: attrList.List(),
+		ProcThreadAttributeList: attrList.List(),
 	}
 
 	pi := &windows.ProcessInformation{}
-	flags := windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_UNICODE_ENVIRONMENT
+	flags := uint32(windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_UNICODE_ENVIRONMENT)
 
 	err = windows.CreateProcess(nil, cmdLine, nil, nil, false, flags, nil, nil, &si.StartupInfo, pi)
 	if err != nil {

--- a/session_windows.go
+++ b/session_windows.go
@@ -44,3 +44,6 @@ func ManageSessions() {
 	vtui.FrameManager.Run(reader)
 	reader.Close()
 }
+
+func runServer(sockPath string) {}
+func runClient(sockPath string) {}


### PR DESCRIPTION
 * corretly get terminal size
 * defined missing methods runClient runServer
 * uint32 for CreateProcess flags