### PR TITLE
NetFox: restore cursor position on connection disconnect

### DIFF
--- a/file_panel.go
+++ b/file_panel.go
@@ -173,8 +173,9 @@ type FileSystemPanel struct {
 	cancelLoad       context.CancelFunc
 	isLoading        bool
 	loadingTimer     *time.Timer
-	pendingSelection string
-	fastFindMode     bool
+	pendingSelection  string
+	providerEntryName string // name of entry used to enter a provider VFS (e.g. NetFox connection name)
+	fastFindMode      bool
 	fastFindStr      string
 
 	sortMode    SortMode
@@ -1131,7 +1132,12 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 					fp.vfs.Close()
 
 					fp.vfs = parent
-					fp.pendingSelection = fp.vfs.Base(oldPath)
+					if fp.providerEntryName != "" {
+						fp.pendingSelection = fp.providerEntryName
+						fp.providerEntryName = ""
+					} else {
+						fp.pendingSelection = fp.vfs.Base(oldPath)
+					}
 					fp.ReadDirectory()
 					return true
 				}
@@ -1170,16 +1176,18 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 					vtui.RunAsync(func(ctx *vtui.TaskContext) {
 						newVfs, err := provider.Open(ctx.Context, fp.vfs, fullPath)
 						ctx.RunOnUI(func() {
-							if err != nil {
-								fp.isLoading = false
-								fp.updateTitle(err)
-								fp.ReadDirectory() // Возвращаемся к списку соединений
-								vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to connect to %s:\n%v", selected.Name, err), []string{"&Ok"})
-								return
-							}
-							fp.vfs = newVfs
-							fp.pendingSelection = ".."
-							fp.ReadDirectory()
+						if err != nil {
+							fp.isLoading = false
+							fp.updateTitle(err)
+							fp.pendingSelection = selected.Name
+							fp.ReadDirectory() // Возвращаемся к списку соединений
+							vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to connect to %s:\n%v", selected.Name, err), []string{"&Ok"})
+							return
+						}
+						fp.providerEntryName = selected.Name
+						fp.vfs = newVfs
+						fp.pendingSelection = ".."
+						fp.ReadDirectory()
 						})
 					})
 					return true

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2204,6 +2204,7 @@ func (pf *PanelsFrame) switchToVFS(fsp *FileSystemPanel, newVFS vfs.VFS) {
 			pf.ptyMutex.Unlock()
 		}
 		fsp.dirCache = make(map[string]dirCacheEntry)
+		fsp.providerEntryName = ""
 		fsp.vfs = newVFS
 		fsp.ReadDirectory()
 		pf.RefreshAll()
@@ -2229,7 +2230,12 @@ func (pf *PanelsFrame) NavigateToPath(fsp *FileSystemPanel, targetPath string) b
 
 		fsp.dirCache = make(map[string]dirCacheEntry)
 		fsp.vfs = parent
-		fsp.pendingSelection = fsp.vfs.Base(oldPath)
+		if fsp.providerEntryName != "" {
+			fsp.pendingSelection = fsp.providerEntryName
+			fsp.providerEntryName = ""
+		} else {
+			fsp.pendingSelection = fsp.vfs.Base(oldPath)
+		}
 		fsp.ReadDirectory()
 		return true
 	}


### PR DESCRIPTION
Store the connection entry name when entering a provider VFS and use
it as pendingSelection when exiting back to the parent panel. Without
this, the cursor jumped to <Add connection> after disconnecting from
a successful or failed SFTP/FTP session because Base(remotePath)
returned a remote directory name instead of the connection name.

close: https://github.com/unxed/f4/issues/170