### PR TITLE
Add folder bookmarks (10 slots, dialog, drive-menu integration)

### DIFF
--- a/bookmarks.go
+++ b/bookmarks.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // Folder bookmarks: ten numbered slots, each remembering one directory,
@@ -143,6 +145,28 @@ func SaveBookmarks(path string, s BookmarkSet) error {
 		return err
 	}
 	return os.Rename(tmp, path)
+}
+
+// truncPathLeft shortens path to at most width display cells by dropping
+// characters from the front and marking the cut with an ellipsis. far2l
+// truncates the paths it lists in menus the same way round
+// (mix/StrCells.cpp, StrCellsTruncateLeft): the tail of a path is the
+// part that identifies it.
+func truncPathLeft(path string, width int) string {
+	const ellipsis = "…"
+	if width <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(path) <= width {
+		return path
+	}
+	runes := []rune(path)
+	for i := 1; i < len(runes); i++ {
+		if runewidth.StringWidth(string(runes[i:]))+1 <= width {
+			return ellipsis + string(runes[i:])
+		}
+	}
+	return ellipsis
 }
 
 // bookmarkSlot maps a section name to its slot index, or -1 when the

--- a/bookmarks.go
+++ b/bookmarks.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Folder bookmarks: ten numbered slots, each remembering one directory,
+// addressable by the digit hotkeys far2l uses. The on-disk layout is
+// far2l's own, so ~/.config/far2l/settings/bookmarks.ini can be copied to
+// ~/.config/f4/settings/bookmarks.ini (or the other way round) unchanged.
+
+// Bookmark is a single slot of the table.
+type Bookmark struct {
+	Path       string // absolute filesystem path; empty means slot is unset
+	Plugin     string // preserved from far2l; f4 does not act on it yet
+	PluginData string
+	PluginFile string
+}
+
+// IsEmpty is true when nothing meaningful is stored in this slot.
+// A slot counts as non-empty if Path or Plugin is set.
+func (b Bookmark) IsEmpty() bool { return b.Path == "" && b.Plugin == "" }
+
+// BookmarkSet is the full 10-slot table. Indices map directly to the digit
+// hotkey: BookmarkSet[3] is what RightCtrl+3 jumps to.
+type BookmarkSet [10]Bookmark
+
+// BookmarksFilePath returns the user-config location of the bookmark table.
+// The filename matches far2l so the same file can be shared between
+// ~/.config/far2l/settings/bookmarks.ini and the f4 directory without
+// renaming.
+func BookmarksFilePath() string {
+	configDir, _ := os.UserConfigDir()
+	return filepath.Join(configDir, "f4", "settings", "bookmarks.ini")
+}
+
+// LoadBookmarks reads a far2l-compatible bookmarks.ini from path. A missing
+// file is not an error: an empty set is returned. Sections outside [0]..[9]
+// are ignored, so the loader is safe to point at a mixed-content INI, and
+// malformed lines are skipped rather than failing the whole file.
+func LoadBookmarks(path string) (BookmarkSet, error) {
+	var set BookmarkSet
+
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return set, nil
+		}
+		return set, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	slot := -1
+	for scanner.Scan() {
+		line := strings.TrimRight(scanner.Text(), "\r\n")
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, ";") || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
+			slot = bookmarkSlot(trimmed[1 : len(trimmed)-1])
+			continue
+		}
+		if slot < 0 {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq == -1 {
+			continue
+		}
+		key := strings.TrimSpace(line[:eq])
+		val := strings.TrimSpace(line[eq+1:])
+		switch key {
+		case "Path":
+			set[slot].Path = val
+		case "Plugin":
+			set[slot].Plugin = val
+		case "PluginData":
+			set[slot].PluginData = val
+		case "PluginFile":
+			set[slot].PluginFile = val
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return BookmarkSet{}, err
+	}
+
+	return set, nil
+}
+
+// SaveBookmarks writes the set to path in far2l-compatible INI form,
+// atomically (temp file + rename). Parent directories are created as
+// needed. Empty slots are left out entirely, the way far2l does it: a
+// missing section is what marks a slot as free.
+func SaveBookmarks(path string, s BookmarkSet) error {
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+	}
+
+	var buf strings.Builder
+	first := true
+	// Sections may sit in any order on disk; write them ascending so saves
+	// are deterministic.
+	for i := range s {
+		if s[i].IsEmpty() {
+			continue
+		}
+		if !first {
+			buf.WriteByte('\n')
+		}
+		first = false
+		buf.WriteByte('[')
+		buf.WriteString(strconv.Itoa(i))
+		buf.WriteString("]\n")
+
+		// far2l emits all four keys alphabetically, even when the plugin
+		// fields are empty strings.
+		buf.WriteString("Path=")
+		buf.WriteString(s[i].Path)
+		buf.WriteByte('\n')
+		buf.WriteString("Plugin=")
+		buf.WriteString(s[i].Plugin)
+		buf.WriteByte('\n')
+		buf.WriteString("PluginData=")
+		buf.WriteString(s[i].PluginData)
+		buf.WriteByte('\n')
+		buf.WriteString("PluginFile=")
+		buf.WriteString(s[i].PluginFile)
+		buf.WriteByte('\n')
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// bookmarkSlot maps a section name to its slot index, or -1 when the
+// section is not one of far2l's [0]..[9] bookmark sections.
+func bookmarkSlot(name string) int {
+	if len(name) != 1 || name[0] < '0' || name[0] > '9' {
+		return -1
+	}
+	return int(name[0] - '0')
+}

--- a/bookmarks_dialog.go
+++ b/bookmarks_dialog.go
@@ -1,0 +1,201 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// Bookmarks dialog: ten fixed rows, one per slot, reachable from
+// F9 → Commands → Bookmarks. Same layout and keys as far2l's
+// BookmarksMenu (bookmarks/BookmarksMenu.cpp) — the port is of the UX,
+// not of the code.
+
+// bookmarksFrame wraps a vtui.VMenu so the dialog can draw a hotkey hint
+// on its bottom border without extending vtui itself, exactly the way
+// userMenuFrame does it for the F2 menu.
+type bookmarksFrame struct {
+	*vtui.VMenu
+	bottomHint string
+}
+
+func (b *bookmarksFrame) Show(scr *vtui.ScreenBuf) {
+	b.VMenu.Show(scr)
+	if b.bottomHint == "" {
+		return
+	}
+	x1, _, x2, y2 := b.VMenu.GetPosition()
+	vtui.NewPainter(scr).DrawTitle(x1, y2, x2, b.bottomHint, vtui.Palette[vtui.ColMenuTitle])
+}
+
+// bookmarksDialog owns the table as loaded from disk plus the menu that
+// displays it. Every mutation writes straight back to file, so there is
+// no "apply" step and nothing to undo on Esc.
+type bookmarksDialog struct {
+	pf   *PanelsFrame
+	file string
+	set  BookmarkSet
+	menu *vtui.VMenu
+}
+
+// ShowBookmarksDialog is the entry point wired to CmBookmarks.
+func ShowBookmarksDialog(pf *PanelsFrame) {
+	d, err := newBookmarksDialog(pf, BookmarksFilePath())
+	if err != nil {
+		vtui.ShowMessage(Msg("Bookmarks.Title"),
+			fmt.Sprintf(Msg("Bookmarks.LoadError"), err),
+			[]string{"&Ok"})
+		return
+	}
+	d.open()
+}
+
+// newBookmarksDialog reads the table from path. The error is returned
+// rather than displayed so the caller decides how to surface it — and so
+// this half can be exercised without a live UI.
+func newBookmarksDialog(pf *PanelsFrame, path string) (*bookmarksDialog, error) {
+	set, err := LoadBookmarks(path)
+	if err != nil {
+		return nil, err
+	}
+	return &bookmarksDialog{pf: pf, file: path, set: set}, nil
+}
+
+// open builds the menu and pushes it as a modal frame.
+func (d *bookmarksDialog) open() {
+	// Empty rows carry CmBookmarkEmptySlot, which is permanently disabled:
+	// vtui then draws them dimmed and swallows Enter on them, which is
+	// exactly the "empty slot is a no-op" behavior far2l has. No other
+	// menu uses this command, so it never needs re-enabling.
+	vtui.FrameManager.DisabledCommands.Disable(CmBookmarkEmptySlot)
+
+	d.menu = vtui.NewVMenu(Msg("Bookmarks.Title"))
+	d.render()
+
+	w, h := d.size()
+	x := (d.pf.lastW - w) / 2
+	y := (d.pf.lastH - h) / 2
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	d.menu.SetPosition(x, y, x+w-1, y+h-1)
+
+	d.menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
+		if !e.KeyDown {
+			return false
+		}
+		shift := e.ControlKeyState&vtinput.ShiftPressed != 0
+		ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
+		alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
+
+		// Keys the top frame declines fall through to vtui's own global
+		// handlers — F1 opens help, F9 activates the menu bar (which a
+		// TypeMenu frame does not block), F12 opens the screen list.
+		// None of that belongs on top of a modal dialog, so the whole
+		// F-key range is swallowed, as the F2 user menu does. F10 is
+		// left to vtui, which closes the menu with it.
+		if !ctrl && !shift && !alt &&
+			e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12 &&
+			e.VirtualKeyCode != vtinput.VK_F10 {
+			return true
+		}
+		return false
+	}
+
+	// Enter (and a mouse click) on a populated row: vtui pops the menu on
+	// its own once we return, so the navigation is posted for after the
+	// frame stack has settled. Empty rows never get here — their command
+	// is disabled, so vtui swallows the key first.
+	d.menu.OnAction = func(uiIdx int) {
+		slot := d.slotAt(uiIdx)
+		if slot < 0 || d.set[slot].IsEmpty() {
+			return
+		}
+		path := d.set[slot].Path
+		pf := d.pf
+		vtui.FrameManager.PostTask(func() {
+			if fsp := pf.getActivePanel(); fsp != nil {
+				pf.NavigateToPath(fsp, path)
+			}
+		})
+	}
+
+	vtui.FrameManager.Push(&bookmarksFrame{VMenu: d.menu, bottomHint: Msg("Bookmarks.BottomHint")})
+}
+
+// render rebuilds all ten rows in place, keeping the cursor where it was.
+// The frame may already be on screen: vtui picks the new items up on the
+// next redraw.
+func (d *bookmarksDialog) render() {
+	pos := d.menu.SelectPos
+	d.menu.Items = nil
+	d.menu.ItemCount = 0
+	for i := range d.set {
+		item := vtui.MenuItem{Text: d.rowText(i), UserData: i}
+		if d.set[i].IsEmpty() {
+			item.Command = CmBookmarkEmptySlot
+		}
+		d.menu.AddItem(item)
+	}
+	d.menu.SetSelectPos(pos)
+}
+
+// rowText formats one row: the hotkey reminder far2l prints in its own
+// dialog title, the slot digit, then the path (or the empty marker).
+func (d *bookmarksDialog) rowText(slot int) string {
+	path := d.set[slot].Path
+	if path == "" {
+		path = Msg("Bookmarks.EmptySlot")
+	}
+	return fmt.Sprintf("%s %d   %s", Msg("Bookmarks.RowPrefix"), slot, escapeAmpersand(path))
+}
+
+// size returns the menu box dimensions: wide enough for the longest row
+// and for the bottom hint, tall enough for all ten slots, clamped to the
+// console — same shape of arithmetic as menuSize in user_menu_ui.go.
+func (d *bookmarksDialog) size() (int, int) {
+	w := 60
+	for i := range d.set {
+		if rw := runewidth.StringWidth(d.rowText(i)) + 4; rw > w {
+			w = rw
+		}
+	}
+	if minForHint := runewidth.StringWidth(Msg("Bookmarks.BottomHint")) + 2; w < minForHint {
+		w = minForHint
+	}
+	if d.pf.lastW > 0 && w > d.pf.lastW-4 {
+		w = d.pf.lastW - 4
+	}
+	if w < 24 {
+		w = 24
+	}
+
+	h := len(d.set) + 2
+	maxH := d.pf.lastH - 6
+	if maxH < 5 {
+		maxH = 5
+	}
+	if h > maxH {
+		h = maxH
+	}
+	return w, h
+}
+
+// slotAt maps a menu row to its slot index, or -1 when the row is out of
+// range. Rows and slots are 1:1 today; going through UserData keeps that
+// an implementation detail.
+func (d *bookmarksDialog) slotAt(uiPos int) int {
+	if d.menu == nil || uiPos < 0 || uiPos >= len(d.menu.Items) {
+		return -1
+	}
+	slot, ok := d.menu.Items[uiPos].UserData.(int)
+	if !ok || slot < 0 || slot >= len(d.set) {
+		return -1
+	}
+	return slot
+}

