### PR TITLE
Fix duplicate 'A' hotkey in Options menu (closes #214)

### DIFF
--- a/lang.go
+++ b/lang.go
@@ -79,7 +79,7 @@ var Lng = map[string]string{
 	"Menu.EditorSettings":          "Editor settings",
 	"Menu.AppearanceSettings":      "Appearance settings",
 	"Menu.ConfirmationsSettings":   "Confirmations",
-	"Menu.AutoUpdateSettings":      "Auto update",
+	"Menu.AutoUpdateSettings":      "A&uto update",
 	"Menu.Options.Plugins":         "Manage plugins",
 	"EditorSettings.Title":         " Editor settings ",
 	"EditorSettings.AutoComplete":  "Enable &Autocomplete",

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -199,7 +199,7 @@ func NewPanelsFrame() *PanelsFrame {
 			{Text: "&" + Msg("Menu.AppearanceSettings"), Command: CmAppearanceSettings},
 			{Text: "&" + Msg("Menu.ConfirmationsSettings"), Command: CmConfirmationsSettings},
 			{Separator: true},
-			{Text: "&" + Msg("Menu.AutoUpdateSettings"), Command: CmUpdateSettings},
+			{Text: Msg("Menu.AutoUpdateSettings"), Command: CmUpdateSettings},
 			{Separator: true},
 			{Text: "&" + Msg("Menu.Options.Plugins"), Command: CmPlugins},
 		}},


### PR DESCRIPTION
Closes #214.

## Summary

Both "Appearance settings" and "Auto update" in the Options menu had `A` as their hotkey — the menu builder always prepends `&` to each label, so any item starting with the same letter collides. Moved "Auto update" to `U` (the natural second letter of "**A**uto") by embedding the `&` inside the localised string as `A&uto update` and dropping the auto-prepended `&` for that one entry.

Rest of the Options menu is unaffected — Panel settings (`P`), Editor settings (`E`), Appearance settings (`A`), Confirmations (`C`), Manage plugins (`M`). None use `U`, so no new collision.

## Test plan

- [x] `go build ./...` clean, `gofmt -w -s` clean.
- [x] Manual smoke: F9 → Options. "Appearance settings" underlines `A`, "Auto update" underlines `u`. Pressing `U` in the open menu opens the Auto-update dialog.
