### PR TITLE
Add Ctrl+Shift+Up/Down for asymmetric panel height

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -927,8 +927,9 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// Ctrl+Up / Ctrl+Down — grow/shrink the panel-area vs terminal-area
 	// split. In far2l this drives both LeftHeightDecrement and
-	// RightHeightDecrement symmetrically (asymmetric Ctrl+Shift+Up/Down
-	// is a deliberate follow-up). We bump both fields in lockstep here.
+	// RightHeightDecrement symmetrically. We bump both fields in
+	// lockstep here; the asymmetric Ctrl+Shift+Up/Down handler right
+	// below adjusts only the active panel.
 	if (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) && ctrl && !alt && !shift && e.KeyDown {
 		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
 			// Ctrl+Up moves the panels' bottom edge up (shrinks them,
@@ -945,6 +946,34 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 				pf.rightHeightDecrement = nextR
 				AppConfig.LeftHeightDecrement = nextL
 				AppConfig.RightHeightDecrement = nextR
+				RequestSaveConfig()
+				pf.ResizeConsole(pf.lastW, pf.lastH)
+				vtui.FrameManager.HardRefresh()
+			}
+			return true
+		}
+	}
+
+	// Ctrl+Shift+Up / Ctrl+Shift+Down — adjust only the *active* panel's
+	// height, giving an asymmetric split. Matches far2l's behavior on the
+	// same keys.
+	if (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) && ctrl && !alt && shift && e.KeyDown {
+		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
+			delta := -1
+			if e.VirtualKeyCode == vtinput.VK_UP {
+				delta = 1
+			}
+			cur := &pf.rightHeightDecrement
+			cfg := &AppConfig.RightHeightDecrement
+			if pf.activeIdx == 0 {
+				cur = &pf.leftHeightDecrement
+				cfg = &AppConfig.LeftHeightDecrement
+			}
+			next := *cur + delta
+			maxHD := pf.lastH - 7
+			if next >= 0 && (maxHD <= 0 || next <= maxHD) {
+				*cur = next
+				*cfg = next
 				RequestSaveConfig()
 				pf.ResizeConsole(pf.lastW, pf.lastH)
 				vtui.FrameManager.HardRefresh()

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3639,3 +3639,84 @@ func TestPanelsFrame_LayoutDecrements_InitFromAppConfig(t *testing.T) {
 			pf.widthDecrement, pf.leftHeightDecrement, pf.rightHeightDecrement)
 	}
 }
+
+// TestPanelsFrame_CtrlShiftArrows_AsymmetricHeight exercises far2l's
+// Ctrl+Shift+Up / Ctrl+Shift+Down: bumps only the ACTIVE panel's height
+// decrement, leaving the other panel untouched. Same gate as plain
+// Ctrl+Up/Down (panels visible + cmdline empty).
+func TestPanelsFrame_CtrlShiftArrows_AsymmetricHeight(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	send := func(pf *PanelsFrame, vk uint16) {
+		pf.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true,
+			VirtualKeyCode:  vk,
+			ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
+		})
+	}
+
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	// Baseline: both decrements 0.
+	if pf.leftHeightDecrement != 0 || pf.rightHeightDecrement != 0 {
+		t.Fatalf("precondition: expected 0/0, got %d/%d",
+			pf.leftHeightDecrement, pf.rightHeightDecrement)
+	}
+	baseLeftH := panelHeight(pf.panels[0])
+	baseRightH := panelHeight(pf.panels[1])
+
+	// Active = right (mock default). Ctrl+Shift+Up bumps only right.
+	send(pf, vtinput.VK_UP)
+	if pf.leftHeightDecrement != 0 || pf.rightHeightDecrement != 1 {
+		t.Errorf("active=right Ctrl+Shift+Up: got %d/%d, want 0/1",
+			pf.leftHeightDecrement, pf.rightHeightDecrement)
+	}
+	if panelHeight(pf.panels[0]) != baseLeftH {
+		t.Errorf("left panel changed unexpectedly")
+	}
+	if panelHeight(pf.panels[1]) != baseRightH-1 {
+		t.Errorf("right panel height=%d, want %d",
+			panelHeight(pf.panels[1]), baseRightH-1)
+	}
+	if AppConfig.RightHeightDecrement != 1 {
+		t.Errorf("AppConfig.RightHeightDecrement=%d, want 1",
+			AppConfig.RightHeightDecrement)
+	}
+	AppConfig.RightHeightDecrement = 0 // cleanup for later tests
+
+	// Ctrl+Shift+Down on active=right undoes it.
+	send(pf, vtinput.VK_DOWN)
+	if pf.rightHeightDecrement != 0 {
+		t.Errorf("Ctrl+Shift+Down: rightHeightDecrement=%d, want 0",
+			pf.rightHeightDecrement)
+	}
+
+	// Switch to left, Ctrl+Shift+Up bumps left only.
+	pf.activeIdx = 0
+	send(pf, vtinput.VK_UP)
+	if pf.leftHeightDecrement != 1 || pf.rightHeightDecrement != 0 {
+		t.Errorf("active=left Ctrl+Shift+Up: got %d/%d, want 1/0",
+			pf.leftHeightDecrement, pf.rightHeightDecrement)
+	}
+	AppConfig.LeftHeightDecrement = 0 // cleanup
+
+	// Clamp: Ctrl+Shift+Down on a zero-decrement panel must not go negative.
+	pf.leftHeightDecrement = 0
+	send(pf, vtinput.VK_DOWN)
+	if pf.leftHeightDecrement != 0 {
+		t.Errorf("Ctrl+Shift+Down past 0: leftHeightDecrement=%d, want 0 (clamp)",
+			pf.leftHeightDecrement)
+	}
+
+	// Non-empty cmdline: Ctrl+Shift+Up/Down must NOT resize.
+	pf.leftHeightDecrement = 0
+	pf.cmdLine.Edit.SetText("hello")
+	send(pf, vtinput.VK_UP)
+	if pf.leftHeightDecrement != 0 {
+		t.Errorf("non-empty cmdline: leftHeightDecrement changed to %d, want 0",
+			pf.leftHeightDecrement)
+	}
+	pf.cmdLine.Edit.SetText("")
+}


