### PR TITLE
fix: reposition panels/terminal when toggling menu bar or Ctrl+O

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1657,6 +1657,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.FileOpPathDisplay = comboPath.Menu.SelectPos
 		SaveConfig()
 		dlg.Close()
+		pf.ResizeConsole(pf.lastW, pf.lastH)
 		pf.RefreshAll()
 	}
 

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -120,8 +120,9 @@ type PanelsFrame struct {
 	termView   *TerminalView
 	parser     *AnsiParser
 
-	lastAlt  bool
-	lastBusy bool
+	lastAlt          bool
+	lastBusy         bool
+	lastShowPanels   bool
 
 	lastAutoRefresh time.Time
 	lastKey         rune
@@ -141,6 +142,7 @@ func NewPanelsFrame() *PanelsFrame {
 	pf.SetHelp("Panels")
 	pf.showKeyBar = true
 	pf.showPanels = true
+	pf.lastShowPanels = true
 	pf.showLeftPanel = true
 	pf.showRightPanel = true
 
@@ -533,9 +535,10 @@ func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 	isBusy := pf.isPtyBusy()
 
 	// 1. Dynamic Layout Adjustment
-	if pf.termView.UseAltScreen != pf.lastAlt || isBusy != pf.lastBusy {
+	if pf.termView.UseAltScreen != pf.lastAlt || isBusy != pf.lastBusy || pf.showPanels != pf.lastShowPanels {
 		pf.lastAlt = pf.termView.UseAltScreen
 		pf.lastBusy = isBusy
+		pf.lastShowPanels = pf.showPanels
 		pf.ResizeConsole(pf.lastW, pf.lastH)
 	}
 


### PR DESCRIPTION
Close: https://github.com/unxed/f4/issues/222