### PR TITLE
Add Ctrl+arrow panel resize hotkeys (far2l parity)

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -638,8 +638,10 @@ func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 	}
 
 	if pf.showPanels {
-		// Если одна из панелей скрыта — показываем терминал под видимой панелью
-		if !pf.showLeftPanel || !pf.showRightPanel {
+		// Показываем терминал под панелями если: одна из панелей скрыта
+		// (терминал занимает освободившуюся половину), либо панели уменьшены
+		// по высоте (Ctrl+Up) и терминал должен просвечивать снизу.
+		if !pf.showLeftPanel || !pf.showRightPanel || pf.heightDecrement > 0 {
 			pf.termView.SetVisible(true)
 			pf.termView.Show(scr)
 		} else {
@@ -912,9 +914,11 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	// deliberate follow-up.
 	if (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) && ctrl && !alt && !shift && e.KeyDown {
 		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
-			delta := 1 // Down shrinks panels (grows terminal above)
+			// Ctrl+Up moves the panels' bottom edge up (shrinks them,
+			// exposes more terminal). Ctrl+Down does the reverse.
+			delta := -1
 			if e.VirtualKeyCode == vtinput.VK_UP {
-				delta = -1
+				delta = 1
 			}
 			next := pf.heightDecrement + delta
 			maxHD := pf.lastH - 7

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -113,6 +113,14 @@ type PanelsFrame struct {
 	lastW          int
 	lastH          int
 
+	// Panel geometry offsets, adjusted by Ctrl+Left/Right (width) and
+	// Ctrl+Up/Down (height). Names and semantics match far2l's [Layout]:
+	// widthDecrement > 0 grows the right panel, < 0 grows the left;
+	// heightDecrement >= 0 shrinks BOTH panels from the bottom, growing
+	// the terminal area above them.
+	widthDecrement  int
+	heightDecrement int
+
 	// Integrated Terminal
 	pty        PtyBackend
 	remotePtys map[vfs.VFS]PtyBackend
@@ -497,17 +505,40 @@ func (pf *PanelsFrame) ResizeConsole(w, h int) {
 		pf.termView.Resize(w, termH)
 	}
 
-	// 2. Panel Area: Leaves one additional line for the f4 CommandLine
-	panelY2 := h - 2
+	// 2. Panel Area: Leaves one additional line for the f4 CommandLine.
+	// heightDecrement shrinks the panel area from the bottom; the freed
+	// rows go to the terminal area above (matches far2l's LeftHeightDecrement/
+	// RightHeightDecrement, applied symmetrically here).
+	hd := pf.heightDecrement
+	if maxHD := h - 7; maxHD > 0 && hd > maxHD {
+		hd = maxHD
+	}
+	if hd < 0 {
+		hd = 0
+	}
+	panelY2 := h - 2 - hd
 	if pf.showKeyBar {
-		panelY2 = h - 3
+		panelY2 = h - 3 - hd
 	}
 	panelH := panelY2 - contentY1 + 1
 	if panelH < 0 {
 		panelH = 0
 	}
 
-	leftW := w / 2
+	// widthDecrement shifts the split between the two panels: positive
+	// grows the right panel (as in far2l).
+	wd := pf.widthDecrement
+	if maxWD := (w / 2) - 10; maxWD > 0 {
+		if wd > maxWD {
+			wd = maxWD
+		}
+		if wd < -maxWD {
+			wd = -maxWD
+		}
+	} else {
+		wd = 0
+	}
+	leftW := w/2 - wd
 	rightW := w - leftW
 
 	if pf.panels[0] == nil {
@@ -851,10 +882,47 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
-	// Ctrl+Left / Ctrl+Right - Navigate words in command line even if panels are active (Far compatible)
+	// Ctrl+Left / Ctrl+Right — panel width resize when panels are visible
+	// and the command line is empty (far2l's FilePanels::ProcessKey gate).
+	// With a non-empty cmdline, fall through to word navigation instead.
 	if (e.VirtualKeyCode == vtinput.VK_LEFT || e.VirtualKeyCode == vtinput.VK_RIGHT) && ctrl && !alt && !shift && e.KeyDown {
+		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
+			delta := 1
+			if e.VirtualKeyCode == vtinput.VK_LEFT {
+				delta = -1
+			}
+			next := pf.widthDecrement + delta
+			if maxWD := (pf.lastW / 2) - 10; maxWD > 0 && next <= maxWD && next >= -maxWD {
+				pf.widthDecrement = next
+				pf.ResizeConsole(pf.lastW, pf.lastH)
+				vtui.FrameManager.HardRefresh()
+			}
+			return true
+		}
 		if pf.cmdLine.IsVisible() {
 			pf.cmdLine.ProcessKey(e)
+			return true
+		}
+	}
+
+	// Ctrl+Up / Ctrl+Down — grow/shrink the panel-area vs terminal-area
+	// split. In far2l this drives both LeftHeightDecrement and
+	// RightHeightDecrement symmetrically; we keep them merged into a
+	// single heightDecrement field. Asymmetric Ctrl+Shift+Up/Down is a
+	// deliberate follow-up.
+	if (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) && ctrl && !alt && !shift && e.KeyDown {
+		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
+			delta := 1 // Down shrinks panels (grows terminal above)
+			if e.VirtualKeyCode == vtinput.VK_UP {
+				delta = -1
+			}
+			next := pf.heightDecrement + delta
+			maxHD := pf.lastH - 7
+			if next >= 0 && (maxHD <= 0 || next <= maxHD) {
+				pf.heightDecrement = next
+				pf.ResizeConsole(pf.lastW, pf.lastH)
+				vtui.FrameManager.HardRefresh()
+			}
 			return true
 		}
 	}

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3543,24 +3543,25 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 	}
 	pf.cmdLine.Edit.SetText("")
 
-	// Height: Ctrl+Down shrinks panel area (heightDecrement +1),
-	// Ctrl+Up grows it back. Ctrl+Up at 0 must clamp, not go negative.
+	// Height: Ctrl+Up shrinks panel area (heightDecrement +1, boundary
+	// moves up), Ctrl+Down grows it back. Ctrl+Down at 0 must clamp,
+	// not go negative.
 	pf.heightDecrement = 0
 	pf.ResizeConsole(80, 25)
 	basePanelH := panelHeight(pf.panels[0])
 
-	send(pf, vtinput.VK_DOWN)
+	send(pf, vtinput.VK_UP)
 	if pf.heightDecrement != 1 {
-		t.Errorf("Ctrl+Down: heightDecrement=%d, want 1", pf.heightDecrement)
+		t.Errorf("Ctrl+Up: heightDecrement=%d, want 1", pf.heightDecrement)
 	}
 	if got := panelHeight(pf.panels[0]); got != basePanelH-1 {
-		t.Errorf("Ctrl+Down: panel height=%d, want %d", got, basePanelH-1)
+		t.Errorf("Ctrl+Up: panel height=%d, want %d", got, basePanelH-1)
 	}
 
-	send(pf, vtinput.VK_UP)
-	send(pf, vtinput.VK_UP) // Second Up at 0 should be a no-op (clamp).
+	send(pf, vtinput.VK_DOWN)
+	send(pf, vtinput.VK_DOWN) // Second Down at 0 should be a no-op (clamp).
 	if pf.heightDecrement != 0 {
-		t.Errorf("Ctrl+Up past 0: heightDecrement=%d, want 0 (clamp)", pf.heightDecrement)
+		t.Errorf("Ctrl+Down past 0: heightDecrement=%d, want 0 (clamp)", pf.heightDecrement)
 	}
 
 	// Width clamp: on an 80-col terminal, maxWD = 40 - 10 = 30. Push past it.

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3490,3 +3490,86 @@ func TestPanelsFrame_CtrlP_TogglesPassivePanel(t *testing.T) {
 		t.Errorf("Ctrl+P should have shown the right panel again, got R=%v", pf.showRightPanel)
 	}
 }
+
+func panelWidth(p Panel) int  { x1, _, x2, _ := p.GetPosition(); return x2 - x1 + 1 }
+func panelHeight(p Panel) int { _, y1, _, y2 := p.GetPosition(); return y2 - y1 + 1 }
+
+// TestPanelsFrame_CtrlArrows_ResizePanels exercises the far2l-style
+// panel resize keys: Ctrl+Left/Right shift the width split, Ctrl+Up/Down
+// shrink/grow the panel-vs-terminal split. Requires empty cmdline;
+// non-empty cmdline must fall through to word-navigation.
+func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	send := func(pf *PanelsFrame, vk uint16) {
+		pf.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true,
+			VirtualKeyCode:  vk,
+			ControlKeyState: vtinput.LeftCtrlPressed,
+		})
+	}
+
+	// Width: Ctrl+Right grows right panel (widthDecrement +1);
+	// Ctrl+Left shrinks it back and then grows left.
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	baseLeft := panelWidth(pf.panels[0])
+
+	send(pf, vtinput.VK_RIGHT)
+	if pf.widthDecrement != 1 {
+		t.Errorf("Ctrl+Right: widthDecrement=%d, want 1", pf.widthDecrement)
+	}
+	if got := panelWidth(pf.panels[0]); got != baseLeft-1 {
+		t.Errorf("Ctrl+Right: left panel width=%d, want %d", got, baseLeft-1)
+	}
+
+	send(pf, vtinput.VK_LEFT)
+	send(pf, vtinput.VK_LEFT)
+	if pf.widthDecrement != -1 {
+		t.Errorf("Ctrl+Left twice: widthDecrement=%d, want -1", pf.widthDecrement)
+	}
+	if got := panelWidth(pf.panels[0]); got != baseLeft+1 {
+		t.Errorf("Ctrl+Left twice: left panel width=%d, want %d", got, baseLeft+1)
+	}
+
+	// Non-empty cmdline: Ctrl+Left/Right must NOT resize.
+	pf.widthDecrement = 0
+	pf.ResizeConsole(80, 25)
+	pf.cmdLine.Edit.SetText("hello")
+	send(pf, vtinput.VK_RIGHT)
+	if pf.widthDecrement != 0 {
+		t.Errorf("non-empty cmdline: widthDecrement changed to %d, want 0", pf.widthDecrement)
+	}
+	pf.cmdLine.Edit.SetText("")
+
+	// Height: Ctrl+Down shrinks panel area (heightDecrement +1),
+	// Ctrl+Up grows it back. Ctrl+Up at 0 must clamp, not go negative.
+	pf.heightDecrement = 0
+	pf.ResizeConsole(80, 25)
+	basePanelH := panelHeight(pf.panels[0])
+
+	send(pf, vtinput.VK_DOWN)
+	if pf.heightDecrement != 1 {
+		t.Errorf("Ctrl+Down: heightDecrement=%d, want 1", pf.heightDecrement)
+	}
+	if got := panelHeight(pf.panels[0]); got != basePanelH-1 {
+		t.Errorf("Ctrl+Down: panel height=%d, want %d", got, basePanelH-1)
+	}
+
+	send(pf, vtinput.VK_UP)
+	send(pf, vtinput.VK_UP) // Second Up at 0 should be a no-op (clamp).
+	if pf.heightDecrement != 0 {
+		t.Errorf("Ctrl+Up past 0: heightDecrement=%d, want 0 (clamp)", pf.heightDecrement)
+	}
+
+	// Width clamp: on an 80-col terminal, maxWD = 40 - 10 = 30. Push past it.
+	pf.widthDecrement = 0
+	pf.ResizeConsole(80, 25)
+	for i := 0; i < 40; i++ {
+		send(pf, vtinput.VK_RIGHT)
+	}
+	if pf.widthDecrement != 30 {
+		t.Errorf("width clamp: widthDecrement=%d, want 30", pf.widthDecrement)
+	}
+}


