### PR TITLE
Fix Ctrl+Left/Right resize direction to match far2l/Far3 (closes #231)

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -905,9 +905,13 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	// With a non-empty cmdline, fall through to word navigation instead.
 	if (e.VirtualKeyCode == vtinput.VK_LEFT || e.VirtualKeyCode == vtinput.VK_RIGHT) && ctrl && !alt && !shift && e.KeyDown {
 		if pf.showPanels && pf.cmdLine.Edit.GetText() == "" {
-			delta := 1
+			// Match far2l: Ctrl+Left bumps WidthDecrement, moving the
+			// split to the left (left panel shrinks, right grows).
+			// Ctrl+Right does the reverse. This is the arrow-follows-
+			// boundary intuition and lines up with Far3/far2m.
+			delta := -1
 			if e.VirtualKeyCode == vtinput.VK_LEFT {
-				delta = -1
+				delta = 1
 			}
 			next := pf.widthDecrement + delta
 			if maxWD := (pf.lastW / 2) - 10; maxWD > 0 && next <= maxWD && next >= -maxWD {

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3509,35 +3509,36 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 		})
 	}
 
-	// Width: Ctrl+Right grows right panel (widthDecrement +1);
-	// Ctrl+Left shrinks it back and then grows left.
+	// Width: Ctrl+Left moves the split to the left (widthDecrement +1,
+	// left panel shrinks, right grows) — arrow follows the boundary,
+	// matching far2l / Far3 / far2m. Ctrl+Right does the reverse.
 	pf := setupMockPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	baseLeft := panelWidth(pf.panels[0])
 
-	send(pf, vtinput.VK_RIGHT)
+	send(pf, vtinput.VK_LEFT)
 	if pf.widthDecrement != 1 {
-		t.Errorf("Ctrl+Right: widthDecrement=%d, want 1", pf.widthDecrement)
+		t.Errorf("Ctrl+Left: widthDecrement=%d, want 1", pf.widthDecrement)
 	}
 	if got := panelWidth(pf.panels[0]); got != baseLeft-1 {
-		t.Errorf("Ctrl+Right: left panel width=%d, want %d", got, baseLeft-1)
+		t.Errorf("Ctrl+Left: left panel width=%d, want %d", got, baseLeft-1)
 	}
 
-	send(pf, vtinput.VK_LEFT)
-	send(pf, vtinput.VK_LEFT)
+	send(pf, vtinput.VK_RIGHT)
+	send(pf, vtinput.VK_RIGHT)
 	if pf.widthDecrement != -1 {
-		t.Errorf("Ctrl+Left twice: widthDecrement=%d, want -1", pf.widthDecrement)
+		t.Errorf("Ctrl+Right twice: widthDecrement=%d, want -1", pf.widthDecrement)
 	}
 	if got := panelWidth(pf.panels[0]); got != baseLeft+1 {
-		t.Errorf("Ctrl+Left twice: left panel width=%d, want %d", got, baseLeft+1)
+		t.Errorf("Ctrl+Right twice: left panel width=%d, want %d", got, baseLeft+1)
 	}
 
 	// Non-empty cmdline: Ctrl+Left/Right must NOT resize.
 	pf.widthDecrement = 0
 	pf.ResizeConsole(80, 25)
 	pf.cmdLine.Edit.SetText("hello")
-	send(pf, vtinput.VK_RIGHT)
+	send(pf, vtinput.VK_LEFT)
 	if pf.widthDecrement != 0 {
 		t.Errorf("non-empty cmdline: widthDecrement changed to %d, want 0", pf.widthDecrement)
 	}
@@ -3571,11 +3572,12 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 			pf.leftHeightDecrement, pf.rightHeightDecrement)
 	}
 
-	// Width clamp: on an 80-col terminal, maxWD = 40 - 10 = 30. Push past it.
+	// Width clamp: on an 80-col terminal, maxWD = 40 - 10 = 30. Push
+	// past it with Ctrl+Left (the direction that bumps widthDecrement +1).
 	pf.widthDecrement = 0
 	pf.ResizeConsole(80, 25)
 	for i := 0; i < 40; i++ {
-		send(pf, vtinput.VK_RIGHT)
+		send(pf, vtinput.VK_LEFT)
 	}
 	if pf.widthDecrement != 30 {
 		t.Errorf("width clamp: widthDecrement=%d, want 30", pf.widthDecrement)


### PR DESCRIPTION
Closes #231.

## What was wrong

The `Ctrl+Left` / `Ctrl+Right` width handler introduced in #225 had the sign flipped versus far2l / Far3 / far2m: `Ctrl+Right` was bumping `widthDecrement` (moving the split to the left, growing the right panel), while the Far family does the opposite — the arrow follows the boundary. Verified against `far2l/src/filepanels.cpp:758-777` (`KEY_CTRLLEFT` → `WidthDecrement++`, `KEY_CTRLRIGHT` → `WidthDecrement--`).

## Fix

One-line delta swap in `panels_frame.go`. Now:

- `Ctrl+Left` — split moves to the left, left panel shrinks, right panel grows (`widthDecrement +1`).
- `Ctrl+Right` — split moves to the right, left panel grows, right panel shrinks (`widthDecrement -1`).

Clamp range unchanged.

## Persistence side-effect

`WidthDecrement` stored in `settings.ini` (added in #227) now shares its sign convention with far2l's `config.ini`: positive shrinks the left panel. Users of the previous behaviour will see their existing split visually flip on first launch after this fix; one adjustment restores the desired layout and the corrected value is persisted. This is the price of matching far2l — sharing a config file was the whole point of the `[Layout]` section, so keeping f4-only semantics under the same key names would have been worse.

## Test plan

- [x] `go build ./...` clean, `gofmt -w -s` clean.
- [x] `go test -run TestPanelsFrame_CtrlArrows_ResizePanels -v` passes with the swapped-direction assertions.
- [x] Manual smoke on WSL Ubuntu 22.04: `Ctrl+Left` on default-split panels — left narrows, right widens; `Ctrl+Right` — reverse. Matches far2l on the same terminal.