--- a/bookmarks_dialog.go
+++ b/bookmarks_dialog.go
@@ -20,6 +20,22 @@ import (
 type bookmarksFrame struct {
 	*vtui.VMenu
 	bottomHint string
+	onClose    func()
+}
+
+// IsDone doubles as the close hook. vtui has no OnClose on VMenu and Esc
+// closes through the embedded menu's own SetExitCode, which a wrapper
+// cannot intercept — but the frame manager drops a frame the moment
+// IsDone reports true, so that is the point where "after the dialog goes
+// away" work can be queued. Fires once.
+func (b *bookmarksFrame) IsDone() bool {
+	done := b.VMenu.IsDone()
+	if done && b.onClose != nil {
+		cb := b.onClose
+		b.onClose = nil
+		vtui.FrameManager.PostTask(cb)
+	}
+	return done
 }
 
 func (b *bookmarksFrame) Show(scr *vtui.ScreenBuf) {
@@ -43,14 +59,25 @@ type bookmarksDialog struct {
 
 // ShowBookmarksDialog is the entry point wired to CmBookmarks.
 func ShowBookmarksDialog(pf *PanelsFrame) {
+	ShowBookmarksDialogAt(pf, 0, nil)
+}
+
+// ShowBookmarksDialogAt opens the dialog with the cursor on a given slot
+// and runs onClose (may be nil) once the dialog is gone. The drive menu
+// uses both: far2l's F4 there opens this dialog on the slot under the
+// cursor and returns to the menu afterwards.
+func ShowBookmarksDialogAt(pf *PanelsFrame, slot int, onClose func()) {
 	d, err := newBookmarksDialog(pf, BookmarksFilePath())
 	if err != nil {
 		vtui.ShowMessage(Msg("Bookmarks.Title"),
 			fmt.Sprintf(Msg("Bookmarks.LoadError"), err),
 			[]string{"&Ok"})
+		if onClose != nil {
+			onClose()
+		}
 		return
 	}
-	d.open()
+	d.open(slot, onClose)
 }
 
 // newBookmarksDialog reads the table from path. The error is returned
@@ -64,8 +91,8 @@ func newBookmarksDialog(pf *PanelsFrame, path string) (*bookmarksDialog, error) 
 	return &bookmarksDialog{pf: pf, file: path, set: set}, nil
 }
 
-// open builds the menu and pushes it as a modal frame.
-func (d *bookmarksDialog) open() {
+// open builds the menu and pushes it as a modal frame, cursor on slot.
+func (d *bookmarksDialog) open(slot int, onClose func()) {
 	// Empty rows carry CmBookmarkEmptySlot, which is permanently disabled:
 	// vtui then draws them dimmed and swallows Enter on them, which is
 	// exactly the "empty slot is a no-op" behavior far2l has. No other
@@ -74,6 +101,7 @@ func (d *bookmarksDialog) open() {
 
 	d.menu = vtui.NewVMenu(Msg("Bookmarks.Title"))
 	d.render()
+	d.menu.SetSelectPos(slot)
 
 	w, h := d.size()
 	x := (d.pf.lastW - w) / 2
@@ -158,7 +186,11 @@ func (d *bookmarksDialog) open() {
 		})
 	}
 
-	vtui.FrameManager.Push(&bookmarksFrame{VMenu: d.menu, bottomHint: Msg("Bookmarks.BottomHint")})
+	vtui.FrameManager.Push(&bookmarksFrame{
+		VMenu:      d.menu,
+		bottomHint: Msg("Bookmarks.BottomHint"),
+		onClose:    onClose,
+	})
 }
 
 // render rebuilds all ten rows in place, keeping the cursor where it was.

--- a/bookmarks_dialog.go
+++ b/bookmarks_dialog.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/unxed/vtinput"
@@ -92,6 +93,38 @@ func (d *bookmarksDialog) open() {
 		shift := e.ControlKeyState&vtinput.ShiftPressed != 0
 		ctrl := e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
 		alt := e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0
+
+		slot := d.slotAt(d.menu.SelectPos)
+
+		// Ins stores the panel's directory, Del clears the slot, F4 edits
+		// the path by hand. All three overwrite without asking, as far2l
+		// does, and each one hits the disk immediately.
+		if !ctrl && !shift && !alt {
+			switch e.VirtualKeyCode {
+			case vtinput.VK_INSERT:
+				d.saveCurrentDir(slot)
+				return true
+			case vtinput.VK_DELETE:
+				d.clearSlot(slot)
+				return true
+			case vtinput.VK_F4:
+				d.editPath(slot)
+				return true
+			}
+		}
+
+		// Shift+Up / Shift+Down swap the slot with its neighbour and take
+		// the cursor along, so it stays on the same bookmark.
+		if shift && !ctrl && !alt {
+			switch e.VirtualKeyCode {
+			case vtinput.VK_UP:
+				d.moveSlot(slot, -1)
+				return true
+			case vtinput.VK_DOWN:
+				d.moveSlot(slot, +1)
+				return true
+			}
+		}
 
 		// Keys the top frame declines fall through to vtui's own global
 		// handlers — F1 opens help, F9 activates the menu bar (which a
@@ -184,6 +217,100 @@ func (d *bookmarksDialog) size() (int, int) {
 		h = maxH
 	}
 	return w, h
+}
+
+// saveCurrentDir records the active panel's directory in the slot.
+func (d *bookmarksDialog) saveCurrentDir(slot int) {
+	fsp := d.pf.getActivePanel()
+	if fsp == nil || slot < 0 {
+		return
+	}
+	d.set.setCurrentDir(slot, fsp.vfs.GetPath())
+	d.persist()
+}
+
+// clearSlot empties the slot. No confirmation, matching far2l.
+func (d *bookmarksDialog) clearSlot(slot int) {
+	if slot < 0 {
+		return
+	}
+	d.set.deleteAtSlot(slot)
+	d.persist()
+}
+
+// editPath asks for a path and stores it in the slot. Empty input counts
+// as a cancel rather than "clear the slot" — that is what Del is for.
+func (d *bookmarksDialog) editPath(slot int) {
+	if slot < 0 || slot >= len(d.set) {
+		return
+	}
+	current := d.set[slot].Path
+	vtui.InputBox(Msg("Bookmarks.EditTitle"), Msg("Bookmarks.EditPrompt"), current, func(text string) {
+		text = strings.TrimSpace(text)
+		if text == "" {
+			return
+		}
+		d.set.setCurrentDir(slot, text)
+		d.persist()
+	})
+}
+
+// moveSlot swaps the slot with the neighbour delta rows away and moves
+// the cursor with it. A move off either end is a no-op.
+func (d *bookmarksDialog) moveSlot(slot, delta int) {
+	target := slot + delta
+	if slot < 0 || target < 0 || target >= len(d.set) {
+		return
+	}
+	d.set.swapSlots(slot, target)
+	if d.persist() {
+		d.menu.SetSelectPos(target)
+	}
+}
+
+// persist writes the table back and re-renders. On a write failure the
+// on-disk state wins: the in-memory copy is reloaded so the dialog never
+// shows changes that were not saved.
+func (d *bookmarksDialog) persist() bool {
+	err := SaveBookmarks(d.file, d.set)
+	if err != nil {
+		vtui.ShowMessage(Msg("Bookmarks.Title"),
+			fmt.Sprintf(Msg("Bookmarks.SaveError"), err),
+			[]string{"&Ok"})
+		if reloaded, lerr := LoadBookmarks(d.file); lerr == nil {
+			d.set = reloaded
+		}
+	}
+	d.render()
+	vtui.FrameManager.Redraw()
+	return err == nil
+}
+
+// deleteAtSlot clears the slot, leaving the rest of the table alone.
+func (s *BookmarkSet) deleteAtSlot(i int) {
+	if i < 0 || i >= len(s) {
+		return
+	}
+	s[i] = Bookmark{}
+}
+
+// swapSlots exchanges two slots. Out-of-range indices are ignored so
+// callers can pass "cursor ± 1" without bounds-checking first.
+func (s *BookmarkSet) swapSlots(a, b int) {
+	if a < 0 || a >= len(s) || b < 0 || b >= len(s) {
+		return
+	}
+	s[a], s[b] = s[b], s[a]
+}
+
+// setCurrentDir stores path in the slot and clears the plugin fields:
+// whoever edits a slot from the dialog is recording a filesystem
+// directory, not a plugin location.
+func (s *BookmarkSet) setCurrentDir(i int, path string) {
+	if i < 0 || i >= len(s) {
+		return
+	}
+	s[i] = Bookmark{Path: path}
 }
 
 // slotAt maps a menu row to its slot index, or -1 when the row is out of

--- a/bookmarks_dialog_test.go
+++ b/bookmarks_dialog_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSwapSlots_MovesItemAndPreservesOthers(t *testing.T) {
+	var set BookmarkSet
+	set[3] = Bookmark{Path: "/three"}
+	set[4] = Bookmark{Path: "/four"}
+	set[7] = Bookmark{Path: "/seven"}
+
+	set.swapSlots(3, 4)
+
+	if set[3].Path != "/four" || set[4].Path != "/three" {
+		t.Fatalf("swap failed: [3]=%q [4]=%q", set[3].Path, set[4].Path)
+	}
+	if set[7].Path != "/seven" {
+		t.Errorf("unrelated slot 7 changed: %q", set[7].Path)
+	}
+	for _, i := range []int{0, 1, 2, 5, 6, 8, 9} {
+		if !set[i].IsEmpty() {
+			t.Errorf("slot %d should still be empty: %#v", i, set[i])
+		}
+	}
+}
+
+func TestSwapSlots_ClampsWithinRange(t *testing.T) {
+	var set BookmarkSet
+	set[0] = Bookmark{Path: "/zero"}
+	set[9] = Bookmark{Path: "/nine"}
+	before := set
+
+	// Out-of-range indices are ignored, so the caller can pass
+	// "cursor ± 1" from either end without checking first.
+	set.swapSlots(0, -1)
+	set.swapSlots(9, 10)
+	set.swapSlots(-5, 100)
+
+	if set != before {
+		t.Fatalf("out-of-range swap mutated the table:\ngot  %#v\nwant %#v", set, before)
+	}
+}
+
+func TestDeleteAtSlot_ClearsCompletely(t *testing.T) {
+	var set BookmarkSet
+	set[2] = Bookmark{
+		Path:       "/some/path",
+		Plugin:     "NetRocks",
+		PluginData: "sftp://host",
+		PluginFile: "file.txt",
+	}
+
+	set.deleteAtSlot(2)
+
+	if !set[2].IsEmpty() {
+		t.Fatalf("slot not empty after delete: %#v", set[2])
+	}
+	if set[2] != (Bookmark{}) {
+		t.Errorf("delete left residue behind: %#v", set[2])
+	}
+}
+
+func TestSetCurrentDir_ReplacesPathAndWipesPluginFields(t *testing.T) {
+	var set BookmarkSet
+	set[5] = Bookmark{
+		Path:       "/old",
+		Plugin:     "NetRocks",
+		PluginData: "sftp://host",
+		PluginFile: "file.txt",
+	}
+
+	set.setCurrentDir(5, "/new/cwd")
+
+	want := Bookmark{Path: "/new/cwd"}
+	if set[5] != want {
+		t.Fatalf("got %#v, want %#v", set[5], want)
+	}
+}
+
+func TestNewBookmarksDialog_LoadFailureReturnsError(t *testing.T) {
+	// A directory where the INI is expected: opening succeeds, reading
+	// does not. The dialog must report that instead of crashing.
+	path := filepath.Join(t.TempDir(), "bookmarks.ini")
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	d, err := newBookmarksDialog(nil, path)
+	if err == nil {
+		t.Fatalf("expected an error for an unreadable file, got dialog %#v", d)
+	}
+	if d != nil {
+		t.Errorf("no dialog should be built on failure, got %#v", d)
+	}
+}
+
+func TestBookmarksDialog_RowTextShowsPathOrEmptyMarker(t *testing.T) {
+	d := &bookmarksDialog{}
+	d.set[6] = Bookmark{Path: "/mnt/d/work & play"}
+
+	filled := d.rowText(6)
+	if !strings.Contains(filled, "6") || !strings.Contains(filled, "/mnt/d/work && play") {
+		t.Errorf("row 6 = %q, want the slot digit and the escaped path", filled)
+	}
+	if empty := d.rowText(0); !strings.Contains(empty, Msg("Bookmarks.EmptySlot")) {
+		t.Errorf("row 0 = %q, want the empty marker", empty)
+	}
+}

--- a/bookmarks_test.go
+++ b/bookmarks_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func writeTempBookmarks(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "bookmarks.ini")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	return p
+}
+
+func TestLoadBookmarks_MissingFile(t *testing.T) {
+	set, err := LoadBookmarks(filepath.Join(t.TempDir(), "does_not_exist.ini"))
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if set != (BookmarkSet{}) {
+		t.Fatalf("expected empty set for missing file, got %#v", set)
+	}
+}
+
+// Real-world fixture: a verbatim slice of an actual far2l bookmarks.ini,
+// sections out of order and with gaps, exactly as far2l writes them.
+const realFar2lBookmarksFixture = `[9]
+Path=/home/sogonov/f4
+Plugin=
+PluginData=
+PluginFile=
+
+[6]
+Path=/mnt/d/!!wrkstk/reps/ssh/ski-analyzer
+Plugin=
+PluginData=
+PluginFile=
+
+[8]
+Path=/home/sogonov/scc
+Plugin=
+PluginData=
+PluginFile=
+`
+
+func TestLoadBookmarks_RealFar2lFile(t *testing.T) {
+	p := writeTempBookmarks(t, realFar2lBookmarksFixture)
+	set, err := LoadBookmarks(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	want := map[int]string{
+		6: "/mnt/d/!!wrkstk/reps/ssh/ski-analyzer",
+		8: "/home/sogonov/scc",
+		9: "/home/sogonov/f4",
+	}
+	for slot, path := range want {
+		if set[slot].Path != path {
+			t.Errorf("slot %d: got %q, want %q", slot, set[slot].Path, path)
+		}
+	}
+	for _, slot := range []int{0, 1, 2, 3, 4, 5, 7} {
+		if !set[slot].IsEmpty() {
+			t.Errorf("slot %d should be empty, got %#v", slot, set[slot])
+		}
+	}
+}
+
+func TestSaveBookmarks_OmitsEmptySlots(t *testing.T) {
+	var set BookmarkSet
+	set[4] = Bookmark{Path: "/tmp/only"}
+
+	p := filepath.Join(t.TempDir(), "out.ini")
+	if err := SaveBookmarks(p, set); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "[4]\n") {
+		t.Fatalf("expected section [4], got:\n%s", got)
+	}
+	for i := 0; i <= 9; i++ {
+		if i == 4 {
+			continue
+		}
+		if strings.Contains(got, fmt.Sprintf("[%d]", i)) {
+			t.Errorf("empty slot %d must not be written, got:\n%s", i, got)
+		}
+	}
+}
+
+func TestSaveBookmarks_AscendingOrder(t *testing.T) {
+	var set BookmarkSet
+	set[9] = Bookmark{Path: "/nine"}
+	set[6] = Bookmark{Path: "/six"}
+	set[8] = Bookmark{Path: "/eight"}
+
+	p := filepath.Join(t.TempDir(), "order.ini")
+	if err := SaveBookmarks(p, set); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, _ := os.ReadFile(p)
+	got := string(data)
+
+	i6, i8, i9 := strings.Index(got, "[6]"), strings.Index(got, "[8]"), strings.Index(got, "[9]")
+	if i6 < 0 || i8 < 0 || i9 < 0 {
+		t.Fatalf("missing sections, got:\n%s", got)
+	}
+	if !(i6 < i8 && i8 < i9) {
+		t.Fatalf("sections must be written in ascending order, got:\n%s", got)
+	}
+}
+
+func TestSaveBookmarks_AlphabeticalKeys(t *testing.T) {
+	var set BookmarkSet
+	set[1] = Bookmark{Path: "/home/user"}
+
+	p := filepath.Join(t.TempDir(), "keys.ini")
+	if err := SaveBookmarks(p, set); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, _ := os.ReadFile(p)
+	want := `[1]
+Path=/home/user
+Plugin=
+PluginData=
+PluginFile=
+`
+	if string(data) != want {
+		t.Fatalf("key order/content mismatch:\nGOT:\n%s\nWANT:\n%s", data, want)
+	}
+}
+
+func TestSaveBookmarks_TrailingNewlineAndBlankSeparator(t *testing.T) {
+	var set BookmarkSet
+	set[0] = Bookmark{Path: "/zero"}
+	set[3] = Bookmark{Path: "/three"}
+
+	p := filepath.Join(t.TempDir(), "sep.ini")
+	if err := SaveBookmarks(p, set); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	data, _ := os.ReadFile(p)
+	want := "[0]\nPath=/zero\nPlugin=\nPluginData=\nPluginFile=\n" +
+		"\n" +
+		"[3]\nPath=/three\nPlugin=\nPluginData=\nPluginFile=\n"
+	if string(data) != want {
+		t.Fatalf("byte layout mismatch:\nGOT:\n%q\nWANT:\n%q", data, want)
+	}
+	if !strings.HasSuffix(string(data), "\n") {
+		t.Errorf("file must end with a newline")
+	}
+}
+
+func TestBookmarks_RoundTrip(t *testing.T) {
+	var in BookmarkSet
+	in[0] = Bookmark{Path: "/home/sogonov/f4"}
+	in[2] = Bookmark{Path: "/mnt/d/!!wrkstk/данные"}
+	in[7] = Bookmark{
+		Path:       "/some/mount",
+		Plugin:     "NetRocks",
+		PluginData: "sftp://host/dir",
+		PluginFile: "file.txt",
+	}
+
+	p := filepath.Join(t.TempDir(), "rt.ini")
+	if err := SaveBookmarks(p, in); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	out, err := LoadBookmarks(p)
+	if err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if !reflect.DeepEqual(out, in) {
+		t.Fatalf("round-trip mismatch:\ngot  %#v\nwant %#v", out, in)
+	}
+}
+
+func TestBookmarks_SkipsForeignSections(t *testing.T) {
+	p := writeTempBookmarks(t, `[SomeOther]
+Path=/should/be/ignored
+
+[3]
+Path=/real/one
+Plugin=
+PluginData=
+PluginFile=
+
+[UserMenu/Whatever]
+Label=nope
+`)
+	set, err := LoadBookmarks(p)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if set[3].Path != "/real/one" {
+		t.Fatalf("slot 3: got %q, want %q", set[3].Path, "/real/one")
+	}
+	for i := range set {
+		if i == 3 {
+			continue
+		}
+		if !set[i].IsEmpty() {
+			t.Errorf("foreign section leaked into slot %d: %#v", i, set[i])
+		}
+	}
+}
+
+func TestBookmark_IsEmpty(t *testing.T) {
+	cases := []struct {
+		b    Bookmark
+		want bool
+	}{
+		{Bookmark{}, true},
+		{Bookmark{Path: "x"}, false},
+		{Bookmark{Plugin: "x"}, false},
+	}
+	for _, c := range cases {
+		if got := c.b.IsEmpty(); got != c.want {
+			t.Errorf("IsEmpty(%#v) = %v, want %v", c.b, got, c.want)
+		}
+	}
+}
+
+func TestBookmarksFilePath_HasExpectedSuffix(t *testing.T) {
+	p := BookmarksFilePath()
+	want := filepath.Join("f4", "settings", "bookmarks.ini")
+	if !strings.HasSuffix(p, want) {
+		t.Errorf("BookmarksFilePath()=%q, want suffix %q", p, want)
+	}
+}

--- a/bookmarks_test.go
+++ b/bookmarks_test.go
@@ -232,6 +232,34 @@ func TestBookmark_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestTruncPathLeft(t *testing.T) {
+	const long = "/mnt/d/!!wrkstk/reps/ssh/ski-analyzer"
+	cases := []struct {
+		path  string
+		width int
+		want  string
+	}{
+		{"/home/user", 40, "/home/user"}, // fits, untouched
+		{"/home/user", 10, "/home/user"}, // exactly fits
+		{long, 12, "…ki-analyzer"},       // ellipsis plus 11 cells of tail
+		{"/a/b/c", 1, "…"},
+		{"/a/b/c", 0, ""},
+	}
+	for _, c := range cases {
+		if got := truncPathLeft(c.path, c.width); got != c.want {
+			t.Errorf("truncPathLeft(%q, %d) = %q, want %q", c.path, c.width, got, c.want)
+		}
+	}
+	// The tail is what identifies a path, so it must survive the cut.
+	got := truncPathLeft(long, 20)
+	if !strings.HasPrefix(got, "…") || !strings.HasSuffix(got, "ski-analyzer") {
+		t.Errorf("truncPathLeft(%q, 20) = %q, want an ellipsis plus the tail", long, got)
+	}
+	if w := len([]rune(got)); w > 20 {
+		t.Errorf("truncPathLeft returned %d cells, want at most 20: %q", w, got)
+	}
+}
+
 func TestBookmarksFilePath_HasExpectedSuffix(t *testing.T) {
 	p := BookmarksFilePath()
 	want := filepath.Join("f4", "settings", "bookmarks.ini")

--- a/commands.go
+++ b/commands.go
@@ -43,4 +43,9 @@ const (
 	CmConfirmationsSettings
 	CmPlugins
 	CmUpdateSettings
+	CmBookmarks
+	// CmBookmarkEmptySlot is never emitted: the bookmarks dialog tags its
+	// empty rows with it and keeps it in FrameManager.DisabledCommands so
+	// vtui renders them dimmed and ignores Enter on them.
+	CmBookmarkEmptySlot
 )

--- a/lang.go
+++ b/lang.go
@@ -119,6 +119,9 @@ var Lng = map[string]string{
 	"Bookmarks.EmptySlot":  "<empty>",
 	"Bookmarks.BottomHint": " Del Ins F4 Shift+Up Shift+Down ",
 	"Bookmarks.LoadError":  "Failed to load bookmarks:\n%v",
+	"Bookmarks.SaveError":  "Failed to save bookmarks:\n%v",
+	"Bookmarks.EditTitle":  " Edit bookmark path ",
+	"Bookmarks.EditPrompt": "&Path:",
 
 	// KeyBar Normal
 	"KeyBar.F1":  "Help",

--- a/lang.go
+++ b/lang.go
@@ -69,6 +69,7 @@ var Lng = map[string]string{
 	"Menu.Left.Medium":             "Medium",
 	"Menu.Left.Detailed":           "Detailed",
 	"Menu.Commands.FindFile":       "Find file",
+	"Menu.Commands.Bookmarks":      "Bookmarks",
 	"Menu.SortName":                "Name",
 	"Menu.SortExt":                 "Extension",
 	"Menu.SortTime":                "Time",
@@ -110,6 +111,14 @@ var Lng = map[string]string{
 	"UserMenu.LocalMenuTitle":      "Local menu",
 	"UserMenu.MainMenuTitle":       "Main menu",
 	"UserMenu.MainMenuFAR":         "FAR",
+	// "RCtrl" and "Ctrl+Alt" are English keyboard convention; a
+	// translation may want to spell them out differently, so the whole
+	// row prefix is localizable rather than built in code.
+	"Bookmarks.Title":      " Bookmarks ",
+	"Bookmarks.RowPrefix":  "[RCtrl | Ctrl+Alt] +",
+	"Bookmarks.EmptySlot":  "<empty>",
+	"Bookmarks.BottomHint": " Del Ins F4 Shift+Up Shift+Down ",
+	"Bookmarks.LoadError":  "Failed to load bookmarks:\n%v",
 
 	// KeyBar Normal
 	"KeyBar.F1":  "Help",

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2141,6 +2141,13 @@ func (pf *PanelsFrame) showPluginMenu() {
 }
 
 func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
+	pf.showDriveMenuAt(panelIdx, 0)
+}
+
+// showDriveMenuAt opens the drive menu with the cursor on selectPos. The
+// bookmark keys reopen the menu at the row they acted on, the way far2l
+// loops ChangeDiskMenu around its own Pos (panels/panel.cpp:168).
+func (pf *PanelsFrame) showDriveMenuAt(panelIdx, selectPos int) {
 	menu := vtui.NewVMenu(" Drive ")
 
 	usedHotkeys := make(map[rune]bool)
@@ -2185,6 +2192,7 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 	// the same menu (panels/panel.cpp, AddBookmarkItems) with the slot
 	// digit as the hotkey, so Alt+F1 followed by 6 lands on slot 6.
 	// Unassigned slots are left out.
+	bookmarkRows := map[int]int{} // menu row -> slot, for the keys below
 	if set, err := LoadBookmarks(BookmarksFilePath()); err == nil {
 		firstBookmark := true
 		for i := range set {
@@ -2197,6 +2205,7 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 			}
 			path := set[i].Path
 			usedHotkeys[rune('0'+i)] = true
+			bookmarkRows[menu.GetItemCount()] = i
 			menu.AddItem(vtui.MenuItem{
 				Text: fmt.Sprintf("&%d  %s", i, escapeAmpersand(truncPathLeft(path, 64))),
 				UserData: func(fsp *FileSystemPanel) {
@@ -2242,6 +2251,39 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 
 	// Обработка физических клавиш / и ~ (layout-independent)
 	menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
+		// far2l binds three keys on the bookmark rows of this menu
+		// (panels/panel.cpp:544-600): Ins opens the bookmarks dialog, F4
+		// opens it on the slot under the cursor, Del clears that slot.
+		// The menu comes back afterwards, as it does there. On other rows
+		// F4 and Del are left alone — far2l uses them for mount hotkeys
+		// and unmounting, neither of which f4 has.
+		if e.KeyDown && e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed|
+			vtinput.LeftAltPressed|vtinput.RightAltPressed|vtinput.ShiftPressed) == 0 {
+			pos := menu.SelectPos
+			slot, onBookmark := bookmarkRows[pos]
+			reopen := func() { pf.showDriveMenuAt(panelIdx, pos) }
+
+			switch e.VirtualKeyCode {
+			case vtinput.VK_INSERT:
+				// far2l opens the dialog from any row here, not just a
+				// bookmark one, and always at the first slot.
+				menu.Close()
+				vtui.FrameManager.PostTask(func() { ShowBookmarksDialogAt(pf, 0, reopen) })
+				return true
+			case vtinput.VK_F4:
+				if onBookmark {
+					menu.Close()
+					vtui.FrameManager.PostTask(func() { ShowBookmarksDialogAt(pf, slot, reopen) })
+					return true
+				}
+			case vtinput.VK_DELETE:
+				if onBookmark {
+					pf.clearBookmarkSlot(slot, menu, reopen)
+					return true
+				}
+			}
+		}
+
 		var targetIndex = -1
 		if e.VirtualKeyCode == vtinput.VK_OEM_2 { // Клавиша /?
 			for i, item := range menu.Items {
@@ -2268,7 +2310,7 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 		return false
 	}
 
-	menu.SetSelectPos(0)
+	menu.SetSelectPos(selectPos)
 
 	// Bookmark rows carry paths, so the box no longer fits a fixed width.
 	w, h := 26, menu.GetItemCount()+2
@@ -2313,6 +2355,26 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 		}
 	}
 	vtui.FrameManager.Push(menu)
+}
+
+// clearBookmarkSlot empties one slot straight from the drive menu, which
+// is what Del does there in far2l (panels/panel.cpp:594), then reopens
+// the menu so the row is gone. The table is re-read first: another
+// instance may have rewritten the file since the menu was built.
+func (pf *PanelsFrame) clearBookmarkSlot(slot int, menu *vtui.VMenu, reopen func()) {
+	file := BookmarksFilePath()
+	set, err := LoadBookmarks(file)
+	if err != nil {
+		vtui.DebugLog("BOOKMARKS: load %q failed: %v", file, err)
+		return
+	}
+	set.deleteAtSlot(slot)
+	if err := SaveBookmarks(file, set); err != nil {
+		vtui.DebugLog("BOOKMARKS: save %q failed: %v", file, err)
+		return
+	}
+	menu.Close()
+	vtui.FrameManager.PostTask(reopen)
 }
 
 func (pf *PanelsFrame) switchToVFS(fsp *FileSystemPanel, newVFS vfs.VFS) {

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -807,6 +807,55 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// Folder bookmarks, far2l's hotkey scheme: [RightCtrl | Ctrl+Alt] + N
+	// jumps to slot N, Ctrl+Shift+N stores the current directory there, and
+	// [RightCtrl | Ctrl+Alt] + ~ goes home. The ctrl local above merges both
+	// Ctrl keys, but here the side matters, so the flags are read directly.
+	// Terminals that cannot tell the two Ctrls apart report LeftCtrlPressed
+	// for either one — that is what the Ctrl+Alt alias (far2l offers the
+	// same pair) is for.
+	if e.KeyDown {
+		rctrl := (e.ControlKeyState & vtinput.RightCtrlPressed) != 0
+		lctrl := (e.ControlKeyState & vtinput.LeftCtrlPressed) != 0
+		isBookmarkGoto := (rctrl && !shift && !alt) || ((lctrl || rctrl) && alt && !shift)
+		isBookmarkSave := (lctrl || rctrl) && shift && !alt
+
+		if e.VirtualKeyCode >= vtinput.VK_0 && e.VirtualKeyCode <= vtinput.VK_9 && (isBookmarkGoto || isBookmarkSave) {
+			slot := int(e.VirtualKeyCode - vtinput.VK_0)
+			file := BookmarksFilePath()
+			// Always read fresh: another f4 or far2l instance may have
+			// rewritten the file since we last looked at it.
+			set, err := LoadBookmarks(file)
+			if err != nil {
+				vtui.DebugLog("BOOKMARKS: load %q failed: %v", file, err)
+				return true
+			}
+			if isBookmarkSave {
+				if fsp := pf.getActivePanel(); fsp != nil {
+					set[slot] = Bookmark{Path: fsp.vfs.GetPath()}
+					if err := SaveBookmarks(file, set); err != nil {
+						vtui.DebugLog("BOOKMARKS: save %q failed: %v", file, err)
+					}
+				}
+			} else if !set[slot].IsEmpty() {
+				// An unset slot is a silent no-op, as in far2l.
+				if fsp := pf.getActivePanel(); fsp != nil {
+					pf.NavigateToPath(fsp, set[slot].Path)
+				}
+			}
+			return true
+		}
+
+		if e.VirtualKeyCode == vtinput.VK_OEM_3 && isBookmarkGoto {
+			if home, _ := os.UserHomeDir(); home != "" {
+				if fsp := pf.getActivePanel(); fsp != nil {
+					pf.NavigateToPath(fsp, home)
+				}
+			}
+			return true
+		}
+	}
+
 	// Ctrl+A: Attributes
 	if e.VirtualKeyCode == vtinput.VK_A && ctrl && !alt && !shift && e.KeyDown {
 		actionFileAttributes(pf)

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -149,6 +149,7 @@ func NewPanelsFrame() *PanelsFrame {
 		}},
 		{Label: "&" + Msg("Menu.Commands"), SubItems: []vtui.MenuItem{
 			{Text: "&" + Msg("Menu.Commands.FindFile"), Shortcut: "Alt+F7", Command: CmFindFile},
+			{Text: "&" + Msg("Menu.Commands.Bookmarks"), Command: CmBookmarks},
 		}},
 		// Uncomment to test crash logging
 		//{Label: "&" + Msg("Menu.Options"), SubItems: []vtui.MenuItem{{Text: "Placeholder"}}},
@@ -1491,6 +1492,9 @@ func (pf *PanelsFrame) HandleCommand(cmd int, args any) bool {
 		return true
 	case CmFindFile:
 		actionFindFile(pf)
+		return true
+	case CmBookmarks:
+		ShowBookmarksDialog(pf)
 		return true
 	case CmPanelSettings:
 		actionPanelSettings(pf)

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2181,7 +2181,32 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 		}})
 	}
 
-	// 3. Plugins & custom drives
+	// 3. Folder bookmarks. far2l lists the assigned slots right here in
+	// the same menu (panels/panel.cpp, AddBookmarkItems) with the slot
+	// digit as the hotkey, so Alt+F1 followed by 6 lands on slot 6.
+	// Unassigned slots are left out.
+	if set, err := LoadBookmarks(BookmarksFilePath()); err == nil {
+		firstBookmark := true
+		for i := range set {
+			if set[i].IsEmpty() {
+				continue
+			}
+			if firstBookmark {
+				menu.AddSeparator()
+				firstBookmark = false
+			}
+			path := set[i].Path
+			usedHotkeys[rune('0'+i)] = true
+			menu.AddItem(vtui.MenuItem{
+				Text: fmt.Sprintf("&%d  %s", i, escapeAmpersand(truncPathLeft(path, 64))),
+				UserData: func(fsp *FileSystemPanel) {
+					pf.NavigateToPath(fsp, path)
+				},
+			})
+		}
+	}
+
+	// 4. Plugins & custom drives
 	if len(DriveRegistry) > 0 {
 		menu.AddSeparator()
 		for _, drv := range DriveRegistry {
@@ -2245,16 +2270,34 @@ func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
 
 	menu.SetSelectPos(0)
 
+	// Bookmark rows carry paths, so the box no longer fits a fixed width.
 	w, h := 26, menu.GetItemCount()+2
-	x := (pf.lastW - w) / 2
+	for _, it := range menu.Items {
+		clean, _, _ := vtui.ParseAmpersandString(it.Text)
+		if iw := runewidth.StringWidth(clean) + 6; iw > w {
+			w = iw
+		}
+	}
+	if pf.lastW > 0 && w > pf.lastW-4 {
+		w = pf.lastW - 4
+	}
+	if pf.lastH > 0 && h > pf.lastH-2 {
+		h = pf.lastH - 2
+	}
+
 	y := (pf.lastH - h) / 2
-	if panelIdx == 0 {
-		x = pf.lastW/4 - w/2
-	} else {
+	x := pf.lastW/4 - w/2
+	if panelIdx != 0 {
 		x = pf.lastW*3/4 - w/2
+	}
+	if x+w > pf.lastW {
+		x = pf.lastW - w
 	}
 	if x < 0 {
 		x = 0
+	}
+	if y < 0 {
+		y = 0
 	}
 	menu.SetPosition(x, y, x+w-1, y+h-1)
 

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -210,6 +210,150 @@ func TestPanelsFrame_DriveMenuListsAssignedBookmarks(t *testing.T) {
 	}
 }
 
+// settleFrames does what the render loop does between keystrokes: run the
+// tasks frames posted, then drop the ones that closed themselves.
+func settleFrames(t *testing.T) {
+	t.Helper()
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			continue
+		case <-time.After(200 * time.Millisecond):
+		}
+		break
+	}
+	for _, f := range append([]vtui.Frame(nil), openFrames()...) {
+		if f.IsDone() {
+			vtui.FrameManager.RemoveFrame(f)
+		}
+	}
+}
+
+func openFrames() []vtui.Frame {
+	return vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx].Frames
+}
+
+// findDriveMenu returns the top-most drive menu on the stack. Unrelated
+// tasks (the update check, for one) can push frames above it.
+func findDriveMenu(t *testing.T) *vtui.VMenu {
+	t.Helper()
+	frames := openFrames()
+	for i := len(frames) - 1; i >= 0; i-- {
+		if m, ok := frames[i].(*vtui.VMenu); ok && m.GetTitle() == " Drive " {
+			return m
+		}
+	}
+	t.Fatalf("drive menu not on the frame stack: %#v", frames)
+	return nil
+}
+
+func findBookmarksDialog(t *testing.T) *bookmarksFrame {
+	t.Helper()
+	frames := openFrames()
+	for i := len(frames) - 1; i >= 0; i-- {
+		if d, ok := frames[i].(*bookmarksFrame); ok {
+			return d
+		}
+	}
+	t.Fatalf("bookmarks dialog not on the frame stack: %#v", frames)
+	return nil
+}
+
+func bookmarkRow(t *testing.T, menu *vtui.VMenu) int {
+	t.Helper()
+	for i, it := range menu.Items {
+		if strings.HasPrefix(it.Text, "&6  ") {
+			return i
+		}
+	}
+	t.Fatalf("bookmark row missing: %#v", menu.Items)
+	return -1
+}
+
+func TestPanelsFrame_DriveMenuBookmarkKeys(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ini := filepath.Join(cfg, "f4", "settings", "bookmarks.ini")
+	target := t.TempDir()
+	write := func() {
+		if err := os.WriteFile(ini,
+			[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write()
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+
+	press := func(menu *vtui.VMenu, vk uint16) {
+		menu.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk,
+		})
+	}
+
+	// F4 on the bookmark row opens the dialog on that slot, and closing
+	// the dialog brings the drive menu back.
+	pf.showDriveMenu(1)
+	menu := findDriveMenu(t)
+	menu.SetSelectPos(bookmarkRow(t, menu))
+	press(menu, vtinput.VK_F4)
+	settleFrames(t)
+	dlg := findBookmarksDialog(t)
+	if dlg.SelectPos != 6 {
+		t.Errorf("dialog opened on slot %d, want 6", dlg.SelectPos)
+	}
+	press(dlg.VMenu, vtinput.VK_ESCAPE)
+	settleFrames(t)
+	if !dlg.IsDone() {
+		t.Fatal("Esc did not close the dialog")
+	}
+	settleFrames(t)
+	menu = findDriveMenu(t) // reopened by the dialog's close hook
+	if menu.IsDone() {
+		t.Fatal("drive menu did not come back after the dialog closed")
+	}
+
+	// Ins opens the dialog from any row, always at the first slot.
+	menu.SetSelectPos(0)
+	press(menu, vtinput.VK_INSERT)
+	settleFrames(t)
+	dlg = findBookmarksDialog(t)
+	if dlg.SelectPos != 0 {
+		t.Errorf("Ins opened the dialog on slot %d, want 0", dlg.SelectPos)
+	}
+	press(dlg.VMenu, vtinput.VK_ESCAPE)
+	settleFrames(t)
+	dlg.IsDone()
+	settleFrames(t)
+
+	// Del clears the slot, and the menu that comes back no longer lists it.
+	menu = findDriveMenu(t)
+	menu.SetSelectPos(bookmarkRow(t, menu))
+	press(menu, vtinput.VK_DELETE)
+	settleFrames(t)
+	data, err := os.ReadFile(ini)
+	if err != nil {
+		t.Fatalf("read ini: %v", err)
+	}
+	if strings.Contains(string(data), "[6]") {
+		t.Errorf("Del did not clear the slot on disk:\n%s", data)
+	}
+	menu = findDriveMenu(t)
+	for _, it := range menu.Items {
+		if strings.HasPrefix(it.Text, "&6  ") {
+			t.Errorf("cleared bookmark still listed: %q", it.Text)
+		}
+	}
+}
+
 func TestPanelsFrame_GetActivePTY(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -152,6 +152,64 @@ func TestPanelsFrame_SelectionByMask(t *testing.T) {
 		t.Error("Selection dialog was not shown")
 	}
 }
+func TestPanelsFrame_DriveMenuListsAssignedBookmarks(t *testing.T) {
+	cfg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", cfg)
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	if err := os.WriteFile(filepath.Join(cfg, "f4", "settings", "bookmarks.ini"),
+		[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+
+	pf.showDriveMenu(1)
+	menu, ok := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
+	if !ok {
+		t.Fatalf("drive menu not shown, top frame is %T", vtui.FrameManager.GetTopFrame())
+	}
+
+	row := -1
+	for i, it := range menu.Items {
+		if strings.HasPrefix(it.Text, "&6  ") {
+			row = i
+		}
+		for _, empty := range []string{"&0  ", "&1  ", "&9  "} {
+			if strings.HasPrefix(it.Text, empty) {
+				t.Errorf("unassigned slot listed: %q", it.Text)
+			}
+		}
+	}
+	if row == -1 {
+		t.Fatalf("assigned bookmark missing from the drive menu: %#v", menu.Items)
+	}
+	// Long paths are cut from the front, so only the tail is guaranteed.
+	if !strings.HasSuffix(menu.Items[row].Text, filepath.Base(target)) {
+		t.Errorf("row %q should show the bookmarked path", menu.Items[row].Text)
+	}
+	if !menu.Items[row-1].Separator {
+		t.Errorf("bookmarks should start after a separator, got %#v", menu.Items[row-1])
+	}
+
+	// Pressing the slot digit moves the panel the menu was opened for —
+	// the whole point of the entry: Alt+F2 then 6.
+	fsp := pf.panels[1].(*FileSystemPanel)
+	menu.SetSelectPos(0)
+	menu.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_6, Char: '6',
+	})
+	if got := fsp.vfs.GetPath(); got != target {
+		t.Errorf("panel at %q, want %q", got, target)
+	}
+}
+
 func TestPanelsFrame_GetActivePTY(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()


### PR DESCRIPTION
## Licensing note (up front)

This is a **clean-room re-implementation in Go**. far2l is GPL, f4 is BSD-3, and everything ported here is treated as a **UX and on-disk-format specification** — the ten-slot table, the `.ini` schema, the meaning of the keys (Ins/Del/F4/Shift+Up/Down inside the dialog, RCtrl+N and Ctrl+Shift+N on the panel, Alt+F1/F2 showing bookmarks as drive-menu entries), the direction of path truncation — not as code expression. Concrete references for cross-verification:

* `far2l/src/bookmarks/Bookmarks.cpp` — Set/Get/Clear over the flat INI.
* `far2l/src/bookmarks/BookmarksMenu.cpp` — the dialog layout and its key bindings.
* `far2l/src/panels/panel.cpp:544-600` — Ins/F4/Del on bookmark rows of the drive menu (AddBookmarkItems).
* `far2l/src/panels/panel.cpp:1971` `SaveShortcutFolder` and `panel.cpp:2019` `ExecShortcutFolder` — panel hotkey handlers for RCtrl+N / Ctrl+Shift+N.
* `far2l/mix/StrCells.cpp` `StrCellsTruncateLeft` — the leading-ellipsis truncation used for long paths in the drive menu.

No source was copied. Function and type names, control-flow, error handling, tests and file organization are Go-idiomatic and independent of the C++ layout. Where a comment names a far2l file/line, it's for a reviewer to cross-check behavior, not to teach the reader to think in far2l's structure.

## Summary

Port far2l's folder-bookmark system to f4: ten numbered slots, addressed by digit hotkeys, with a management dialog, integrated into the drive menu. On-disk file is bit-for-bit compatible with far2l's `~/.config/far2l/settings/bookmarks.ini`, so a config authored in either tool works in the other without conversion.

## What's in this PR

Six commits, small each; the split is meant to make review painless.

### Model & persistence

* **`bcbf034`** — `Bookmark` and `BookmarkSet` types, `LoadBookmarks`/`SaveBookmarks` I/O in `bookmarks.go`, with 10 tests covering the file-format edge cases (empty slot, out-of-order sections, foreign sections, ascending output, alphabetical keys, plugin fields round-tripped).

### Panel hotkeys

* **`8557685`** — `RightCtrl+N` / `Ctrl+Alt+N` navigates the active panel to slot N, `Ctrl+Shift+N` stores the panel's current directory there, `RightCtrl+~` / `Ctrl+Alt+~` goes home. Ctrl+Alt is the standard alias for terminals that collapse both Ctrl keys onto one flag (far2l offers the same pair in its own dialog title `[ПравыйCtrl | Ctrl+Alt] + N`).

### Management dialog (F9 → Commands → Bookmarks)

* **`2b96c19`** — scaffold: ten-row list, `Enter` on a populated row navigates. Empty rows carry a permanently-disabled command so vtui dims them and swallows Enter on them, which matches far2l's silent no-op on unassigned slots. Wrapping frame follows the same shape the F2 user menu uses to draw a bottom-border hint, so vtui itself stays untouched.
* **`6e9b53a`** — mutating keys: `Ins` (save cwd), `Del` (clear), `F4` (edit path in an input box), `Shift+Up` / `Shift+Down` (swap with neighbour, cursor follows the moved bookmark). Every mutation goes straight to disk; on a save failure the table is re-read so the dialog never displays a change that wasn't saved. Empty input in F4 counts as cancel — `Del` is the way to clear a slot.

### Drive menu integration (Alt+F1 / Alt+F2)

* **`1940bba`** — the drive menu now lists assigned bookmark slots between the platform drives and the plugin drives, with the slot digit as the hotkey. Paths longer than 64 cells are truncated from the front with an ellipsis, matching far2l's `StrCellsTruncateLeft`. The menu box width now follows the widest row instead of a fixed 26 columns, clamped to the console.
* **`4b6b54d`** — on bookmark rows in that menu: `Ins` opens the bookmarks dialog, `F4` opens it positioned on the slot under the cursor, `Del` clears that slot. In every case the drive menu comes back afterwards — far2l loops around the position it returns, and we do the same via an `IsDone`-driven close callback on the dialog's frame wrapper (vtui has no `OnClose` on `VMenu`, so we hook the point where the frame manager drops the frame). On non-bookmark rows F4 and Del are left alone — far2l uses them for mount hotkeys and unmounting, neither of which f4 has.

## What's not in this PR

* Plugin bookmarks (`Plugin` / `PluginData` / `PluginFile` fields). The I/O layer round-trips them so a config with plugin slots authored in far2l survives a save-back through f4 unchanged, but the dialog only lets you edit filesystem paths, and clearing/editing a slot wipes the plugin fields (as per the spec).
* Recently-visited-folders history — that's a separate Far Manager feature.
* Bulk import/export via a text file — the on-disk INI is already the text file.
* `Ctrl+A` alias for `F4` in the drive menu — far2l has it, we don't.

## Test plan

- [x] `go test ./...` passes.

### Automated

Model/IO and dialog-state mutations are covered by unit tests in `bookmarks_test.go`, `bookmarks_dialog_test.go`, and `panels_frame_test.go` (drive-menu listing + Ins/F4/Del wiring). Panel-frame-driven UI is smoke-tested by hand — same precedent as the F2 user menu port in #118.

### Manual

Tested on WSL Ubuntu 22.04.1, host Windows 11, in three terminal emulators (wezterm, Windows Terminal, default WSL console). Steps below reproduce independently of the tester's own `bookmarks.ini`:

1. Start with no `~/.config/f4/settings/bookmarks.ini` at all (or back up any existing one). Step 2 creates the file, parent directories included.
2. In some directory D1, `Ctrl+Shift+3` — writes `[3]` with `Path=D1` to a freshly-created file. Verified with `cat`.
3. `cd` (via panel) to another directory D2. `Ctrl+Shift+7` — writes `[7]`.
4. `RightCtrl+3` → panel navigates back to D1.
5. `Ctrl+Alt+3` — same as `RightCtrl+3`; alias for terminals that collapse both Ctrls onto one flag.
6. `RightCtrl+~` (or `Ctrl+Alt+~`) — panel navigates to `$HOME`.
7. `RightCtrl+5` — silent no-op (empty slot).
8. F9 → Commands → Bookmarks — dialog opens with 10 rows. Slots 3 and 7 show their paths; the rest show `<empty>`.
9. Cursor to slot 5 (empty), `Ins` — slot 5 now points at wherever the active panel is. Cursor to slot 5, `F4`, type an arbitrary path, OK — slot 5 updated. Cursor to slot 5, `F4`, empty out the input, OK — the slot is unchanged (empty input = cancel).
10. `Del` on slot 5 — cleared, shows `<empty>` again.
11. `Shift+Down` on slot 3 — its contents swap into slot 4, cursor follows.
12. `Alt+F1` → left-panel drive menu. Populated bookmark slots appear as their own rows, each with the digit as its `&`-hotkey. Pressing `4` (i.e. what was slot 3 before the swap) — panel navigates and menu closes.
13. `Alt+F1` again → cursor to a bookmark row → `F4` — bookmarks dialog opens with the cursor on that slot. Close the dialog (Esc) — drive menu comes back.
14. Same, `Del` on a bookmark row of the drive menu — slot cleared, drive menu refreshes without that row.
15. In parallel: opening `bookmarks.ini` in a text editor or another Far-family app between steps confirms every mutation hits disk immediately.

### Terminal-specific notes

- **Windows Terminal** intercepts `Ctrl+Alt+N` (tab switch), so use `RightCtrl+N` there. Same limitation exists in bare far2l on WT.
- **wezterm** garbled mouse events in the built-in terminal until unxed/vtinput#5 (Win32-wrap unwrap) is merged; f4-only bookmarks-keyboard is unaffected by that.
- **Default WSL console** — everything works, no regressions vs. main.
