### PR TITLE
fix: prevent duplicate line indices from buf.prewarm() by checking offsets in AppendOffsets

### DIFF
--- a/piecetable/lineindex.go
+++ b/piecetable/lineindex.go
@@ -45,12 +45,15 @@ func (li *LineIndex) Rebuild(pt *PieceTable) {
 func (li *LineIndex) AppendOffsets(offsets []int, maxAllowed int) {
 	li.mu.Lock()
 	defer li.mu.Unlock()
-	for _, off := range offsets {
-		if off <= maxAllowed {
-			li.offsets = append(li.offsets, off)
-		}
-	}
+        lastOffset := li.offsets[len(li.offsets)-1]
+        for _, off := range offsets {
+            if off > lastOffset && off <= maxAllowed {
+                li.offsets = append(li.offsets, off)
+                lastOffset = off
+            }
+        }
 }
+
 
 // LineCount returns total number of lines.
 func (li *LineIndex) LineCount() int {


### PR DESCRIPTION
Необходимые изменения вызванные внедрением https://github.com/unxed/f4/pull/174
Tests (69 editor tests + 23 piecetable tests) pass after the fix

close: https://github.com/unxed/f4/issues/177