### PR TITLE
Add F2 user menu, ported from far2l

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -100,6 +100,11 @@ type EditorView struct {
 	CursorBeyondEOL     bool
 	CursorVirtualSpaces int
 	UseEditorConfig     bool
+
+	// OnClose, if set, fires once after the editor has been torn down.
+	// Used by callers (e.g. the user menu's Ctrl+F4 handler) that want
+	// to react to the file content once the user is done editing.
+	OnClose func()
 }
 
 func (ev *EditorView) ApplyEditorConfig() {
@@ -195,6 +200,9 @@ func (ev *EditorView) Close() {
 		ev.file.Close()
 	}
 	ev.BaseFrame.Close()
+	if ev.OnClose != nil {
+		ev.OnClose()
+	}
 }
 
 func NewEditorView(pt *piecetable.PieceTable, v vfs.VFS, path string) *EditorView {

--- a/farmenu_file.go
+++ b/farmenu_file.go
@@ -20,10 +20,12 @@ import (
 // nested level is terminated by "}\r\n". Separator items use HotKey "--"
 // and an empty label.
 //
-// Encoding: far2l writes UTF-16LE with a BOM (SIGN_WIDE_LE), but its
-// reader (GetFileFormat) also accepts UTF-8 with or without BOM. We
-// always write UTF-8 without BOM (round-trips cleanly through far2l)
-// and read all of UTF-16LE/BE/UTF-8±BOM/plain UTF-8 on input.
+// Encoding: far2l writes SIGN_WIDE_LE as one wchar_t, so the on-disk
+// encoding follows the build platform's wchar_t width — UTF-16LE on
+// Windows (2-byte wchar_t) but UTF-32LE on Linux/macOS/BSD (4-byte
+// wchar_t). We detect both, plus UTF-16BE/UTF-32BE/UTF-8 with BOM, and
+// fall back to plain UTF-8 otherwise. We always write UTF-8 without a
+// BOM, which far2l's GetFileFormat accepts when no BOM is present.
 
 const (
 	farMenuColonSep      = ":  " // colon + two spaces between HotKey and Label
@@ -59,7 +61,14 @@ func WriteFarMenu(w io.Writer, items []UserMenuItem) error {
 }
 
 func decodeFarMenuBytes(b []byte) (string, error) {
+	// Order matters: a UTF-32LE BOM (FF FE 00 00) starts with the same
+	// two bytes as a UTF-16LE BOM (FF FE), so the wider check has to
+	// come first. Same for the BE pair.
 	switch {
+	case len(b) >= 4 && b[0] == 0xFF && b[1] == 0xFE && b[2] == 0x00 && b[3] == 0x00:
+		return decodeUTF32Bytes(b[4:], binary.LittleEndian), nil
+	case len(b) >= 4 && b[0] == 0x00 && b[1] == 0x00 && b[2] == 0xFE && b[3] == 0xFF:
+		return decodeUTF32Bytes(b[4:], binary.BigEndian), nil
 	case len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF:
 		return string(b[3:]), nil
 	case len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE:
@@ -68,7 +77,7 @@ func decodeFarMenuBytes(b []byte) (string, error) {
 		return decodeUTF16Bytes(b[2:], binary.BigEndian), nil
 	}
 	if !utf8.Valid(b) {
-		return "", errors.New("FarMenu.ini: input is neither valid UTF-8 nor BOM-marked UTF-16")
+		return "", errors.New("FarMenu.ini: input is neither valid UTF-8 nor BOM-marked UTF-16/UTF-32")
 	}
 	return string(b), nil
 }
@@ -82,6 +91,19 @@ func decodeUTF16Bytes(b []byte, bo binary.ByteOrder) string {
 		u16[i] = bo.Uint16(b[i*2 : i*2+2])
 	}
 	return string(utf16.Decode(u16))
+}
+
+func decodeUTF32Bytes(b []byte, bo binary.ByteOrder) string {
+	b = b[:len(b)-len(b)%4]
+	runes := make([]rune, 0, len(b)/4)
+	for i := 0; i < len(b); i += 4 {
+		r := rune(bo.Uint32(b[i : i+4]))
+		if r < 0 || r > 0x10FFFF || (r >= 0xD800 && r <= 0xDFFF) {
+			r = utf8.RuneError
+		}
+		runes = append(runes, r)
+	}
+	return string(runes)
 }
 
 func splitTextLines(s string) []string {

--- a/farmenu_file.go
+++ b/farmenu_file.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
+	"runtime"
 	"strings"
 	"unicode/utf16"
 	"unicode/utf8"
@@ -20,12 +21,17 @@ import (
 // nested level is terminated by "}\r\n". Separator items use HotKey "--"
 // and an empty label.
 //
-// Encoding: far2l writes SIGN_WIDE_LE as one wchar_t, so the on-disk
-// encoding follows the build platform's wchar_t width — UTF-16LE on
-// Windows (2-byte wchar_t) but UTF-32LE on Linux/macOS/BSD (4-byte
-// wchar_t). We detect both, plus UTF-16BE/UTF-32BE/UTF-8 with BOM, and
-// fall back to plain UTF-8 otherwise. We always write UTF-8 without a
-// BOM, which far2l's GetFileFormat accepts when no BOM is present.
+// Encoding (read): we accept everything anyone might hand us — UTF-8
+// with or without BOM, UTF-16 LE/BE with BOM, UTF-32 LE/BE with BOM.
+// far2l on Linux/macOS/BSD writes UTF-32LE because its SIGN_WIDE_LE is
+// emitted as one wchar_t and wchar_t is 4 bytes there; Far Manager 2
+// on Windows writes UTF-16LE (2-byte wchar_t).
+//
+// Encoding (write): we mirror the dominant native tool on the running
+// platform so the file we produce is consumable by it without any
+// conversion. On Windows that's Far Manager 2 → UTF-16LE+BOM; on
+// Linux/macOS/BSD that's far2l → UTF-32LE+BOM. Both with CRLF line
+// endings, matching the upstream tools byte-for-byte.
 
 const (
 	farMenuColonSep      = ":  " // colon + two spaces between HotKey and Label
@@ -51,13 +57,54 @@ func ParseFarMenu(r io.Reader) ([]UserMenuItem, error) {
 	return items, nil
 }
 
-// WriteFarMenu writes items to w in far2l-compatible text format.
-// Output is UTF-8 without BOM with CRLF line endings.
+// WriteFarMenu writes items to w using the platform-native wide
+// encoding (UTF-16LE+BOM on Windows, UTF-32LE+BOM elsewhere) so the
+// resulting FarMenu.ini is consumable by the dominant tool on that
+// platform without conversion.
 func WriteFarMenu(w io.Writer, items []UserMenuItem) error {
+	text := renderFarMenuText(items)
+	_, err := w.Write(encodeFarMenuForPlatform(text))
+	return err
+}
+
+// renderFarMenuText returns the canonical FarMenu.ini representation
+// as a UTF-8 string with CRLF endings. WriteFarMenu wraps it with the
+// platform wide encoding; the editor-temp-file path in user_menu_ui.go
+// uses the raw UTF-8 bytes directly so the user gets a friendly file
+// to hand-edit.
+func renderFarMenuText(items []UserMenuItem) string {
 	var buf bytes.Buffer
 	writeFarMenuLevel(&buf, items)
-	_, err := w.Write(buf.Bytes())
-	return err
+	return buf.String()
+}
+
+// encodeFarMenuForPlatform applies the wchar_t-width-dependent encoding
+// the running platform's native tool produces.
+func encodeFarMenuForPlatform(s string) []byte {
+	if runtime.GOOS == "windows" {
+		return encodeUTF16LEWithBOM(s)
+	}
+	return encodeUTF32LEWithBOM(s)
+}
+
+func encodeUTF16LEWithBOM(s string) []byte {
+	u16 := utf16.Encode([]rune(s))
+	buf := make([]byte, 0, 2+len(u16)*2)
+	buf = append(buf, 0xFF, 0xFE)
+	for _, w := range u16 {
+		buf = binary.LittleEndian.AppendUint16(buf, w)
+	}
+	return buf
+}
+
+func encodeUTF32LEWithBOM(s string) []byte {
+	runes := []rune(s)
+	buf := make([]byte, 0, 4+len(runes)*4)
+	buf = append(buf, 0xFF, 0xFE, 0x00, 0x00)
+	for _, r := range runes {
+		buf = binary.LittleEndian.AppendUint32(buf, uint32(r))
+	}
+	return buf
 }
 
 func decodeFarMenuBytes(b []byte) (string, error) {

--- a/farmenu_file.go
+++ b/farmenu_file.go
@@ -1,0 +1,203 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"io"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+)
+
+// FarMenu.ini text format, as written by far2l (usermenu.cpp:103):
+//
+//	HotKey:  Label\r\n
+//	    Command1\r\n
+//	    Command2\r\n
+//
+// For submenu items, the line right after the header is "{\r\n", and the
+// nested level is terminated by "}\r\n". Separator items use HotKey "--"
+// and an empty label.
+//
+// Encoding: far2l writes UTF-16LE with a BOM (SIGN_WIDE_LE), but its
+// reader (GetFileFormat) also accepts UTF-8 with or without BOM. We
+// always write UTF-8 without BOM (round-trips cleanly through far2l)
+// and read all of UTF-16LE/BE/UTF-8±BOM/plain UTF-8 on input.
+
+const (
+	farMenuColonSep      = ":  " // colon + two spaces between HotKey and Label
+	farMenuCommandIndent = "    "
+	farMenuLineEnding    = "\r\n"
+)
+
+// ParseFarMenu reads a FarMenu.ini text file and returns its items.
+func ParseFarMenu(r io.Reader) ([]UserMenuItem, error) {
+	raw, err := io.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	text, err := decodeFarMenuBytes(raw)
+	if err != nil {
+		return nil, err
+	}
+	p := &farMenuParser{lines: splitTextLines(text)}
+	items := p.parseLevel()
+	if items == nil {
+		items = []UserMenuItem{}
+	}
+	return items, nil
+}
+
+// WriteFarMenu writes items to w in far2l-compatible text format.
+// Output is UTF-8 without BOM with CRLF line endings.
+func WriteFarMenu(w io.Writer, items []UserMenuItem) error {
+	var buf bytes.Buffer
+	writeFarMenuLevel(&buf, items)
+	_, err := w.Write(buf.Bytes())
+	return err
+}
+
+func decodeFarMenuBytes(b []byte) (string, error) {
+	switch {
+	case len(b) >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF:
+		return string(b[3:]), nil
+	case len(b) >= 2 && b[0] == 0xFF && b[1] == 0xFE:
+		return decodeUTF16Bytes(b[2:], binary.LittleEndian), nil
+	case len(b) >= 2 && b[0] == 0xFE && b[1] == 0xFF:
+		return decodeUTF16Bytes(b[2:], binary.BigEndian), nil
+	}
+	if !utf8.Valid(b) {
+		return "", errors.New("FarMenu.ini: input is neither valid UTF-8 nor BOM-marked UTF-16")
+	}
+	return string(b), nil
+}
+
+func decodeUTF16Bytes(b []byte, bo binary.ByteOrder) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u16 := make([]uint16, len(b)/2)
+	for i := range u16 {
+		u16[i] = bo.Uint16(b[i*2 : i*2+2])
+	}
+	return string(utf16.Decode(u16))
+}
+
+func splitTextLines(s string) []string {
+	// Normalize CRLF and lone CR to LF, then split. Trailing empty string
+	// from a final newline is fine; the parser skips blank lines.
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.Split(s, "\n")
+}
+
+type farMenuParser struct {
+	lines []string
+	pos   int
+}
+
+// parseLevel parses items until it hits "}" or EOF. The opening "{" of
+// a nested level (if any) must be consumed by the caller before calling.
+func (p *farMenuParser) parseLevel() []UserMenuItem {
+	var items []UserMenuItem
+	for p.pos < len(p.lines) {
+		line := strings.TrimRight(p.lines[p.pos], " \t")
+		if line == "" {
+			p.pos++
+			continue
+		}
+		if line == "}" {
+			p.pos++
+			return items
+		}
+		if line == "{" {
+			// Stray opening before any item — far2l ignores it.
+			p.pos++
+			continue
+		}
+		if isFarMenuSpaceByte(line[0]) {
+			// Indented line with no item to attach to — drop it (matches
+			// far2l, which would attach to the previous item's command
+			// list at KeyNumber < 0 and silently no-op).
+			p.pos++
+			continue
+		}
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			p.pos++
+			continue
+		}
+		item := UserMenuItem{
+			HotKey: line[:colon],
+			Label:  strings.TrimLeft(line[colon+1:], " \t"),
+		}
+		p.pos++
+		if p.peekIsSubmenuOpen() {
+			// Skip blank lines, then consume the "{".
+			for p.pos < len(p.lines) {
+				cur := strings.TrimRight(p.lines[p.pos], " \t")
+				p.pos++
+				if cur == "{" {
+					break
+				}
+			}
+			children := p.parseLevel()
+			if children == nil {
+				children = []UserMenuItem{}
+			}
+			item.Submenu = children
+		} else {
+			for p.pos < len(p.lines) {
+				cl := strings.TrimRight(p.lines[p.pos], " \t")
+				if cl == "" {
+					p.pos++
+					continue
+				}
+				if cl == "}" || !isFarMenuSpaceByte(cl[0]) {
+					break
+				}
+				item.Commands = append(item.Commands, strings.TrimLeft(cl, " \t"))
+				p.pos++
+			}
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func (p *farMenuParser) peekIsSubmenuOpen() bool {
+	for i := p.pos; i < len(p.lines); i++ {
+		line := strings.TrimRight(p.lines[i], " \t")
+		if line == "" {
+			continue
+		}
+		return line == "{"
+	}
+	return false
+}
+
+func isFarMenuSpaceByte(c byte) bool { return c == ' ' || c == '\t' }
+
+func writeFarMenuLevel(buf *bytes.Buffer, items []UserMenuItem) {
+	for i := range items {
+		it := &items[i]
+		buf.WriteString(it.HotKey)
+		buf.WriteString(farMenuColonSep)
+		buf.WriteString(it.Label)
+		buf.WriteString(farMenuLineEnding)
+		if it.IsSubmenu() {
+			buf.WriteString("{")
+			buf.WriteString(farMenuLineEnding)
+			writeFarMenuLevel(buf, it.Submenu)
+			buf.WriteString("}")
+			buf.WriteString(farMenuLineEnding)
+		} else {
+			for _, cmd := range it.Commands {
+				buf.WriteString(farMenuCommandIndent)
+				buf.WriteString(cmd)
+				buf.WriteString(farMenuLineEnding)
+			}
+		}
+	}
+}

--- a/farmenu_file_test.go
+++ b/farmenu_file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 	"unicode/utf16"
@@ -280,46 +281,105 @@ func TestParseFarMenu_InvalidUTF8(t *testing.T) {
 	}
 }
 
-func TestWriteFarMenu_OneItem_CRLF_NoBOM(t *testing.T) {
-	var buf bytes.Buffer
-	err := WriteFarMenu(&buf, []UserMenuItem{
+func TestRenderFarMenuText_OneItem(t *testing.T) {
+	got := renderFarMenuText([]UserMenuItem{
 		{HotKey: "a", Label: "Apple", Commands: []string{"eat"}},
 	})
-	if err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	got := buf.String()
 	want := "a:  Apple\r\n    eat\r\n"
 	if got != want {
 		t.Fatalf("output mismatch:\nGOT  %q\nWANT %q", got, want)
 	}
-	// Explicit BOM-absence check: a far2l-authored file would lead with FF FE.
-	if bytes.HasPrefix(buf.Bytes(), []byte{0xFF, 0xFE}) ||
-		bytes.HasPrefix(buf.Bytes(), []byte{0xEF, 0xBB, 0xBF}) {
-		t.Errorf("output unexpectedly includes a BOM")
-	}
 }
 
-func TestWriteFarMenu_Submenu(t *testing.T) {
-	var buf bytes.Buffer
-	_ = WriteFarMenu(&buf, []UserMenuItem{
+func TestRenderFarMenuText_Submenu(t *testing.T) {
+	got := renderFarMenuText([]UserMenuItem{
 		{HotKey: "m", Label: "Menu", Submenu: []UserMenuItem{
 			{HotKey: "a", Label: "A", Commands: []string{"x"}},
 		}},
 	})
 	want := "m:  Menu\r\n{\r\na:  A\r\n    x\r\n}\r\n"
-	if buf.String() != want {
-		t.Fatalf("submenu output:\nGOT  %q\nWANT %q", buf.String(), want)
+	if got != want {
+		t.Fatalf("submenu output:\nGOT  %q\nWANT %q", got, want)
 	}
 }
 
-func TestWriteFarMenu_Separator(t *testing.T) {
-	var buf bytes.Buffer
-	_ = WriteFarMenu(&buf, []UserMenuItem{
+func TestRenderFarMenuText_Separator(t *testing.T) {
+	got := renderFarMenuText([]UserMenuItem{
 		{HotKey: "--", Label: ""},
 	})
-	if buf.String() != "--:  \r\n" {
-		t.Fatalf("separator output: %q", buf.String())
+	if got != "--:  \r\n" {
+		t.Fatalf("separator output: %q", got)
+	}
+}
+
+func TestWriteFarMenu_PlatformEncodingHasBOM(t *testing.T) {
+	var buf bytes.Buffer
+	if err := WriteFarMenu(&buf, []UserMenuItem{
+		{HotKey: "a", Label: "Apple", Commands: []string{"eat"}},
+	}); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	b := buf.Bytes()
+	switch runtime.GOOS {
+	case "windows":
+		if !bytes.HasPrefix(b, []byte{0xFF, 0xFE}) {
+			t.Errorf("Windows build should write UTF-16LE BOM, got %x", b[:min(4, len(b))])
+		}
+		if bytes.HasPrefix(b, []byte{0xFF, 0xFE, 0x00, 0x00}) {
+			t.Errorf("Windows build wrote UTF-32 BOM instead of UTF-16")
+		}
+	default:
+		if !bytes.HasPrefix(b, []byte{0xFF, 0xFE, 0x00, 0x00}) {
+			t.Errorf("Unix build should write UTF-32LE BOM, got %x", b[:min(8, len(b))])
+		}
+	}
+	// Round-trip via the multi-encoding reader regardless of platform.
+	out, err := ParseFarMenu(bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("re-parse failed: %v", err)
+	}
+	if len(out) != 1 || out[0].Label != "Apple" {
+		t.Fatalf("round-trip mangled: %#v", out)
+	}
+}
+
+func TestEncodeUTF16LEWithBOM(t *testing.T) {
+	got := encodeUTF16LEWithBOM("c:")
+	want := []byte{0xFF, 0xFE, 'c', 0x00, ':', 0x00}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}
+
+func TestEncodeUTF32LEWithBOM(t *testing.T) {
+	got := encodeUTF32LEWithBOM("c:")
+	want := []byte{
+		0xFF, 0xFE, 0x00, 0x00,
+		'c', 0x00, 0x00, 0x00,
+		':', 0x00, 0x00, 0x00,
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("got %x, want %x", got, want)
+	}
+}
+
+func TestEncode_CyrillicSurvivesBothEncodings(t *testing.T) {
+	src := "Яблоко"
+	for _, c := range []struct {
+		name string
+		fn   func(string) []byte
+	}{
+		{"UTF-16LE", encodeUTF16LEWithBOM},
+		{"UTF-32LE", encodeUTF32LEWithBOM},
+	} {
+		decoded, err := decodeFarMenuBytes(c.fn(src))
+		if err != nil {
+			t.Errorf("%s decode: %v", c.name, err)
+			continue
+		}
+		if decoded != src {
+			t.Errorf("%s round-trip: got %q want %q", c.name, decoded, src)
+		}
 	}
 }
 
@@ -384,18 +444,18 @@ func TestFarMenu_CrossFormatRoundTrip(t *testing.T) {
 	}
 }
 
-func TestFarMenu_BytewiseFar2lFormat(t *testing.T) {
-	// Confirm we emit exactly what far2l's MenuRegToFile produces (modulo
-	// encoding — we use UTF-8 instead of UTF-16LE). Reference output is
-	// pieced together from usermenu.cpp:103-137 verbatim.
+func TestRenderFarMenuText_MatchesFar2lLayout(t *testing.T) {
+	// Confirm the canonical text we render mirrors what far2l's
+	// MenuRegToFile emits modulo encoding. Reference is pieced together
+	// from usermenu.cpp:103-137. WriteFarMenu wraps this in the
+	// platform's wide encoding; the layout itself must stay identical.
 	items := []UserMenuItem{
 		{HotKey: "c", Label: "VSCode", Commands: []string{"code ."}},
 		{HotKey: "t", Label: "tmux", Submenu: []UserMenuItem{
 			{HotKey: "l", Label: "list", Commands: []string{"tmux ls"}},
 		}},
 	}
-	var buf bytes.Buffer
-	_ = WriteFarMenu(&buf, items)
+	got := renderFarMenuText(items)
 	want := "c:  VSCode\r\n" +
 		"    code .\r\n" +
 		"t:  tmux\r\n" +
@@ -403,7 +463,7 @@ func TestFarMenu_BytewiseFar2lFormat(t *testing.T) {
 		"l:  list\r\n" +
 		"    tmux ls\r\n" +
 		"}\r\n"
-	if buf.String() != want {
-		t.Fatalf("byte-level format drift:\nGOT  %q\nWANT %q", buf.String(), want)
+	if got != want {
+		t.Fatalf("text-layout drift:\nGOT  %q\nWANT %q", got, want)
 	}
 }

--- a/farmenu_file_test.go
+++ b/farmenu_file_test.go
@@ -197,6 +197,69 @@ func TestParseFarMenu_UTF16BEWithBOM(t *testing.T) {
 	}
 }
 
+func TestParseFarMenu_UTF32LEWithBOM(t *testing.T) {
+	// This is what far2l actually writes on Linux/macOS/BSD: SIGN_WIDE_LE
+	// emitted as a single 4-byte wchar_t. Looks like FF FE 00 00 ... .
+	body := "c:  code\r\n    code .\r\n"
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFF, 0xFE, 0x00, 0x00})
+	for _, r := range body {
+		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+	}
+	got, err := ParseFarMenu(&buf)
+	if err != nil {
+		t.Fatalf("UTF-32LE decode: %v", err)
+	}
+	if len(got) != 1 || got[0].HotKey != "c" || got[0].Label != "code" ||
+		len(got[0].Commands) != 1 || got[0].Commands[0] != "code ." {
+		t.Fatalf("UTF-32LE parsed wrong: %#v", got)
+	}
+}
+
+func TestParseFarMenu_UTF32LEWithCyrillic(t *testing.T) {
+	body := "a:  Яблоко\r\n"
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFF, 0xFE, 0x00, 0x00})
+	for _, r := range body {
+		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+	}
+	got, _ := ParseFarMenu(&buf)
+	if len(got) != 1 || got[0].Label != "Яблоко" {
+		t.Fatalf("UTF-32LE cyrillic mangled: %#v", got)
+	}
+}
+
+func TestParseFarMenu_UTF32BEWithBOM(t *testing.T) {
+	body := "a:  X\r\n"
+	var buf bytes.Buffer
+	buf.Write([]byte{0x00, 0x00, 0xFE, 0xFF})
+	for _, r := range body {
+		_ = binary.Write(&buf, binary.BigEndian, uint32(r))
+	}
+	got, _ := ParseFarMenu(&buf)
+	if len(got) != 1 || got[0].HotKey != "a" || got[0].Label != "X" {
+		t.Fatalf("UTF-32BE decoded wrong: %#v", got)
+	}
+}
+
+// Disambiguation check: UTF-32LE BOM is "FF FE 00 00" and UTF-16LE BOM
+// is "FF FE", so the wider format must be detected first or else a real
+// UTF-32 file gets misparsed as UTF-16 (every other char appears empty,
+// which is exactly the symptom seen on far2l-authored FarMenu.ini on
+// Linux).
+func TestParseFarMenu_UTF32LE_NotMistakenForUTF16LE(t *testing.T) {
+	body := "a:  Apple\r\n"
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFF, 0xFE, 0x00, 0x00})
+	for _, r := range body {
+		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+	}
+	got, _ := ParseFarMenu(&buf)
+	if len(got) != 1 || got[0].Label != "Apple" {
+		t.Fatalf("UTF-32LE misparsed (likely as UTF-16LE): %#v", got)
+	}
+}
+
 func TestParseFarMenu_LFOnlyLineEndings(t *testing.T) {
 	got := parseFarMenuString(t, "a:  Apple\n    cmd\nb:  Banana\n")
 	if len(got) != 2 || got[0].Commands[0] != "cmd" || got[1].Label != "Banana" {

--- a/farmenu_file_test.go
+++ b/farmenu_file_test.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"reflect"
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+func parseFarMenuString(t *testing.T, s string) []UserMenuItem {
+	t.Helper()
+	items, err := ParseFarMenu(strings.NewReader(s))
+	if err != nil {
+		t.Fatalf("ParseFarMenu: %v", err)
+	}
+	return items
+}
+
+func TestParseFarMenu_Empty(t *testing.T) {
+	for _, in := range []string{"", "\r\n", "\n\n\n", "   \r\n   \r\n"} {
+		items := parseFarMenuString(t, in)
+		if len(items) != 0 {
+			t.Errorf("empty input %q yielded %v", in, items)
+		}
+	}
+}
+
+func TestParseFarMenu_OneItem_OneCommand(t *testing.T) {
+	got := parseFarMenuString(t, "a:  Apple\r\n    eat\r\n")
+	want := []UserMenuItem{{HotKey: "a", Label: "Apple", Commands: []string{"eat"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}
+
+func TestParseFarMenu_MultipleItems(t *testing.T) {
+	got := parseFarMenuString(t, ""+
+		"a:  Apple\r\n"+
+		"    cmd1\r\n"+
+		"b:  Banana\r\n"+
+		"    cmd2\r\n"+
+		"    cmd3\r\n")
+	if len(got) != 2 {
+		t.Fatalf("want 2 items, got %d (%#v)", len(got), got)
+	}
+	if got[0].Label != "Apple" || got[1].Label != "Banana" {
+		t.Errorf("labels: %q / %q", got[0].Label, got[1].Label)
+	}
+	if !reflect.DeepEqual(got[1].Commands, []string{"cmd2", "cmd3"}) {
+		t.Errorf("multi commands lost: %#v", got[1].Commands)
+	}
+}
+
+func TestParseFarMenu_BlankLinesIgnored(t *testing.T) {
+	got := parseFarMenuString(t, ""+
+		"\r\n"+
+		"a:  Apple\r\n"+
+		"\r\n"+
+		"    cmd1\r\n"+
+		"\r\n"+
+		"    cmd2\r\n"+
+		"\r\n"+
+		"b:  Banana\r\n")
+	if len(got) != 2 {
+		t.Fatalf("want 2 items, got %d", len(got))
+	}
+	if !reflect.DeepEqual(got[0].Commands, []string{"cmd1", "cmd2"}) {
+		t.Errorf("blanks broke command grouping: %#v", got[0].Commands)
+	}
+}
+
+func TestParseFarMenu_Submenu(t *testing.T) {
+	got := parseFarMenuString(t, ""+
+		"m:  Menu\r\n"+
+		"{\r\n"+
+		"a:  Apple\r\n"+
+		"    eat\r\n"+
+		"b:  Banana\r\n"+
+		"    peel\r\n"+
+		"}\r\n")
+	if len(got) != 1 || !got[0].IsSubmenu() {
+		t.Fatalf("want submenu, got %#v", got)
+	}
+	sub := got[0].Submenu
+	if len(sub) != 2 || sub[0].Label != "Apple" || sub[1].Label != "Banana" {
+		t.Fatalf("submenu items wrong: %#v", sub)
+	}
+	if sub[0].Commands[0] != "eat" || sub[1].Commands[0] != "peel" {
+		t.Errorf("commands lost: %#v", sub)
+	}
+}
+
+func TestParseFarMenu_EmptySubmenu(t *testing.T) {
+	got := parseFarMenuString(t, "m:  Menu\r\n{\r\n}\r\n")
+	if len(got) != 1 || !got[0].IsSubmenu() {
+		t.Fatalf("want submenu, got %#v", got)
+	}
+	if len(got[0].Submenu) != 0 {
+		t.Errorf("expected empty submenu, got %d children", len(got[0].Submenu))
+	}
+}
+
+func TestParseFarMenu_NestedSubmenus(t *testing.T) {
+	got := parseFarMenuString(t, ""+
+		"a:  A\r\n"+
+		"{\r\n"+
+		"b:  B\r\n"+
+		"{\r\n"+
+		"c:  C\r\n"+
+		"    deep\r\n"+
+		"}\r\n"+
+		"}\r\n")
+	if len(got) != 1 || !got[0].IsSubmenu() {
+		t.Fatalf("top: %#v", got)
+	}
+	mid := got[0].Submenu
+	if len(mid) != 1 || !mid[0].IsSubmenu() {
+		t.Fatalf("mid: %#v", mid)
+	}
+	leaf := mid[0].Submenu
+	if len(leaf) != 1 || leaf[0].Label != "C" || leaf[0].Commands[0] != "deep" {
+		t.Fatalf("leaf: %#v", leaf)
+	}
+}
+
+func TestParseFarMenu_Separator(t *testing.T) {
+	got := parseFarMenuString(t, "--:  \r\n")
+	if len(got) != 1 || !got[0].IsSeparator() || got[0].Label != "" {
+		t.Fatalf("separator: %#v", got)
+	}
+}
+
+func TestParseFarMenu_ColonInLabel(t *testing.T) {
+	// far2l splits on the FIRST colon; everything after is the label.
+	got := parseFarMenuString(t, "a:  foo: bar: baz\r\n    cmd\r\n")
+	if len(got) != 1 || got[0].HotKey != "a" || got[0].Label != "foo: bar: baz" {
+		t.Fatalf("first-colon split broken: %#v", got)
+	}
+}
+
+func TestParseFarMenu_NoColonSkipped(t *testing.T) {
+	got := parseFarMenuString(t, "this is junk\r\na:  Apple\r\n    cmd\r\n")
+	if len(got) != 1 || got[0].Label != "Apple" {
+		t.Fatalf("junk lines should be skipped: %#v", got)
+	}
+}
+
+func TestParseFarMenu_TabIndentedCommand(t *testing.T) {
+	got := parseFarMenuString(t, "a:  Apple\r\n\tcmd\r\n")
+	if len(got) != 1 || len(got[0].Commands) != 1 || got[0].Commands[0] != "cmd" {
+		t.Fatalf("tab indent not treated as command: %#v", got)
+	}
+}
+
+func TestParseFarMenu_UTF8WithBOM(t *testing.T) {
+	src := append([]byte{0xEF, 0xBB, 0xBF}, []byte("a:  Apple\r\n    cmd\r\n")...)
+	got, err := ParseFarMenu(bytes.NewReader(src))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != 1 || got[0].Label != "Apple" {
+		t.Fatalf("UTF-8 BOM not stripped: %#v", got)
+	}
+}
+
+func TestParseFarMenu_UTF16LEWithBOM(t *testing.T) {
+	// This is the format far2l actually writes.
+	body := "a:  Яблоко\r\n    cmd\r\n"
+	u16 := utf16.Encode([]rune(body))
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFF, 0xFE})
+	for _, w := range u16 {
+		_ = binary.Write(&buf, binary.LittleEndian, w)
+	}
+	got, err := ParseFarMenu(&buf)
+	if err != nil {
+		t.Fatalf("decode UTF-16LE: %v", err)
+	}
+	if len(got) != 1 || got[0].Label != "Яблоко" {
+		t.Fatalf("UTF-16LE decoded wrong: %#v", got)
+	}
+}
+
+func TestParseFarMenu_UTF16BEWithBOM(t *testing.T) {
+	body := "a:  X\r\n"
+	u16 := utf16.Encode([]rune(body))
+	var buf bytes.Buffer
+	buf.Write([]byte{0xFE, 0xFF})
+	for _, w := range u16 {
+		_ = binary.Write(&buf, binary.BigEndian, w)
+	}
+	got, _ := ParseFarMenu(&buf)
+	if len(got) != 1 || got[0].HotKey != "a" || got[0].Label != "X" {
+		t.Fatalf("UTF-16BE decoded wrong: %#v", got)
+	}
+}
+
+func TestParseFarMenu_LFOnlyLineEndings(t *testing.T) {
+	got := parseFarMenuString(t, "a:  Apple\n    cmd\nb:  Banana\n")
+	if len(got) != 2 || got[0].Commands[0] != "cmd" || got[1].Label != "Banana" {
+		t.Fatalf("LF-only lines broken: %#v", got)
+	}
+}
+
+func TestParseFarMenu_LoneCRLineEndings(t *testing.T) {
+	got := parseFarMenuString(t, "a:  Apple\r    cmd\rb:  Banana\r")
+	if len(got) != 2 || got[0].Commands[0] != "cmd" || got[1].Label != "Banana" {
+		t.Fatalf("CR-only lines broken: %#v", got)
+	}
+}
+
+func TestParseFarMenu_InvalidUTF8(t *testing.T) {
+	if _, err := ParseFarMenu(bytes.NewReader([]byte{0x80, 0xFF, 0xC0})); err == nil {
+		t.Errorf("expected error on garbage bytes with no BOM")
+	}
+}
+
+func TestWriteFarMenu_OneItem_CRLF_NoBOM(t *testing.T) {
+	var buf bytes.Buffer
+	err := WriteFarMenu(&buf, []UserMenuItem{
+		{HotKey: "a", Label: "Apple", Commands: []string{"eat"}},
+	})
+	if err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := buf.String()
+	want := "a:  Apple\r\n    eat\r\n"
+	if got != want {
+		t.Fatalf("output mismatch:\nGOT  %q\nWANT %q", got, want)
+	}
+	// Explicit BOM-absence check: a far2l-authored file would lead with FF FE.
+	if bytes.HasPrefix(buf.Bytes(), []byte{0xFF, 0xFE}) ||
+		bytes.HasPrefix(buf.Bytes(), []byte{0xEF, 0xBB, 0xBF}) {
+		t.Errorf("output unexpectedly includes a BOM")
+	}
+}
+
+func TestWriteFarMenu_Submenu(t *testing.T) {
+	var buf bytes.Buffer
+	_ = WriteFarMenu(&buf, []UserMenuItem{
+		{HotKey: "m", Label: "Menu", Submenu: []UserMenuItem{
+			{HotKey: "a", Label: "A", Commands: []string{"x"}},
+		}},
+	})
+	want := "m:  Menu\r\n{\r\na:  A\r\n    x\r\n}\r\n"
+	if buf.String() != want {
+		t.Fatalf("submenu output:\nGOT  %q\nWANT %q", buf.String(), want)
+	}
+}
+
+func TestWriteFarMenu_Separator(t *testing.T) {
+	var buf bytes.Buffer
+	_ = WriteFarMenu(&buf, []UserMenuItem{
+		{HotKey: "--", Label: ""},
+	})
+	if buf.String() != "--:  \r\n" {
+		t.Fatalf("separator output: %q", buf.String())
+	}
+}
+
+func TestFarMenu_RoundTrip(t *testing.T) {
+	in := []UserMenuItem{
+		{HotKey: "c", Label: "VSCode", Commands: []string{"code ."}},
+		{HotKey: "t", Label: "tmux", Submenu: []UserMenuItem{
+			{HotKey: "l", Label: "list", Commands: []string{"tmux ls"}},
+			{HotKey: "a", Label: "attach", Commands: []string{"tmux attach"}},
+		}},
+		{HotKey: "--", Label: ""},
+		{HotKey: "x", Label: "exit", Commands: []string{"exit"}},
+	}
+	var buf bytes.Buffer
+	if err := WriteFarMenu(&buf, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := ParseFarMenu(bytes.NewReader(buf.Bytes()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("round-trip mismatch:\ngot  %#v\nwant %#v", out, in)
+	}
+}
+
+func TestFarMenu_CrossFormatRoundTrip(t *testing.T) {
+	// Same tree should survive: model -> FarMenu.ini -> model
+	//                          -> main_menu.ini -> model
+	// All three representations must reconstruct the same structure.
+	tree := []UserMenuItem{
+		{HotKey: "1", Label: "one", Commands: []string{"echo 1"}},
+		{HotKey: "g", Label: "group", Submenu: []UserMenuItem{
+			{HotKey: "a", Label: "alpha", Commands: []string{"echo a", "echo b"}},
+		}},
+		{HotKey: "--", Label: ""},
+		{HotKey: "z", Label: "last", Commands: []string{"echo z"}},
+	}
+
+	var txt bytes.Buffer
+	if err := WriteFarMenu(&txt, tree); err != nil {
+		t.Fatalf("WriteFarMenu: %v", err)
+	}
+	viaText, err := ParseFarMenu(bytes.NewReader(txt.Bytes()))
+	if err != nil {
+		t.Fatalf("ParseFarMenu: %v", err)
+	}
+	if !reflect.DeepEqual(viaText, tree) {
+		t.Fatalf("FarMenu.ini round-trip lost data:\ngot  %#v\nwant %#v", viaText, tree)
+	}
+
+	p := writeTemp(t, "")
+	if err := SaveMainMenu(p, tree); err != nil {
+		t.Fatalf("SaveMainMenu: %v", err)
+	}
+	viaINI, err := LoadMainMenu(p)
+	if err != nil {
+		t.Fatalf("LoadMainMenu: %v", err)
+	}
+	if !reflect.DeepEqual(viaINI, tree) {
+		t.Fatalf("main_menu.ini round-trip lost data:\ngot  %#v\nwant %#v", viaINI, tree)
+	}
+}
+
+func TestFarMenu_BytewiseFar2lFormat(t *testing.T) {
+	// Confirm we emit exactly what far2l's MenuRegToFile produces (modulo
+	// encoding — we use UTF-8 instead of UTF-16LE). Reference output is
+	// pieced together from usermenu.cpp:103-137 verbatim.
+	items := []UserMenuItem{
+		{HotKey: "c", Label: "VSCode", Commands: []string{"code ."}},
+		{HotKey: "t", Label: "tmux", Submenu: []UserMenuItem{
+			{HotKey: "l", Label: "list", Commands: []string{"tmux ls"}},
+		}},
+	}
+	var buf bytes.Buffer
+	_ = WriteFarMenu(&buf, items)
+	want := "c:  VSCode\r\n" +
+		"    code .\r\n" +
+		"t:  tmux\r\n" +
+		"{\r\n" +
+		"l:  list\r\n" +
+		"    tmux ls\r\n" +
+		"}\r\n"
+	if buf.String() != want {
+		t.Fatalf("byte-level format drift:\nGOT  %q\nWANT %q", buf.String(), want)
+	}
+}

--- a/lang.go
+++ b/lang.go
@@ -95,6 +95,9 @@ var Lng = map[string]string{
 	"FindFile.TextPrompt":          "Containing text:",
 	"FindFile.BtnFind":             "&Find",
 	"History.FoldersTitle":         " Folders History ",
+	"UserMenu.LocalMenuTitle":      "Local menu",
+	"UserMenu.MainMenuTitle":       "Main menu",
+	"UserMenu.MainMenuFAR":         "FAR",
 
 	// KeyBar Normal
 	"KeyBar.F1":  "Help",

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -696,6 +696,12 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// F2: user menu (FarMenu.ini local → near binary → main_menu.ini).
+	if e.VirtualKeyCode == vtinput.VK_F2 && !alt && !ctrl && !shift && e.KeyDown {
+		ShowUserMenu(pf)
+		return true
+	}
+
 	// Ctrl+A: Attributes
 	if e.VirtualKeyCode == vtinput.VK_A && ctrl && !alt && !shift && e.KeyDown {
 		actionFileAttributes(pf)

--- a/user_menu.go
+++ b/user_menu.go
@@ -1,0 +1,15 @@
+package main
+
+// UserMenuItem is a single entry in the f4 user menu, mirroring far2l's
+// internal flat representation. A leaf item has Commands; a submenu has
+// a non-nil Submenu (empty slice is a valid empty submenu). Separators
+// are marked by HotKey == "--".
+type UserMenuItem struct {
+	HotKey   string
+	Label    string
+	Commands []string
+	Submenu  []UserMenuItem
+}
+
+func (it *UserMenuItem) IsSeparator() bool { return it.HotKey == "--" }
+func (it *UserMenuItem) IsSubmenu() bool   { return it.Submenu != nil }

--- a/user_menu_ini.go
+++ b/user_menu_ini.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// mainMenuRoot is the section prefix far2l uses for the persistent main menu.
+// Keep it bit-for-bit identical so a user_menu.ini authored in far2l can be
+// dropped into ~/.config/f4/settings/main_menu.ini and vice versa.
+const mainMenuRoot = "UserMenu/MainMenu"
+
+// LoadMainMenu reads a far2l-compatible main menu INI from path. A missing
+// file is not an error: an empty slice is returned. Sections outside the
+// UserMenu/MainMenu subtree are ignored, so the loader is safe to point at
+// a mixed-content INI.
+func LoadMainMenu(path string) ([]UserMenuItem, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []UserMenuItem{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+
+	sections := map[string]map[string]string{}
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	var cur map[string]string
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r\n")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, ";") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			name := trimmed[1 : len(trimmed)-1]
+			if name == mainMenuRoot || strings.HasPrefix(name, mainMenuRoot+"/") {
+				if _, ok := sections[name]; !ok {
+					sections[name] = map[string]string{}
+				}
+				cur = sections[name]
+			} else {
+				cur = nil
+			}
+			continue
+		}
+		if cur == nil {
+			continue
+		}
+		// Preserve the value verbatim. Keys are tidied; values can carry
+		// trailing spaces that matter for shell commands, but far2l itself
+		// trims them on read, so we do the same to round-trip cleanly.
+		if eq := strings.IndexByte(line, '='); eq != -1 {
+			key := strings.TrimSpace(line[:eq])
+			val := strings.TrimSpace(line[eq+1:])
+			if key != "" {
+				cur[key] = val
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return buildTree(sections, mainMenuRoot), nil
+}
+
+// SaveMainMenu writes items to path in far2l-compatible flat INI form.
+// Parent directories are created as needed.
+func SaveMainMenu(path string, items []UserMenuItem) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	var buf strings.Builder
+	first := true
+	writeTree(&buf, items, mainMenuRoot, &first)
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func buildTree(sections map[string]map[string]string, prefix string) []UserMenuItem {
+	var items []UserMenuItem
+	for i := 0; ; i++ {
+		key := fmt.Sprintf("%s/Item%d", prefix, i)
+		sec, ok := sections[key]
+		if !ok {
+			break
+		}
+		item := UserMenuItem{
+			HotKey: sec["HotKey"],
+			Label:  sec["Label"],
+		}
+		if isSubmenuFlag(sec["Submenu"]) {
+			children := buildTree(sections, key)
+			if children == nil {
+				children = []UserMenuItem{}
+			}
+			item.Submenu = children
+		} else {
+			var cmds []string
+			for j := 0; ; j++ {
+				cmd, ok := sec[fmt.Sprintf("Command%d", j)]
+				if !ok {
+					break
+				}
+				cmds = append(cmds, cmd)
+			}
+			item.Commands = cmds
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func writeTree(buf *strings.Builder, items []UserMenuItem, prefix string, first *bool) {
+	for i := range items {
+		it := &items[i]
+		section := fmt.Sprintf("%s/Item%d", prefix, i)
+		if !*first {
+			buf.WriteByte('\n')
+		}
+		*first = false
+		buf.WriteByte('[')
+		buf.WriteString(section)
+		buf.WriteString("]\n")
+
+		// Match far2l's apparent on-disk key ordering: alphabetical, which
+		// also keeps writes deterministic regardless of map iteration.
+		if !it.IsSubmenu() {
+			for j, cmd := range it.Commands {
+				buf.WriteString("Command")
+				buf.WriteString(strconv.Itoa(j))
+				buf.WriteByte('=')
+				buf.WriteString(cmd)
+				buf.WriteByte('\n')
+			}
+		}
+		buf.WriteString("HotKey=")
+		buf.WriteString(it.HotKey)
+		buf.WriteByte('\n')
+		buf.WriteString("Label=")
+		buf.WriteString(it.Label)
+		buf.WriteByte('\n')
+		if it.IsSubmenu() {
+			buf.WriteString("Submenu=1\n")
+			writeTree(buf, it.Submenu, section, first)
+		} else {
+			buf.WriteString("Submenu=0\n")
+		}
+	}
+}
+
+func isSubmenuFlag(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return false
+	}
+	return n != 0
+}

--- a/user_menu_ini_test.go
+++ b/user_menu_ini_test.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeTemp(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "main_menu.ini")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	return p
+}
+
+func TestLoadMainMenu_MissingFile(t *testing.T) {
+	items, err := LoadMainMenu(filepath.Join(t.TempDir(), "does_not_exist.ini"))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("expected empty slice for missing file, got %v", items)
+	}
+}
+
+func TestLoadMainMenu_FlatLeafItem(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+Command0=code .
+HotKey=c
+Label=open VSCode
+Submenu=0
+`)
+	items, err := LoadMainMenu(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	want := []UserMenuItem{{
+		HotKey:   "c",
+		Label:    "open VSCode",
+		Commands: []string{"code ."},
+	}}
+	if !reflect.DeepEqual(items, want) {
+		t.Fatalf("got %#v, want %#v", items, want)
+	}
+}
+
+func TestLoadMainMenu_MultipleCommands(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+Command0=cd /tmp
+Command1=ls -la
+Command2=pwd
+HotKey=m
+Label=multi
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	got := items[0].Commands
+	want := []string{"cd /tmp", "ls -la", "pwd"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands: got %v, want %v", got, want)
+	}
+}
+
+func TestLoadMainMenu_Submenu(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+HotKey=t
+Label=tmux
+Submenu=1
+
+[UserMenu/MainMenu/Item0/Item0]
+Command0=tmux ls
+HotKey=l
+Label=list
+Submenu=0
+
+[UserMenu/MainMenu/Item0/Item1]
+Command0=tmux attach
+HotKey=a
+Label=attach
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 {
+		t.Fatalf("want 1 item, got %d", len(items))
+	}
+	parent := items[0]
+	if parent.HotKey != "t" || parent.Label != "tmux" {
+		t.Fatalf("parent fields wrong: %#v", parent)
+	}
+	if !parent.IsSubmenu() {
+		t.Fatalf("expected submenu, got leaf")
+	}
+	if len(parent.Submenu) != 2 {
+		t.Fatalf("want 2 children, got %d", len(parent.Submenu))
+	}
+	if parent.Submenu[0].Label != "list" || parent.Submenu[1].Label != "attach" {
+		t.Fatalf("children order/labels wrong: %#v", parent.Submenu)
+	}
+	if parent.Submenu[0].Commands[0] != "tmux ls" {
+		t.Fatalf("child[0] command: %q", parent.Submenu[0].Commands[0])
+	}
+}
+
+func TestLoadMainMenu_NestedSubmenus(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+HotKey=a
+Label=A
+Submenu=1
+
+[UserMenu/MainMenu/Item0/Item0]
+HotKey=b
+Label=B
+Submenu=1
+
+[UserMenu/MainMenu/Item0/Item0/Item0]
+Command0=echo deep
+HotKey=c
+Label=C
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 || !items[0].IsSubmenu() {
+		t.Fatalf("top: %#v", items)
+	}
+	if !items[0].Submenu[0].IsSubmenu() {
+		t.Fatalf("mid: %#v", items[0].Submenu)
+	}
+	leaf := items[0].Submenu[0].Submenu[0]
+	if leaf.IsSubmenu() {
+		t.Fatalf("expected leaf at depth 3")
+	}
+	if leaf.Label != "C" || leaf.Commands[0] != "echo deep" {
+		t.Fatalf("leaf wrong: %#v", leaf)
+	}
+}
+
+func TestLoadMainMenu_SkipsForeignSections(t *testing.T) {
+	p := writeTemp(t, `[Some/Other/Section]
+Key=value
+
+[UserMenu/MainMenu/Item0]
+Command0=ok
+HotKey=x
+Label=mine
+Submenu=0
+
+[Unrelated]
+Foo=bar
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 || items[0].Label != "mine" {
+		t.Fatalf("foreign sections not skipped: %#v", items)
+	}
+}
+
+func TestLoadMainMenu_StopsAtMissingIndex(t *testing.T) {
+	// Item0 and Item2 present, Item1 missing => Item2 should NOT be picked up.
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+Command0=a
+HotKey=a
+Label=A
+Submenu=0
+
+[UserMenu/MainMenu/Item2]
+Command0=c
+HotKey=c
+Label=C
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 {
+		t.Fatalf("indexing must be contiguous; got %d items: %#v", len(items), items)
+	}
+}
+
+func TestLoadMainMenu_EmptySubmenu(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+HotKey=e
+Label=empty
+Submenu=1
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 || !items[0].IsSubmenu() {
+		t.Fatalf("expected one submenu item, got %#v", items)
+	}
+	if len(items[0].Submenu) != 0 {
+		t.Fatalf("expected zero children, got %d", len(items[0].Submenu))
+	}
+}
+
+func TestLoadMainMenu_Separator(t *testing.T) {
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+HotKey=--
+Label=
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 || !items[0].IsSeparator() {
+		t.Fatalf("expected separator, got %#v", items)
+	}
+}
+
+func TestSaveMainMenu_RoundTrip(t *testing.T) {
+	in := []UserMenuItem{
+		{HotKey: "c", Label: "VSCode", Commands: []string{"code ."}},
+		{HotKey: "t", Label: "tmux", Submenu: []UserMenuItem{
+			{HotKey: "l", Label: "list", Commands: []string{"tmux ls"}},
+			{HotKey: "a", Label: "attach", Commands: []string{"tmux attach -t main"}},
+		}},
+		{HotKey: "--", Label: "", Commands: []string{}},
+		{HotKey: "x", Label: "exit", Commands: []string{"exit"}},
+	}
+	dir := t.TempDir()
+	p := filepath.Join(dir, "out.ini")
+	if err := SaveMainMenu(p, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out, err := LoadMainMenu(p)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	// Normalize the empty-Commands separator: load returns nil for
+	// "no Command keys present", we wrote with an empty slice.
+	in[2].Commands = nil
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("round-trip mismatch:\ngot  %#v\nwant %#v", out, in)
+	}
+}
+
+func TestSaveMainMenu_DeterministicAndAlphabetical(t *testing.T) {
+	in := []UserMenuItem{
+		{HotKey: "c", Label: "VSCode", Commands: []string{"code ."}},
+	}
+	p := filepath.Join(t.TempDir(), "det.ini")
+	if err := SaveMainMenu(p, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, _ := os.ReadFile(p)
+	want := `[UserMenu/MainMenu/Item0]
+Command0=code .
+HotKey=c
+Label=VSCode
+Submenu=0
+`
+	if string(data) != want {
+		t.Fatalf("output not deterministic/alphabetical:\nGOT:\n%s\nWANT:\n%s", data, want)
+	}
+}
+
+func TestSaveMainMenu_BlankLineBetweenSections(t *testing.T) {
+	in := []UserMenuItem{
+		{HotKey: "a", Label: "A", Commands: []string{"a"}},
+		{HotKey: "b", Label: "B", Commands: []string{"b"}},
+	}
+	p := filepath.Join(t.TempDir(), "blanks.ini")
+	_ = SaveMainMenu(p, in)
+	data, _ := os.ReadFile(p)
+	if !strings.Contains(string(data), "Submenu=0\n\n[UserMenu/MainMenu/Item1]") {
+		t.Fatalf("expected blank line between sibling sections, got:\n%s", data)
+	}
+}
+
+func TestSaveMainMenu_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "nested", "deeper", "main_menu.ini")
+	if err := SaveMainMenu(p, []UserMenuItem{{HotKey: "a", Label: "a", Commands: []string{"a"}}}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+}
+
+// Real-world fixture: a verbatim slice of the user's actual far2l user_menu.ini.
+// This is the bug-for-bug compatibility check.
+const realFar2lFixture = `[UserMenu/MainMenu/Item0]
+Command0=code .
+HotKey=c
+Label=открыть VSCode в текущем пути в WSL-режиме
+Submenu=0
+
+[UserMenu/MainMenu/Item1]
+Command0=claude
+HotKey=a
+Label=claude code
+Submenu=0
+
+[UserMenu/MainMenu/Item2]
+HotKey=t
+Label=tmux
+Submenu=1
+
+[UserMenu/MainMenu/Item2/Item0]
+Command0=bash ~/sledy/start-all.sh
+HotKey=S
+Label=start ALL (redis + бэк + фронт в tmux, без блокировки)
+Submenu=0
+
+[UserMenu/MainMenu/Item2/Item1]
+Command0=bash ~/sledy/stop-all.sh
+HotKey=K
+Label=kill ALL (остановить всё)
+Submenu=0
+
+[UserMenu/MainMenu/Item3]
+HotKey=b
+Label=backend
+Submenu=1
+
+[UserMenu/MainMenu/Item3/Item0]
+Command0=cd /home/sogonov/sledy/go-basa.backend
+Command1=source .venv/bin/activate && uvicorn app.main:app --reload
+HotKey=r
+Label=run uvicorn dev
+Submenu=0
+
+[UserMenu/MainMenu/Item3/Item1]
+Command0=cd /home/sogonov/sledy/go-basa.backend
+Command1=source .venv/bin/activate && pytest -v "!?test path?tests/test_X.py::test_Y!"
+HotKey=o
+Label=pytest один тест (с подсказкой)
+Submenu=0
+`
+
+func TestLoadMainMenu_RealFar2lFile(t *testing.T) {
+	p := writeTemp(t, realFar2lFixture)
+	items, err := LoadMainMenu(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(items) != 4 {
+		t.Fatalf("want 4 top-level items, got %d", len(items))
+	}
+
+	// Spot-check unicode label.
+	if items[0].Label != "открыть VSCode в текущем пути в WSL-режиме" {
+		t.Fatalf("unicode label corrupted: %q", items[0].Label)
+	}
+
+	// Submenu structure.
+	if !items[2].IsSubmenu() || len(items[2].Submenu) != 2 {
+		t.Fatalf("tmux submenu: %#v", items[2])
+	}
+
+	// Multi-command and embedded "!?...!" substitution token must survive.
+	pytest := items[3].Submenu[1]
+	if pytest.HotKey != "o" || len(pytest.Commands) != 2 {
+		t.Fatalf("pytest item: %#v", pytest)
+	}
+	if !strings.Contains(pytest.Commands[1], `"!?test path?tests/test_X.py::test_Y!"`) {
+		t.Fatalf("substitution token mangled: %q", pytest.Commands[1])
+	}
+}
+
+func TestSaveMainMenu_RealFar2lFile_RoundTripSemantics(t *testing.T) {
+	// Save -> load -> compare. We don't require byte-identical output to
+	// the original (far2l's whitespace varies), only structural equality.
+	src := writeTemp(t, realFar2lFixture)
+	items, err := LoadMainMenu(src)
+	if err != nil {
+		t.Fatalf("initial load: %v", err)
+	}
+	dst := filepath.Join(t.TempDir(), "out.ini")
+	if err := SaveMainMenu(dst, items); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	items2, err := LoadMainMenu(dst)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reflect.DeepEqual(items, items2) {
+		t.Fatalf("structural round-trip failed:\nfirst:  %#v\nsecond: %#v", items, items2)
+	}
+}
+
+func TestUserMenuItem_IsSeparator(t *testing.T) {
+	cases := []struct {
+		it   UserMenuItem
+		want bool
+	}{
+		{UserMenuItem{HotKey: "--"}, true},
+		{UserMenuItem{HotKey: "-"}, false},
+		{UserMenuItem{HotKey: ""}, false},
+		{UserMenuItem{HotKey: "a"}, false},
+	}
+	for _, c := range cases {
+		if got := c.it.IsSeparator(); got != c.want {
+			t.Errorf("IsSeparator(%q) = %v, want %v", c.it.HotKey, got, c.want)
+		}
+	}
+}
+
+func TestUserMenuItem_IsSubmenu(t *testing.T) {
+	leaf := UserMenuItem{HotKey: "a", Commands: []string{"x"}}
+	emptySub := UserMenuItem{HotKey: "s", Submenu: []UserMenuItem{}}
+	fullSub := UserMenuItem{HotKey: "s", Submenu: []UserMenuItem{{HotKey: "x"}}}
+	if leaf.IsSubmenu() {
+		t.Errorf("leaf reported as submenu")
+	}
+	if !emptySub.IsSubmenu() {
+		t.Errorf("empty (non-nil) submenu must report true")
+	}
+	if !fullSub.IsSubmenu() {
+		t.Errorf("populated submenu must report true")
+	}
+}
+
+func TestLoadMainMenu_SubmenuFlagTolerance(t *testing.T) {
+	// Whitespace around '1' shouldn't trip the flag parser.
+	p := writeTemp(t, `[UserMenu/MainMenu/Item0]
+HotKey=s
+Label=sub
+Submenu= 1
+
+[UserMenu/MainMenu/Item0/Item0]
+Command0=ok
+HotKey=o
+Label=ok
+Submenu=0
+`)
+	items, _ := LoadMainMenu(p)
+	if len(items) != 1 || !items[0].IsSubmenu() || len(items[0].Submenu) != 1 {
+		t.Fatalf("submenu flag whitespace not tolerated: %#v", items)
+	}
+}

--- a/user_menu_subst.go
+++ b/user_menu_subst.go
@@ -1,0 +1,237 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// User-menu command substitution. This is a minimal subset of
+// far2l's fnparce.cpp (~870 lines of C++) covering what's actually used
+// in user_menu.ini files seen in practice. Tokens not in this list are
+// passed through verbatim so the shell sees them unmodified; we can
+// extend the set incrementally based on real-world configs.
+//
+// Supported tokens (active panel by default, '!#' switches to passive):
+//
+//	!!              literal '!'
+//	!.!             file name under cursor (with extension)
+//	!`!             extension of the cursor file, including the dot
+//	!\!             current panel directory
+//	!&              space-joined basenames of marked files (or cursor file)
+//	!@!             path of a temp file containing one marked basename per line
+//	!?title?init!   prompt the user for input; init is the prefilled value
+//	!#              switch subsequent tokens to the passive panel
+//	!^              switch subsequent tokens back to the active panel
+//
+// In addition, $VAR and ${VAR} are expanded via os.ExpandEnv after the
+// far2l-style tokens are resolved.
+
+// PanelSnapshot is a minimal snapshot of one panel's state, used as input
+// to SubstFileName. Snapshot is taken before the menu opens so a slow
+// substitution (e.g. !?...!) can't race against panel updates.
+type PanelSnapshot struct {
+	CurDir      string
+	CurrentFile string   // basename, "" if no file under cursor or it's ".."
+	Marked      []string // basenames; falls back to []string{CurrentFile} if nothing was explicitly marked
+}
+
+// SubstContext bundles everything SubstFileName needs.
+type SubstContext struct {
+	Active  PanelSnapshot
+	Passive PanelSnapshot
+
+	// AskUser is called for !?title?init! tokens. The callback should
+	// return the entered text and ok=true on Enter, or "", false on Esc /
+	// cancel. If nil, !?...! tokens expand to their default ("init").
+	AskUser func(title, init string) (text string, ok bool)
+
+	// MarkedListTempDir overrides the temp directory for !@! files
+	// (mainly for tests). Defaults to os.TempDir().
+	MarkedListTempDir string
+}
+
+// SubstResult holds the outcome of a substitution.
+type SubstResult struct {
+	Command    string
+	TempFiles  []string // !@! files created; caller removes them after command runs
+	Cancelled  bool     // user dismissed a !?...! prompt
+	ListFiles  bool     // true if any !@!/!&-like aggregate token was used
+}
+
+func SubstFileName(cmd string, ctx *SubstContext) SubstResult {
+	if ctx == nil {
+		return SubstResult{Command: cmd}
+	}
+
+	var (
+		out       strings.Builder
+		temp      []string
+		cancelled bool
+		listFiles bool
+	)
+
+	usePassive := false
+	src := cmd
+	i := 0
+	for i < len(src) {
+		if src[i] != '!' {
+			out.WriteByte(src[i])
+			i++
+			continue
+		}
+		// At a '!' — try every supported token in priority order.
+		rest := src[i:]
+
+		// !! → literal '!'
+		if strings.HasPrefix(rest, "!!") {
+			out.WriteByte('!')
+			i += 2
+			continue
+		}
+		// !# / !^ — flip the "which panel is the source"
+		if strings.HasPrefix(rest, "!#") {
+			usePassive = true
+			i += 2
+			continue
+		}
+		if strings.HasPrefix(rest, "!^") {
+			usePassive = false
+			i += 2
+			continue
+		}
+		// !?title?init!
+		if strings.HasPrefix(rest, "!?") {
+			body, consumed, ok := parsePromptToken(rest)
+			if ok {
+				title, init, _ := splitPromptBody(body)
+				value := init
+				if ctx.AskUser != nil {
+					answered, accepted := ctx.AskUser(title, init)
+					if !accepted {
+						cancelled = true
+						return SubstResult{Cancelled: true}
+					}
+					value = answered
+				}
+				out.WriteString(value)
+				i += consumed
+				continue
+			}
+		}
+
+		panel := &ctx.Active
+		if usePassive {
+			panel = &ctx.Passive
+		}
+
+		// !.!  →  current file (basename)
+		if strings.HasPrefix(rest, "!.!") {
+			out.WriteString(panel.CurrentFile)
+			i += 3
+			continue
+		}
+		// !`!  →  extension including the dot
+		if strings.HasPrefix(rest, "!`!") {
+			out.WriteString(filepath.Ext(panel.CurrentFile))
+			i += 3
+			continue
+		}
+		// !\!  →  current directory
+		if strings.HasPrefix(rest, "!\\!") {
+			out.WriteString(panel.CurDir)
+			i += 3
+			continue
+		}
+		// !&  →  space-joined marked basenames. far2l does not quote;
+		// authors are expected to do their own quoting (e.g. "!.!") or
+		// use !@! for filenames with spaces.
+		if strings.HasPrefix(rest, "!&") {
+			files := marked(panel)
+			out.WriteString(strings.Join(files, " "))
+			listFiles = true
+			i += 2
+			continue
+		}
+		// !@!  →  path of a temp file with marked basenames (one per line)
+		if strings.HasPrefix(rest, "!@!") {
+			path, err := writeMarkedListFile(marked(panel), ctx.MarkedListTempDir)
+			if err == nil {
+				out.WriteString(path)
+				temp = append(temp, path)
+				listFiles = true
+			}
+			i += 3
+			continue
+		}
+
+		// Not a recognized token: pass the '!' through and move on.
+		out.WriteByte('!')
+		i++
+	}
+
+	// $VAR / ${VAR} after our own tokens, so a user could legitimately
+	// write something like `!\!/${FOO}`.
+	final := os.ExpandEnv(out.String())
+
+	return SubstResult{
+		Command:   final,
+		TempFiles: temp,
+		Cancelled: cancelled,
+		ListFiles: listFiles,
+	}
+}
+
+// parsePromptToken returns the body between !? and the closing !, plus
+// the total bytes consumed (including the opening !? and closing !).
+// Returns ok=false if the token is malformed (no closing !).
+func parsePromptToken(s string) (body string, consumed int, ok bool) {
+	if !strings.HasPrefix(s, "!?") {
+		return "", 0, false
+	}
+	end := strings.IndexByte(s[2:], '!')
+	if end < 0 {
+		return "", 0, false
+	}
+	return s[2 : 2+end], 2 + end + 1, true
+}
+
+// splitPromptBody parses "title?init" out of the body. If no '?' is
+// present, the whole body is treated as title and init is empty. far2l
+// has additional history-hint syntax ("title?$history?init") that we
+// don't (yet) implement.
+func splitPromptBody(body string) (title, init string, hasInit bool) {
+	q := strings.IndexByte(body, '?')
+	if q < 0 {
+		return body, "", false
+	}
+	return body[:q], body[q+1:], true
+}
+
+func marked(p *PanelSnapshot) []string {
+	if len(p.Marked) > 0 {
+		return p.Marked
+	}
+	if p.CurrentFile != "" {
+		return []string{p.CurrentFile}
+	}
+	return nil
+}
+
+func writeMarkedListFile(files []string, tmpDir string) (string, error) {
+	if tmpDir == "" {
+		tmpDir = os.TempDir()
+	}
+	f, err := os.CreateTemp(tmpDir, "f4-menu-list-*.lst")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	for _, name := range files {
+		if _, err := fmt.Fprintln(f, name); err != nil {
+			return "", err
+		}
+	}
+	return f.Name(), nil
+}

--- a/user_menu_subst_test.go
+++ b/user_menu_subst_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func baseCtx() *SubstContext {
+	return &SubstContext{
+		Active: PanelSnapshot{
+			CurDir:      "/home/me/work",
+			CurrentFile: "main.go",
+			Marked:      []string{"main.go", "util.go"},
+		},
+		Passive: PanelSnapshot{
+			CurDir:      "/tmp",
+			CurrentFile: "report.txt",
+			Marked:      []string{"report.txt"},
+		},
+	}
+}
+
+func subst(t *testing.T, cmd string, ctx *SubstContext) SubstResult {
+	t.Helper()
+	return SubstFileName(cmd, ctx)
+}
+
+func TestSubst_DotFile(t *testing.T) {
+	r := subst(t, `cat !.!`, baseCtx())
+	if r.Command != "cat main.go" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_LiteralBang(t *testing.T) {
+	r := subst(t, `echo !! works`, baseCtx())
+	if r.Command != "echo ! works" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_DoubleLiteralBang(t *testing.T) {
+	// Adjacent !! pairs must not interfere with each other.
+	r := subst(t, `!!!.!!!`, baseCtx())
+	if r.Command != "!main.go!" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_Extension(t *testing.T) {
+	r := subst(t, "echo !`!", baseCtx())
+	if r.Command != "echo .go" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_ExtensionNoFile(t *testing.T) {
+	ctx := baseCtx()
+	ctx.Active.CurrentFile = ""
+	r := subst(t, "echo !`!.", ctx)
+	if r.Command != "echo ." {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_CurDir(t *testing.T) {
+	r := subst(t, `cd !\!`, baseCtx())
+	if r.Command != "cd /home/me/work" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_MarkedSpaceJoined(t *testing.T) {
+	r := subst(t, "tar czf out.tar.gz !&", baseCtx())
+	if r.Command != "tar czf out.tar.gz main.go util.go" {
+		t.Fatalf("got %q", r.Command)
+	}
+	if !r.ListFiles {
+		t.Errorf("ListFiles flag should be set")
+	}
+}
+
+func TestSubst_MarkedFallbackToCurrent(t *testing.T) {
+	ctx := baseCtx()
+	ctx.Active.Marked = nil
+	r := subst(t, "cat !&", ctx)
+	if r.Command != "cat main.go" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_PassiveActiveToggle(t *testing.T) {
+	r := subst(t, `cp !.! !#!\!/!.!`, baseCtx())
+	// !.!=active main.go; then !# switches; !\!=passive /tmp; !.!=passive report.txt
+	if r.Command != "cp main.go /tmp/report.txt" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_PassiveToggleAndBack(t *testing.T) {
+	r := subst(t, `!.! !# !.! !^ !.!`, baseCtx())
+	// active main.go, switch, passive report.txt, switch back, active main.go
+	if r.Command != "main.go  report.txt  main.go" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_PromptAccepted(t *testing.T) {
+	ctx := baseCtx()
+	ctx.AskUser = func(title, init string) (string, bool) {
+		if title != "name" {
+			t.Errorf("title=%q", title)
+		}
+		if init != "default" {
+			t.Errorf("init=%q", init)
+		}
+		return "answer", true
+	}
+	r := subst(t, `echo !?name?default!`, ctx)
+	if r.Command != "echo answer" || r.Cancelled {
+		t.Fatalf("got %q cancelled=%v", r.Command, r.Cancelled)
+	}
+}
+
+func TestSubst_PromptCancelled(t *testing.T) {
+	ctx := baseCtx()
+	ctx.AskUser = func(title, init string) (string, bool) {
+		return "", false
+	}
+	r := subst(t, `echo !?name?default!`, ctx)
+	if !r.Cancelled {
+		t.Fatalf("expected Cancelled, got %#v", r)
+	}
+}
+
+func TestSubst_PromptNoCallbackUsesInit(t *testing.T) {
+	r := subst(t, `echo !?name?defaultval!`, baseCtx())
+	if r.Command != "echo defaultval" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_PromptTitleOnly(t *testing.T) {
+	// "?init" half is optional; far2l treats the whole body as title.
+	r := subst(t, `echo !?just title!`, baseCtx())
+	if r.Command != "echo " {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_PromptUnterminatedPassesThrough(t *testing.T) {
+	// "!?foo" with no closing '!' is malformed — the '!' must not be
+	// silently eaten.
+	r := subst(t, `echo !?broken`, baseCtx())
+	if r.Command != "echo !?broken" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_EnvExpansion(t *testing.T) {
+	t.Setenv("F4_TEST_VAR", "Hello")
+	r := subst(t, `echo $F4_TEST_VAR ${F4_TEST_VAR}!`, baseCtx())
+	if r.Command != "echo Hello Hello!" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_EnvAfterTokens(t *testing.T) {
+	// $VAR is expanded AFTER !X! tokens so users can interpolate them.
+	t.Setenv("F4_TEST_VAR", "real_main.go")
+	r := subst(t, `cp !.! $F4_TEST_VAR`, baseCtx())
+	if r.Command != "cp main.go real_main.go" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_MarkedListTempFile(t *testing.T) {
+	ctx := baseCtx()
+	ctx.MarkedListTempDir = t.TempDir()
+	r := subst(t, `xargs cat <!@!`, ctx)
+	if len(r.TempFiles) != 1 {
+		t.Fatalf("expected one temp file, got %d", len(r.TempFiles))
+	}
+	if !strings.Contains(r.Command, r.TempFiles[0]) {
+		t.Fatalf("temp path not in command: %q", r.Command)
+	}
+	data, err := os.ReadFile(r.TempFiles[0])
+	if err != nil {
+		t.Fatalf("read temp: %v", err)
+	}
+	got := string(data)
+	if got != "main.go\nutil.go\n" {
+		t.Fatalf("temp file contents %q", got)
+	}
+}
+
+func TestSubst_UnrecognizedTokenPassesThrough(t *testing.T) {
+	// Tokens we don't support must NOT be eaten — pass them through so
+	// they reach the shell verbatim (no surprising data loss).
+	r := subst(t, `echo !~ !-! !+!`, baseCtx())
+	if r.Command != "echo !~ !-! !+!" {
+		t.Fatalf("got %q", r.Command)
+	}
+}
+
+func TestSubst_NilContext(t *testing.T) {
+	r := SubstFileName(`echo !.!`, nil)
+	if r.Command != "echo !.!" {
+		t.Fatalf("nil context should return command unchanged, got %q", r.Command)
+	}
+}
+
+func TestSubst_RealWorldExample(t *testing.T) {
+	// From the user's actual far2l user_menu.ini.
+	ctx := baseCtx()
+	ctx.AskUser = func(title, init string) (string, bool) {
+		if title != "test path" {
+			t.Errorf("title=%q", title)
+		}
+		return "tests/test_users.py::test_login", true
+	}
+	cmd := `source .venv/bin/activate && pytest -v "!?test path?tests/test_X.py::test_Y!"`
+	r := subst(t, cmd, ctx)
+	want := `source .venv/bin/activate && pytest -v "tests/test_users.py::test_login"`
+	if r.Command != want {
+		t.Fatalf("got %q", r.Command)
+	}
+}

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -462,13 +463,18 @@ func (s *userMenuState) goBack(current *vtui.VMenu) {
 func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath string) {
 	items := loadRootForMode(mode, sourcePath)
 
+	var initBuf bytes.Buffer
+	if werr := WriteFarMenu(&initBuf, items); werr != nil {
+		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot serialize menu:\n%v", werr), []string{"&Ok"})
+		return
+	}
 	tmp, err := os.CreateTemp("", "f4-usermenu-*.ini")
 	if err != nil {
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot create temp file:\n%v", err), []string{"&Ok"})
 		return
 	}
 	tmpPath := tmp.Name()
-	if werr := WriteFarMenu(tmp, items); werr != nil {
+	if _, werr := tmp.Write(initBuf.Bytes()); werr != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot write temp file:\n%v", werr), []string{"&Ok"})
@@ -479,7 +485,7 @@ func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath 
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot close temp file:\n%v", cerr), []string{"&Ok"})
 		return
 	}
-	initStat, _ := os.Stat(tmpPath)
+	initBytes := initBuf.Bytes()
 
 	onClose := func() {
 		defer os.Remove(tmpPath)
@@ -488,14 +494,18 @@ func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath 
 		// returns to the menu loop after FrameManager->ExecuteModalEV).
 		defer vtui.FrameManager.PostTask(func() { ShowUserMenu(pf) })
 
-		stat, statErr := os.Stat(tmpPath)
-		if statErr != nil {
+		// Compare bytes (not mtime): EditorView.SaveToFile restores the
+		// original mtime/perms after an atomic rename to preserve file
+		// ownership semantics, so size+mtime equal can't tell us whether
+		// the user actually edited anything.
+		finalBytes, readErr := os.ReadFile(tmpPath)
+		if readErr != nil {
 			return
 		}
-		if initStat != nil && stat.Size() == initStat.Size() && stat.ModTime().Equal(initStat.ModTime()) {
+		if bytes.Equal(initBytes, finalBytes) {
 			return
 		}
-		parsed, parseErr := loadFarMenuFile(tmpPath)
+		parsed, parseErr := ParseFarMenu(bytes.NewReader(finalBytes))
 		if parseErr != nil {
 			vtui.FrameManager.PostTask(func() {
 				vtui.ShowMessage(" User menu ",

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -235,23 +235,30 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 			return true
 		}
 		// F1..F12: jump to the item whose HotKey is "F<n>" and activate it.
+		// Any F-key not bound to a menu item is swallowed so it doesn't
+		// fall through to the panel-level handler underneath (F3=View,
+		// F5=Copy, etc. would be very surprising while the menu is open).
 		if !shift && !ctrl && !alt && e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12 {
 			fn := uint32(e.VirtualKeyCode-vtinput.VK_F1) + 1
-			if uiIdx, ok := findMenuItemByUserData(menu, fnKeyTarget[fn]); ok {
-				menu.SetSelectPos(uiIdx)
-				if itemIdx, _ := menu.Items[uiIdx].UserData.(int); itemIdx >= 0 && itemIdx < len(items) {
-					if items[itemIdx].IsSubmenu() {
-						s.enterSubmenu(menu, items, title, items[itemIdx])
-						return true
-					}
-				}
-				// Leaf: simulate Enter so vtui's default OnAction fires.
-				menu.ProcessKey(&vtinput.InputEvent{
-					Type: vtinput.KeyEventType, KeyDown: true,
-					VirtualKeyCode: vtinput.VK_RETURN,
-				})
+			target, mapped := fnKeyTarget[fn]
+			if !mapped {
 				return true
 			}
+			uiIdx, ok := findMenuItemByUserData(menu, target)
+			if !ok {
+				return true
+			}
+			menu.SetSelectPos(uiIdx)
+			if target >= 0 && target < len(items) && items[target].IsSubmenu() {
+				s.enterSubmenu(menu, items, title, items[target])
+				return true
+			}
+			// Leaf: simulate Enter so vtui's default OnAction fires.
+			menu.ProcessKey(&vtinput.InputEvent{
+				Type: vtinput.KeyEventType, KeyDown: true,
+				VirtualKeyCode: vtinput.VK_RETURN,
+			})
+			return true
 		}
 		// Enter / Right on a submenu item: descend into the child.
 		if !shift && !ctrl && !alt &&

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -26,6 +26,10 @@ const (
 
 const farMenuFileName = "FarMenu.ini"
 
+// submenuMarker is the right-aligned glyph that flags an item as opening
+// a nested submenu, matching far2l's choice (vmenu.cpp:1980).
+const submenuMarker = "►" // ►
+
 // MainMenuFilePath returns the user-config location for the persistent
 // main menu. The filename matches far2l so the same file can be shared
 // between ~/.config/far2l/settings/user_menu.ini and the f4 directory
@@ -147,12 +151,18 @@ func ShowUserMenu(pf *PanelsFrame) {
 
 func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 	menu := vtui.NewVMenu(" " + title + " ")
+	// Depth captured at push time stays stable even if the user dismisses
+	// child menus with Esc (which doesn't tick popClosed). Using this
+	// instead of len(s.stack) avoids treating the root as a submenu after
+	// stale stack entries pile up.
+	depth := len(s.stack)
 	s.stack = append(s.stack, menu)
 
 	// Map F1..F24 hotkeys to item indices for fast lookup in OnKeyDown.
 	// vtui already handles single-char (&-prefixed) hotkeys natively.
 	fnKeyTarget := map[uint32]int{}
 
+	hasSubmenus := false
 	for i, it := range items {
 		if it.IsSeparator() {
 			menu.AddSeparator()
@@ -161,13 +171,20 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 		if fn := parseFunctionKey(it.HotKey); fn > 0 {
 			fnKeyTarget[fn] = i
 		}
-		menu.AddItem(vtui.MenuItem{
+		mi := vtui.MenuItem{
 			Text:     formatMenuItemText(it),
 			UserData: i,
-		})
+		}
+		if it.IsSubmenu() {
+			// far2l uses U+25BA as the submenu marker (vmenu.cpp:1980);
+			// the right-aligned Shortcut slot is the closest analogue.
+			mi.Shortcut = submenuMarker
+			hasSubmenus = true
+		}
+		menu.AddItem(mi)
 	}
 
-	w, h := menuSize(s.pf, menu.GetItemCount(), items)
+	w, h := menuSize(s.pf, menu.GetItemCount(), items, hasSubmenus)
 	x := (s.pf.lastW - w) / 2
 	y := (s.pf.lastH - h) / 2
 	if x < 0 {
@@ -224,6 +241,15 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 					}
 				}
 			}
+		}
+		// Left arrow → back to the parent menu, but only when we're
+		// actually inside a submenu. At the root level it's a no-op
+		// (matches usermenu.cpp:575: closes only when Title is set).
+		if !shift && !ctrl && !alt && e.VirtualKeyCode == vtinput.VK_LEFT {
+			if depth > 0 {
+				menu.Close()
+			}
+			return true // swallow either way so it doesn't bubble to panels
 		}
 		return false
 	}
@@ -349,7 +375,8 @@ func findMenuItemByUserData(menu *vtui.VMenu, itemIdx int) (int, bool) {
 }
 
 // menuSize returns suggested width/height for a menu given its content.
-func menuSize(pf *PanelsFrame, itemCount int, items []UserMenuItem) (int, int) {
+// hasSubmenus reserves space for the right-aligned ► marker.
+func menuSize(pf *PanelsFrame, itemCount int, items []UserMenuItem, hasSubmenus bool) (int, int) {
 	maxLabel := 20
 	for _, it := range items {
 		if it.IsSeparator() {
@@ -361,6 +388,9 @@ func menuSize(pf *PanelsFrame, itemCount int, items []UserMenuItem) (int, int) {
 		}
 	}
 	w := maxLabel + 4
+	if hasSubmenus {
+		w += 2 // reserve room for the trailing "► "
+	}
 	if pf.lastW > 0 && w > pf.lastW-4 {
 		w = pf.lastW - 4
 	}

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -33,6 +33,31 @@ const farMenuFileName = "FarMenu.ini"
 // a nested submenu, matching far2l's choice (vmenu.cpp:1980).
 const submenuMarker = "►" // ►
 
+// userMenuBottomHint is the keybinding cheat-sheet drawn on the bottom
+// border of every user-menu level. Far Manager has had a hint like this
+// since the original Roshal release (usermenu.cpp:535 sets it via
+// SetBottomTitle); listing only the chords f4 actually responds to.
+const userMenuBottomHint = " Del Ins Ctrl+F4 Ctrl+Up/Down "
+
+// userMenuFrame wraps a vtui.VMenu so the user menu can draw a hotkey
+// hint on its bottom border without extending vtui itself (the library
+// ships as a submodule and would be its own PR). All Frame interface
+// methods are promoted from the embedded VMenu; we only override Show
+// to paint the hint over the bottom border line.
+type userMenuFrame struct {
+	*vtui.VMenu
+	bottomHint string
+}
+
+func (u *userMenuFrame) Show(scr *vtui.ScreenBuf) {
+	u.VMenu.Show(scr)
+	if u.bottomHint == "" {
+		return
+	}
+	x1, _, x2, y2 := u.VMenu.GetPosition()
+	vtui.NewPainter(scr).DrawTitle(x1, y2, x2, u.bottomHint, vtui.Palette[vtui.ColMenuTitle])
+}
+
 // MainMenuFilePath returns the user-config location for the persistent
 // main menu. The filename matches far2l so the same file can be shared
 // between ~/.config/far2l/settings/user_menu.ini and the f4 directory
@@ -520,7 +545,7 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 		})
 	}
 
-	vtui.FrameManager.Push(menu)
+	vtui.FrameManager.Push(&userMenuFrame{VMenu: menu, bottomHint: userMenuBottomHint})
 }
 
 // enterSubmenu records the current cursor, descends into items[subIdx],
@@ -815,6 +840,10 @@ func menuSize(pf *PanelsFrame, itemCount int, items []UserMenuItem, hasSubmenus 
 	w := maxLabel + 4
 	if hasSubmenus {
 		w += 2 // reserve room for the trailing "► "
+	}
+	// Reserve room for the bottom hotkey hint plus two box corners.
+	if minForHint := len(userMenuBottomHint) + 2; w < minForHint {
+		w = minForHint
 	}
 	if pf.lastW > 0 && w > pf.lastW-4 {
 		w = pf.lastW - 4

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -647,18 +647,18 @@ func (s *userMenuState) goBack(current *vtui.VMenu) {
 func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath string) {
 	items := loadRootForMode(mode, sourcePath)
 
-	var initBuf bytes.Buffer
-	if werr := WriteFarMenu(&initBuf, items); werr != nil {
-		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot serialize menu:\n%v", werr), []string{"&Ok"})
-		return
-	}
+	// The temp file is what the user actually edits, so write it as
+	// plain UTF-8 even though the on-disk FarMenu.ini we ultimately
+	// save back uses the platform's wide encoding. Editors are far
+	// happier with UTF-8 and the parser accepts both on the way back.
+	initBytes := []byte(renderFarMenuText(items))
 	tmp, err := os.CreateTemp("", "f4-usermenu-*.ini")
 	if err != nil {
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot create temp file:\n%v", err), []string{"&Ok"})
 		return
 	}
 	tmpPath := tmp.Name()
-	if _, werr := tmp.Write(initBuf.Bytes()); werr != nil {
+	if _, werr := tmp.Write(initBytes); werr != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot write temp file:\n%v", werr), []string{"&Ok"})
@@ -669,7 +669,6 @@ func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath 
 		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot close temp file:\n%v", cerr), []string{"&Ok"})
 		return
 	}
-	initBytes := initBuf.Bytes()
 
 	onClose := func() {
 		defer os.Remove(tmpPath)

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -151,10 +151,10 @@ func ShowUserMenu(pf *PanelsFrame) {
 
 func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 	menu := vtui.NewVMenu(" " + title + " ")
-	// Depth captured at push time stays stable even if the user dismisses
-	// child menus with Esc (which doesn't tick popClosed). Using this
-	// instead of len(s.stack) avoids treating the root as a submenu after
-	// stale stack entries pile up.
+	// Depth captured at push time stays stable even if Esc/Left dismisses
+	// some children later (we don't try to keep s.stack in sync on those
+	// paths). Using a captured value instead of len(s.stack) avoids
+	// misclassifying the root once stale entries pile up.
 	depth := len(s.stack)
 	s.stack = append(s.stack, menu)
 
@@ -215,11 +215,18 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 			})
 			return true
 		}
-		// F1..F12: jump to the item whose HotKey is "F<n>".
+		// F1..F12: jump to the item whose HotKey is "F<n>" and activate it.
 		if !shift && !ctrl && !alt && e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12 {
 			fn := uint32(e.VirtualKeyCode-vtinput.VK_F1) + 1
 			if uiIdx, ok := findMenuItemByUserData(menu, fnKeyTarget[fn]); ok {
 				menu.SetSelectPos(uiIdx)
+				if itemIdx, _ := menu.Items[uiIdx].UserData.(int); itemIdx >= 0 && itemIdx < len(items) {
+					if items[itemIdx].IsSubmenu() {
+						pushChild(s, items[itemIdx], title)
+						return true
+					}
+				}
+				// Leaf: simulate Enter so vtui's default OnAction fires.
 				menu.ProcessKey(&vtinput.InputEvent{
 					Type: vtinput.KeyEventType, KeyDown: true,
 					VirtualKeyCode: vtinput.VK_RETURN,
@@ -227,20 +234,25 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 				return true
 			}
 		}
-		// Right arrow → enter submenu (matches Enter for these items).
-		if !shift && !ctrl && !alt && e.VirtualKeyCode == vtinput.VK_RIGHT {
+		// Enter / Right on a submenu item: push the child without closing
+		// the parent, so Left arrow can return to it.
+		if !shift && !ctrl && !alt &&
+			(e.VirtualKeyCode == vtinput.VK_RETURN || e.VirtualKeyCode == vtinput.VK_RIGHT) {
 			pos := menu.SelectPos
 			if pos >= 0 && pos < len(menu.Items) {
 				if idx, ok := menu.Items[pos].UserData.(int); ok && idx >= 0 && idx < len(items) {
 					if items[idx].IsSubmenu() {
-						menu.ProcessKey(&vtinput.InputEvent{
-							Type: vtinput.KeyEventType, KeyDown: true,
-							VirtualKeyCode: vtinput.VK_RETURN,
-						})
+						pushChild(s, items[idx], title)
 						return true
 					}
 				}
 			}
+			// Right on a leaf is a no-op; Enter on a leaf falls through to
+			// vtui's default RETURN handler so OnAction runs.
+			if e.VirtualKeyCode == vtinput.VK_RIGHT {
+				return true
+			}
+			return false
 		}
 		// Left arrow → back to the parent menu, but only when we're
 		// actually inside a submenu. At the root level it's a no-op
@@ -263,24 +275,20 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 			return
 		}
 		chosen := items[idx]
-		menu.Close()
-		// Defer to post-task so the menu is fully popped before we either
-		// push a child or set the command line.
 		if chosen.IsSubmenu() {
-			parentTitle := title
-			label := stripAmpersand(chosen.Label)
-			vtui.FrameManager.PostTask(func() {
-				// Track the now-closed parent's removal from our stack.
-				s.popClosed()
-				s.pushLevel(chosen.Submenu, parentTitle+" -> "+label)
-			})
-		} else {
-			cmds := chosen.Commands
-			vtui.FrameManager.PostTask(func() {
-				s.popClosed()
-				executeMenuCommands(s.pf, cmds)
-			})
+			// Submenus are handled in OnKeyDown to keep the parent open.
+			// We only land here on mouse click; treat it the same way.
+			pushChild(s, chosen, title)
+			return
 		}
+		// Leaf item: vtui will pop this menu on its own after we return.
+		// Close any remaining parent levels and run the commands once the
+		// frame stack has settled.
+		cmds := chosen.Commands
+		vtui.FrameManager.PostTask(func() {
+			s.closeAll()
+			executeMenuCommands(s.pf, cmds)
+		})
 	}
 
 	vtui.FrameManager.Push(menu)
@@ -293,12 +301,15 @@ func (s *userMenuState) closeAll() {
 	s.stack = nil
 }
 
-// popClosed drops the topmost menu from our local stack after it has
-// been dismissed by vtui.
-func (s *userMenuState) popClosed() {
-	if len(s.stack) > 0 {
-		s.stack = s.stack[:len(s.stack)-1]
-	}
+// pushChild opens a submenu on top of the current menu. The parent is
+// left alive on the frame stack so that Left arrow / Esc in the child
+// returns the user to it (matching every Far version since the original).
+func pushChild(s *userMenuState, parent UserMenuItem, parentTitle string) {
+	child := parent.Submenu
+	childTitle := parentTitle + " -> " + stripAmpersand(parent.Label)
+	vtui.FrameManager.PostTask(func() {
+		s.pushLevel(child, childTitle)
+	})
 }
 
 // formatMenuItemText builds the displayed string for an item:

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -1,0 +1,472 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// User menu UI: F2 opens a vertical menu loaded from FarMenu.ini in the
+// current directory (walking up to the root), or from FarMenu.ini next
+// to the executable, or from ~/.config/f4/settings/main_menu.ini.
+// Shift+F2 cycles the source as far2l does.
+
+// MenuMode picks where the menu items come from.
+type MenuMode int
+
+const (
+	MenuModeLocal MenuMode = iota // FarMenu.ini in cwd or any parent
+	MenuModeFar                   // FarMenu.ini next to the f4 binary
+	MenuModeMain                  // main_menu.ini in user config
+)
+
+const farMenuFileName = "FarMenu.ini"
+
+// MainMenuFilePath returns the user-config location for the persistent
+// main menu, parallel to far2l's ~/.config/far2l/settings/user_menu.ini.
+func MainMenuFilePath() string {
+	configDir, _ := os.UserConfigDir()
+	return filepath.Join(configDir, "f4", "settings", "main_menu.ini")
+}
+
+// findLocalFarMenu walks startDir upward looking for FarMenu.ini.
+func findLocalFarMenu(startDir string) (path string, found bool) {
+	dir := startDir
+	for {
+		candidate := filepath.Join(dir, farMenuFileName)
+		if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+			return candidate, true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", false
+		}
+		dir = parent
+	}
+}
+
+// findFarMenuNearBinary looks for FarMenu.ini next to the running executable.
+func findFarMenuNearBinary() (path string, found bool) {
+	exe, err := os.Executable()
+	if err != nil {
+		return "", false
+	}
+	candidate := filepath.Join(filepath.Dir(exe), farMenuFileName)
+	if st, err := os.Stat(candidate); err == nil && !st.IsDir() {
+		return candidate, true
+	}
+	return "", false
+}
+
+// loadFarMenuFile reads a FarMenu.ini (text format) into a slice.
+func loadFarMenuFile(path string) ([]UserMenuItem, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return ParseFarMenu(f)
+}
+
+// loadMenuForMode returns (items, title, sourcePath, ok). ok=false means
+// this mode has no data — caller may want to try the next mode.
+func loadMenuForMode(pf *PanelsFrame, mode MenuMode) (items []UserMenuItem, title, source string, ok bool) {
+	switch mode {
+	case MenuModeLocal:
+		fsp, _ := pf.panels[pf.activeIdx].(*FileSystemPanel)
+		if fsp == nil {
+			return nil, Msg("UserMenu.LocalMenuTitle"), "", false
+		}
+		path, found := findLocalFarMenu(fsp.vfs.GetPath())
+		if !found {
+			return nil, Msg("UserMenu.LocalMenuTitle"), "", false
+		}
+		loaded, err := loadFarMenuFile(path)
+		if err != nil {
+			return nil, Msg("UserMenu.LocalMenuTitle"), path, false
+		}
+		return loaded, Msg("UserMenu.LocalMenuTitle"), path, true
+	case MenuModeFar:
+		path, found := findFarMenuNearBinary()
+		if !found {
+			return nil, fmt.Sprintf("%s (%s)", Msg("UserMenu.MainMenuTitle"), Msg("UserMenu.MainMenuFAR")), "", false
+		}
+		loaded, err := loadFarMenuFile(path)
+		if err != nil {
+			return nil, fmt.Sprintf("%s (%s)", Msg("UserMenu.MainMenuTitle"), Msg("UserMenu.MainMenuFAR")), path, false
+		}
+		return loaded, fmt.Sprintf("%s (%s)", Msg("UserMenu.MainMenuTitle"), Msg("UserMenu.MainMenuFAR")), path, true
+	case MenuModeMain:
+		path := MainMenuFilePath()
+		loaded, err := LoadMainMenu(path)
+		if err != nil {
+			return nil, Msg("UserMenu.MainMenuTitle"), path, false
+		}
+		return loaded, Msg("UserMenu.MainMenuTitle"), path, len(loaded) > 0
+	}
+	return nil, "", "", false
+}
+
+// resolveMenuStart finds the first non-empty mode at or after initial,
+// returning items/title and the mode actually used.
+func resolveMenuStart(pf *PanelsFrame, initial MenuMode) (items []UserMenuItem, title string, mode MenuMode) {
+	for offset := 0; offset < 3; offset++ {
+		m := MenuMode((int(initial) + offset) % 3)
+		if loaded, t, _, ok := loadMenuForMode(pf, m); ok {
+			return loaded, t, m
+		}
+	}
+	// Nothing found anywhere — fall back to main with an empty list so
+	// the user still sees the menu chrome and can press Shift+F2 / Esc.
+	_, t, _, _ := loadMenuForMode(pf, MenuModeMain)
+	return nil, t, MenuModeMain
+}
+
+// userMenuState shares ownership of the pushed VMenu chain so we can
+// close the whole stack on Shift+F2 cycle or shellable-action.
+type userMenuState struct {
+	pf    *PanelsFrame
+	mode  MenuMode
+	stack []*vtui.VMenu
+}
+
+// ShowUserMenu is the entry point. It loads the user menu starting from
+// the local (cwd-relative) mode and pushes a modal VMenu.
+func ShowUserMenu(pf *PanelsFrame) {
+	items, title, mode := resolveMenuStart(pf, MenuModeLocal)
+	s := &userMenuState{pf: pf, mode: mode}
+	s.pushLevel(items, title)
+	_ = title // referenced for future submenu breadcrumbs
+}
+
+func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
+	menu := vtui.NewVMenu(" " + title + " ")
+	s.stack = append(s.stack, menu)
+
+	// Map F1..F24 hotkeys to item indices for fast lookup in OnKeyDown.
+	// vtui already handles single-char (&-prefixed) hotkeys natively.
+	fnKeyTarget := map[uint32]int{}
+
+	for i, it := range items {
+		if it.IsSeparator() {
+			menu.AddSeparator()
+			continue
+		}
+		if fn := parseFunctionKey(it.HotKey); fn > 0 {
+			fnKeyTarget[fn] = i
+		}
+		menu.AddItem(vtui.MenuItem{
+			Text:     formatMenuItemText(it),
+			UserData: i,
+		})
+	}
+
+	w, h := menuSize(s.pf, menu.GetItemCount(), items)
+	x := (s.pf.lastW - w) / 2
+	y := (s.pf.lastH - h) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	menu.SetPosition(x, y, x+w-1, y+h-1)
+
+	menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
+		if !e.KeyDown {
+			return false
+		}
+		shift := e.ControlKeyState&vtinput.ShiftPressed != 0
+		ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
+		alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
+
+		// Shift+F2 cycles the menu source mode.
+		if e.VirtualKeyCode == vtinput.VK_F2 && shift && !ctrl && !alt {
+			s.closeAll()
+			next := MenuMode((int(s.mode) + 1) % 3)
+			vtui.FrameManager.PostTask(func() {
+				items, title, mode := resolveMenuStart(s.pf, next)
+				s.mode = mode
+				s.stack = nil
+				s.pushLevel(items, title)
+			})
+			return true
+		}
+		// F1..F12: jump to the item whose HotKey is "F<n>".
+		if !shift && !ctrl && !alt && e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12 {
+			fn := uint32(e.VirtualKeyCode-vtinput.VK_F1) + 1
+			if uiIdx, ok := findMenuItemByUserData(menu, fnKeyTarget[fn]); ok {
+				menu.SetSelectPos(uiIdx)
+				menu.ProcessKey(&vtinput.InputEvent{
+					Type: vtinput.KeyEventType, KeyDown: true,
+					VirtualKeyCode: vtinput.VK_RETURN,
+				})
+				return true
+			}
+		}
+		// Right arrow → enter submenu (matches Enter for these items).
+		if !shift && !ctrl && !alt && e.VirtualKeyCode == vtinput.VK_RIGHT {
+			pos := menu.SelectPos
+			if pos >= 0 && pos < len(menu.Items) {
+				if idx, ok := menu.Items[pos].UserData.(int); ok && idx >= 0 && idx < len(items) {
+					if items[idx].IsSubmenu() {
+						menu.ProcessKey(&vtinput.InputEvent{
+							Type: vtinput.KeyEventType, KeyDown: true,
+							VirtualKeyCode: vtinput.VK_RETURN,
+						})
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	menu.OnAction = func(uiIdx int) {
+		if uiIdx < 0 || uiIdx >= len(menu.Items) {
+			return
+		}
+		idx, ok := menu.Items[uiIdx].UserData.(int)
+		if !ok || idx < 0 || idx >= len(items) {
+			return
+		}
+		chosen := items[idx]
+		menu.Close()
+		// Defer to post-task so the menu is fully popped before we either
+		// push a child or set the command line.
+		if chosen.IsSubmenu() {
+			parentTitle := title
+			label := stripAmpersand(chosen.Label)
+			vtui.FrameManager.PostTask(func() {
+				// Track the now-closed parent's removal from our stack.
+				s.popClosed()
+				s.pushLevel(chosen.Submenu, parentTitle+" -> "+label)
+			})
+		} else {
+			cmds := chosen.Commands
+			vtui.FrameManager.PostTask(func() {
+				s.popClosed()
+				executeMenuCommands(s.pf, cmds)
+			})
+		}
+	}
+
+	vtui.FrameManager.Push(menu)
+}
+
+func (s *userMenuState) closeAll() {
+	for _, m := range s.stack {
+		m.Close()
+	}
+	s.stack = nil
+}
+
+// popClosed drops the topmost menu from our local stack after it has
+// been dismissed by vtui.
+func (s *userMenuState) popClosed() {
+	if len(s.stack) > 0 {
+		s.stack = s.stack[:len(s.stack)-1]
+	}
+}
+
+// formatMenuItemText builds the displayed string for an item:
+//
+//	"&a    label"   – single-char hotkey, vtui underlines via the '&'
+//	"F3    label"   – function key (vtui has no special handling needed)
+//	"      label"   – no hotkey
+func formatMenuItemText(it UserMenuItem) string {
+	const labelCol = 6
+	label := escapeAmpersand(it.Label)
+	if fn := parseFunctionKey(it.HotKey); fn > 0 {
+		return fmt.Sprintf("%-*s%s", labelCol, it.HotKey, label)
+	}
+	if it.HotKey == "" {
+		return strings.Repeat(" ", labelCol) + label
+	}
+	// Single char (printable) — let vtui wire up the hotkey.
+	return fmt.Sprintf("&%s%s%s", it.HotKey, strings.Repeat(" ", labelCol-1-len(it.HotKey)), label)
+}
+
+// escapeAmpersand doubles literal '&' so vtui doesn't treat them as
+// hotkey markers in the label portion.
+func escapeAmpersand(s string) string {
+	return strings.ReplaceAll(s, "&", "&&")
+}
+
+func stripAmpersand(s string) string {
+	// Drop a single (non-doubled) '&' for display in breadcrumbs.
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '&' {
+			if i+1 < len(s) && s[i+1] == '&' {
+				b.WriteByte('&')
+				i++
+				continue
+			}
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
+// parseFunctionKey returns 1..24 for "F1".."F24", or 0 otherwise.
+func parseFunctionKey(hk string) uint32 {
+	if len(hk) < 2 || (hk[0] != 'F' && hk[0] != 'f') {
+		return 0
+	}
+	n := 0
+	for _, c := range hk[1:] {
+		if c < '0' || c > '9' {
+			return 0
+		}
+		n = n*10 + int(c-'0')
+		if n > 24 {
+			return 0
+		}
+	}
+	if n < 1 || n > 24 {
+		return 0
+	}
+	return uint32(n)
+}
+
+// findMenuItemByUserData returns the UI index of the item whose UserData
+// matches itemIdx.
+func findMenuItemByUserData(menu *vtui.VMenu, itemIdx int) (int, bool) {
+	for i, it := range menu.Items {
+		if v, ok := it.UserData.(int); ok && v == itemIdx {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// menuSize returns suggested width/height for a menu given its content.
+func menuSize(pf *PanelsFrame, itemCount int, items []UserMenuItem) (int, int) {
+	maxLabel := 20
+	for _, it := range items {
+		if it.IsSeparator() {
+			continue
+		}
+		w := len(it.Label) + 8 // hotkey + spacing
+		if w > maxLabel {
+			maxLabel = w
+		}
+	}
+	w := maxLabel + 4
+	if pf.lastW > 0 && w > pf.lastW-4 {
+		w = pf.lastW - 4
+	}
+	if w < 24 {
+		w = 24
+	}
+	h := itemCount + 2
+	maxH := pf.lastH - 6
+	if maxH < 5 {
+		maxH = 5
+	}
+	if h > maxH {
+		h = maxH
+	}
+	if h < 3 {
+		h = 3
+	}
+	return w, h
+}
+
+// executeMenuCommands resolves substitutions on a list of commands taken
+// from a single menu item and dispatches the result through the command
+// line as if the user had typed it and pressed Enter.
+func executeMenuCommands(pf *PanelsFrame, commands []string) {
+	if len(commands) == 0 || pf.cmdLine == nil {
+		return
+	}
+
+	active := snapshotPanel(pf, pf.activeIdx)
+	passive := snapshotPanel(pf, 1-pf.activeIdx)
+	ctx := &SubstContext{Active: active, Passive: passive}
+
+	var lines []string
+	for _, raw := range commands {
+		t := strings.TrimSpace(raw)
+		if t == "" {
+			continue
+		}
+		// Skip REM-style comments (case-insensitive, with separator) and ::.
+		if isMenuComment(t) {
+			continue
+		}
+		// "@" silent prefix isn't supported yet (would need to suppress
+		// panel show/hide). Strip it so the command at least runs.
+		t = strings.TrimPrefix(t, "@")
+
+		res := SubstFileName(t, ctx)
+		if res.Cancelled {
+			return
+		}
+		if res.Command != "" {
+			lines = append(lines, res.Command)
+		}
+	}
+	if len(lines) == 0 {
+		return
+	}
+
+	// Join with ';' so multiple commands run sequentially in one shell.
+	// We lose the panel-follows-cd nicety that far2l gets from intercepting
+	// each cd in cmdline, but the user can still use a single "cd" command
+	// per menu item to get that effect.
+	joined := strings.Join(lines, "; ")
+	pf.cmdLine.Edit.SetText(joined)
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_RETURN,
+	})
+}
+
+func isMenuComment(line string) bool {
+	if strings.HasPrefix(line, "::") {
+		return true
+	}
+	if len(line) < 3 {
+		return false
+	}
+	if !strings.EqualFold(line[:3], "REM") {
+		return false
+	}
+	if len(line) == 3 {
+		return true
+	}
+	c := line[3]
+	return c == ' ' || c == '\t'
+}
+
+// snapshotPanel captures the panel state SubstContext needs. Returns a
+// zero-value snapshot when the slot isn't a file system panel.
+func snapshotPanel(pf *PanelsFrame, idx int) PanelSnapshot {
+	if idx < 0 || idx >= len(pf.panels) {
+		return PanelSnapshot{}
+	}
+	fsp, ok := pf.panels[idx].(*FileSystemPanel)
+	if !ok || fsp == nil || fsp.vfs == nil {
+		return PanelSnapshot{}
+	}
+	snap := PanelSnapshot{
+		CurDir: fsp.vfs.GetPath(),
+	}
+	if cur := fsp.getRawSelectedName(); cur != "" && cur != ".." {
+		snap.CurrentFile = cur
+	}
+	for _, name := range fsp.GetSelectedNames() {
+		if name == ".." {
+			continue
+		}
+		snap.Marked = append(snap.Marked, name)
+	}
+	return snap
+}

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -483,6 +483,10 @@ func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath 
 
 	onClose := func() {
 		defer os.Remove(tmpPath)
+		// Always reopen the menu after the editor closes so the user
+		// sees their edits applied immediately (matches far2l: control
+		// returns to the menu loop after FrameManager->ExecuteModalEV).
+		defer vtui.FrameManager.PostTask(func() { ShowUserMenu(pf) })
 
 		stat, statErr := os.Stat(tmpPath)
 		if statErr != nil {

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -27,10 +27,12 @@ const (
 const farMenuFileName = "FarMenu.ini"
 
 // MainMenuFilePath returns the user-config location for the persistent
-// main menu, parallel to far2l's ~/.config/far2l/settings/user_menu.ini.
+// main menu. The filename matches far2l so the same file can be shared
+// between ~/.config/far2l/settings/user_menu.ini and the f4 directory
+// without renaming.
 func MainMenuFilePath() string {
 	configDir, _ := os.UserConfigDir()
-	return filepath.Join(configDir, "f4", "settings", "main_menu.ini")
+	return filepath.Join(configDir, "f4", "settings", "user_menu.ini")
 }
 
 // findLocalFarMenu walks startDir upward looking for FarMenu.ini.

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -209,23 +209,21 @@ func resolveMenuStart(pf *PanelsFrame, initial MenuMode) (items []UserMenuItem, 
 	return nil, t, MenuModeMain, defaultSavePath(pf, MenuModeMain)
 }
 
-// menuLevel snapshots the data needed to recreate a parent menu when
-// the user returns to it from a submenu. far2l does the same: the
-// inner ProcessSingleMenu loop recreates VMenu with the saved MenuPos
-// on EC_CLOSE_LEVEL (usermenu.cpp:738-744). Showing only one menu at a
-// time keeps the screen uncluttered.
-type menuLevel struct {
-	items    []UserMenuItem
-	title    string
-	selected int
-}
-
-// userMenuState carries navigation history across pushLevel invocations.
+// userMenuState owns the full menu tree as loaded from disk plus the
+// path from the root to the level currently on screen. In-place edits
+// (Del, Ctrl+up/down) walk the same tree to find the slice to mutate,
+// save the root, and re-render at the same path. far2l shows only one
+// menu at a time: ProcessSingleMenu recreates the parent VMenu with
+// the saved MenuPos on EC_CLOSE_LEVEL (usermenu.cpp:738-744). We do
+// the same — `selStack` is one entry per ancestor.
 type userMenuState struct {
 	pf         *PanelsFrame
 	mode       MenuMode
 	sourcePath string // file Ctrl+F4 opens and edits save back to
-	history    []menuLevel
+	rootTitle  string // base title; submenu titles append " -> child"
+	rootItems  []UserMenuItem
+	path       []int // indices from root to the current level
+	selStack   []int // saved cursor position at each ancestor level
 }
 
 // ShowUserMenu is the entry point. It loads the user menu starting from
@@ -235,8 +233,75 @@ func ShowUserMenu(pf *PanelsFrame) {
 	if source == "" {
 		source = defaultSavePath(pf, mode)
 	}
-	s := &userMenuState{pf: pf, mode: mode, sourcePath: source}
-	s.pushLevel(items, title, 0)
+	s := &userMenuState{
+		pf:         pf,
+		mode:       mode,
+		sourcePath: source,
+		rootTitle:  title,
+		rootItems:  items,
+	}
+	s.openCurrent(0)
+}
+
+// currentItems returns the items slice at the level the user is viewing.
+func (s *userMenuState) currentItems() []UserMenuItem {
+	items := s.rootItems
+	for _, idx := range s.path {
+		if idx < 0 || idx >= len(items) || !items[idx].IsSubmenu() {
+			return nil
+		}
+		items = items[idx].Submenu
+	}
+	return items
+}
+
+// currentTitle builds the title with " -> " breadcrumbs for each
+// submenu the user descended through.
+func (s *userMenuState) currentTitle() string {
+	items := s.rootItems
+	t := s.rootTitle
+	for _, idx := range s.path {
+		if idx < 0 || idx >= len(items) {
+			return t
+		}
+		t = t + " -> " + stripAmpersand(items[idx].Label)
+		items = items[idx].Submenu
+	}
+	return t
+}
+
+// replaceCurrentItems swaps the slice at the current path. Needed when
+// a mutation (delete, insert) changes the slice length.
+func (s *userMenuState) replaceCurrentItems(newItems []UserMenuItem) {
+	if len(s.path) == 0 {
+		s.rootItems = newItems
+		return
+	}
+	items := s.rootItems
+	for i := 0; i < len(s.path)-1; i++ {
+		items = items[s.path[i]].Submenu
+	}
+	items[s.path[len(s.path)-1]].Submenu = newItems
+}
+
+// openCurrent pushes the menu for the current path with the given cursor.
+func (s *userMenuState) openCurrent(selected int) {
+	s.pushLevel(s.currentItems(), s.currentTitle(), selected)
+}
+
+// saveRoot persists rootItems to the source file in its native format.
+// Errors are surfaced as a modal message so the user knows.
+func (s *userMenuState) saveRoot() bool {
+	if s.sourcePath == "" {
+		return false
+	}
+	if err := saveRootForMode(s.mode, s.sourcePath, s.rootItems); err != nil {
+		vtui.ShowMessage(" User menu ",
+			fmt.Sprintf("Failed to save menu:\n%v", err),
+			[]string{"&Ok"})
+		return false
+	}
+	return true
 }
 
 func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSelect int) {
@@ -249,7 +314,9 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 	hasSubmenus := false
 	for i, it := range items {
 		if it.IsSeparator() {
-			menu.AddSeparator()
+			// Carry UserData so Del / Ctrl+up/down can find the items
+			// index from the UI index uniformly across all entries.
+			menu.AddItem(vtui.MenuItem{Separator: true, UserData: i})
 			continue
 		}
 		if fn := parseFunctionKey(it.HotKey); fn > 0 {
@@ -290,10 +357,11 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 		ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
 		alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
 
-		// Shift+F2 cycles the menu source mode. Clear history so the
+		// Shift+F2 cycles the menu source mode. Drop the path so the
 		// fresh root doesn't try to "return" to the previous mode's chain.
 		if e.VirtualKeyCode == vtinput.VK_F2 && shift && !ctrl && !alt {
-			s.history = nil
+			s.path = nil
+			s.selStack = nil
 			menu.Close()
 			next := MenuMode((int(s.mode) + 1) % 3)
 			vtui.FrameManager.PostTask(func() {
@@ -303,10 +371,30 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 					newSrc = defaultSavePath(s.pf, newMode)
 				}
 				s.sourcePath = newSrc
-				s.pushLevel(newItems, newTitle, 0)
+				s.rootTitle = newTitle
+				s.rootItems = newItems
+				s.openCurrent(0)
 			})
 			return true
 		}
+		openInExternalEditor := func() {
+			sourcePath := s.sourcePath
+			if sourcePath == "" {
+				sourcePath = defaultSavePath(s.pf, s.mode)
+			}
+			if sourcePath == "" {
+				return
+			}
+			pf := s.pf
+			mode := s.mode
+			s.path = nil
+			s.selStack = nil
+			menu.Close()
+			vtui.FrameManager.PostTask(func() {
+				editCurrentMenuInExternalEditor(pf, mode, sourcePath)
+			})
+		}
+
 		// Ctrl+F4 edits the menu via a temp file, matching far2l
 		// usermenu.cpp:619-678: dump the current root tree as FarMenu.ini
 		// text, open the temp file in the editor, on close parse it back
@@ -314,25 +402,36 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 		// format. If the user didn't change anything we skip the save; if
 		// parsing fails we surface an error and keep the original intact.
 		if e.VirtualKeyCode == vtinput.VK_F4 && ctrl && !shift && !alt {
-			sourcePath := s.sourcePath
-			if sourcePath == "" {
-				sourcePath = defaultSavePath(s.pf, s.mode)
-			}
-			if sourcePath == "" {
-				return true
-			}
-			pf := s.pf
-			mode := s.mode
-			s.history = nil
-			menu.Close()
-			vtui.FrameManager.PostTask(func() {
-				editCurrentMenuInExternalEditor(pf, mode, sourcePath)
-			})
+			openInExternalEditor()
+			return true
+		}
+		// Insert: in far2l this pops a "command or submenu?" dialog and
+		// then the per-item edit form. We don't have that form yet, so
+		// fall back to the bulk Ctrl+F4 editor — the user can append a
+		// new section by hand. Eventually we'll grow a proper dialog.
+		if e.VirtualKeyCode == vtinput.VK_INSERT && !ctrl && !shift && !alt {
+			openInExternalEditor()
+			return true
+		}
+		// Del: confirm and remove the item under the cursor.
+		if e.VirtualKeyCode == vtinput.VK_DELETE && !ctrl && !shift && !alt {
+			s.deleteAt(menu, items)
+			return true
+		}
+		// Ctrl+Up / Ctrl+Down: move the current item up/down within
+		// this level, no wrap (matches usermenu.cpp:603-617).
+		if e.VirtualKeyCode == vtinput.VK_UP && ctrl && !shift && !alt {
+			s.swapWithNeighbor(menu, items, -1)
+			return true
+		}
+		if e.VirtualKeyCode == vtinput.VK_DOWN && ctrl && !shift && !alt {
+			s.swapWithNeighbor(menu, items, +1)
 			return true
 		}
 		// Shift+F10 quits the entire menu chain (usermenu.cpp:685).
 		if e.VirtualKeyCode == vtinput.VK_F10 && shift && !ctrl && !alt {
-			s.history = nil
+			s.path = nil
+			s.selStack = nil
 			menu.Close()
 			return true
 		}
@@ -358,7 +457,7 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 			}
 			menu.SetSelectPos(uiIdx)
 			if target >= 0 && target < len(items) && items[target].IsSubmenu() {
-				s.enterSubmenu(menu, items, title, items[target])
+				s.enterSubmenu(menu, target)
 				return true
 			}
 			// Leaf: simulate Enter so vtui's default OnAction fires.
@@ -375,7 +474,7 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 			if pos >= 0 && pos < len(menu.Items) {
 				if idx, ok := menu.Items[pos].UserData.(int); ok && idx >= 0 && idx < len(items) {
 					if items[idx].IsSubmenu() {
-						s.enterSubmenu(menu, items, title, items[idx])
+						s.enterSubmenu(menu, idx)
 						return true
 					}
 				}
@@ -407,14 +506,15 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 		if chosen.IsSubmenu() {
 			// Submenus are handled by OnKeyDown for the keyboard paths.
 			// We only land here on mouse click; do the same thing.
-			s.enterSubmenu(menu, items, title, chosen)
+			s.enterSubmenu(menu, idx)
 			return
 		}
 		// Leaf item: vtui will pop this menu on its own after we return.
-		// Drop the history so we don't try to reopen a parent on the way
+		// Drop the path so we don't try to reopen a parent on the way
 		// out, then dispatch the commands once the frame stack has settled.
 		cmds := chosen.Commands
-		s.history = nil
+		s.path = nil
+		s.selStack = nil
 		vtui.FrameManager.PostTask(func() {
 			executeMenuCommands(s.pf, cmds)
 		})
@@ -423,34 +523,118 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 	vtui.FrameManager.Push(menu)
 }
 
-// enterSubmenu records the current level so goBack can recreate it,
-// closes the current menu, and pushes the child after the pop settles.
-func (s *userMenuState) enterSubmenu(current *vtui.VMenu, parentItems []UserMenuItem, parentTitle string, sub UserMenuItem) {
-	s.history = append(s.history, menuLevel{
-		items:    parentItems,
-		title:    parentTitle,
-		selected: current.SelectPos,
-	})
+// enterSubmenu records the current cursor, descends into items[subIdx],
+// and renders the child level.
+func (s *userMenuState) enterSubmenu(current *vtui.VMenu, subIdx int) {
+	s.selStack = append(s.selStack, current.SelectPos)
+	s.path = append(s.path, subIdx)
 	current.Close()
-	childTitle := parentTitle + " -> " + stripAmpersand(sub.Label)
-	childItems := sub.Submenu
 	vtui.FrameManager.PostTask(func() {
-		s.pushLevel(childItems, childTitle, 0)
+		s.openCurrent(0)
 	})
 }
 
-// goBack closes the current menu. If there's a saved parent level, it
-// is reopened with its prior cursor position; otherwise the user lands
-// back on the panels.
-func (s *userMenuState) goBack(current *vtui.VMenu) {
-	current.Close()
-	if len(s.history) == 0 {
+// itemIndexAtUI returns the items[] index for the menu's UI row at pos,
+// or -1 if pos is out of bounds or the UserData is missing.
+func itemIndexAtUI(menu *vtui.VMenu, pos int) int {
+	if pos < 0 || pos >= len(menu.Items) {
+		return -1
+	}
+	idx, ok := menu.Items[pos].UserData.(int)
+	if !ok {
+		return -1
+	}
+	return idx
+}
+
+// deleteAt removes the item at the cursor with a confirmation dialog
+// (none for separators — those are visual-only). On success the root
+// is saved and the menu is rerendered with the cursor clamped.
+func (s *userMenuState) deleteAt(current *vtui.VMenu, items []UserMenuItem) {
+	idx := itemIndexAtUI(current, current.SelectPos)
+	if idx < 0 || idx >= len(items) {
 		return
 	}
-	prev := s.history[len(s.history)-1]
-	s.history = s.history[:len(s.history)-1]
+	chosen := items[idx]
+
+	apply := func() {
+		newItems := make([]UserMenuItem, 0, len(items)-1)
+		newItems = append(newItems, items[:idx]...)
+		newItems = append(newItems, items[idx+1:]...)
+		s.replaceCurrentItems(newItems)
+		if !s.saveRoot() {
+			return
+		}
+		newPos := idx
+		if newPos >= len(newItems) {
+			newPos = len(newItems) - 1
+		}
+		if newPos < 0 {
+			newPos = 0
+		}
+		current.Close()
+		vtui.FrameManager.PostTask(func() {
+			s.openCurrent(newPos)
+		})
+	}
+
+	if chosen.IsSeparator() {
+		apply()
+		return
+	}
+	label := stripAmpersand(chosen.Label)
+	if label == "" {
+		label = chosen.HotKey
+	}
+	dlg := vtui.ShowMessage(" User menu ",
+		fmt.Sprintf("Delete menu item:\n\n  %s", label),
+		[]string{"&Delete", "Cancel"})
+	dlg.OnResult = func(code int) {
+		if code == 0 {
+			apply()
+		}
+	}
+}
+
+// swapWithNeighbor moves the cursor item by `delta` positions (±1)
+// within the current level, in place. Separators participate in the
+// swap so users can reorder them too.
+func (s *userMenuState) swapWithNeighbor(current *vtui.VMenu, items []UserMenuItem, delta int) {
+	a := itemIndexAtUI(current, current.SelectPos)
+	if a < 0 || a >= len(items) {
+		return
+	}
+	b := a + delta
+	if b < 0 || b >= len(items) {
+		return
+	}
+	items[a], items[b] = items[b], items[a]
+	if !s.saveRoot() {
+		items[a], items[b] = items[b], items[a]
+		return
+	}
+	current.Close()
 	vtui.FrameManager.PostTask(func() {
-		s.pushLevel(prev.items, prev.title, prev.selected)
+		s.openCurrent(b)
+	})
+}
+
+// goBack closes the current menu. If there's an ancestor level it is
+// reopened with the cursor position that was active when the user
+// descended; otherwise the user lands back on the panels.
+func (s *userMenuState) goBack(current *vtui.VMenu) {
+	current.Close()
+	if len(s.path) == 0 {
+		return
+	}
+	s.path = s.path[:len(s.path)-1]
+	sel := 0
+	if len(s.selStack) > 0 {
+		sel = s.selStack[len(s.selStack)-1]
+		s.selStack = s.selStack[:len(s.selStack)-1]
+	}
+	vtui.FrameManager.PostTask(func() {
+		s.openCurrent(sel)
 	})
 }
 

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/unxed/f4/piecetable"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
@@ -77,6 +78,59 @@ func loadFarMenuFile(path string) ([]UserMenuItem, error) {
 	}
 	defer f.Close()
 	return ParseFarMenu(f)
+}
+
+// saveFarMenuFile writes a FarMenu.ini text-format file atomically.
+func saveFarMenuFile(path string, items []UserMenuItem) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+	tmp := path + ".tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return err
+	}
+	if err := WriteFarMenu(f, items); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(tmp)
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// loadRootForMode reads the current root menu from disk based on the
+// source mode and path. Missing files are not an error — they yield an
+// empty slice so a fresh menu can be authored.
+func loadRootForMode(mode MenuMode, path string) []UserMenuItem {
+	switch mode {
+	case MenuModeMain:
+		items, _ := LoadMainMenu(path)
+		return items
+	default:
+		items, err := loadFarMenuFile(path)
+		if err != nil {
+			return nil
+		}
+		return items
+	}
+}
+
+// saveRootForMode writes items back to the source file using whichever
+// on-disk format that source uses (flat INI for the main menu, FarMenu.ini
+// text for the per-directory and near-binary files).
+func saveRootForMode(mode MenuMode, path string, items []UserMenuItem) error {
+	switch mode {
+	case MenuModeMain:
+		return SaveMainMenu(path, items)
+	default:
+		return saveFarMenuFile(path, items)
+	}
 }
 
 // defaultSavePath returns the path Ctrl+F4 should open in the editor
@@ -252,24 +306,26 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 			})
 			return true
 		}
-		// Ctrl+F4 opens the underlying file in the editor (matches far2l
-		// usermenu.cpp:619 "редактировать все меню"). The menu is dismissed
-		// first so the editor takes the whole screen; F2 reloads the menu
-		// from disk after the user finishes editing and exits.
+		// Ctrl+F4 edits the menu via a temp file, matching far2l
+		// usermenu.cpp:619-678: dump the current root tree as FarMenu.ini
+		// text, open the temp file in the editor, on close parse it back
+		// and write it to the real source path in that source's native
+		// format. If the user didn't change anything we skip the save; if
+		// parsing fails we surface an error and keep the original intact.
 		if e.VirtualKeyCode == vtinput.VK_F4 && ctrl && !shift && !alt {
-			path := s.sourcePath
-			if path == "" {
-				path = defaultSavePath(s.pf, s.mode)
+			sourcePath := s.sourcePath
+			if sourcePath == "" {
+				sourcePath = defaultSavePath(s.pf, s.mode)
 			}
-			if path == "" {
+			if sourcePath == "" {
 				return true
 			}
+			pf := s.pf
+			mode := s.mode
 			s.history = nil
 			menu.Close()
-			editorDir := filepath.Dir(path)
-			pf := s.pf
 			vtui.FrameManager.PostTask(func() {
-				actionOpenEditor(pf, vfs.NewOSVFS(editorDir), path)
+				editCurrentMenuInExternalEditor(pf, mode, sourcePath)
 			})
 			return true
 		}
@@ -395,6 +451,82 @@ func (s *userMenuState) goBack(current *vtui.VMenu) {
 	vtui.FrameManager.PostTask(func() {
 		s.pushLevel(prev.items, prev.title, prev.selected)
 	})
+}
+
+// editCurrentMenuInExternalEditor implements the Ctrl+F4 flow modelled
+// after far2l (usermenu.cpp:619-678): write the current root tree to a
+// temp file as FarMenu.ini text, open the editor on the temp file, and
+// on close re-parse the file and persist it back to the source path
+// using that source's native format. The original source is left
+// untouched if the user made no changes or if parsing fails.
+func editCurrentMenuInExternalEditor(pf *PanelsFrame, mode MenuMode, sourcePath string) {
+	items := loadRootForMode(mode, sourcePath)
+
+	tmp, err := os.CreateTemp("", "f4-usermenu-*.ini")
+	if err != nil {
+		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot create temp file:\n%v", err), []string{"&Ok"})
+		return
+	}
+	tmpPath := tmp.Name()
+	if werr := WriteFarMenu(tmp, items); werr != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot write temp file:\n%v", werr), []string{"&Ok"})
+		return
+	}
+	if cerr := tmp.Close(); cerr != nil {
+		os.Remove(tmpPath)
+		vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot close temp file:\n%v", cerr), []string{"&Ok"})
+		return
+	}
+	initStat, _ := os.Stat(tmpPath)
+
+	onClose := func() {
+		defer os.Remove(tmpPath)
+
+		stat, statErr := os.Stat(tmpPath)
+		if statErr != nil {
+			return
+		}
+		if initStat != nil && stat.Size() == initStat.Size() && stat.ModTime().Equal(initStat.ModTime()) {
+			return
+		}
+		parsed, parseErr := loadFarMenuFile(tmpPath)
+		if parseErr != nil {
+			vtui.FrameManager.PostTask(func() {
+				vtui.ShowMessage(" User menu ",
+					fmt.Sprintf("Failed to parse edited menu:\n%v\n\nOriginal kept.", parseErr),
+					[]string{"&Ok"})
+			})
+			return
+		}
+		if saveErr := saveRootForMode(mode, sourcePath, parsed); saveErr != nil {
+			vtui.FrameManager.PostTask(func() {
+				vtui.ShowMessage(" User menu ",
+					fmt.Sprintf("Failed to save menu:\n%v", saveErr),
+					[]string{"&Ok"})
+			})
+		}
+	}
+
+	openTempInEditor(pf, tmpPath, onClose)
+}
+
+// openTempInEditor creates an EditorView on the given path with an
+// OnClose hook. It mirrors actionOpenEditor's setup but reads
+// synchronously since user-menu temp files are tiny.
+func openTempInEditor(pf *PanelsFrame, path string, onClose func()) {
+	dir := filepath.Dir(path)
+	v := vfs.NewOSVFS(dir)
+
+	data, _ := os.ReadFile(path)
+	pt := piecetable.New(data)
+
+	editor := NewEditorView(pt, v, path)
+	editor.OnClose = onClose
+	editor.ResizeConsole(pf.lastW, pf.lastH)
+	editor.StartIndexing()
+	vtui.FrameManager.AddScreen(editor)
 }
 
 // formatMenuItemText builds the displayed string for an item:

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -132,12 +132,22 @@ func resolveMenuStart(pf *PanelsFrame, initial MenuMode) (items []UserMenuItem, 
 	return nil, t, MenuModeMain
 }
 
-// userMenuState shares ownership of the pushed VMenu chain so we can
-// close the whole stack on Shift+F2 cycle or shellable-action.
+// menuLevel snapshots the data needed to recreate a parent menu when
+// the user returns to it from a submenu. far2l does the same: the
+// inner ProcessSingleMenu loop recreates VMenu with the saved MenuPos
+// on EC_CLOSE_LEVEL (usermenu.cpp:738-744). Showing only one menu at a
+// time keeps the screen uncluttered.
+type menuLevel struct {
+	items    []UserMenuItem
+	title    string
+	selected int
+}
+
+// userMenuState carries navigation history across pushLevel invocations.
 type userMenuState struct {
-	pf    *PanelsFrame
-	mode  MenuMode
-	stack []*vtui.VMenu
+	pf      *PanelsFrame
+	mode    MenuMode
+	history []menuLevel
 }
 
 // ShowUserMenu is the entry point. It loads the user menu starting from
@@ -145,18 +155,11 @@ type userMenuState struct {
 func ShowUserMenu(pf *PanelsFrame) {
 	items, title, mode := resolveMenuStart(pf, MenuModeLocal)
 	s := &userMenuState{pf: pf, mode: mode}
-	s.pushLevel(items, title)
-	_ = title // referenced for future submenu breadcrumbs
+	s.pushLevel(items, title, 0)
 }
 
-func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
+func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSelect int) {
 	menu := vtui.NewVMenu(" " + title + " ")
-	// Depth captured at push time stays stable even if Esc/Left dismisses
-	// some children later (we don't try to keep s.stack in sync on those
-	// paths). Using a captured value instead of len(s.stack) avoids
-	// misclassifying the root once stale entries pile up.
-	depth := len(s.stack)
-	s.stack = append(s.stack, menu)
 
 	// Map F1..F24 hotkeys to item indices for fast lookup in OnKeyDown.
 	// vtui already handles single-char (&-prefixed) hotkeys natively.
@@ -194,6 +197,9 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 		y = 0
 	}
 	menu.SetPosition(x, y, x+w-1, y+h-1)
+	if initialSelect > 0 && initialSelect < menu.GetItemCount() {
+		menu.SetSelectPos(initialSelect)
+	}
 
 	menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
 		if !e.KeyDown {
@@ -203,16 +209,29 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 		ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
 		alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
 
-		// Shift+F2 cycles the menu source mode.
+		// Shift+F2 cycles the menu source mode. Clear history so the
+		// fresh root doesn't try to "return" to the previous mode's chain.
 		if e.VirtualKeyCode == vtinput.VK_F2 && shift && !ctrl && !alt {
-			s.closeAll()
+			s.history = nil
+			menu.Close()
 			next := MenuMode((int(s.mode) + 1) % 3)
 			vtui.FrameManager.PostTask(func() {
-				items, title, mode := resolveMenuStart(s.pf, next)
-				s.mode = mode
-				s.stack = nil
-				s.pushLevel(items, title)
+				newItems, newTitle, newMode := resolveMenuStart(s.pf, next)
+				s.mode = newMode
+				s.pushLevel(newItems, newTitle, 0)
 			})
+			return true
+		}
+		// Shift+F10 quits the entire menu chain (usermenu.cpp:685).
+		if e.VirtualKeyCode == vtinput.VK_F10 && shift && !ctrl && !alt {
+			s.history = nil
+			menu.Close()
+			return true
+		}
+		// Esc and F10: back one level, or close at the root.
+		if !shift && !ctrl && !alt &&
+			(e.VirtualKeyCode == vtinput.VK_ESCAPE || e.VirtualKeyCode == vtinput.VK_F10) {
+			s.goBack(menu)
 			return true
 		}
 		// F1..F12: jump to the item whose HotKey is "F<n>" and activate it.
@@ -222,7 +241,7 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 				menu.SetSelectPos(uiIdx)
 				if itemIdx, _ := menu.Items[uiIdx].UserData.(int); itemIdx >= 0 && itemIdx < len(items) {
 					if items[itemIdx].IsSubmenu() {
-						pushChild(s, items[itemIdx], title)
+						s.enterSubmenu(menu, items, title, items[itemIdx])
 						return true
 					}
 				}
@@ -234,15 +253,14 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 				return true
 			}
 		}
-		// Enter / Right on a submenu item: push the child without closing
-		// the parent, so Left arrow can return to it.
+		// Enter / Right on a submenu item: descend into the child.
 		if !shift && !ctrl && !alt &&
 			(e.VirtualKeyCode == vtinput.VK_RETURN || e.VirtualKeyCode == vtinput.VK_RIGHT) {
 			pos := menu.SelectPos
 			if pos >= 0 && pos < len(menu.Items) {
 				if idx, ok := menu.Items[pos].UserData.(int); ok && idx >= 0 && idx < len(items) {
 					if items[idx].IsSubmenu() {
-						pushChild(s, items[idx], title)
+						s.enterSubmenu(menu, items, title, items[idx])
 						return true
 					}
 				}
@@ -254,14 +272,10 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 			}
 			return false
 		}
-		// Left arrow → back to the parent menu, but only when we're
-		// actually inside a submenu. At the root level it's a no-op
-		// (matches usermenu.cpp:575: closes only when Title is set).
+		// Left arrow → back to the parent menu, no-op at the root.
 		if !shift && !ctrl && !alt && e.VirtualKeyCode == vtinput.VK_LEFT {
-			if depth > 0 {
-				menu.Close()
-			}
-			return true // swallow either way so it doesn't bubble to panels
+			s.goBack(menu)
+			return true
 		}
 		return false
 	}
@@ -276,17 +290,17 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 		}
 		chosen := items[idx]
 		if chosen.IsSubmenu() {
-			// Submenus are handled in OnKeyDown to keep the parent open.
-			// We only land here on mouse click; treat it the same way.
-			pushChild(s, chosen, title)
+			// Submenus are handled by OnKeyDown for the keyboard paths.
+			// We only land here on mouse click; do the same thing.
+			s.enterSubmenu(menu, items, title, chosen)
 			return
 		}
 		// Leaf item: vtui will pop this menu on its own after we return.
-		// Close any remaining parent levels and run the commands once the
-		// frame stack has settled.
+		// Drop the history so we don't try to reopen a parent on the way
+		// out, then dispatch the commands once the frame stack has settled.
 		cmds := chosen.Commands
+		s.history = nil
 		vtui.FrameManager.PostTask(func() {
-			s.closeAll()
 			executeMenuCommands(s.pf, cmds)
 		})
 	}
@@ -294,21 +308,34 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string) {
 	vtui.FrameManager.Push(menu)
 }
 
-func (s *userMenuState) closeAll() {
-	for _, m := range s.stack {
-		m.Close()
-	}
-	s.stack = nil
+// enterSubmenu records the current level so goBack can recreate it,
+// closes the current menu, and pushes the child after the pop settles.
+func (s *userMenuState) enterSubmenu(current *vtui.VMenu, parentItems []UserMenuItem, parentTitle string, sub UserMenuItem) {
+	s.history = append(s.history, menuLevel{
+		items:    parentItems,
+		title:    parentTitle,
+		selected: current.SelectPos,
+	})
+	current.Close()
+	childTitle := parentTitle + " -> " + stripAmpersand(sub.Label)
+	childItems := sub.Submenu
+	vtui.FrameManager.PostTask(func() {
+		s.pushLevel(childItems, childTitle, 0)
+	})
 }
 
-// pushChild opens a submenu on top of the current menu. The parent is
-// left alive on the frame stack so that Left arrow / Esc in the child
-// returns the user to it (matching every Far version since the original).
-func pushChild(s *userMenuState, parent UserMenuItem, parentTitle string) {
-	child := parent.Submenu
-	childTitle := parentTitle + " -> " + stripAmpersand(parent.Label)
+// goBack closes the current menu. If there's a saved parent level, it
+// is reopened with its prior cursor position; otherwise the user lands
+// back on the panels.
+func (s *userMenuState) goBack(current *vtui.VMenu) {
+	current.Close()
+	if len(s.history) == 0 {
+		return
+	}
+	prev := s.history[len(s.history)-1]
+	s.history = s.history[:len(s.history)-1]
 	vtui.FrameManager.PostTask(func() {
-		s.pushLevel(child, childTitle)
+		s.pushLevel(prev.items, prev.title, prev.selected)
 	})
 }
 

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
@@ -78,6 +79,27 @@ func loadFarMenuFile(path string) ([]UserMenuItem, error) {
 	return ParseFarMenu(f)
 }
 
+// defaultSavePath returns the path Ctrl+F4 should open in the editor
+// for a given mode when no menu file exists yet, so the user can
+// author one from scratch and save it where the loader will find it.
+func defaultSavePath(pf *PanelsFrame, mode MenuMode) string {
+	switch mode {
+	case MenuModeLocal:
+		if fsp, ok := pf.panels[pf.activeIdx].(*FileSystemPanel); ok && fsp != nil && fsp.vfs != nil {
+			return filepath.Join(fsp.vfs.GetPath(), farMenuFileName)
+		}
+		return ""
+	case MenuModeFar:
+		if exe, err := os.Executable(); err == nil {
+			return filepath.Join(filepath.Dir(exe), farMenuFileName)
+		}
+		return ""
+	case MenuModeMain:
+		return MainMenuFilePath()
+	}
+	return ""
+}
+
 // loadMenuForMode returns (items, title, sourcePath, ok). ok=false means
 // this mode has no data — caller may want to try the next mode.
 func loadMenuForMode(pf *PanelsFrame, mode MenuMode) (items []UserMenuItem, title, source string, ok bool) {
@@ -118,18 +140,18 @@ func loadMenuForMode(pf *PanelsFrame, mode MenuMode) (items []UserMenuItem, titl
 }
 
 // resolveMenuStart finds the first non-empty mode at or after initial,
-// returning items/title and the mode actually used.
-func resolveMenuStart(pf *PanelsFrame, initial MenuMode) (items []UserMenuItem, title string, mode MenuMode) {
+// returning items/title/source and the mode actually used.
+func resolveMenuStart(pf *PanelsFrame, initial MenuMode) (items []UserMenuItem, title string, mode MenuMode, source string) {
 	for offset := 0; offset < 3; offset++ {
 		m := MenuMode((int(initial) + offset) % 3)
-		if loaded, t, _, ok := loadMenuForMode(pf, m); ok {
-			return loaded, t, m
+		if loaded, t, src, ok := loadMenuForMode(pf, m); ok {
+			return loaded, t, m, src
 		}
 	}
 	// Nothing found anywhere — fall back to main with an empty list so
 	// the user still sees the menu chrome and can press Shift+F2 / Esc.
 	_, t, _, _ := loadMenuForMode(pf, MenuModeMain)
-	return nil, t, MenuModeMain
+	return nil, t, MenuModeMain, defaultSavePath(pf, MenuModeMain)
 }
 
 // menuLevel snapshots the data needed to recreate a parent menu when
@@ -145,16 +167,20 @@ type menuLevel struct {
 
 // userMenuState carries navigation history across pushLevel invocations.
 type userMenuState struct {
-	pf      *PanelsFrame
-	mode    MenuMode
-	history []menuLevel
+	pf         *PanelsFrame
+	mode       MenuMode
+	sourcePath string // file Ctrl+F4 opens and edits save back to
+	history    []menuLevel
 }
 
 // ShowUserMenu is the entry point. It loads the user menu starting from
 // the local (cwd-relative) mode and pushes a modal VMenu.
 func ShowUserMenu(pf *PanelsFrame) {
-	items, title, mode := resolveMenuStart(pf, MenuModeLocal)
-	s := &userMenuState{pf: pf, mode: mode}
+	items, title, mode, source := resolveMenuStart(pf, MenuModeLocal)
+	if source == "" {
+		source = defaultSavePath(pf, mode)
+	}
+	s := &userMenuState{pf: pf, mode: mode, sourcePath: source}
 	s.pushLevel(items, title, 0)
 }
 
@@ -216,9 +242,34 @@ func (s *userMenuState) pushLevel(items []UserMenuItem, title string, initialSel
 			menu.Close()
 			next := MenuMode((int(s.mode) + 1) % 3)
 			vtui.FrameManager.PostTask(func() {
-				newItems, newTitle, newMode := resolveMenuStart(s.pf, next)
+				newItems, newTitle, newMode, newSrc := resolveMenuStart(s.pf, next)
 				s.mode = newMode
+				if newSrc == "" {
+					newSrc = defaultSavePath(s.pf, newMode)
+				}
+				s.sourcePath = newSrc
 				s.pushLevel(newItems, newTitle, 0)
+			})
+			return true
+		}
+		// Ctrl+F4 opens the underlying file in the editor (matches far2l
+		// usermenu.cpp:619 "редактировать все меню"). The menu is dismissed
+		// first so the editor takes the whole screen; F2 reloads the menu
+		// from disk after the user finishes editing and exits.
+		if e.VirtualKeyCode == vtinput.VK_F4 && ctrl && !shift && !alt {
+			path := s.sourcePath
+			if path == "" {
+				path = defaultSavePath(s.pf, s.mode)
+			}
+			if path == "" {
+				return true
+			}
+			s.history = nil
+			menu.Close()
+			editorDir := filepath.Dir(path)
+			pf := s.pf
+			vtui.FrameManager.PostTask(func() {
+				actionOpenEditor(pf, vfs.NewOSVFS(editorDir), path)
 			})
 			return true
 		}

--- a/user_menu_ui_test.go
+++ b/user_menu_ui_test.go
@@ -179,7 +179,7 @@ func TestFindLocalFarMenu_PicksClosest(t *testing.T) {
 
 func TestMainMenuFilePath_HasExpectedSuffix(t *testing.T) {
 	p := MainMenuFilePath()
-	want := filepath.Join("f4", "settings", "main_menu.ini")
+	want := filepath.Join("f4", "settings", "user_menu.ini")
 	if !strings.HasSuffix(p, want) {
 		t.Errorf("MainMenuFilePath()=%q, want suffix %q", p, want)
 	}

--- a/user_menu_ui_test.go
+++ b/user_menu_ui_test.go
@@ -1,0 +1,200 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestParseFunctionKey(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint32
+	}{
+		{"F1", 1},
+		{"F2", 2},
+		{"F12", 12},
+		{"F24", 24},
+		{"f3", 3}, // case insensitive on the leading F
+		{"F0", 0},
+		{"F25", 0},
+		{"F", 0},
+		{"FF", 0},
+		{"a", 0},
+		{"", 0},
+		{"--", 0},
+		{"F1a", 0},
+	}
+	for _, c := range cases {
+		if got := parseFunctionKey(c.in); got != c.want {
+			t.Errorf("parseFunctionKey(%q) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestEscapeAmpersand(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"foo", "foo"},
+		{"R&D", "R&&D"},
+		{"&start", "&&start"},
+		{"a&b&c", "a&&b&&c"},
+	}
+	for _, c := range cases {
+		if got := escapeAmpersand(c.in); got != c.want {
+			t.Errorf("escapeAmpersand(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStripAmpersand(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"foo", "foo"},
+		{"R&&D", "R&D"},
+		{"&Open", "Open"},
+		{"a&b&c", "abc"},
+		{"foo&&bar", "foo&bar"},
+	}
+	for _, c := range cases {
+		if got := stripAmpersand(c.in); got != c.want {
+			t.Errorf("stripAmpersand(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestIsMenuComment(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"REM this is a comment", true},
+		{"rem lowercase too", true},
+		{"REM", true},
+		{"REM\tcomment with tab", true},
+		{"REMOVE", false}, // no separator after REM
+		{":: shell-style comment", true},
+		{":single colon", false},
+		{"normal command", false},
+		{"  REM indented", false}, // caller strips spaces first
+	}
+	for _, c := range cases {
+		if got := isMenuComment(c.in); got != c.want {
+			t.Errorf("isMenuComment(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFormatMenuItemText_SingleChar(t *testing.T) {
+	got := formatMenuItemText(UserMenuItem{HotKey: "a", Label: "Apple"})
+	// Hotkey marker '&a' plus enough padding to bring the label to column 6
+	if !strings.HasPrefix(got, "&a") {
+		t.Errorf("missing & marker for single-char hotkey: %q", got)
+	}
+	if !strings.HasSuffix(got, "Apple") {
+		t.Errorf("label missing: %q", got)
+	}
+}
+
+func TestFormatMenuItemText_FunctionKey(t *testing.T) {
+	got := formatMenuItemText(UserMenuItem{HotKey: "F3", Label: "Build"})
+	// F-keys must not use the '&' marker (would underline 'F').
+	if strings.HasPrefix(got, "&") {
+		t.Errorf("F-key should not have & marker: %q", got)
+	}
+	if !strings.HasPrefix(got, "F3") || !strings.HasSuffix(got, "Build") {
+		t.Errorf("unexpected layout: %q", got)
+	}
+}
+
+func TestFormatMenuItemText_NoHotkey(t *testing.T) {
+	got := formatMenuItemText(UserMenuItem{HotKey: "", Label: "Plain"})
+	if !strings.HasSuffix(got, "Plain") {
+		t.Errorf("missing label: %q", got)
+	}
+}
+
+func TestFormatMenuItemText_AmpersandInLabel(t *testing.T) {
+	got := formatMenuItemText(UserMenuItem{HotKey: "x", Label: "R&D"})
+	// The '&' in label must be doubled so vtui doesn't underline 'D'.
+	if !strings.Contains(got, "R&&D") {
+		t.Errorf("label ampersand not escaped: %q", got)
+	}
+}
+
+func TestFindLocalFarMenu_WalksUp(t *testing.T) {
+	root := t.TempDir()
+	deep := filepath.Join(root, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wanted := filepath.Join(root, "a", farMenuFileName)
+	if err := os.WriteFile(wanted, []byte("x:  X\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, found := findLocalFarMenu(deep)
+	if !found {
+		t.Fatalf("expected to find FarMenu.ini at %q from %q", wanted, deep)
+	}
+	// Resolve to absolute to avoid /var vs /private/var on macOS.
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	wantAbs, _ := filepath.EvalSymlinks(wanted)
+	if gotAbs != wantAbs {
+		t.Errorf("found %q, want %q", gotAbs, wantAbs)
+	}
+}
+
+func TestFindLocalFarMenu_NotFound(t *testing.T) {
+	dir := t.TempDir()
+	_, found := findLocalFarMenu(dir)
+	if found {
+		t.Errorf("expected no FarMenu.ini in empty tree")
+	}
+}
+
+func TestFindLocalFarMenu_PicksClosest(t *testing.T) {
+	// When two ancestors have FarMenu.ini, the closer one wins.
+	root := t.TempDir()
+	mid := filepath.Join(root, "mid")
+	leaf := filepath.Join(mid, "leaf")
+	if err := os.MkdirAll(leaf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootMenu := filepath.Join(root, farMenuFileName)
+	midMenu := filepath.Join(mid, farMenuFileName)
+	if err := os.WriteFile(rootMenu, []byte("r:  R\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(midMenu, []byte("m:  M\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, _ := findLocalFarMenu(leaf)
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	midAbs, _ := filepath.EvalSymlinks(midMenu)
+	if gotAbs != midAbs {
+		t.Errorf("closest wins: got %q, want %q", gotAbs, midAbs)
+	}
+}
+
+func TestMainMenuFilePath_HasExpectedSuffix(t *testing.T) {
+	p := MainMenuFilePath()
+	want := filepath.Join("f4", "settings", "main_menu.ini")
+	if !strings.HasSuffix(p, want) {
+		t.Errorf("MainMenuFilePath()=%q, want suffix %q", p, want)
+	}
+}
+
+func TestFindMenuItemByUserData(t *testing.T) {
+	menu := vtui.NewVMenu("test")
+	menu.AddItem(vtui.MenuItem{Text: "a", UserData: 3})
+	menu.AddItem(vtui.MenuItem{Text: "b", UserData: 7})
+	menu.AddItem(vtui.MenuItem{Text: "c", UserData: 1})
+
+	if idx, ok := findMenuItemByUserData(menu, 7); !ok || idx != 1 {
+		t.Errorf("got idx=%d ok=%v, want 1/true", idx, ok)
+	}
+	if _, ok := findMenuItemByUserData(menu, 99); ok {
+		t.Errorf("expected not found for unknown UserData")
+	}
+}


### PR DESCRIPTION
## Summary

Ports the F2 user menu from far2l with bug-for-bug format compatibility,
so existing far2l configs work in f4 unchanged.

- `F2` opens a modal menu loaded from one of (in order): `FarMenu.ini`
  in the current directory or any parent, `FarMenu.ini` next to the
  binary, `~/.config/f4/settings/user_menu.ini`.
- `Shift+F2` cycles through the three sources.
- Single-char hotkeys (vtui's `&` markers) and `F1..F24` hotkeys jump
  to the item whose `HotKey=` matches.
- `Enter` / `Right` enter submenus; `Left` / `Esc` / `F10` go back;
  `Shift+F10` quits the whole chain. Submenu items get the `►` marker
  far2l uses (`vmenu.cpp:1980`). Only one menu is on screen at a
  time — the parent is recreated on return with its previous cursor
  position restored, matching far2l's `ProcessSingleMenu` loop
  (`usermenu.cpp:738`).
- Leaf items run their `Command0..N` lines through a minimal subset
  of far2l's `fnparce.cpp` substitutions (`!.!`, `` !`! ``, `!\!`,
  `!&`, `!@!`, `!#`, `!^`, `!!`, `!?title?init!`, plus `$VAR`/`${VAR}`).
  Commands are joined with `;` and dispatched through the existing
  command-line + Enter pipeline so the panel's `cd` interception,
  PTY wrapping, and history all still apply.
- `Ctrl+F4` opens the menu as a UTF-8 temp `FarMenu.ini` text file
  in the f4 editor. On close the file is re-parsed and saved back to
  the source path in its native format. The menu auto-reopens with
  the result, matching `usermenu.cpp:619-678` ("редактировать всё
  меню") and `ExecuteModalEV` return-to-loop. On parse error the
  original is kept untouched.
- `Del` removes the item under the cursor (with confirmation for
  non-separators); `Ctrl+Up` / `Ctrl+Down` move it within the level;
  `Ins` opens the Ctrl+F4 editor as a fallback until a per-item
  dialog lands.
- The bottom border carries a hotkey hint
  ("Del Ins Ctrl+F4 Ctrl+Up/Down"), matching Far Manager's habit
  since the original Roshal release (`usermenu.cpp:535`).

### Format compatibility

- **`user_menu.ini`** mirrors far2l's flat INI exactly — same path
  under `~/.config/f4/settings/`, same section layout
  (`[UserMenu/MainMenu/Item2/Item0]`), same keys (`HotKey`, `Label`,
  `Submenu`, `Command0..N`). A file from
  `~/.config/far2l/settings/user_menu.ini` works as-is.
- **`FarMenu.ini`** reader handles all five encodings: UTF-32 LE/BE
  with BOM, UTF-16 LE/BE with BOM, UTF-8 with or without BOM. UTF-32
  detection must run before UTF-16 (the BOM `FF FE 00 00` is a
  superset of `FF FE`). Writer mirrors what the native tool produces
  on each platform so f4-authored files are drop-in compatible:
  UTF-16LE+BOM+CRLF on Windows (matches Far Manager 2), UTF-32LE+BOM+CRLF
  on Linux/macOS/BSD (matches far2l, whose `SIGN_WIDE_LE` is one
  `wchar_t` — 4 bytes there). The temp file the user actually edits
  under Ctrl+F4 is plain UTF-8 so editors are happy.

### What's NOT in this PR

- The per-item edit dialog (HotKey + Label + multi-line Commands
  fields). far2l uses `DI_MEMOEDIT` which vtui doesn't have yet;
  `Ins` and `F4`/`Shift+F4` would route there. Until then `Ctrl+F4`
  covers all editing through the bulk text editor. Plan is a small
  dialog with HotKey+Label fields plus `F4`-opens-EditorView for the
  Commands field, in a follow-up.
- The full `fnparce.cpp` (`!~`, `!-!`, `!+!`, `!:`, `!/`, `!`-alone,
  history hints in `!?…?$…?…!`). The current set covers what I see
  in real-world configs.
- Panel-follows-`cd` when a multi-command menu item begins with
  `cd <path>`. Currently commands are joined with `;` and dispatched
  as one, so the in-shell `cd` runs but the panel cwd doesn't change.
  Far2l intercepts each command separately to get this. Easy fix:
  detect a pure-`cd` first command and dispatch it through cmdLine
  separately. Deferred to keep this PR focused.

### Wired-up files

- `user_menu.go` — model.
- `user_menu_ini.go` — `user_menu.ini` (flat INI) I/O.
- `farmenu_file.go` — `FarMenu.ini` (text) I/O with multi-encoding
  detection and platform-aware wide-encoded output.
- `user_menu_subst.go` — `!X!` and env-var substitutions.
- `user_menu_ui.go` — modal navigation, submenu rebuild-on-return,
  hotkey lookup, in-place edits, Ctrl+F4 editor flow, bottom-border
  hint via a small `userMenuFrame` wrapper around vtui's VMenu (no
  vtui changes needed).
- `editor_view.go` — adds an `OnClose` hook (3 lines) so Ctrl+F4
  can parse and persist after the editor closes.
- `panels_frame.go` — binds `F2` to `ShowUserMenu`.
- `lang.go` — three UserMenu title strings.

## Test plan

- [x] `go test ./...` passes locally.

### WSL Ubuntu 22.04.1 (Linux/amd64)

- [x] Load `~/.config/far2l/settings/user_menu.ini` copied unchanged
      into `~/.config/f4/settings/user_menu.ini` — hotkey navigation,
      submenu descent, Shift+F2 cycle.
- [x] Load a real far2l-on-Linux `FarMenu.ini` (UTF-32LE BOM) from
      the current panel directory — parses cleanly, the UTF-32 BOM
      detection works.
- [x] `Ctrl+F4` round-trip for both formats: edit a `user_menu.ini`
      menu in the temp file as friendly FarMenu.ini text, save, and
      see the changes persisted back to the flat INI source. Same for
      a directory-local FarMenu.ini.
- [x] `Del` with confirmation, `Ctrl+Up`/`Ctrl+Down` reorder, `Ins`
      opens the bulk editor, `Shift+F2` cycles `LOCAL → FAR → MAIN`.
- [x] Substitutions: `!.!`, `!\!`, `!&`, `!?title?init!` with default
      passthrough.

### Windows 11

- [x] Read a native Far Manager 2 `FarMenu.ini` (UTF-16LE+BOM) — the
      menu opens correctly.
- [x] `Ctrl+F4`, `Ctrl+Up`/`Ctrl+Down`, `Del`, `Ins` (= Ctrl+F4 path)
      all work.
- [x] Round-trip the other way: f4 on Windows saves a `FarMenu.ini`,
      native Far Manager 2 reads it back without conversion.

### Not yet tested

- [ ] Far Manager 3. The on-disk formats it inherits from Far2 should
      keep f4 in good shape, but I haven't tried it.
