### PR TITLE
enable DXIL compilation for DX12 backend

### DIFF
--- a/gui_windows.go
+++ b/gui_windows.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 
 	"github.com/unxed/vtui"
@@ -11,6 +12,14 @@ import (
 func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
+	}
+	// DX12: use naga DXIL backend instead of HLSL→FXC
+	// to avoid 2-6s shader compilation via d3dcompiler_47.dll
+	if os.Getenv("GOGPU_DX12_DXIL") == "" {
+		api := os.Getenv("GOGPU_GRAPHICS_API")
+		if api == "" || strings.EqualFold(api, "dx12") || strings.EqualFold(api, "d3d12") || strings.EqualFold(api, "directx") {
+			os.Setenv("GOGPU_DX12_DXIL", "1")
+		}
 	}
 	return vtui.RunInGUIWindow(100, 30, backend, func() {
 		SetupUI()


### PR DESCRIPTION
решение проблем:
https://github.com/unxed/f4/issues/166

суть:
устанавливаем переменную окружения GOGPU_DX12_DXIL=1 при выборе DX12

Проблема: при старте с DX12 каждый шейдер компилируется через d3dcompiler_47.dll (внешний компилятор Microsoft). Это даёт +2-6 секунд холодного старта.

Решение: GOGPU_DX12_DXIL=1 заменяет внешний d3dcompiler на встроенный компилятор naga — результат тот же DXIL байткод, но без лишней DLL.

Почему FPS не просядет:

Компиляция шейдеров происходит один раз при создании пайплайна, а не каждый кадр
На выходе оба пути дают идентичные D3D12 пайплайны — исполнение на GPU одинаковое
Для файлового менеджера (рендер текста и простых прямоугольников) разница в производительности отсутствует
Переключает только DX12 путь; Vulkan/GLES не затрагивает