### PR TITLE
Fix path to crash directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -343,7 +343,7 @@ func SetupUI() {
 	}
 
 	// Прокидываем путь портативного конфига в изолированные пакеты vtui и vfs
-	vtui.CrashDirBase = configDir
+	vtui.CrashDirBase = filepath.Dir(configDir)
 	vfs.CustomConfigDir = configDir
 
 	// Load legacy color overrides if they exist


### PR DESCRIPTION
под Win краши писались сюда
C:\Users\Zeroes\AppData\Roaming\f4\f4\crashes\

теперь будут сюда:
C:\Users\Zeroes\AppData\Roaming\f4\crashes\ 
