### PR TITLE
Menu hotkey follow-ups: Exit gets X, Auto update highlights second word

### DIFF
--- a/lang.go
+++ b/lang.go
@@ -58,7 +58,7 @@ var Lng = map[string]string{
 	"Menu.Commands": "Commands",
 	"Menu.Options":  "Options",
 	"Menu.Right":    "Right",
-	"Menu.Exit":     "Exit",
+	"Menu.Exit":     "E&xit",
 	// Files Menu specific strings
 	"Menu.Files.View":              "View",
 	"Menu.Files.Edit":              "Edit",
@@ -79,7 +79,7 @@ var Lng = map[string]string{
 	"Menu.EditorSettings":          "Editor settings",
 	"Menu.AppearanceSettings":      "Appearance settings",
 	"Menu.ConfirmationsSettings":   "Confirmations",
-	"Menu.AutoUpdateSettings":      "A&uto update",
+	"Menu.AutoUpdateSettings":      "Auto &update",
 	"Menu.Options.Plugins":         "Manage plugins",
 	"EditorSettings.Title":         " Editor settings ",
 	"EditorSettings.AutoComplete":  "Enable &Autocomplete",


### PR DESCRIPTION
Two menu-hotkey nits that surfaced after #229:

## Changes

* **Exit** in the Left menu had no hotkey at all — the label used `Msg("Menu.Exit")` without a `&` marker. Bind it to `x` (`E&xit`). The `E` slot in that same submenu is already taken by "Extension", and `x` matches the Windows-app convention for Exit.

* **Auto update** in the Options menu got its hotkey moved to `u` in #229, but the marker landed inside the first word (`A&uto update`) — the second word is what identifies the entry semantically. Move the marker to `Auto &update` — the hotkey stays `u`, just underlined in the more natural place.

## Hotkey audit for the neighbouring items

Re-checked all submenus and dialogs while I was here. After these two changes, no other duplicates within a single column:

* **Left / Right** (identical): `M`edium, `D`etailed, `N`ame, `E`xtension, `T`ime, `S`ize, `U`nsorted, Bac`k`ground, E`x`it (Left only) — all unique.
* **Files**: `V`iew, `E`dit, `C`opy, `R`ename or move, `M`ake folder, `D`elete — all unique.
* **Commands**: `F`ind file, `B`ookmarks — unique.
* **Options**: `P`anel settings, `E`ditor settings, `A`ppearance settings, `C`onfirmations, Auto `u`pdate, `M`anage plugins — unique.
* **Panel / Editor / Appearance / Confirmations / Update Settings** dialogs — checked each; all internally unique.

## Test plan

- [x] `go build ./...` clean, `gofmt -w -s` clean.
- [x] Manual smoke: F9 → Left shows `Exit` with `x` underlined and closes f4 on `X`. F9 → Options shows `Auto update` with the `u` in "update" underlined, and pressing `U` opens the Auto-update dialog.