### PR DESCRIPTION
## Licensing note (up front)

Clean-room in Go: the behavior mirrors far/far2l (`FilePanels::ProcessKey` gate on empty cmdline, `[Layout] WidthDecrement` / `LeftHeightDecrement` / `RightHeightDecrement` from `ConfigOpt.cpp`), no source copied. Field names in the diff (`widthDecrement`, `heightDecrement`) match far2l's on-disk config keys so a future persistence PR can serialise them into a `[Layout]` section that stays interchangeable with far2l's `settings.ini`.

## Summary

Add far2l's Ctrl+arrow panel resize keys, in-memory only:

- `Ctrl+Left` / `Ctrl+Right` — shift the split between the two panels. Only fires when the panels are visible and the command line is empty; with text in the cmdline, falls through to word navigation (existing behavior, unchanged). Clamp: each panel stays ≥ 10 columns (`|widthDecrement| ≤ w/2 - 10`).
- `Ctrl+Up` / `Ctrl+Down` — grow or shrink the panel area versus the terminal area above it, symmetrically on both panels. Same "panels visible + cmdline empty" gate. Clamp: `0 ≤ heightDecrement ≤ h - 7`.

Both keys reuse the existing `ResizeConsole` + `HardRefresh` path already used by `Ctrl+F1` / `Ctrl+F2` / `Ctrl+O`, so relayout, focus, and redraw behave identically.

