### PR TITLE
Persist panel resize offsets in far2l-compatible [Layout] section

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/unxed/vtui"
 )
@@ -98,6 +100,21 @@ type F4Config struct {
 	UpdateInterval          int    // 0 = Never, 1 = Every start, 2 = Daily, 3 = Weekly
 	LastUpdateCheck         int64  // Unix timestamp
 	LastUpdateVersion       string // Version string or PublishedAt timestamp
+
+	// [Layout] mirrors far2l's config.ini section of the same name so
+	// a config shared with far2l keeps working in both. Adjusted by
+	// Ctrl+Left/Right (width split) and Ctrl+Up/Down (panel/terminal
+	// vertical split, applied symmetrically to both height fields).
+	// Ctrl+Clear resets all three to 0.
+	WidthDecrement       int
+	LeftHeightDecrement  int
+	RightHeightDecrement int
+
+	// LayoutExtras is any [Layout] key we don't recognise (e.g. far2l's
+	// FullscreenHelp, PanelsDisposition). Read at LoadConfig and written
+	// back verbatim on SaveConfig so f4 doesn't strip far2l-only options
+	// from a shared config file.
+	LayoutExtras map[string]string
 }
 
 var AppConfig = F4Config{
@@ -223,6 +240,23 @@ func LoadConfig() {
 	AppConfig.EditorTabSize = 4
 	fmt.Sscanf(ini.GetString("Editor", "TabSize", "4"), "%d", &AppConfig.EditorTabSize)
 
+	// [Layout] — three known keys plus round-trip storage for anything else.
+	fmt.Sscanf(ini.GetString("Layout", "WidthDecrement", "0"), "%d", &AppConfig.WidthDecrement)
+	fmt.Sscanf(ini.GetString("Layout", "LeftHeightDecrement", "0"), "%d", &AppConfig.LeftHeightDecrement)
+	fmt.Sscanf(ini.GetString("Layout", "RightHeightDecrement", "0"), "%d", &AppConfig.RightHeightDecrement)
+	AppConfig.LayoutExtras = nil
+	if layout, ok := ini.data["Layout"]; ok {
+		for k, v := range layout {
+			switch k {
+			case "WidthDecrement", "LeftHeightDecrement", "RightHeightDecrement":
+				continue
+			}
+			if AppConfig.LayoutExtras == nil {
+				AppConfig.LayoutExtras = make(map[string]string)
+			}
+			AppConfig.LayoutExtras[k] = v
+		}
+	}
 }
 
 func SaveConfig() {
@@ -278,6 +312,30 @@ func SaveConfig() {
 	sb.WriteString("\n[Plugins]\n")
 	sb.WriteString(fmt.Sprintf("List = %s\n", strings.Join(AppConfig.RegisteredPlugins, "|")))
 
+	// [Layout]: emit our three keys plus any unrecognised keys we loaded
+	// (round-trip). Keys are written alphabetically to match far2l's
+	// on-disk order, so a diff against far2l's config.ini stays minimal.
+	layoutKeys := map[string]string{
+		"WidthDecrement":       fmt.Sprintf("%d", AppConfig.WidthDecrement),
+		"LeftHeightDecrement":  fmt.Sprintf("%d", AppConfig.LeftHeightDecrement),
+		"RightHeightDecrement": fmt.Sprintf("%d", AppConfig.RightHeightDecrement),
+	}
+	for k, v := range AppConfig.LayoutExtras {
+		if _, taken := layoutKeys[k]; taken {
+			continue
+		}
+		layoutKeys[k] = v
+	}
+	names := make([]string, 0, len(layoutKeys))
+	for k := range layoutKeys {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	sb.WriteString("\n[Layout]\n")
+	for _, k := range names {
+		sb.WriteString(fmt.Sprintf("%s=%s\n", k, layoutKeys[k]))
+	}
+
 	err := os.WriteFile(path, []byte(sb.String()), 0644)
 	if err != nil {
 		vtui.DebugLog("CONFIG: Failed to save application settings: %v", err)
@@ -286,3 +344,24 @@ func SaveConfig() {
 
 	vtui.DebugLog("CONFIG: Saved application settings to %s", path)
 }
+
+// RequestSaveConfig schedules a debounced SaveConfig call. Multiple calls
+// within the debounce window collapse into a single write. Used by the
+// panel-resize hotkeys, where holding Ctrl+Arrow can fire many times per
+// second and we don't want to fsync on every keystroke. The final value
+// still lands on disk because the shutdown path calls SaveConfig directly.
+func RequestSaveConfig() {
+	saveConfigTimerMu.Lock()
+	defer saveConfigTimerMu.Unlock()
+	if saveConfigTimer != nil {
+		saveConfigTimer.Stop()
+	}
+	saveConfigTimer = time.AfterFunc(saveConfigDebounce, SaveConfig)
+}
+
+var (
+	saveConfigTimerMu sync.Mutex
+	saveConfigTimer   *time.Timer
+)
+
+const saveConfigDebounce = 500 * time.Millisecond

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -186,5 +187,65 @@ func TestConfig_GuiDimensionsPersistence(t *testing.T) {
 	}
 	if AppConfig.ConfirmExit {
 		t.Error("Expected ConfirmExit to be loaded as false, got true")
+	}
+}
+
+// TestConfig_LayoutRoundTrip verifies that the [Layout] section persists
+// our three known keys and round-trips any unknown keys (e.g. far2l's
+// FullscreenHelp / PanelsDisposition) untouched on save.
+func TestConfig_LayoutRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	iniPath := filepath.Join(tmpDir, "settings.ini")
+
+	origUserPathFunc := getUserConfigIniPath
+	origPathsFunc := getConfigIniPaths
+	getUserConfigIniPath = func() string { return iniPath }
+	getConfigIniPaths = func() []string { return []string{iniPath} }
+	oldCfg := AppConfig
+	defer func() {
+		getUserConfigIniPath = origUserPathFunc
+		getConfigIniPaths = origPathsFunc
+		AppConfig = oldCfg
+	}()
+
+	// Seed a config file with our three keys AND two far2l-only keys.
+	seed := "[Layout]\n" +
+		"WidthDecrement=3\n" +
+		"LeftHeightDecrement=5\n" +
+		"RightHeightDecrement=7\n" +
+		"FullscreenHelp=1\n" +
+		"PanelsDisposition=2\n"
+	if err := os.WriteFile(iniPath, []byte(seed), 0644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	LoadConfig()
+	if AppConfig.WidthDecrement != 3 || AppConfig.LeftHeightDecrement != 5 || AppConfig.RightHeightDecrement != 7 {
+		t.Errorf("LoadConfig [Layout] values: W=%d L=%d R=%d, want 3/5/7",
+			AppConfig.WidthDecrement, AppConfig.LeftHeightDecrement, AppConfig.RightHeightDecrement)
+	}
+	if AppConfig.LayoutExtras["FullscreenHelp"] != "1" || AppConfig.LayoutExtras["PanelsDisposition"] != "2" {
+		t.Errorf("LoadConfig extras: %v", AppConfig.LayoutExtras)
+	}
+
+	// Save and re-read the file — extras must survive verbatim.
+	AppConfig.WidthDecrement = -2
+	SaveConfig()
+	out, err := os.ReadFile(iniPath)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	body := string(out)
+	for _, want := range []string{
+		"[Layout]",
+		"FullscreenHelp=1",
+		"LeftHeightDecrement=5",
+		"PanelsDisposition=2",
+		"RightHeightDecrement=7",
+		"WidthDecrement=-2",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("SaveConfig missing %q in output:\n%s", want, body)
+		}
 	}
 }

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -116,10 +116,14 @@ type PanelsFrame struct {
 	// Panel geometry offsets, adjusted by Ctrl+Left/Right (width) and
 	// Ctrl+Up/Down (height). Names and semantics match far2l's [Layout]:
 	// widthDecrement > 0 grows the right panel, < 0 grows the left;
-	// heightDecrement >= 0 shrinks BOTH panels from the bottom, growing
-	// the terminal area above them.
-	widthDecrement  int
-	heightDecrement int
+	// leftHeightDecrement / rightHeightDecrement >= 0 shrink the
+	// corresponding panel from the bottom, growing the terminal area
+	// above it. Ctrl+Up/Down bumps both symmetrically for now — the
+	// asymmetric Ctrl+Shift+Up/Down handler will come as a follow-up
+	// PR, which is why the fields are split already.
+	widthDecrement       int
+	leftHeightDecrement  int
+	rightHeightDecrement int
 
 	// Integrated Terminal
 	pty        PtyBackend
@@ -154,6 +158,9 @@ func NewPanelsFrame() *PanelsFrame {
 	pf.lastShowPanels = true
 	pf.showLeftPanel = true
 	pf.showRightPanel = true
+	pf.widthDecrement = AppConfig.WidthDecrement
+	pf.leftHeightDecrement = AppConfig.LeftHeightDecrement
+	pf.rightHeightDecrement = AppConfig.RightHeightDecrement
 
 	pf.menuBar = vtui.NewMenuBar(nil)
 	pf.menuBar.SetOwner(pf)
@@ -506,21 +513,28 @@ func (pf *PanelsFrame) ResizeConsole(w, h int) {
 	}
 
 	// 2. Panel Area: Leaves one additional line for the f4 CommandLine.
-	// heightDecrement shrinks the panel area from the bottom; the freed
-	// rows go to the terminal area above (matches far2l's LeftHeightDecrement/
-	// RightHeightDecrement, applied symmetrically here).
-	hd := pf.heightDecrement
-	if maxHD := h - 7; maxHD > 0 && hd > maxHD {
-		hd = maxHD
-	}
-	if hd < 0 {
-		hd = 0
-	}
-	panelY2 := h - 2 - hd
+	// leftHeightDecrement / rightHeightDecrement shrink the corresponding
+	// panel from the bottom; the freed rows go to the terminal area above
+	// (matches far2l's [Layout] section of the same name).
+	basePanelY2 := h - 2
 	if pf.showKeyBar {
-		panelY2 = h - 3 - hd
+		basePanelY2 = h - 3
 	}
-	panelH := panelY2 - contentY1 + 1
+	maxHD := h - 7
+	clampHD := func(hd int) int {
+		if hd < 0 {
+			return 0
+		}
+		if maxHD > 0 && hd > maxHD {
+			return maxHD
+		}
+		return hd
+	}
+	leftPanelY2 := basePanelY2 - clampHD(pf.leftHeightDecrement)
+	rightPanelY2 := basePanelY2 - clampHD(pf.rightHeightDecrement)
+	// panelH is only used to seed the two panels on first construction;
+	// after that each panel takes its own height from SetPosition below.
+	panelH := basePanelY2 - contentY1 + 1
 	if panelH < 0 {
 		panelH = 0
 	}
@@ -545,16 +559,18 @@ func (pf *PanelsFrame) ResizeConsole(w, h int) {
 		pf.panels[0] = NewFileSystemPanel(0, contentY1, leftW, panelH, vfs.NewOSVFS("."))
 		pf.panels[1] = NewFileSystemPanel(leftW, contentY1, rightW, panelH, vfs.NewOSVFS("."))
 	} else {
-		pf.panels[0].SetPosition(0, contentY1, leftW-1, panelY2)
-		pf.panels[1].SetPosition(leftW, contentY1, w-1, panelY2)
+		pf.panels[0].SetPosition(0, contentY1, leftW-1, leftPanelY2)
+		pf.panels[1].SetPosition(leftW, contentY1, w-1, rightPanelY2)
 
 		for i, p := range pf.panels {
 			width := leftW
+			panelY2Cur := leftPanelY2
 			if i == 1 {
 				width = rightW
+				panelY2Cur = rightPanelY2
 			}
 			if fsp, ok := p.(*FileSystemPanel); ok {
-				fsp.Resize(width, panelH)
+				fsp.Resize(width, panelY2Cur-contentY1+1)
 			}
 		}
 	}
@@ -641,7 +657,7 @@ func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 		// Показываем терминал под панелями если: одна из панелей скрыта
 		// (терминал занимает освободившуюся половину), либо панели уменьшены
 		// по высоте (Ctrl+Up) и терминал должен просвечивать снизу.
-		if !pf.showLeftPanel || !pf.showRightPanel || pf.heightDecrement > 0 {
+		if !pf.showLeftPanel || !pf.showRightPanel || pf.leftHeightDecrement > 0 || pf.rightHeightDecrement > 0 {
 			pf.termView.SetVisible(true)
 			pf.termView.Show(scr)
 		} else {
@@ -896,6 +912,8 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 			next := pf.widthDecrement + delta
 			if maxWD := (pf.lastW / 2) - 10; maxWD > 0 && next <= maxWD && next >= -maxWD {
 				pf.widthDecrement = next
+				AppConfig.WidthDecrement = next
+				RequestSaveConfig()
 				pf.ResizeConsole(pf.lastW, pf.lastH)
 				vtui.FrameManager.HardRefresh()
 			}
@@ -909,9 +927,8 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// Ctrl+Up / Ctrl+Down — grow/shrink the panel-area vs terminal-area
 	// split. In far2l this drives both LeftHeightDecrement and
-	// RightHeightDecrement symmetrically; we keep them merged into a
-	// single heightDecrement field. Asymmetric Ctrl+Shift+Up/Down is a
-	// deliberate follow-up.
+	// RightHeightDecrement symmetrically (asymmetric Ctrl+Shift+Up/Down
+	// is a deliberate follow-up). We bump both fields in lockstep here.
 	if (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) && ctrl && !alt && !shift && e.KeyDown {
 		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
 			// Ctrl+Up moves the panels' bottom edge up (shrinks them,
@@ -920,15 +937,37 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 			if e.VirtualKeyCode == vtinput.VK_UP {
 				delta = 1
 			}
-			next := pf.heightDecrement + delta
+			nextL := pf.leftHeightDecrement + delta
+			nextR := pf.rightHeightDecrement + delta
 			maxHD := pf.lastH - 7
-			if next >= 0 && (maxHD <= 0 || next <= maxHD) {
-				pf.heightDecrement = next
+			if nextL >= 0 && nextR >= 0 && (maxHD <= 0 || (nextL <= maxHD && nextR <= maxHD)) {
+				pf.leftHeightDecrement = nextL
+				pf.rightHeightDecrement = nextR
+				AppConfig.LeftHeightDecrement = nextL
+				AppConfig.RightHeightDecrement = nextR
+				RequestSaveConfig()
 				pf.ResizeConsole(pf.lastW, pf.lastH)
 				vtui.FrameManager.HardRefresh()
 			}
 			return true
 		}
+	}
+
+	// Ctrl+Clear (NumPad 5 with NumLock off) resets all three layout
+	// decrements to 0, matching far2l's Ctrl+Clear.
+	if e.VirtualKeyCode == vtinput.VK_CLEAR && ctrl && !alt && !shift && e.KeyDown {
+		if pf.showPanels && (pf.widthDecrement != 0 || pf.leftHeightDecrement != 0 || pf.rightHeightDecrement != 0) {
+			pf.widthDecrement = 0
+			pf.leftHeightDecrement = 0
+			pf.rightHeightDecrement = 0
+			AppConfig.WidthDecrement = 0
+			AppConfig.LeftHeightDecrement = 0
+			AppConfig.RightHeightDecrement = 0
+			RequestSaveConfig()
+			pf.ResizeConsole(pf.lastW, pf.lastH)
+			vtui.FrameManager.HardRefresh()
+		}
+		return true
 	}
 
 	// Raw input mode fallback for active shell commands (non-AltScreen, e.g. ping).

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3543,25 +3543,32 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 	}
 	pf.cmdLine.Edit.SetText("")
 
-	// Height: Ctrl+Up shrinks panel area (heightDecrement +1, boundary
-	// moves up), Ctrl+Down grows it back. Ctrl+Down at 0 must clamp,
-	// not go negative.
-	pf.heightDecrement = 0
+	// Height: Ctrl+Up shrinks the panel area from the bottom (both
+	// leftHeightDecrement and rightHeightDecrement +1, moving both
+	// panels' bottom edge up in lockstep). Ctrl+Down reverses it.
+	// Ctrl+Down at 0 must clamp, not go negative.
+	pf.leftHeightDecrement = 0
+	pf.rightHeightDecrement = 0
 	pf.ResizeConsole(80, 25)
 	basePanelH := panelHeight(pf.panels[0])
 
 	send(pf, vtinput.VK_UP)
-	if pf.heightDecrement != 1 {
-		t.Errorf("Ctrl+Up: heightDecrement=%d, want 1", pf.heightDecrement)
+	if pf.leftHeightDecrement != 1 || pf.rightHeightDecrement != 1 {
+		t.Errorf("Ctrl+Up: heightDecrements=%d/%d, want 1/1",
+			pf.leftHeightDecrement, pf.rightHeightDecrement)
 	}
 	if got := panelHeight(pf.panels[0]); got != basePanelH-1 {
 		t.Errorf("Ctrl+Up: panel height=%d, want %d", got, basePanelH-1)
 	}
+	if got := panelHeight(pf.panels[1]); got != basePanelH-1 {
+		t.Errorf("Ctrl+Up: right panel height=%d, want %d", got, basePanelH-1)
+	}
 
 	send(pf, vtinput.VK_DOWN)
 	send(pf, vtinput.VK_DOWN) // Second Down at 0 should be a no-op (clamp).
-	if pf.heightDecrement != 0 {
-		t.Errorf("Ctrl+Down past 0: heightDecrement=%d, want 0 (clamp)", pf.heightDecrement)
+	if pf.leftHeightDecrement != 0 || pf.rightHeightDecrement != 0 {
+		t.Errorf("Ctrl+Down past 0: heightDecrements=%d/%d, want 0/0 (clamp)",
+			pf.leftHeightDecrement, pf.rightHeightDecrement)
 	}
 
 	// Width clamp: on an 80-col terminal, maxWD = 40 - 10 = 30. Push past it.
@@ -3572,5 +3579,63 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 	}
 	if pf.widthDecrement != 30 {
 		t.Errorf("width clamp: widthDecrement=%d, want 30", pf.widthDecrement)
+	}
+}
+
+// TestPanelsFrame_CtrlClear_ResetsLayoutDecrements verifies that Ctrl+Clear
+// (NumPad 5 with NumLock off) zeroes widthDecrement / leftHeightDecrement /
+// rightHeightDecrement in one shot, matching far2l's Ctrl+Clear.
+func TestPanelsFrame_CtrlClear_ResetsLayoutDecrements(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	pf.widthDecrement = 5
+	pf.leftHeightDecrement = 3
+	pf.rightHeightDecrement = 4
+	AppConfig.WidthDecrement = 5
+	AppConfig.LeftHeightDecrement = 3
+	AppConfig.RightHeightDecrement = 4
+	defer func() {
+		AppConfig.WidthDecrement = 0
+		AppConfig.LeftHeightDecrement = 0
+		AppConfig.RightHeightDecrement = 0
+	}()
+
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_CLEAR,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+
+	if pf.widthDecrement != 0 || pf.leftHeightDecrement != 0 || pf.rightHeightDecrement != 0 {
+		t.Errorf("Ctrl+Clear: fields = %d/%d/%d, want 0/0/0",
+			pf.widthDecrement, pf.leftHeightDecrement, pf.rightHeightDecrement)
+	}
+	if AppConfig.WidthDecrement != 0 || AppConfig.LeftHeightDecrement != 0 || AppConfig.RightHeightDecrement != 0 {
+		t.Errorf("Ctrl+Clear: AppConfig = %d/%d/%d, want 0/0/0",
+			AppConfig.WidthDecrement, AppConfig.LeftHeightDecrement, AppConfig.RightHeightDecrement)
+	}
+}
+
+// TestPanelsFrame_LayoutDecrements_InitFromAppConfig verifies that a
+// fresh PanelsFrame picks up saved layout offsets from AppConfig so a
+// restart restores the last on-disk state.
+func TestPanelsFrame_LayoutDecrements_InitFromAppConfig(t *testing.T) {
+	oldW, oldL, oldR := AppConfig.WidthDecrement, AppConfig.LeftHeightDecrement, AppConfig.RightHeightDecrement
+	AppConfig.WidthDecrement = -3
+	AppConfig.LeftHeightDecrement = 4
+	AppConfig.RightHeightDecrement = 5
+	defer func() {
+		AppConfig.WidthDecrement, AppConfig.LeftHeightDecrement, AppConfig.RightHeightDecrement = oldW, oldL, oldR
+	}()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+
+	if pf.widthDecrement != -3 || pf.leftHeightDecrement != 4 || pf.rightHeightDecrement != 5 {
+		t.Errorf("init from AppConfig: got %d/%d/%d, want -3/4/5",
+			pf.widthDecrement, pf.leftHeightDecrement, pf.rightHeightDecrement)
 	}
 }


### PR DESCRIPTION
## Licensing note (up front)

Clean-room in Go: schema mirrors far2l's `[Layout]` (`WidthDecrement` / `LeftHeightDecrement` / `RightHeightDecrement`, verified against `far2l/src/cfg/ConfigOpt.cpp:461-463` and against a live `~/.config/far2l/settings/config.ini`). No source copied. Field names, method names, control flow and tests are Go-idiomatic and independent of far2l's C++ layout — the far2l reference is treated purely as an on-disk-format specification, same treatment we gave `bookmarks.ini` in #216.

## Summary

Persist the panel-resize offsets introduced in #225 to `settings.ini`, using the `[Layout]` section name and keys from far2l — a config authored in either tool keeps working in both without conversion. Also introduces `Ctrl+Clear` for reset, and splits the internal `heightDecrement` into `leftHeightDecrement` / `rightHeightDecrement` so the fields map 1:1 onto the far2l keys.

## What's in this PR

### Structural change

* `heightDecrement` → `leftHeightDecrement` + `rightHeightDecrement`; layout math now computes `panelY2` per panel. `Ctrl+Up` / `Ctrl+Down` still bumps both fields in lockstep (behavior unchanged from user's perspective — symmetric shrink/grow), but loading asymmetric values from disk already renders correctly per-panel.
* The "draw the terminal under the shrunk panels" branch (from #225) now fires when *either* height decrement is non-zero, not just one shared field.

### Persistence

* `[Layout]` section in `~/.config/f4/settings.ini`, keys sorted alphabetically (matching far2l's on-disk order — `LeftHeightDecrement`, `RightHeightDecrement`, `WidthDecrement`).
* `LoadConfig` reads the three known keys plus every other key in `[Layout]` into `AppConfig.LayoutExtras` (a `map[string]string`). `SaveConfig` writes our three keys + everything from `LayoutExtras`, sorted alphabetically. So far2l-only options that appear in a shared config file (`FullscreenHelp`, `PanelsDisposition`, and any future additions) survive a round-trip through f4 untouched.
* Fresh `PanelsFrame` seeds `widthDecrement` / `leftHeightDecrement` / `rightHeightDecrement` from `AppConfig`, so a restart restores the last on-disk state.

### Save timing

Saved *debounced* via `RequestSaveConfig`: each key press schedules a write 500 ms later; further presses in that window reset the timer. Holding `Ctrl+Arrow` to sweep the split doesn't fsync per keystroke, and the shutdown `SaveConfig` call already runs on exit so the final value lands on disk even if the debounce timer hasn't fired.

Chose debounce over per-keystroke save because a common flow (based on our discussion in #225) is to hold the key and eyeball the split into place — that would be dozens of writes per second otherwise. Chose against an explicit "Auto-save panel state" option (far2l has one under `[System]`) — kept the surface small; can be added later if anyone wants to opt out of persistence.

### Ctrl+Clear reset

Bound `Ctrl+Clear` (NumPad 5 with NumLock off — `vtinput.VK_CLEAR`) to zero all three decrements in one shot and persist immediately. Matches far2l's `Ctrl+Clear`.

## What's not in this PR

* `Ctrl+Shift+Up` / `Ctrl+Shift+Down` — asymmetric height (adjusts only the *active* panel). That's the whole reason `heightDecrement` is split here — this PR is the structural groundwork, the hotkey lands in the follow-up so the review surface stays small.
* An "Auto-save layout" toggle under Options — not adding until someone actually wants to disable persistence.
* Migration from a hypothetical old f4 config format — nothing to migrate; `[Layout]` is new, missing keys parse as 0 (defaults), matching the pre-persistence behavior.

## Test plan

- [x] `go test ./...` passes.
- [x] `go build ./...` clean, `gofmt -w -s` clean on the changed files.

### Automated (added in this PR)

* `TestConfig_LayoutRoundTrip` — seeds a config with `WidthDecrement=3 / LeftHeightDecrement=5 / RightHeightDecrement=7 / FullscreenHelp=1 / PanelsDisposition=2`, calls `LoadConfig` (verifies known keys go to fields, unknown to `LayoutExtras`), mutates `WidthDecrement` to `-2`, calls `SaveConfig`, re-reads the file, and asserts every line survives verbatim including the two far2l-only keys.
* `TestPanelsFrame_CtrlArrows_ResizePanels` (from #225) extended to assert both height fields move symmetrically on `Ctrl+Up` / `Ctrl+Down` and both panels' heights change together.
* `TestPanelsFrame_CtrlClear_ResetsLayoutDecrements` — one `Ctrl+Clear` press zeros the three panel fields and their mirror in `AppConfig`.
* `TestPanelsFrame_LayoutDecrements_InitFromAppConfig` — a fresh `PanelsFrame` picks up saved offsets from `AppConfig` so a restart restores the last state.

### Manual

Tested on WSL Ubuntu 22.04 in wezterm, Windows Terminal and default WSL console, starting from an empty `~/.config/f4/settings.ini`:

1. Press `Ctrl+Up` a few times — panels shrink from the bottom, terminal shows through.
2. Restart f4 — panels come back at the same shrunk size (verifies save + load).
3. Edit `settings.ini` to `LeftHeightDecrement=15 RightHeightDecrement=3`, restart — left panel is noticeably shorter than right (per-panel layout works).
4. Press `Ctrl+Up` / `Ctrl+Down` — both fields still move together, asymmetry preserved (`(15+N, 3+N)`), matching far2l.
5. Press `Ctrl+Clear` (Num5 with NumLock off) — all three decrements reset to 0, panels return to full-height symmetric layout, `settings.ini` updates within a second.
6. Copy `[Layout] FullscreenHelp=0 PanelsDisposition=0` into `settings.ini`, restart f4, do a few `Ctrl+Right` to change `WidthDecrement`, wait 1s — `settings.ini` contains our new `WidthDecrement` AND the untouched `FullscreenHelp` / `PanelsDisposition` (round-trip verified).
