### PR TITLE
editor: eliminate brief [Loading...] flash on file open under Windows

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -367,6 +367,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 
 	if f != nil {
 		buf = NewAsyncBuffer(context.Background(), f)
+		buf.prewarm()
 		pt = piecetable.NewWithBuffer(buf)
 	} else {
 		pt = piecetable.New(nil)

--- a/async_buffer.go
+++ b/async_buffer.go
@@ -45,6 +45,28 @@ func (b *AsyncBuffer) Size() int {
 	return b.size
 }
 
+// Prewarm synchronously loads the first chunk so the first render
+// never sees ErrLoading, avoiding a brief [Loading...] flash.
+func (b *AsyncBuffer) prewarm() {
+	if b.size == 0 {
+		return
+	}
+	sz := b.chunkSize
+	if sz > b.size {
+		sz = b.size
+	}
+	data := make([]byte, sz)
+	n, err := b.file.ReadAt(b.ctx, data, 0)
+	if b.ctx.Err() != nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if err == nil || err == io.EOF {
+		b.loaded[0] = data[:n]
+	}
+}
+
 func (b *AsyncBuffer) Read(offset, length int) ([]byte, error) {
 	if offset < 0 || offset >= b.size || length <= 0 {
 		return nil, nil


### PR DESCRIPTION
editor: eliminate brief [Loading...] flash on file open under Windows

Synchronously prewarm the first async buffer chunk before adding the
editor screen, so the initial render never sees ErrLoading.
Under Linux the async fetch typically completes before the first frame;
Windows I/O is slower, causing a one-frame [Loading...] splash.

Close: https://github.com/unxed/f4/issues/171