### PR DESCRIPTION
## Licensing note (up front)

Clean-room in Go: the behaviour mirrors far2l's `Ctrl+Shift+Up/Down` — "adjust only the active panel's height decrement" — verified against a live far2l session. No source consulted. The handler is a structural twin of the symmetric `Ctrl+Up/Down` block right above it; the only difference is that it writes to one of the two split fields (chosen by `activeIdx`) instead of both.

## Summary

Add `Ctrl+Shift+Up` / `Ctrl+Shift+Down` matching far2l. Adjusts only the **active** panel's height decrement, leaving the other panel untouched. Structural groundwork (`leftHeightDecrement` / `rightHeightDecrement` split, persistence, debounce) landed in #227; this PR just adds the hotkey on top.

- `Ctrl+Shift+Up` — bumps the active panel's `HeightDecrement` by +1 (its bottom edge moves up, that half of the terminal area grows above it).
- `Ctrl+Shift+Down` — reverse, clamped at 0.
- Same gate as the symmetric handler: only fires when panels are visible and the command line is empty. Same `pf.lastH - 7` clamp on the upper bound.
- Writes to `pf.leftHeightDecrement` / `pf.rightHeightDecrement` depending on `pf.activeIdx`, syncs to `AppConfig.*HeightDecrement`, calls `RequestSaveConfig` — reuses the same debounce plumbing #227 introduced.

## Test plan

- [x] `go test ./...` passes.
- [x] `go build ./...` clean, `gofmt -w -s` clean.

### Automated

`TestPanelsFrame_CtrlShiftArrows_AsymmetricHeight` — exercises: active=right hits only right, active=left hits only left, `AppConfig` mirrors the change, `Ctrl+Shift+Down` at 0 clamps, non-empty cmdline falls through (no resize).

### Manual

Tested on WSL Ubuntu 22.04. Steps to reproduce:

1. Focus the left panel, press `Ctrl+Shift+Up` a few times — left panel shrinks from the bottom, right stays full-height (asymmetric split).
2. `Ctrl+Shift+Down` on the same panel — restores it.
3. Tab to the right panel, `Ctrl+Shift+Up` — now only right shrinks.
4. Plain `Ctrl+Up/Down` still bumps both together (existing behaviour untouched), preserving the asymmetry offset.
5. `Ctrl+Clear` (from #227) still resets both, no interference.
6. Type text in the cmdline, `Ctrl+Shift+Up/Down` — no panel change (gate works).

### Terminal-specific notes

Ctrl+Shift+Up/Down is claimed by several terminal emulators for their own actions (tab-move / pane-navigation / font-size / find-in-history depending on the emulator). f4 doesn't get the keystroke unless the emulator releases it. What was verified:

- **Default WSL console:** works out of the box.
- **f4 GUI backend (`f4` without `--tty`):** works.
- **Windows Terminal:** claims `Ctrl+Shift+Up/Down` by default for tab reordering; unbinding those in the terminal's keybindings makes f4 receive them. Same limitation as bare far2l on WT.
- **wezterm:** also claims the combination; kept it in place on the test box, so f4 doesn't see the keystroke in that emulator. Works fine everywhere else. No f4-side workaround is possible — terminal captures the event before it reaches the app.

No f4 behaviour regression in any of those cases: with the keystroke intercepted, panels simply don't respond, symmetric `Ctrl+Up/Down` still works as before.