## What's not in this PR

Deliberately out of scope, for a later design-discussable PR:

- `Ctrl+Shift+Up` / `Ctrl+Shift+Down` — asymmetric height (only the active panel's `HeightDecrement`, giving a step-cut layout). The struct field is a single `heightDecrement` for now; splitting into `leftHeightDecrement` / `rightHeightDecrement` when we add the asymmetric key is a mechanical rename.
- `Ctrl+Clear` reset (far2l has it; f4 has no natural home for it yet).
- Persistence — `widthDecrement` / `heightDecrement` reset to `0` on restart. Adding a `[Layout]` section to `settings.ini` with those two (later three) keys would be format-compatible with far2l but is its own PR because it touches the settings-migration story.

## Test plan

- [x] `go test -run TestPanelsFrame_CtrlArrows_ResizePanels -v ./...` passes. The test drives all four keys through `ProcessKey` and asserts panel widths / heights change in the expected direction, hits the width clamp at 30 on an 80-col terminal, hits the height clamp at 0 on `Ctrl+Up`, and confirms non-empty cmdline blocks the width path (falls through to word-nav instead).
- [x] `go build ./...` clean, `gofmt -w -s .` clean on the changed files.
- [x] Manual smoke on WSL Ubuntu 22.04 in wezterm, Windows Terminal and default WSL console, starting from an empty cmdline: `Ctrl+Right` walks the split rightward one column per press, `Ctrl+Left` walks it back; `Ctrl+Down` shrinks both panels from the bottom (terminal area above grows correspondingly), `Ctrl+Up` restores. With text typed on the cmdline, `Ctrl+Left`/`Ctrl+Right` do word navigation as before.
