### PR TITLE
InfoPanel: opt-in CPU/GPU sections + row cursor, selection and copy

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1640,7 +1640,7 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	dlg := vtui.NewCenteredDialog(60, 24, Msg("PanelSettings.Title"))
+	dlg := vtui.NewCenteredDialog(60, 25, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
 	chkHidden := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowHidden"), false)
@@ -1684,6 +1684,12 @@ func actionPanelSettings(pf *PanelsFrame) {
 		chkAlwaysMenu.State = 1
 	}
 
+	chkCPUGPU := vtui.NewCheckbox(0, 0, Msg("PanelSettings.InfoPanelCPUGPU"), false)
+	chkCPUGPU.State = 0
+	if AppConfig.InfoPanelCPUGPU {
+		chkCPUGPU.State = 1
+	}
+
 	modes := []string{Msg("Op.Queue"), Msg("Op.Background"), Msg("Op.Foreground")}
 	comboMode := vtui.NewComboBox(0, 0, 30, modes)
 	comboMode.DropdownOnly = true
@@ -1709,6 +1715,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(chkVim)
 	dlg.AddItem(chkSync)
 	dlg.AddItem(chkAlwaysMenu)
+	dlg.AddItem(chkCPUGPU)
 	dlg.AddItem(lblMode)
 	dlg.AddItem(comboMode)
 	dlg.AddItem(lblPath)
@@ -1716,7 +1723,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
 
-	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 54-4, 24-4)
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 54-4, 25-4)
 	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkHighlight, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
@@ -1725,6 +1732,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 
 	vbox.Add(chkSync, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkAlwaysMenu, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkCPUGPU, vtui.Margins{Top: 1}, vtui.AlignLeft)
 
 	rowMode := vtui.NewHBoxLayout(0, 0, 54-4, 1)
 	rowMode.Add(lblMode, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -1754,6 +1762,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.VimHotkeys = chkVim.State == 1
 		AppConfig.SyncPanelLoad = chkSync.State == 1
 		AppConfig.AlwaysShowMenuBar = chkAlwaysMenu.State == 1
+		AppConfig.InfoPanelCPUGPU = chkCPUGPU.State == 1
 		AppConfig.DefaultFileOpMode = comboMode.Menu.SelectPos
 		AppConfig.FileOpPathDisplay = comboPath.Menu.SelectPos
 		SaveConfig()

--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ type F4Config struct {
 	HighlightDir             bool
 	SavePanelPaths           bool
 	InfoPanelBytes           bool // Ctrl+L info panel: true = raw bytes, false = human (GiB/MiB…)
+	InfoPanelCPUGPU          bool // Ctrl+L info panel: show CPU and GPU sections (off by default)
 	KeepTerminalCursor       bool
 	CommandLineAutoComplete  bool
 	VimHotkeys               bool
@@ -137,6 +138,7 @@ var AppConfig = F4Config{
 	HighlightDir:             true,
 	SavePanelPaths:           true,
 	InfoPanelBytes:           false,
+	InfoPanelCPUGPU:          false,
 	KeepTerminalCursor:       false,
 	CommandLineAutoComplete:  true,
 	VimHotkeys:               false,
@@ -230,6 +232,7 @@ func LoadConfig() {
 	AppConfig.HighlightDir = ini.GetString("Panel", "HighlightDir", "1") == "1"
 	AppConfig.SavePanelPaths = ini.GetString("Panel", "SavePanelPaths", "1") == "1"
 	AppConfig.InfoPanelBytes = ini.GetString("Panel", "InfoPanelBytes", "0") == "1"
+	AppConfig.InfoPanelCPUGPU = ini.GetString("Panel", "InfoPanelCPUGPU", "0") == "1"
 	AppConfig.KeepTerminalCursor = ini.GetString("Panel", "KeepTerminalCursor", "0") == "1"
 	AppConfig.CommandLineAutoComplete = ini.GetString("Panel", "CommandLineAutoComplete", "1") == "1"
 	AppConfig.VimHotkeys = ini.GetString("Panel", "VimHotkeys", "0") == "1"
@@ -325,6 +328,7 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("HighlightDir = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.HighlightDir]))
 	sb.WriteString(fmt.Sprintf("SavePanelPaths = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SavePanelPaths]))
 	sb.WriteString(fmt.Sprintf("InfoPanelBytes = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelBytes]))
+	sb.WriteString(fmt.Sprintf("InfoPanelCPUGPU = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelCPUGPU]))
 	sb.WriteString(fmt.Sprintf("KeepTerminalCursor = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.KeepTerminalCursor]))
 	sb.WriteString(fmt.Sprintf("CommandLineAutoComplete = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.CommandLineAutoComplete]))
 	sb.WriteString(fmt.Sprintf("VimHotkeys = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.VimHotkeys]))

--- a/cpu_info.go
+++ b/cpu_info.go
@@ -1,0 +1,18 @@
+package main
+
+// CPUInfo is what the InfoPanel's CPU section renders. Fields are
+// filled only where the OS supplies them; the panel skips missing
+// rows. Load and LoadAvg are kept as separate signals — Linux gives
+// loadavg for free from /proc/loadavg, Windows and macOS produce an
+// instantaneous percent.
+type CPUInfo struct {
+	Model         string
+	PhysicalCores int        // real cores (sockets × cores-per-socket); 0 if unknown
+	LogicalCores  int        // hardware threads visible to the OS (runtime.NumCPU baseline)
+	FreqMHz       int        // nominal/max clock in MHz; 0 if unknown or fixed (Apple Silicon)
+	CacheBytes    [4]uint64  // L1..L4 in bytes; 0-entries render as blank
+	LoadAvg       [3]float64 // 1 / 5 / 15 minute averages (Linux, macOS)
+	HasLoad       bool       // true when LoadAvg is populated
+	Load          int        // 0..100 (Windows)
+	HasLoadPct    bool       // true when Load is populated
+}

--- a/cpu_info_darwin.go
+++ b/cpu_info_darwin.go
@@ -1,0 +1,95 @@
+//go:build darwin
+
+package main
+
+import (
+	"encoding/binary"
+	"runtime"
+	"sync"
+	"syscall"
+)
+
+var (
+	cpuStaticOnce sync.Once
+	cachedCPU     CPUInfo
+)
+
+func cpuInfo() (CPUInfo, bool) {
+	cpuStaticOnce.Do(func() {
+		cachedCPU = readStaticDarwinCPU()
+	})
+	info := cachedCPU
+	if la, ok := readLoadAvgDarwin(); ok {
+		info.LoadAvg = la
+		info.HasLoad = true
+	}
+	if info.Model == "" && info.LogicalCores == 0 && info.PhysicalCores == 0 &&
+		info.FreqMHz == 0 && info.CacheBytes == [4]uint64{} && !info.HasLoad {
+		return CPUInfo{}, false
+	}
+	return info, true
+}
+
+func readStaticDarwinCPU() CPUInfo {
+	info := CPUInfo{LogicalCores: runtime.NumCPU()}
+	if s, err := syscall.Sysctl("machdep.cpu.brand_string"); err == nil {
+		info.Model = s
+	}
+	if n, ok := sysctlUint64("hw.physicalcpu"); ok {
+		info.PhysicalCores = int(n)
+	}
+	// hw.cpufrequency returns nominal clock in Hz on Intel; on Apple
+	// Silicon this key is absent (fixed-frequency P/E cores with
+	// on-die scaling — no meaningful single number). Skip on error.
+	if hz, ok := sysctlUint64("hw.cpufrequency"); ok && hz > 0 {
+		info.FreqMHz = int(hz / 1_000_000)
+	}
+	// L1i and L1d live under separate keys — sum them into L1.
+	l1i, _ := sysctlUint64("hw.l1icachesize")
+	l1d, _ := sysctlUint64("hw.l1dcachesize")
+	info.CacheBytes[0] = l1i + l1d
+	if n, ok := sysctlUint64("hw.l2cachesize"); ok {
+		info.CacheBytes[1] = n
+	}
+	if n, ok := sysctlUint64("hw.l3cachesize"); ok {
+		info.CacheBytes[2] = n
+	}
+	return info
+}
+
+// sysctlUint64 wraps syscall.Sysctl for numeric keys. Darwin returns
+// them as raw little-endian bytes; length is 4 or 8 depending on
+// the key (hw.cpufrequency is 8 on 64-bit systems, hw.l*cachesize
+// is 8, hw.physicalcpu is 4).
+func sysctlUint64(name string) (uint64, bool) {
+	raw, err := syscall.Sysctl(name)
+	if err != nil {
+		return 0, false
+	}
+	b := []byte(raw)
+	switch len(b) {
+	case 4:
+		return uint64(binary.LittleEndian.Uint32(b)), true
+	case 8:
+		return binary.LittleEndian.Uint64(b), true
+	}
+	return 0, false
+}
+
+// readLoadAvgDarwin reads vm.loadavg. macOS returns a struct loadavg
+// (fixpt_t ldavg[3]; long fscale). fscale is stable at 2048 on
+// Darwin (sys/resource.h: FSCALE = 1<<11), so we skip decoding it —
+// makes the parse layout-independent.
+func readLoadAvgDarwin() ([3]float64, bool) {
+	raw, err := syscall.Sysctl("vm.loadavg")
+	if err != nil || len(raw) < 12 {
+		return [3]float64{}, false
+	}
+	const fscale = 2048.0
+	var out [3]float64
+	for i := 0; i < 3; i++ {
+		v := binary.LittleEndian.Uint32([]byte(raw[i*4 : i*4+4]))
+		out[i] = float64(v) / fscale
+	}
+	return out, true
+}

--- a/cpu_info_linux.go
+++ b/cpu_info_linux.go
@@ -1,0 +1,210 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var (
+	cpuStaticOnce sync.Once
+	cachedCPU     CPUInfo
+)
+
+func cpuInfo() (CPUInfo, bool) {
+	cpuStaticOnce.Do(func() {
+		cachedCPU = readStaticLinuxCPU()
+	})
+	info := cachedCPU
+	if la, ok := readLoadAvg(); ok {
+		info.LoadAvg = la
+		info.HasLoad = true
+	}
+	if info.Model == "" && info.LogicalCores == 0 && info.PhysicalCores == 0 &&
+		info.FreqMHz == 0 && info.CacheBytes == [4]uint64{} && !info.HasLoad {
+		return CPUInfo{}, false
+	}
+	return info, true
+}
+
+func readStaticLinuxCPU() CPUInfo {
+	info := CPUInfo{LogicalCores: runtime.NumCPU()}
+	parseProcCPUInfo(&info)
+	if info.FreqMHz == 0 {
+		if khz, ok := readUintFile("/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq"); ok {
+			info.FreqMHz = int(khz / 1000)
+		}
+	}
+	readLinuxCaches(&info)
+	return info
+}
+
+// parseProcCPUInfo pulls model name, cpu MHz and physical-core count
+// from /proc/cpuinfo. Physical cores are counted as the number of
+// distinct (physical id, core id) pairs — the same trick lscpu uses.
+// On single-socket kernels that omit physical id we fall back to
+// "cpu cores" from the first processor block, which is per-socket.
+func parseProcCPUInfo(info *CPUInfo) {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return
+	}
+	defer f.Close()
+
+	pairs := map[string]struct{}{}
+	physID, coreID := "", ""
+	haveTopology := false
+	firstBlockCores := 0
+	sockets := map[string]struct{}{}
+
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		colon := strings.IndexByte(line, ':')
+		if colon < 0 {
+			if physID != "" && coreID != "" {
+				pairs[physID+"/"+coreID] = struct{}{}
+				sockets[physID] = struct{}{}
+				haveTopology = true
+			}
+			physID, coreID = "", ""
+			continue
+		}
+		key := strings.TrimSpace(line[:colon])
+		val := strings.TrimSpace(line[colon+1:])
+		switch key {
+		case "model name", "Model", "cpu model":
+			if info.Model == "" {
+				info.Model = val
+			}
+		case "cpu MHz":
+			if info.FreqMHz == 0 {
+				if f, err := strconv.ParseFloat(val, 64); err == nil {
+					info.FreqMHz = int(f + 0.5)
+				}
+			}
+		case "physical id":
+			physID = val
+		case "core id":
+			coreID = val
+		case "cpu cores":
+			if firstBlockCores == 0 {
+				firstBlockCores, _ = strconv.Atoi(val)
+			}
+		}
+	}
+	if physID != "" && coreID != "" {
+		pairs[physID+"/"+coreID] = struct{}{}
+		sockets[physID] = struct{}{}
+		haveTopology = true
+	}
+	switch {
+	case haveTopology && len(pairs) > 0:
+		info.PhysicalCores = len(pairs)
+	case firstBlockCores > 0:
+		// Single-socket fallback: kernels that don't emit
+		// physical id still print cpu cores per-processor.
+		info.PhysicalCores = firstBlockCores
+	}
+}
+
+// readLinuxCaches scans /sys/devices/system/cpu/cpu0/cache and
+// aggregates unified/data-side caches per level. We use cpu0 as the
+// witness — cores within a socket share caches from L2 upward, and
+// asymmetric big.LITTLE cores (Alder Lake) still list the same L1
+// per cpu. Sizes come as "32K" / "12M" strings.
+func readLinuxCaches(info *CPUInfo) {
+	entries, err := filepath.Glob("/sys/devices/system/cpu/cpu0/cache/index*")
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		level := 0
+		if s, err := os.ReadFile(filepath.Join(e, "level")); err == nil {
+			level, _ = strconv.Atoi(strings.TrimSpace(string(s)))
+		}
+		if level < 1 || level > 4 {
+			continue
+		}
+		typ := ""
+		if s, err := os.ReadFile(filepath.Join(e, "type")); err == nil {
+			typ = strings.TrimSpace(string(s))
+		}
+		// L1 has separate Data / Instruction; sum both under "L1".
+		// L2+ are unified — we take the size once.
+		if level > 1 && typ == "Instruction" {
+			continue
+		}
+		sizeStr := ""
+		if s, err := os.ReadFile(filepath.Join(e, "size")); err == nil {
+			sizeStr = strings.TrimSpace(string(s))
+		}
+		bytes := parseCacheSize(sizeStr)
+		if bytes == 0 {
+			continue
+		}
+		info.CacheBytes[level-1] += bytes
+	}
+}
+
+func parseCacheSize(s string) uint64 {
+	if s == "" {
+		return 0
+	}
+	mult := uint64(1)
+	switch s[len(s)-1] {
+	case 'K', 'k':
+		mult = 1024
+		s = s[:len(s)-1]
+	case 'M', 'm':
+		mult = 1024 * 1024
+		s = s[:len(s)-1]
+	case 'G', 'g':
+		mult = 1024 * 1024 * 1024
+		s = s[:len(s)-1]
+	}
+	n, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n * mult
+}
+
+func readUintFile(path string) (uint64, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(strings.TrimSpace(string(b)), 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// readLoadAvg parses the first three numbers from /proc/loadavg.
+func readLoadAvg() ([3]float64, bool) {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return [3]float64{}, false
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) < 3 {
+		return [3]float64{}, false
+	}
+	var out [3]float64
+	for i := 0; i < 3; i++ {
+		v, err := strconv.ParseFloat(fields[i], 64)
+		if err != nil {
+			return [3]float64{}, false
+		}
+		out[i] = v
+	}
+	return out, true
+}

--- a/cpu_info_other.go
+++ b/cpu_info_other.go
@@ -1,0 +1,16 @@
+//go:build !linux && !windows && !darwin
+
+package main
+
+import "runtime"
+
+// cpuInfo stub for the *BSDs / illumos where fs_info is already a
+// stub too — surface at least the core count so the section renders
+// something meaningful. Model + load stay empty.
+func cpuInfo() (CPUInfo, bool) {
+	c := runtime.NumCPU()
+	if c <= 0 {
+		return CPUInfo{}, false
+	}
+	return CPUInfo{LogicalCores: c}, true
+}

--- a/cpu_info_windows.go
+++ b/cpu_info_windows.go
@@ -1,0 +1,290 @@
+//go:build windows
+
+package main
+
+import (
+	"encoding/binary"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+	"golang.org/x/sys/windows"
+)
+
+var (
+	cpuStaticOnce sync.Once
+	cachedCPU     CPUInfo
+)
+
+// pdhInit runs once and, on success, populates the four function
+// pointers used by sampleCPULoad. On any failure we leave them nil
+// and the CPU section still renders Model + Cores.
+var (
+	pdhOnce sync.Once
+	pdhOK   bool
+
+	pdhOpenQueryW               func(dataSrc *uint16, userData uintptr, hQuery *uintptr) uint32
+	pdhAddEnglishCounterW       func(hQuery uintptr, path *uint16, userData uintptr, hCounter *uintptr) uint32
+	pdhCollectQueryData         func(hQuery uintptr) uint32
+	pdhGetFormattedCounterValue func(hCounter uintptr, format uint32, counterType *uint32, val *pdhFmtCounterValueDouble) uint32
+)
+
+// PDH counter names are English-only when queried through
+// PdhAddEnglishCounterW, which sidesteps localization. Utility is
+// the Task-Manager metric (Win8+); Time is the classic fallback.
+const (
+	pdhCounterUtility = `\Processor Information(_Total)\% Processor Utility`
+	pdhCounterTime    = `\Processor Information(_Total)\% Processor Time`
+	pdhFmtDouble      = 0x00000200
+	pdhCstatusValid   = 0
+)
+
+// PDH_FMT_COUNTERVALUE with the double member selected. Explicit
+// _pad so the layout is unambiguous on x64 regardless of Go's
+// struct-packing choices.
+type pdhFmtCounterValueDouble struct {
+	CStatus   uint32
+	_pad      uint32
+	DoubleVal float64
+}
+
+var (
+	cpuLoadMu  sync.Mutex
+	hQuery     uintptr
+	hCounter   uintptr
+	haveSample bool
+	lastSample time.Time
+	lastPct    int
+	hasLast    bool
+)
+
+const cpuSampleInterval = 500 * time.Millisecond
+
+func cpuInfo() (CPUInfo, bool) {
+	cpuStaticOnce.Do(func() {
+		cachedCPU = readStaticWindowsCPU()
+	})
+	info := cachedCPU
+	if pct, ok := sampleCPULoad(); ok {
+		info.Load = pct
+		info.HasLoadPct = true
+	}
+	if info.Model == "" && info.LogicalCores == 0 && info.PhysicalCores == 0 &&
+		info.FreqMHz == 0 && info.CacheBytes == [4]uint64{} && !info.HasLoadPct {
+		return CPUInfo{}, false
+	}
+	return info, true
+}
+
+func readStaticWindowsCPU() CPUInfo {
+	info := CPUInfo{LogicalCores: runtime.NumCPU()}
+	info.Model = readCPUModelReg()
+	info.FreqMHz = readCPUFreqReg()
+	readWindowsTopology(&info)
+	return info
+}
+
+// initPDH loads pdh.dll, opens a query, and adds the counter.
+// Called lazily on first sample. Silent failure: pdhOK stays false
+// and sampleCPULoad short-circuits. RegisterLibFunc panics on a
+// missing symbol, hence the recover — pdh.dll is present on all
+// current Windows installs but we tolerate its absence anyway.
+func initPDH() {
+	pdhOnce.Do(func() {
+		defer func() {
+			if r := recover(); r != nil {
+				pdhOK = false
+			}
+		}()
+		h, err := purego.Dlopen("pdh.dll", 0)
+		if err != nil || h == 0 {
+			return
+		}
+		purego.RegisterLibFunc(&pdhOpenQueryW, h, "PdhOpenQueryW")
+		purego.RegisterLibFunc(&pdhAddEnglishCounterW, h, "PdhAddEnglishCounterW")
+		purego.RegisterLibFunc(&pdhCollectQueryData, h, "PdhCollectQueryData")
+		purego.RegisterLibFunc(&pdhGetFormattedCounterValue, h, "PdhGetFormattedCounterValue")
+
+		if pdhOpenQueryW(nil, 0, &hQuery) != 0 {
+			return
+		}
+		util, _ := syscall.UTF16PtrFromString(pdhCounterUtility)
+		if pdhAddEnglishCounterW(hQuery, util, 0, &hCounter) != 0 {
+			// Older Windows / disabled counter set — fall back
+			// to % Processor Time. Same metric the old
+			// GetSystemTimes path produced, so we don't regress.
+			classic, _ := syscall.UTF16PtrFromString(pdhCounterTime)
+			if pdhAddEnglishCounterW(hQuery, classic, 0, &hCounter) != 0 {
+				return
+			}
+		}
+		pdhOK = true
+	})
+}
+
+// sampleCPULoad returns the last computed CPU load %. Throttled to
+// once per cpuSampleInterval so the panel can Show() as fast as it
+// likes without hammering PDH. Returns ok=false until we have two
+// samples (PDH's first collect is unusable).
+func sampleCPULoad() (int, bool) {
+	initPDH()
+	if !pdhOK {
+		return 0, false
+	}
+
+	cpuLoadMu.Lock()
+	defer cpuLoadMu.Unlock()
+
+	now := time.Now()
+	if hasLast && now.Sub(lastSample) < cpuSampleInterval {
+		return lastPct, true
+	}
+	if pdhCollectQueryData(hQuery) != 0 {
+		return lastPct, hasLast
+	}
+	lastSample = now
+	if !haveSample {
+		haveSample = true
+		return 0, false
+	}
+	var v pdhFmtCounterValueDouble
+	if pdhGetFormattedCounterValue(hCounter, pdhFmtDouble, nil, &v) != 0 || v.CStatus != pdhCstatusValid {
+		return lastPct, hasLast
+	}
+	pct := int(v.DoubleVal + 0.5)
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	lastPct = pct
+	hasLast = true
+	return pct, true
+}
+
+// readCPUModelReg reads the ProcessorNameString registry value the
+// kernel populates at boot. Empty on failure — caller skips the row.
+func readCPUModelReg() string {
+	keyPath, err := windows.UTF16PtrFromString(`HARDWARE\DESCRIPTION\System\CentralProcessor\0`)
+	if err != nil {
+		return ""
+	}
+	var h windows.Handle
+	if err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, keyPath, 0, windows.KEY_READ, &h); err != nil {
+		return ""
+	}
+	defer windows.RegCloseKey(h)
+
+	name, err := windows.UTF16PtrFromString("ProcessorNameString")
+	if err != nil {
+		return ""
+	}
+	var typ, size uint32
+	if err := windows.RegQueryValueEx(h, name, nil, &typ, nil, &size); err != nil {
+		return ""
+	}
+	if size == 0 {
+		return ""
+	}
+	buf := make([]byte, size)
+	if err := windows.RegQueryValueEx(h, name, nil, &typ, &buf[0], &size); err != nil {
+		return ""
+	}
+	u16 := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[0])), size/2)
+	return windows.UTF16ToString(u16)
+}
+
+// readCPUFreqReg pulls the ~MHz DWORD from the same registry key.
+// It's the nominal clock (base MHz), not the current turbo state —
+// good enough for an info-panel row and consistent with what wmic
+// / Task Manager list under "Base speed".
+func readCPUFreqReg() int {
+	keyPath, err := windows.UTF16PtrFromString(`HARDWARE\DESCRIPTION\System\CentralProcessor\0`)
+	if err != nil {
+		return 0
+	}
+	var h windows.Handle
+	if err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, keyPath, 0, windows.KEY_READ, &h); err != nil {
+		return 0
+	}
+	defer windows.RegCloseKey(h)
+	name, err := windows.UTF16PtrFromString("~MHz")
+	if err != nil {
+		return 0
+	}
+	var typ, size uint32 = 0, 4
+	var val uint32
+	if err := windows.RegQueryValueEx(h, name, nil, &typ, (*byte)(unsafe.Pointer(&val)), &size); err != nil {
+		return 0
+	}
+	return int(val)
+}
+
+// GetLogicalProcessorInformation gives us physical-core count and
+// per-level cache sizes in one call. We loop, sizing the buffer on
+// the first ERROR_INSUFFICIENT_BUFFER, then walk 32-byte entries.
+var (
+	kernel32CPU                        = windows.NewLazySystemDLL("kernel32.dll")
+	procGetLogicalProcessorInformation = kernel32CPU.NewProc("GetLogicalProcessorInformation")
+)
+
+const (
+	relationProcessorCore = 0
+	relationCache         = 2
+)
+
+// Each SYSTEM_LOGICAL_PROCESSOR_INFORMATION entry is 32 bytes on
+// x64 / amd64 build target: ULONG_PTR(8) + Relationship(4) + pad(4)
+// + union(16). We keep the layout explicit rather than importing a
+// header, because purego doesn't rewrap it and neither does
+// golang.org/x/sys/windows.
+const slpiSize = 32
+
+func readWindowsTopology(info *CPUInfo) {
+	// Two-pass sizing.
+	var need uint32
+	r1, _, _ := procGetLogicalProcessorInformation.Call(0, uintptr(unsafe.Pointer(&need)))
+	if r1 != 0 || need == 0 {
+		return
+	}
+	buf := make([]byte, need)
+	r2, _, _ := procGetLogicalProcessorInformation.Call(
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&need)),
+	)
+	if r2 == 0 {
+		return
+	}
+	entries := int(need) / slpiSize
+	for i := 0; i < entries; i++ {
+		e := buf[i*slpiSize : (i+1)*slpiSize]
+		mask := binary.LittleEndian.Uint64(e[0:8])
+		rel := binary.LittleEndian.Uint32(e[8:12])
+		payload := e[16:32]
+		switch rel {
+		case relationProcessorCore:
+			info.PhysicalCores++
+			_ = mask // logical threads = popcount(mask); already have via runtime.NumCPU
+		case relationCache:
+			// CACHE_DESCRIPTOR: BYTE Level; BYTE Associativity;
+			// WORD LineSize; DWORD Size; ProcessorCacheType Type.
+			level := int(payload[0])
+			size := binary.LittleEndian.Uint32(payload[4:8])
+			cType := binary.LittleEndian.Uint32(payload[8:12])
+			// PROCESSOR_CACHE_TYPE: 0 Unified, 1 Instruction,
+			// 2 Data, 3 Trace. Skip Instruction on L2+ (unified
+			// is authoritative); at L1 we count both I+D.
+			if level < 1 || level > 4 || size == 0 {
+				continue
+			}
+			if level > 1 && cType == 1 {
+				continue
+			}
+			info.CacheBytes[level-1] += uint64(size)
+		}
+	}
+}

--- a/gpu_info.go
+++ b/gpu_info.go
@@ -1,0 +1,9 @@
+package main
+
+// GPUInfo is what the InfoPanel's GPU section renders. Systems with
+// dGPU + iGPU return two entries. Empty slice → section is hidden
+// entirely (macOS, headless *BSD, containers with no /dev/dri).
+type GPUInfo struct {
+	Model  string
+	Driver string // kernel driver on Linux, DriverDesc/Provider on Windows; "" if unknown
+}

--- a/gpu_info_darwin.go
+++ b/gpu_info_darwin.go
@@ -1,0 +1,13 @@
+//go:build darwin
+
+package main
+
+// gpuInfo on darwin: IOKit is the honest source but pulling it
+// requires cgo, which we deliberately avoid. On Apple Silicon the
+// GPU shares its identity with the CPU (Apple M2 Pro = both), and
+// the info panel already renders CPU model. Rather than surface a
+// noisy or misleading string, we skip the section. A follow-up can
+// pull in an IOKit binding if anyone wants a distinct GPU row.
+func gpuInfo() ([]GPUInfo, bool) {
+	return nil, false
+}

--- a/gpu_info_linux.go
+++ b/gpu_info_linux.go
@@ -4,11 +4,14 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 var (
@@ -92,19 +95,88 @@ func enumerateLinuxGPUs() []GPUInfo {
 	}
 	// WSL2 fallback. Microsoft's GPU passthrough uses dxgkrnl via
 	// /dev/dxg instead of exposing anything under /sys/class/drm.
-	// If we found nothing above and /dev/dxg is present, at least
-	// tell the user *something* is there rather than hide the
-	// section — the host adapter name would need dxgkio ioctl
-	// plumbing which is out of scope for a display panel.
+	// Ask Windows for the host adapter name(s) through WSL interop:
+	// wmic.exe is on $PATH by default in WSL, sub-second, and gives
+	// the same string dxdiag / Device Manager show.
 	if len(out) == 0 {
 		if _, err := os.Stat("/dev/dxg"); err == nil {
-			out = append(out, GPUInfo{
-				Model:  Msg("InfoPanel.GPUWSLVirt"),
-				Driver: "dxgkrnl",
-			})
+			names := queryHostGPUsFromWSL()
+			if len(names) > 0 {
+				for _, n := range names {
+					out = append(out, GPUInfo{Model: n, Driver: "dxgkrnl"})
+				}
+			} else {
+				// Interop unavailable (Windows LTSC without wmic,
+				// PowerShell blocked, /mnt/c not mounted) — at
+				// least confirm the passthrough is there.
+				out = append(out, GPUInfo{
+					Model:  Msg("InfoPanel.GPUWSLVirt"),
+					Driver: "dxgkrnl",
+				})
+			}
 		}
 	}
 	return out
+}
+
+// queryHostGPUsFromWSL runs a Windows-side query for the host GPU
+// adapter list via WSL interop. Prefers wmic (~250 ms in practice)
+// and falls back to PowerShell (~1.5 s) if wmic is missing —
+// Microsoft has been sunsetting wmic since Server 2012 R2 and
+// removed it from newer LTSC images. Both binaries live on the
+// interop PATH inside WSL by default, so exec.LookPath finds them
+// without any /mnt/c/... hard-coding.
+func queryHostGPUsFromWSL() []string {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// wmic path win32_videocontroller get name /format:list emits
+	//   Name=<adapter1>\r\n\r\n
+	//   Name=<adapter2>\r\n\r\n
+	// which parses trivially. /format:list is chosen over the
+	// default table format because the latter pads with trailing
+	// spaces and localised column headers.
+	if p, err := exec.LookPath("wmic.exe"); err == nil {
+		out, err := exec.CommandContext(ctx,
+			p, "path", "win32_videocontroller", "get", "name", "/format:list").Output()
+		if err == nil {
+			if names := parseWmicNames(string(out)); len(names) > 0 {
+				return names
+			}
+		}
+	}
+	// PowerShell path prints one adapter name per line.
+	if p, err := exec.LookPath("powershell.exe"); err == nil {
+		out, err := exec.CommandContext(ctx,
+			p, "-NoProfile", "-Command",
+			"(Get-CimInstance Win32_VideoController).Name").Output()
+		if err == nil {
+			var names []string
+			for _, line := range strings.Split(string(out), "\n") {
+				line = strings.TrimSpace(line)
+				if line != "" {
+					names = append(names, line)
+				}
+			}
+			return names
+		}
+	}
+	return nil
+}
+
+func parseWmicNames(out string) []string {
+	var names []string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Name=") {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(line, "Name="))
+		if v != "" {
+			names = append(names, v)
+		}
+	}
+	return names
 }
 
 // readDriverFromUevent picks the DRIVER=... line out of a device's

--- a/gpu_info_linux.go
+++ b/gpu_info_linux.go
@@ -1,0 +1,223 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+var (
+	gpuOnce   sync.Once
+	cachedGPU []GPUInfo
+)
+
+// gpuInfo enumerates /sys/class/drm/card[N] and returns a best-effort
+// human name for each. Order of preference:
+//
+//  1. /proc/driver/nvidia/gpus/*/information — NVIDIA proprietary
+//     driver exposes the marketing name here in one line.
+//  2. /sys/class/drm/cardN/device/label — sometimes present on
+//     modern kernels (Chrome OS / ThinkPads set it; upstream doesn't
+//     always).
+//  3. PCI vendor/device IDs, resolved through /usr/share/hwdata/pci.ids
+//     if the file exists — same DB lspci uses. No dependency added.
+//  4. Raw PCI IDs (`8086:9a49`) as a last resort so the row is at
+//     least identifiable.
+//
+// Everything is cached — the GPU set doesn't change at runtime.
+func gpuInfo() ([]GPUInfo, bool) {
+	gpuOnce.Do(func() {
+		cachedGPU = enumerateLinuxGPUs()
+	})
+	return cachedGPU, len(cachedGPU) > 0
+}
+
+func enumerateLinuxGPUs() []GPUInfo {
+	var out []GPUInfo
+	// NVIDIA proprietary driver first — its names are cleaner than
+	// anything you can build from PCI IDs alone.
+	if names := readNvidiaGPUs(); len(names) > 0 {
+		for _, n := range names {
+			// The proprietary NVIDIA driver identifies itself as
+			// "nvidia" — that's the module name loaded via
+			// modprobe, same string sysfs reports for the DRM
+			// card. Hard-coded rather than probed because
+			// /proc/driver/nvidia only exists when that exact
+			// module is loaded.
+			out = append(out, GPUInfo{Model: n, Driver: "nvidia"})
+		}
+	}
+
+	cards, _ := filepath.Glob("/sys/class/drm/card[0-9]*")
+	// Filter out cardN-* connector entries (HDMI-A-1 etc.); only
+	// keep the base card devices.
+	filtered := cards[:0]
+	for _, c := range cards {
+		if strings.Contains(filepath.Base(c), "-") {
+			continue
+		}
+		filtered = append(filtered, c)
+	}
+	for _, card := range filtered {
+		dev := filepath.Join(card, "device")
+
+		// Skip a card we already covered via the nvidia branch.
+		if len(out) > 0 {
+			vendor := strings.TrimSpace(readFileTrim(filepath.Join(dev, "vendor")))
+			if strings.EqualFold(vendor, "0x10de") {
+				continue
+			}
+		}
+
+		driver := readDriverFromUevent(filepath.Join(dev, "uevent"))
+		if label := strings.TrimSpace(readFileTrim(filepath.Join(dev, "label"))); label != "" {
+			out = append(out, GPUInfo{Model: label, Driver: driver})
+			continue
+		}
+		vendor := strings.TrimPrefix(strings.TrimSpace(readFileTrim(filepath.Join(dev, "vendor"))), "0x")
+		device := strings.TrimPrefix(strings.TrimSpace(readFileTrim(filepath.Join(dev, "device"))), "0x")
+		if vendor == "" && device == "" {
+			continue
+		}
+		if name := lookupPCIName(vendor, device); name != "" {
+			out = append(out, GPUInfo{Model: name, Driver: driver})
+			continue
+		}
+		out = append(out, GPUInfo{Model: fmt.Sprintf("%s:%s", vendor, device), Driver: driver})
+	}
+	return out
+}
+
+// readDriverFromUevent picks the DRIVER=... line out of a device's
+// uevent file. Values are the kernel module name loaded for the
+// card — "i915" (Intel), "amdgpu" / "radeon" (AMD), "nouveau"
+// (open NVIDIA), "vmwgfx" / "virtio_gpu" on VMs. Empty on
+// containers without /sys/class/drm or when the file is unreadable.
+func readDriverFromUevent(path string) string {
+	f, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, "DRIVER=") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "DRIVER="))
+		}
+	}
+	return ""
+}
+
+// readNvidiaGPUs pulls the "Model" line from each
+// /proc/driver/nvidia/gpus/*/information. Empty when the module
+// isn't loaded (nouveau or no-NVIDIA systems).
+func readNvidiaGPUs() []string {
+	entries, err := filepath.Glob("/proc/driver/nvidia/gpus/*/information")
+	if err != nil || len(entries) == 0 {
+		return nil
+	}
+	var out []string
+	for _, path := range entries {
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := sc.Text()
+			if colon := strings.IndexByte(line, ':'); colon > 0 {
+				if strings.TrimSpace(line[:colon]) == "Model" {
+					out = append(out, strings.TrimSpace(line[colon+1:]))
+					break
+				}
+			}
+		}
+		f.Close()
+	}
+	return out
+}
+
+func readFileTrim(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// lookupPCIName looks up a vendor:device pair in /usr/share/hwdata/pci.ids
+// (present on essentially every distro that ships lspci). Returns
+// "Vendor Device" or "" if the file or the IDs aren't found.
+func lookupPCIName(vendor, device string) string {
+	if vendor == "" {
+		return ""
+	}
+	vendor = strings.ToLower(vendor)
+	device = strings.ToLower(device)
+	for _, path := range []string{"/usr/share/hwdata/pci.ids", "/usr/share/misc/pci.ids"} {
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		vName, dName := scanPCIIDs(f, vendor, device)
+		f.Close()
+		if dName != "" && vName != "" {
+			return vName + " " + dName
+		}
+		if vName != "" {
+			return vName + " " + device
+		}
+	}
+	return ""
+}
+
+// scanPCIIDs parses the pci.ids tab-indented format:
+//
+//	VVVV  Vendor name
+//	<TAB>DDDD  Device name
+//	<TAB><TAB>SSSS ...
+//
+// We stop scanning after the vendor block is exhausted (indent drops
+// back to 0 for a new vendor line).
+func scanPCIIDs(f *os.File, vendor, device string) (string, string) {
+	var vName, dName string
+	sc := bufio.NewScanner(f)
+	inVendor := false
+	for sc.Scan() {
+		line := sc.Text()
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if line[0] != '\t' {
+			if inVendor {
+				break
+			}
+			if len(line) < 4 {
+				continue
+			}
+			if strings.EqualFold(line[:4], vendor) {
+				inVendor = true
+				vName = strings.TrimSpace(line[4:])
+			}
+			continue
+		}
+		if !inVendor || device == "" || strings.HasPrefix(line, "\t\t") {
+			continue
+		}
+		body := strings.TrimLeft(line, "\t")
+		if len(body) < 4 {
+			continue
+		}
+		if strings.EqualFold(body[:4], device) {
+			dName = strings.TrimSpace(body[4:])
+			return vName, dName
+		}
+	}
+	return vName, dName
+}

--- a/gpu_info_linux.go
+++ b/gpu_info_linux.go
@@ -90,6 +90,20 @@ func enumerateLinuxGPUs() []GPUInfo {
 		}
 		out = append(out, GPUInfo{Model: fmt.Sprintf("%s:%s", vendor, device), Driver: driver})
 	}
+	// WSL2 fallback. Microsoft's GPU passthrough uses dxgkrnl via
+	// /dev/dxg instead of exposing anything under /sys/class/drm.
+	// If we found nothing above and /dev/dxg is present, at least
+	// tell the user *something* is there rather than hide the
+	// section — the host adapter name would need dxgkio ioctl
+	// plumbing which is out of scope for a display panel.
+	if len(out) == 0 {
+		if _, err := os.Stat("/dev/dxg"); err == nil {
+			out = append(out, GPUInfo{
+				Model:  Msg("InfoPanel.GPUWSLVirt"),
+				Driver: "dxgkrnl",
+			})
+		}
+	}
 	return out
 }
 

--- a/gpu_info_other.go
+++ b/gpu_info_other.go
@@ -1,0 +1,9 @@
+//go:build !linux && !windows && !darwin
+
+package main
+
+// gpuInfo stub for *BSD / illumos. Same rationale as fs_info_other:
+// no per-BSD ports carried until someone actually asks.
+func gpuInfo() ([]GPUInfo, bool) {
+	return nil, false
+}

--- a/gpu_info_windows.go
+++ b/gpu_info_windows.go
@@ -1,0 +1,150 @@
+//go:build windows
+
+package main
+
+import (
+	"strings"
+	"sync"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+var (
+	gpuOnce   sync.Once
+	cachedGPU []GPUInfo
+)
+
+// DISPLAY_DEVICEW as defined in wingdi.h. Fixed-size UTF-16 buffers
+// per the SDK; we let Windows write in and then decode. StateFlags
+// is captured but no longer used as a filter — the user asked to
+// see both the iGPU and a spun-down dGPU on Optimus laptops, and
+// EnumDisplayDevices is the only API that lists them without WMI.
+type displayDeviceW struct {
+	cb           uint32
+	DeviceName   [32]uint16
+	DeviceString [128]uint16
+	StateFlags   uint32
+	DeviceID     [128]uint16
+	DeviceKey    [128]uint16
+}
+
+var (
+	modUser32              = windows.NewLazySystemDLL("user32.dll")
+	procEnumDisplayDevices = modUser32.NewProc("EnumDisplayDevicesW")
+)
+
+// gpuInfo enumerates adapters via EnumDisplayDevices. On multi-GPU
+// laptops both the iGPU and dGPU show up; duplicates by DeviceString
+// are collapsed. Driver name comes from the DeviceKey → registry
+// hop (\Registry\Machine\... → HKLM\...\DriverDesc).
+func gpuInfo() ([]GPUInfo, bool) {
+	gpuOnce.Do(func() {
+		cachedGPU = enumerateWindowsGPUs()
+	})
+	return cachedGPU, len(cachedGPU) > 0
+}
+
+func enumerateWindowsGPUs() []GPUInfo {
+	seen := map[string]struct{}{}
+	var out []GPUInfo
+	for i := uint32(0); ; i++ {
+		var d displayDeviceW
+		d.cb = uint32(unsafe.Sizeof(d))
+		r, _, _ := procEnumDisplayDevices.Call(
+			0,
+			uintptr(i),
+			uintptr(unsafe.Pointer(&d)),
+			0,
+		)
+		if r == 0 {
+			break
+		}
+		name := utf16ToStringGPU(d.DeviceString[:])
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+		driver := readGPUDriverName(utf16ToStringGPU(d.DeviceKey[:]))
+		out = append(out, GPUInfo{Model: name, Driver: driver})
+	}
+	return out
+}
+
+// readGPUDriverName resolves DeviceKey (`\Registry\Machine\...`) to
+// the DriverDesc value it stores. Falls back to ProviderName if
+// DriverDesc is empty (some Basic Display driver installs). Empty
+// on any failure — caller renders the row without a Driver line.
+func readGPUDriverName(deviceKey string) string {
+	// EnumDisplayDevices returns the key as a fully-qualified NT
+	// path (\Registry\Machine\...); RegOpenKeyEx expects the tail
+	// under HKLM. Trim both accepted prefixes.
+	sub := deviceKey
+	for _, prefix := range []string{
+		`\Registry\Machine\`,
+		`\REGISTRY\MACHINE\`,
+	} {
+		if strings.HasPrefix(sub, prefix) {
+			sub = sub[len(prefix):]
+			break
+		}
+	}
+	if sub == "" || sub == deviceKey {
+		// Prefix wasn't the shape we expected — give up rather
+		// than open a random registry path.
+		return ""
+	}
+	keyPath, err := windows.UTF16PtrFromString(sub)
+	if err != nil {
+		return ""
+	}
+	var h windows.Handle
+	if err := windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, keyPath, 0, windows.KEY_READ, &h); err != nil {
+		return ""
+	}
+	defer windows.RegCloseKey(h)
+
+	for _, valName := range []string{"DriverDesc", "ProviderName"} {
+		if s := readRegString(h, valName); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func readRegString(h windows.Handle, name string) string {
+	nPtr, err := windows.UTF16PtrFromString(name)
+	if err != nil {
+		return ""
+	}
+	var typ, size uint32
+	if err := windows.RegQueryValueEx(h, nPtr, nil, &typ, nil, &size); err != nil {
+		return ""
+	}
+	if size == 0 {
+		return ""
+	}
+	buf := make([]byte, size)
+	if err := windows.RegQueryValueEx(h, nPtr, nil, &typ, &buf[0], &size); err != nil {
+		return ""
+	}
+	u16 := unsafe.Slice((*uint16)(unsafe.Pointer(&buf[0])), size/2)
+	return strings.TrimSpace(windows.UTF16ToString(u16))
+}
+
+// utf16ToStringGPU handles a fixed-size buffer that may or may not
+// be NUL-terminated. syscall.UTF16ToString stops at the first NUL;
+// if there isn't one we still get the right result.
+func utf16ToStringGPU(u []uint16) string {
+	for i, c := range u {
+		if c == 0 {
+			return syscall.UTF16ToString(u[:i])
+		}
+	}
+	return syscall.UTF16ToString(u)
+}

--- a/info_panel.go
+++ b/info_panel.go
@@ -427,7 +427,17 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 			if cur == "" || y > maxY {
 				return
 			}
-			ip.rows = append(ip.rows, infoRow{text: hangIndent + cur, y: y})
+			// Tag continuation lines with the same (section, label)
+			// as the parent row so selecting the row highlights the
+			// wrap too — the line break is a display artifact, not
+			// a semantic boundary. copyable stays false so navigation
+			// still skips these and copy doesn't duplicate the value.
+			ip.rows = append(ip.rows, infoRow{
+				section: currentSection,
+				label:   label,
+				text:    hangIndent + cur,
+				y:       y,
+			})
 			y++
 			cur = ""
 		}
@@ -584,9 +594,12 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 
 	// Restore the persisted selection so the highlight survives a
 	// rebuild (which happens on every Show). Keyed by section+label
-	// — see InfoPanel.selection docs for the rationale.
+	// — see InfoPanel.selection docs for the rationale. Applied to
+	// every row (not just copyable) so a wrapRow's continuation
+	// lines light up alongside their parent when the label is
+	// selected.
 	for i := range ip.rows {
-		if ip.rows[i].copyable && ip.selection[rowKey(ip.rows[i].section, ip.rows[i].label)] {
+		if ip.rows[i].label != "" && ip.selection[rowKey(ip.rows[i].section, ip.rows[i].label)] {
 			ip.rows[i].selected = true
 		}
 	}

--- a/info_panel.go
+++ b/info_panel.go
@@ -43,6 +43,14 @@ type InfoPanel struct {
 	// cursor indexes into rows; only rows with copyable == true are
 	// stopping points. Clamped by moveCursor on each navigation call.
 	cursor int
+	// selection persists across rebuilds. Keyed by "section|label"
+	// because labels alone collide (CPU and GPU both use i18n key
+	// InfoPanel.*Model = "Model"). Values fluctuate (Load %, free
+	// bytes) — losing a selection when a value changes is worse
+	// than keying by section+label and accepting that the copied
+	// value reflects the current sample, which is what the user
+	// sees.
+	selection map[string]bool
 }
 
 // infoRow captures one rendered line so the highlight (when focused)
@@ -50,6 +58,7 @@ type InfoPanel struct {
 // Section headers and blank spacers set copyable=false; navigation
 // skips them.
 type infoRow struct {
+	section  string
 	label    string
 	value    string
 	copyable bool
@@ -59,6 +68,16 @@ type infoRow struct {
 	// recompute alignment.
 	text string
 	y    int
+	// selected is filled from ip.selection on each Show — it's not
+	// authoritative, only a rendering hint.
+	selected bool
+}
+
+// rowKey composes the selection-map key for a row. Empty section
+// (Computer/User header before any sectionHeader() call) keeps the
+// key well-formed and still unique across sections.
+func rowKey(section, label string) string {
+	return section + "|" + label
 }
 
 // NewInfoPanel creates an info panel positioned over src's slot.
@@ -66,7 +85,7 @@ type infoRow struct {
 // current layout (PanelsFrame.ResizeConsole does this).
 func NewInfoPanel(src *FileSystemPanel) *InfoPanel {
 	x1, y1, x2, y2 := src.GetPosition()
-	ip := &InfoPanel{src: src, cursor: -1}
+	ip := &InfoPanel{src: src, cursor: -1, selection: map[string]bool{}}
 	ip.SetVisible(true)
 	ip.frame = vtui.NewBorderedFrame(x1, y1, x2, y2, vtui.SingleBox, Msg("InfoPanel.Title"))
 	ip.frame.ColorBoxIdx = ColPanelBox
@@ -105,9 +124,11 @@ func (ip *InfoPanel) SetFocus(f bool) {
 
 func (ip *InfoPanel) IsFocused() bool { return ip.focused }
 
-// ProcessKey consumes Up / Down / Home / End / C while focused. All
-// other keys (including B and Ctrl+L) fall through to the global
+// ProcessKey consumes navigation, selection and C while focused. All
+// other keys (B and Ctrl+L in particular) fall through to the global
 // handler chain so the units toggle and close behaviour still work.
+// Shift+Up/Down mirror the file panel's convention: toggle the
+// current row's selection, then move. Ins toggles without moving.
 func (ip *InfoPanel) ProcessKey(e *vtinput.InputEvent) bool {
 	if !e.KeyDown || !ip.focused {
 		return false
@@ -115,22 +136,66 @@ func (ip *InfoPanel) ProcessKey(e *vtinput.InputEvent) bool {
 	if e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed|vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0 {
 		return false
 	}
+	shift := e.ControlKeyState&vtinput.ShiftPressed != 0
+
 	switch e.VirtualKeyCode {
 	case vtinput.VK_UP:
+		if shift {
+			ip.toggleSelectionAtCursor()
+		}
 		ip.moveCursor(-1)
 	case vtinput.VK_DOWN:
+		if shift {
+			ip.toggleSelectionAtCursor()
+		}
 		ip.moveCursor(+1)
 	case vtinput.VK_HOME:
+		if shift {
+			ip.toggleSelectionAtCursor()
+		}
 		ip.setCursorToFirstCopyable()
 	case vtinput.VK_END:
+		if shift {
+			ip.toggleSelectionAtCursor()
+		}
 		ip.setCursorToLastCopyable()
+	case vtinput.VK_INSERT:
+		if shift {
+			return false
+		}
+		ip.toggleSelectionAtCursor()
+		ip.moveCursor(+1)
 	case vtinput.VK_C:
+		if shift {
+			return false
+		}
 		ip.copyCurrent()
 	default:
 		return false
 	}
 	vtui.FrameManager.HardRefresh()
 	return true
+}
+
+// toggleSelectionAtCursor flips the persistent selection bit for the
+// row under the cursor. No-op on non-copyable rows (headers, blanks)
+// so the user doesn't have to worry about invisible state.
+func (ip *InfoPanel) toggleSelectionAtCursor() {
+	if ip.cursor < 0 || ip.cursor >= len(ip.rows) {
+		return
+	}
+	r := &ip.rows[ip.cursor]
+	if !r.copyable {
+		return
+	}
+	key := rowKey(r.section, r.label)
+	if ip.selection[key] {
+		delete(ip.selection, key)
+		r.selected = false
+	} else {
+		ip.selection[key] = true
+		r.selected = true
+	}
 }
 
 // ProcessMouse: alt panels don't handle clicks — fall through.
@@ -188,22 +253,43 @@ func (ip *InfoPanel) setCursorToLastCopyable() {
 	}
 }
 
-// copyCurrent puts the current row's value into vtui's clipboard and
-// flashes a toast so the user knows something happened. Uses the raw
-// value (label stripped) — that's what people paste elsewhere.
+// copyCurrent copies the row(s) under the C hotkey to the clipboard.
+//
+//   - With at least one row selected via Shift+Up/Down or Ins:
+//     joins every selected row as "label: value" per line, in the
+//     order they appear on screen. Toast shows "Copied N rows".
+//   - Otherwise: copies the current row's raw value (no label),
+//     which is what single-row-copy has always done.
+//
+// vtui.SetClipboard already tries far2l IPC → OS clipboard →
+// OSC 52 in order, so a single call covers every terminal case f4
+// supports.
 func (ip *InfoPanel) copyCurrent() {
-	if ip.cursor < 0 || ip.cursor >= len(ip.rows) {
+	var selRows []infoRow
+	for _, r := range ip.rows {
+		if r.selected && r.copyable && r.value != "" {
+			selRows = append(selRows, r)
+		}
+	}
+	if len(selRows) == 0 {
+		if ip.cursor < 0 || ip.cursor >= len(ip.rows) {
+			return
+		}
+		r := ip.rows[ip.cursor]
+		if !r.copyable || r.value == "" {
+			return
+		}
+		vtui.SetClipboard(r.value)
+		vtui.ShowToast(fmt.Sprintf("%s: %s", Msg("InfoPanel.Copied"), r.value), 2*time.Second)
 		return
 	}
-	r := ip.rows[ip.cursor]
-	if !r.copyable || r.value == "" {
-		return
+	var lines []string
+	for _, r := range selRows {
+		lines = append(lines, r.label+": "+r.value)
 	}
-	// SetClipboard already tries far2l IPC → OS clipboard → OSC 52
-	// in order, so a single call covers every terminal case f4
-	// supports.
-	vtui.SetClipboard(r.value)
-	vtui.ShowToast(fmt.Sprintf("%s: %s", Msg("InfoPanel.Copied"), r.value), 2*time.Second)
+	joined := strings.Join(lines, "\n")
+	vtui.SetClipboard(joined)
+	vtui.ShowToast(fmt.Sprintf("%s: %d", Msg("InfoPanel.CopiedRows"), len(selRows)), 2*time.Second)
 }
 
 func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
@@ -229,6 +315,12 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 
 	y := ip.Y1 + 1
 	maxY := ip.Y2 - 1
+
+	// currentSection is updated by sectionHeader; row/wrapRow tag
+	// every infoRow they emit with it so the selection map can key
+	// by section+label rather than label alone (avoids CPU Model /
+	// GPU Model colliding on the same "Model" i18n string).
+	currentSection := ""
 
 	// Two-column row: label on the left, value right-aligned. Both
 	// use the same attr as the frame background so the row reads as
@@ -257,7 +349,8 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 			}
 		}
 		ip.rows = append(ip.rows, infoRow{
-			label: label, value: value, copyable: copyable && value != "",
+			section: currentSection,
+			label:   label, value: value, copyable: copyable && value != "",
 			text: text, y: y,
 		})
 		y++
@@ -317,13 +410,15 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		// copyable flag so the full value can be yanked with C.
 		if firstValue == "" {
 			ip.rows = append(ip.rows, infoRow{
-				label: label, value: value, copyable: true, text: labelPad, y: y,
+				section: currentSection,
+				label:   label, value: value, copyable: true, text: labelPad, y: y,
 			})
 			y++
 		} else {
 			text := labelPad + strings.Repeat(" ", innerW-labelW-runewidth.StringWidth(firstValue)) + firstValue
 			ip.rows = append(ip.rows, infoRow{
-				label: label, value: value, copyable: true, text: text, y: y,
+				section: currentSection,
+				label:   label, value: value, copyable: true, text: text, y: y,
 			})
 			y++
 		}
@@ -350,11 +445,12 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		flush()
 	}
 
-	sectionHeader := func(text string) {
+	sectionHeader := func(title string) {
 		if y > maxY {
 			return
 		}
-		text = " " + text + " "
+		currentSection = title
+		text := " " + title + " "
 		w := runewidth.StringWidth(text)
 		pad := 0
 		if w < innerW {
@@ -486,19 +582,36 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		}
 	}
 
+	// Restore the persisted selection so the highlight survives a
+	// rebuild (which happens on every Show). Keyed by section+label
+	// — see InfoPanel.selection docs for the rationale.
+	for i := range ip.rows {
+		if ip.rows[i].copyable && ip.selection[rowKey(ip.rows[i].section, ip.rows[i].label)] {
+			ip.rows[i].selected = true
+		}
+	}
+
 	// If the cursor is stale (out of range after a resize) or was
 	// never placed, seed it on the first copyable row.
 	if ip.cursor < 0 || ip.cursor >= len(ip.rows) || !ip.rows[ip.cursor].copyable {
 		ip.setCursorToFirstCopyable()
 	}
 
-	// Render pass — pushes each row to the screen at its recorded y,
-	// swapping in the cursor colour for the highlighted row when the
-	// panel is focused.
+	// Render pass — pushes each row to the screen at its recorded y.
+	// Colour picks in order of increasing "attention":
+	//   plain → selected → cursor → cursor-on-selected
+	// so a selected row you're standing on gets the highest-contrast
+	// treatment (matches ColPanelSelectedCursor in the file panel).
 	for i, r := range ip.rows {
 		lineAttr := attr
-		if ip.focused && i == ip.cursor && r.copyable {
+		isCursor := ip.focused && i == ip.cursor && r.copyable
+		switch {
+		case isCursor && r.selected:
+			lineAttr = vtui.Palette[ColPanelSelectedCursor]
+		case isCursor:
 			lineAttr = vtui.Palette[ColPanelCursor]
+		case r.selected:
+			lineAttr = vtui.Palette[ColPanelSelectedText]
 		}
 		ip.writeLine(scr, r.text, lineAttr, innerW, r.y)
 	}

--- a/info_panel.go
+++ b/info_panel.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"strings"
+	"time"
 
 	"github.com/mattn/go-runewidth"
 	"github.com/unxed/vtinput"
@@ -27,14 +28,37 @@ type AltPanel interface {
 
 // InfoPanel is far2l's Ctrl+L information panel. It shows the
 // active file panel's location and system context — computer/user,
-// current directory and disk space. Per-file details ("Quick view")
-// belong to Ctrl+Q (a follow-up PR); git status and description-file
-// (README/Descript.ion) rendering are also deliberately deferred.
+// current directory, disk space, memory and (when enabled) CPU/GPU.
+// Per-file details ("Quick view") belong to Ctrl+Q; git status and
+// description-file (README/Descript.ion) rendering are deferred.
 type InfoPanel struct {
 	vtui.ScreenObject
 	src     *FileSystemPanel
 	frame   *vtui.BorderedFrame
 	focused bool
+
+	// rows is rebuilt on every Show and remembered for hit-testing by
+	// ProcessKey (Up/Down/C need to know what's on screen).
+	rows []infoRow
+	// cursor indexes into rows; only rows with copyable == true are
+	// stopping points. Clamped by moveCursor on each navigation call.
+	cursor int
+}
+
+// infoRow captures one rendered line so the highlight (when focused)
+// and the C-copies-value command can share what the Show pass built.
+// Section headers and blank spacers set copyable=false; navigation
+// skips them.
+type infoRow struct {
+	label    string
+	value    string
+	copyable bool
+	// text is the pre-composed label + gap + value line (or the
+	// wrapped label-only line for wrapRow's first segment). It's
+	// stashed so a redraw of the cursor row doesn't have to
+	// recompute alignment.
+	text string
+	y    int
 }
 
 // NewInfoPanel creates an info panel positioned over src's slot.
@@ -42,7 +66,7 @@ type InfoPanel struct {
 // current layout (PanelsFrame.ResizeConsole does this).
 func NewInfoPanel(src *FileSystemPanel) *InfoPanel {
 	x1, y1, x2, y2 := src.GetPosition()
-	ip := &InfoPanel{src: src}
+	ip := &InfoPanel{src: src, cursor: -1}
 	ip.SetVisible(true)
 	ip.frame = vtui.NewBorderedFrame(x1, y1, x2, y2, vtui.SingleBox, Msg("InfoPanel.Title"))
 	ip.frame.ColorBoxIdx = ColPanelBox
@@ -65,10 +89,9 @@ func (ip *InfoPanel) SetPosition(x1, y1, x2, y2 int) {
 func (ip *InfoPanel) Source() *FileSystemPanel { return ip.src }
 func (ip *InfoPanel) Kind() string             { return "info" }
 
-// SetFocus flips the visible focus marker (title recolours). The alt
-// panel doesn't consume keyboard input — commands still target the
-// source file panel — but showing the frame as focused matches how
-// far2l's Info/Quick view highlight themselves on Tab.
+// SetFocus flips the visible focus marker (title recolours). When the
+// panel is focused it also starts consuming Up / Down / C keys — see
+// ProcessKey.
 func (ip *InfoPanel) SetFocus(f bool) {
 	ip.focused = f
 	if ip.frame != nil {
@@ -82,10 +105,35 @@ func (ip *InfoPanel) SetFocus(f bool) {
 
 func (ip *InfoPanel) IsFocused() bool { return ip.focused }
 
-// ProcessKey / ProcessMouse do nothing — alt panels are display-only.
-// Anything typed on the alt-panel slot falls through to the global
-// handler, which will dispatch to the source file panel underneath.
-func (ip *InfoPanel) ProcessKey(*vtinput.InputEvent) bool   { return false }
+// ProcessKey consumes Up / Down / Home / End / C while focused. All
+// other keys (including B and Ctrl+L) fall through to the global
+// handler chain so the units toggle and close behaviour still work.
+func (ip *InfoPanel) ProcessKey(e *vtinput.InputEvent) bool {
+	if !e.KeyDown || !ip.focused {
+		return false
+	}
+	if e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed|vtinput.LeftAltPressed|vtinput.RightAltPressed) != 0 {
+		return false
+	}
+	switch e.VirtualKeyCode {
+	case vtinput.VK_UP:
+		ip.moveCursor(-1)
+	case vtinput.VK_DOWN:
+		ip.moveCursor(+1)
+	case vtinput.VK_HOME:
+		ip.setCursorToFirstCopyable()
+	case vtinput.VK_END:
+		ip.setCursorToLastCopyable()
+	case vtinput.VK_C:
+		ip.copyCurrent()
+	default:
+		return false
+	}
+	vtui.FrameManager.HardRefresh()
+	return true
+}
+
+// ProcessMouse: alt panels don't handle clicks — fall through.
 func (ip *InfoPanel) ProcessMouse(*vtinput.InputEvent) bool { return false }
 
 // GetSelectedName proxies to the source so callers that inspect
@@ -97,13 +145,74 @@ func (ip *InfoPanel) GetSelectedName() string {
 	return ip.src.GetSelectedName()
 }
 
+// moveCursor advances to the next copyable row in the given
+// direction (+1 or -1), skipping section headers and blank lines.
+// Clamps at the ends — no wrap-around, matches how the file panel
+// treats Up/Down at the extremes.
+func (ip *InfoPanel) moveCursor(delta int) {
+	if len(ip.rows) == 0 {
+		return
+	}
+	if ip.cursor < 0 {
+		ip.setCursorToFirstCopyable()
+		return
+	}
+	i := ip.cursor
+	for {
+		i += delta
+		if i < 0 || i >= len(ip.rows) {
+			return
+		}
+		if ip.rows[i].copyable {
+			ip.cursor = i
+			return
+		}
+	}
+}
+
+func (ip *InfoPanel) setCursorToFirstCopyable() {
+	for i, r := range ip.rows {
+		if r.copyable {
+			ip.cursor = i
+			return
+		}
+	}
+}
+
+func (ip *InfoPanel) setCursorToLastCopyable() {
+	for i := len(ip.rows) - 1; i >= 0; i-- {
+		if ip.rows[i].copyable {
+			ip.cursor = i
+			return
+		}
+	}
+}
+
+// copyCurrent puts the current row's value into vtui's clipboard and
+// flashes a toast so the user knows something happened. Uses the raw
+// value (label stripped) — that's what people paste elsewhere.
+func (ip *InfoPanel) copyCurrent() {
+	if ip.cursor < 0 || ip.cursor >= len(ip.rows) {
+		return
+	}
+	r := ip.rows[ip.cursor]
+	if !r.copyable || r.value == "" {
+		return
+	}
+	// SetClipboard already tries far2l IPC → OS clipboard → OSC 52
+	// in order, so a single call covers every terminal case f4
+	// supports.
+	vtui.SetClipboard(r.value)
+	vtui.ShowToast(fmt.Sprintf("%s: %s", Msg("InfoPanel.Copied"), r.value), 2*time.Second)
+}
+
 func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 	if ip.frame != nil {
 		ip.frame.Show(scr)
 	}
-	// Bottom-border hint reminding the user of the units toggle,
-	// same pattern the bookmarks dialog uses. Drawn on the ┴ line;
-	// keeps the panel self-documenting so we don't need a menu entry.
+	// Bottom-border hint reminding the user of the units toggle and
+	// the copy shortcut. Drawn on the ┴ line so the panel is
+	// self-documenting without a menu entry.
 	if ip.frame != nil && ip.Y2 > ip.Y1+1 {
 		hint := Msg("InfoPanel.UnitsHint")
 		if runewidth.StringWidth(hint) < ip.X2-ip.X1-1 {
@@ -116,64 +225,62 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		return
 	}
 	attr := vtui.Palette[ColPanelInfoText]
+	ip.rows = ip.rows[:0]
+
 	y := ip.Y1 + 1
 	maxY := ip.Y2 - 1
 
-	// Two-column row: label on the left, value right-aligned. Both use
-	// the same attr as the frame background so the row reads as a
-	// single flat block, matching far2l's InfoList layout.
-	row := func(label, value string) {
+	// Two-column row: label on the left, value right-aligned. Both
+	// use the same attr as the frame background so the row reads as
+	// a single flat block, matching far2l's InfoList layout. Returns
+	// the composed text so buildRows can stash it.
+	row := func(label, value string, copyable bool) {
 		if y > maxY {
 			return
 		}
 		labelPad := " " + label
-		if value == "" {
-			ip.writeLine(scr, labelPad, attr, innerW, y)
-			y++
-			return
-		}
-		labelW := runewidth.StringWidth(labelPad)
-		valueW := runewidth.StringWidth(value)
-		// Available room for spaces between label and value.
-		space := innerW - labelW - valueW
-		if space < 1 {
-			// Truncate value to fit.
-			roomForValue := innerW - labelW - 1
-			if roomForValue < 1 {
-				ip.writeLine(scr, labelPad, attr, innerW, y)
-				y++
-				return
+		text := labelPad
+		if value != "" {
+			labelW := runewidth.StringWidth(labelPad)
+			valueW := runewidth.StringWidth(value)
+			space := innerW - labelW - valueW
+			if space < 1 {
+				roomForValue := innerW - labelW - 1
+				if roomForValue < 1 {
+					text = labelPad
+				} else {
+					value = runewidth.Truncate(value, roomForValue, "…")
+					text = labelPad + " " + value
+				}
+			} else {
+				text = labelPad + strings.Repeat(" ", space) + value
 			}
-			value = runewidth.Truncate(value, roomForValue, "…")
-			space = 1
 		}
-		text := labelPad + strings.Repeat(" ", space) + value
-		ip.writeLine(scr, text, attr, innerW, y)
+		ip.rows = append(ip.rows, infoRow{
+			label: label, value: value, copyable: copyable && value != "",
+			text: text, y: y,
+		})
 		y++
 	}
 	blank := func() {
 		if y > maxY {
 			return
 		}
-		ip.writeLine(scr, "", attr, innerW, y)
+		ip.rows = append(ip.rows, infoRow{y: y})
 		y++
 	}
 
-	// wrapRow is like row but, for values too long to share a line
-	// with their label, breaks the value on `sep` and continues it
-	// on hanging continuation lines. Used for Flags where the value
-	// is a naturally-splittable comma-list — Windows NTFS attributes
-	// alone go past 60 cols. Falls back to plain row for short values.
+	// wrapRow is row for a value too long to share a line with its
+	// label — breaks on `sep`, continues on hanging lines. Used for
+	// Flags (Windows NTFS attributes exceed 60 cols).
 	wrapRow := func(label, value, sep string) {
 		labelPad := " " + label
 		labelW := runewidth.StringWidth(labelPad)
 		fitsInline := labelW+1+runewidth.StringWidth(value) <= innerW
 		if fitsInline || value == "" {
-			row(label, value)
+			row(label, value, true)
 			return
 		}
-		// Continuation lines hang two cells past the label start so
-		// the wrapped value visually attaches to its label.
 		hangStart := 3
 		if hangStart >= innerW {
 			hangStart = 1
@@ -181,11 +288,10 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		hangIndent := strings.Repeat(" ", hangStart)
 		hangRoom := innerW - hangStart
 		if hangRoom < 1 {
-			row(label, value)
+			row(label, value, true)
 			return
 		}
 		parts := strings.Split(value, sep)
-		// First line: label followed by as many parts as fit right of it.
 		gap := 1
 		firstRoom := innerW - labelW - gap
 		var first []string
@@ -206,23 +312,27 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 			i++
 		}
 		firstValue := strings.Join(first, "")
+		// First screen line: label + first-chunk (or the label alone
+		// if not even the first token fits). This one carries the
+		// copyable flag so the full value can be yanked with C.
 		if firstValue == "" {
-			// Value's first token alone doesn't fit next to the label;
-			// put the label on its own line and wrap the value below.
-			ip.writeLine(scr, labelPad, attr, innerW, y)
+			ip.rows = append(ip.rows, infoRow{
+				label: label, value: value, copyable: true, text: labelPad, y: y,
+			})
 			y++
 		} else {
 			text := labelPad + strings.Repeat(" ", innerW-labelW-runewidth.StringWidth(firstValue)) + firstValue
-			ip.writeLine(scr, text, attr, innerW, y)
+			ip.rows = append(ip.rows, infoRow{
+				label: label, value: value, copyable: true, text: text, y: y,
+			})
 			y++
 		}
-		// Continuation lines: greedy-pack the remaining parts.
 		cur := ""
 		flush := func() {
 			if cur == "" || y > maxY {
 				return
 			}
-			ip.writeLine(scr, hangIndent+cur, attr, innerW, y)
+			ip.rows = append(ip.rows, infoRow{text: hangIndent + cur, y: y})
 			y++
 			cur = ""
 		}
@@ -244,7 +354,6 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		if y > maxY {
 			return
 		}
-		// Centered heading like far2l's DrawTitle inside InfoList.
 		text = " " + text + " "
 		w := runewidth.StringWidth(text)
 		pad := 0
@@ -255,7 +364,7 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 		if w > innerW {
 			line = runewidth.Truncate(text, innerW, "…")
 		}
-		ip.writeLine(scr, line, attr, innerW, y)
+		ip.rows = append(ip.rows, infoRow{text: line, y: y})
 		y++
 	}
 
@@ -265,8 +374,8 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 	if u, err := user.Current(); err == nil {
 		username = shortUsername(u.Username)
 	}
-	row(Msg("InfoPanel.Computer"), hostname)
-	row(Msg("InfoPanel.User"), username)
+	row(Msg("InfoPanel.Computer"), hostname, true)
+	row(Msg("InfoPanel.User"), username, true)
 	blank()
 
 	// Filesystem.
@@ -280,27 +389,27 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 			fsTitle = fmt.Sprintf("%s (%s)", fsTitle, fs.Type)
 		}
 		sectionHeader(fsTitle)
-		row(Msg("InfoPanel.Total"), formatBytes(fs.Total))
-		row(Msg("InfoPanel.Free"), formatBytes(fs.Free))
+		row(Msg("InfoPanel.Total"), formatBytes(fs.Total), true)
+		row(Msg("InfoPanel.Free"), formatBytes(fs.Free), true)
 		if fs.Label != "" {
-			row(Msg("InfoPanel.Label"), fs.Label)
+			row(Msg("InfoPanel.Label"), fs.Label, true)
 		}
 		if fs.Serial != "" {
-			row(Msg("InfoPanel.Serial"), fs.Serial)
+			row(Msg("InfoPanel.Serial"), fs.Serial, true)
 		}
-		row(Msg("InfoPanel.CurrentDir"), path)
+		row(Msg("InfoPanel.CurrentDir"), path, true)
 		if fs.Mount != "" && fs.Mount != path {
-			row(Msg("InfoPanel.Mount"), fs.Mount)
+			row(Msg("InfoPanel.Mount"), fs.Mount, true)
 		}
 		if fs.MaxFilename > 0 {
-			row(Msg("InfoPanel.MaxFilename"), fmt.Sprintf("%d", fs.MaxFilename))
+			row(Msg("InfoPanel.MaxFilename"), fmt.Sprintf("%d", fs.MaxFilename), true)
 		}
 		if fs.Flags != "" {
 			wrapRow(Msg("InfoPanel.Flags"), fs.Flags, ",")
 		}
 	} else {
 		sectionHeader(fsTitle)
-		row(Msg("InfoPanel.CurrentDir"), path)
+		row(Msg("InfoPanel.CurrentDir"), path, true)
 	}
 
 	// Memory. Same numbers as far2l's InfoList reads via sysinfo(2)
@@ -308,19 +417,90 @@ func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {
 	if mem, ok := memInfo(); ok {
 		blank()
 		sectionHeader(Msg("InfoPanel.MemoryTitle"))
-		row(Msg("InfoPanel.MemLoad"), fmt.Sprintf("%d%%", mem.LoadPercent))
-		row(Msg("InfoPanel.MemTotal"), formatBytes(mem.Total))
-		row(Msg("InfoPanel.MemFree"), formatBytes(mem.Free))
+		row(Msg("InfoPanel.MemLoad"), fmt.Sprintf("%d%%", mem.LoadPercent), true)
+		row(Msg("InfoPanel.MemTotal"), formatBytes(mem.Total), true)
+		row(Msg("InfoPanel.MemFree"), formatBytes(mem.Free), true)
 		if mem.Shared > 0 {
-			row(Msg("InfoPanel.MemShared"), formatBytes(mem.Shared))
+			row(Msg("InfoPanel.MemShared"), formatBytes(mem.Shared), true)
 		}
 		if mem.Buffered > 0 {
-			row(Msg("InfoPanel.MemBuffered"), formatBytes(mem.Buffered))
+			row(Msg("InfoPanel.MemBuffered"), formatBytes(mem.Buffered), true)
 		}
 		if mem.SwapTotal > 0 {
-			row(Msg("InfoPanel.SwapTotal"), formatBytes(mem.SwapTotal))
-			row(Msg("InfoPanel.SwapFree"), formatBytes(mem.SwapFree))
+			row(Msg("InfoPanel.SwapTotal"), formatBytes(mem.SwapTotal), true)
+			row(Msg("InfoPanel.SwapFree"), formatBytes(mem.SwapFree), true)
 		}
+	}
+
+	// CPU + GPU — opt-in, off by default (maintainer's ask). Kept
+	// after Memory so a user who enables the section doesn't have
+	// what they see above shifted downward.
+	if AppConfig.InfoPanelCPUGPU {
+		if cpu, ok := cpuInfo(); ok {
+			blank()
+			sectionHeader(Msg("InfoPanel.CPUTitle"))
+			if cpu.Model != "" {
+				row(Msg("InfoPanel.CPUModel"), cpu.Model, true)
+			}
+			if cpu.PhysicalCores > 0 && cpu.LogicalCores > 0 && cpu.PhysicalCores != cpu.LogicalCores {
+				row(Msg("InfoPanel.CPUCores"),
+					fmt.Sprintf("%d / %d", cpu.PhysicalCores, cpu.LogicalCores), true)
+			} else if cpu.LogicalCores > 0 {
+				row(Msg("InfoPanel.CPUCores"), fmt.Sprintf("%d", cpu.LogicalCores), true)
+			}
+			if cpu.FreqMHz > 0 {
+				row(Msg("InfoPanel.CPUFreq"), formatMHz(cpu.FreqMHz), true)
+			}
+			for i, sz := range cpu.CacheBytes {
+				if sz == 0 {
+					continue
+				}
+				row(fmt.Sprintf("L%d", i+1), formatBytes(sz), true)
+			}
+			switch {
+			case cpu.HasLoadPct:
+				row(Msg("InfoPanel.CPULoad"), fmt.Sprintf("%d%%", cpu.Load), true)
+			case cpu.HasLoad:
+				row(Msg("InfoPanel.CPULoadAvg"),
+					fmt.Sprintf("%.2f %.2f %.2f", cpu.LoadAvg[0], cpu.LoadAvg[1], cpu.LoadAvg[2]),
+					true)
+			}
+		}
+		if gpus, ok := gpuInfo(); ok {
+			blank()
+			sectionHeader(Msg("InfoPanel.GPUTitle"))
+			for i, g := range gpus {
+				label := Msg("InfoPanel.GPUModel")
+				if len(gpus) > 1 {
+					label = fmt.Sprintf("%s %d", label, i+1)
+				}
+				row(label, g.Model, true)
+				if g.Driver != "" {
+					dLabel := Msg("InfoPanel.GPUDriver")
+					if len(gpus) > 1 {
+						dLabel = fmt.Sprintf("%s %d", dLabel, i+1)
+					}
+					row(dLabel, g.Driver, true)
+				}
+			}
+		}
+	}
+
+	// If the cursor is stale (out of range after a resize) or was
+	// never placed, seed it on the first copyable row.
+	if ip.cursor < 0 || ip.cursor >= len(ip.rows) || !ip.rows[ip.cursor].copyable {
+		ip.setCursorToFirstCopyable()
+	}
+
+	// Render pass — pushes each row to the screen at its recorded y,
+	// swapping in the cursor colour for the highlighted row when the
+	// panel is focused.
+	for i, r := range ip.rows {
+		lineAttr := attr
+		if ip.focused && i == ip.cursor && r.copyable {
+			lineAttr = vtui.Palette[ColPanelCursor]
+		}
+		ip.writeLine(scr, r.text, lineAttr, innerW, r.y)
 	}
 }
 
@@ -343,8 +523,7 @@ func formatBytesCommas(b uint64) string {
 	if len(s) <= 3 {
 		return s
 	}
-	// Insert a separator every three digits from the right.
-	sep := " " // non-breaking space
+	sep := " " // non-breaking space (thin thousands separator)
 	var out []byte
 	for i, c := range []byte(s) {
 		if i > 0 && (len(s)-i)%3 == 0 {
@@ -364,6 +543,16 @@ func shortUsername(u string) string {
 		return u[i+1:]
 	}
 	return u
+}
+
+// formatMHz renders a clock speed as MHz or GHz — GHz for anything
+// at or above 1 GHz to match the "3.2 GHz" convention every Task
+// Manager / lscpu / About This Mac uses.
+func formatMHz(mhz int) string {
+	if mhz >= 1000 {
+		return fmt.Sprintf("%.2f GHz", float64(mhz)/1000)
+	}
+	return fmt.Sprintf("%d MHz", mhz)
 }
 
 // formatBytesHuman renders a byte count in binary units (KiB/MiB/…).

--- a/info_panel_test.go
+++ b/info_panel_test.go
@@ -327,6 +327,112 @@ func TestInfoPanel_ProcessKey_UnfocusedIgnoresC(t *testing.T) {
 	}
 }
 
+// TestInfoPanel_ShiftUpDownSelectsAndCCopiesLabelValue checks the
+// multi-row selection UX: Shift+Down toggles the current row's
+// selection and moves the cursor down; a subsequent C copies every
+// selected row as "label: value" per line (in on-screen order),
+// with a two-line minimum so the copy joiner is actually exercised.
+func TestInfoPanel_ShiftUpDownSelectsAndCCopiesLabelValue(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 39, 24)
+	ip.SetFocus(true)
+	ip.Show(scr)
+	ip.setCursorToFirstCopyable()
+
+	// First row: Shift+Down should toggle current selection then move.
+	firstLabel := ip.rows[ip.cursor].label
+	firstValue := ip.rows[ip.cursor].value
+	ip.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_DOWN,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	// Second row (post-move): Shift+Down again, adds it too.
+	secondLabel := ip.rows[ip.cursor].label
+	secondValue := ip.rows[ip.cursor].value
+	ip.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_DOWN,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	firstSection := ip.rows[0].section
+	// After the second Shift+Down the cursor sits on the second
+	// selectable row; recover its section from the row list.
+	secondSection := ""
+	for _, r := range ip.rows {
+		if r.label == secondLabel && r.copyable {
+			secondSection = r.section
+			break
+		}
+	}
+	if !ip.selection[rowKey(firstSection, firstLabel)] ||
+		!ip.selection[rowKey(secondSection, secondLabel)] {
+		t.Fatalf("expected both %q and %q to be selected; got selection=%v",
+			firstLabel, secondLabel, ip.selection)
+	}
+
+	// C copies both rows as label: value per line, in on-screen order.
+	ip.copyCurrent()
+	want := firstLabel + ": " + firstValue + "\n" + secondLabel + ": " + secondValue
+	if got := vtui.GetClipboard(); got != want {
+		t.Errorf("clipboard = %q, want %q", got, want)
+	}
+
+	// Selection persists across a rebuild — the highlight must
+	// survive the next Show, which walks the row list from scratch.
+	ip.Show(scr)
+	for _, r := range ip.rows {
+		if r.label == firstLabel || r.label == secondLabel {
+			if !r.selected {
+				t.Errorf("row %q lost its selected flag after rebuild", r.label)
+			}
+		}
+	}
+}
+
+// TestInfoPanel_InsTogglesSelectionAndMoves verifies Ins behaves
+// like the file-panel Ins: toggle current, advance one row.
+func TestInfoPanel_InsTogglesSelectionAndMoves(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 39, 24)
+	ip.SetFocus(true)
+	ip.Show(scr)
+	ip.setCursorToFirstCopyable()
+
+	startRow := ip.rows[ip.cursor]
+	startCursor := ip.cursor
+	ip.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_INSERT,
+	})
+	if !ip.selection[rowKey(startRow.section, startRow.label)] {
+		t.Errorf("Ins should have selected %q", startRow.label)
+	}
+	if ip.cursor == startCursor {
+		t.Error("Ins should have advanced the cursor by one copyable row")
+	}
+}
+
 // TestInfoPanel_CPUSectionRespectsOption checks that the CPU/GPU
 // section is opt-in — hidden when AppConfig.InfoPanelCPUGPU is off,
 // present when it's on. Guards the maintainer's off-by-default ask.

--- a/info_panel_test.go
+++ b/info_panel_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/unxed/f4/vfs"
@@ -211,6 +212,164 @@ func TestShortUsername(t *testing.T) {
 		if got := shortUsername(c.in); got != c.want {
 			t.Errorf("shortUsername(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestInfoPanel_CursorSkipsNonCopyable makes sure Up/Down land on
+// copyable rows only — never on a section header or blank line.
+func TestInfoPanel_CursorSkipsNonCopyable(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 39, 24)
+	ip.SetFocus(true)
+	ip.Show(scr) // populates rows and seeds cursor
+
+	if ip.cursor < 0 || ip.cursor >= len(ip.rows) {
+		t.Fatalf("expected cursor to be seeded on a row, got %d of %d", ip.cursor, len(ip.rows))
+	}
+	if !ip.rows[ip.cursor].copyable {
+		t.Errorf("cursor landed on a non-copyable row (label=%q)", ip.rows[ip.cursor].label)
+	}
+
+	seen := 0
+	for i := 0; i < 200; i++ {
+		prev := ip.cursor
+		ip.moveCursor(+1)
+		if ip.cursor == prev {
+			break
+		}
+		if !ip.rows[ip.cursor].copyable {
+			t.Fatalf("Down landed on non-copyable row (label=%q)", ip.rows[ip.cursor].label)
+		}
+		seen++
+	}
+	if seen == 0 {
+		t.Fatal("cursor didn't advance at all on repeated Down")
+	}
+	for i := 0; i < 200; i++ {
+		prev := ip.cursor
+		ip.moveCursor(-1)
+		if ip.cursor == prev {
+			break
+		}
+		if !ip.rows[ip.cursor].copyable {
+			t.Fatalf("Up landed on non-copyable row (label=%q)", ip.rows[ip.cursor].label)
+		}
+	}
+}
+
+// TestInfoPanel_CopyCopiesValue verifies that 'C' while focused
+// writes the current row's value (not the label) to vtui.SetClipboard.
+func TestInfoPanel_CopyCopiesValue(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 39, 24)
+	ip.SetFocus(true)
+	ip.Show(scr)
+
+	// Force cursor onto a known row (first copyable) and copy.
+	ip.setCursorToFirstCopyable()
+	if ip.cursor < 0 {
+		t.Fatal("no copyable row found on default info panel — layout regression?")
+	}
+	wantValue := ip.rows[ip.cursor].value
+	if wantValue == "" {
+		t.Fatal("first copyable row has empty value; test premise broken")
+	}
+	ip.copyCurrent()
+	if got := vtui.GetClipboard(); got != wantValue {
+		t.Errorf("SetClipboard got %q, want %q", got, wantValue)
+	}
+}
+
+// TestInfoPanel_ProcessKey_UnfocusedIgnoresC verifies the C copy
+// hotkey only fires when the panel is focused — otherwise it must
+// fall through so the file panel's fast-find still sees it.
+func TestInfoPanel_ProcessKey_UnfocusedIgnoresC(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 39, 24)
+	ip.Show(scr)
+	// Not focused.
+	handled := ip.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_C,
+	})
+	if handled {
+		t.Error("unfocused info panel must not consume C")
+	}
+}
+
+// TestInfoPanel_CPUSectionRespectsOption checks that the CPU/GPU
+// section is opt-in — hidden when AppConfig.InfoPanelCPUGPU is off,
+// present when it's on. Guards the maintainer's off-by-default ask.
+func TestInfoPanel_CPUSectionRespectsOption(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 40)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 60, 40, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	old := AppConfig.InfoPanelCPUGPU
+	defer func() { AppConfig.InfoPanelCPUGPU = old }()
+
+	ip := NewInfoPanel(fsp)
+	ip.SetPosition(0, 0, 59, 39)
+
+	hasLabelPrefix := func(prefix string) bool {
+		for _, r := range ip.rows {
+			if strings.HasPrefix(r.label, prefix) {
+				return true
+			}
+		}
+		return false
+	}
+
+	AppConfig.InfoPanelCPUGPU = false
+	ip.Show(scr)
+	if hasLabelPrefix("Model") || hasLabelPrefix("Cores") {
+		t.Error("CPU rows must not render when InfoPanelCPUGPU is off")
+	}
+
+	AppConfig.InfoPanelCPUGPU = true
+	ip.Show(scr)
+	// Cores is always populated (runtime.NumCPU seeds LogicalCores
+	// on every OS). Label depends on HT — plain "Cores / threads"
+	// when different, or on any i18n change the prefix "Cores"
+	// still matches.
+	if !hasLabelPrefix("Cores") {
+		t.Error("expected CPU 'Cores' row once InfoPanelCPUGPU is enabled")
 	}
 }
 

--- a/info_panel_test.go
+++ b/info_panel_test.go
@@ -400,6 +400,64 @@ func TestInfoPanel_ShiftUpDownSelectsAndCCopiesLabelValue(t *testing.T) {
 	}
 }
 
+// TestInfoPanel_WrapRowContinuationInheritsSelection checks that
+// when a value overflows the panel width and wrapRow spills it onto
+// hanging continuation lines, selecting the row highlights ALL of
+// its screen lines — not just the first. The line break is a
+// display artifact, not a selection boundary. Realised via
+// section+label tagging of continuation rows so ip.selection lights
+// every line owned by the parent label.
+func TestInfoPanel_WrapRowContinuationInheritsSelection(t *testing.T) {
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(40, 25)
+	vtui.FrameManager.Init(scr)
+	vtui.SetDefaultPalette()
+
+	tmp := t.TempDir()
+	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+	fsp.Refresh()
+
+	ip := NewInfoPanel(fsp)
+	// Narrow panel so any real Flags-style row spills onto at least
+	// two hanging lines.
+	ip.SetPosition(0, 0, 39, 24)
+	ip.SetFocus(true)
+	ip.Show(scr)
+
+	// Directly select the Flags label if a wrapped row exists.
+	// If it doesn't (fs has no flags string), simulate one by
+	// invoking wrapRow via a synthesised call. Simpler: iterate
+	// existing rows for two consecutive rows sharing (section,
+	// label) — that's a wrap. If none exist skip the test.
+	var parentIdx int = -1
+	for i := 0; i+1 < len(ip.rows); i++ {
+		r, next := ip.rows[i], ip.rows[i+1]
+		if r.copyable && !next.copyable && r.label != "" &&
+			next.label == r.label && next.section == r.section {
+			parentIdx = i
+			break
+		}
+	}
+	if parentIdx < 0 {
+		t.Skip("no wrapped row present in this environment — nothing to verify")
+	}
+	parent := ip.rows[parentIdx]
+	ip.selection[rowKey(parent.section, parent.label)] = true
+	ip.Show(scr) // triggers the restore loop
+
+	// Every row sharing (section, label) with the parent must now
+	// carry selected=true, contiguous continuation and all.
+	for _, r := range ip.rows {
+		if r.section == parent.section && r.label == parent.label {
+			if !r.selected {
+				t.Errorf("row (section=%q label=%q, text=%q) should be selected",
+					r.section, r.label, r.text)
+			}
+		}
+	}
+}
+
 // TestInfoPanel_InsTogglesSelectionAndMoves verifies Ins behaves
 // like the file-panel Ins: toggle current, advance one row.
 func TestInfoPanel_InsTogglesSelectionAndMoves(t *testing.T) {

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -202,6 +202,7 @@ InfoPanel.CPULoadAvg=Load average
 InfoPanel.GPUTitle=GPU
 InfoPanel.GPUModel=Model
 InfoPanel.GPUDriver=Driver
+InfoPanel.GPUWSLVirt=WSL virtualised GPU (host name not exposed)
 InfoPanel.Copied=Copied
 InfoPanel.CopiedRows=Copied rows
 InfoPanel.UnitsHint= B: units   Ins/Shift+↑↓: select   C: copy

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -108,6 +108,7 @@ PanelSettings.VimHotkeys=Enable &Vim-like hotkeys (j, k, dd, cc, mm)
 PanelSettings.SyncPanelLoad=S&ynchronous panel loading (disable cache/chunking)
 PanelSettings.DefaultMode=Default operation &mode:
 PanelSettings.PathDisplay=File path in progress:
+PanelSettings.InfoPanelCPUGPU=Show CPU/GPU section on i&nfo panel
 
 AppearanceSettings.Title= Appearance settings
 AppearanceSettings.Style=Application &style:
@@ -192,7 +193,17 @@ InfoPanel.MemShared=Shared memory
 InfoPanel.MemBuffered=Buffer memory
 InfoPanel.SwapTotal=Total paging file
 InfoPanel.SwapFree=Free paging file
-InfoPanel.UnitsHint= B: bytes ↔ human
+InfoPanel.CPUTitle=CPU
+InfoPanel.CPUModel=Model
+InfoPanel.CPUCores=Cores / threads
+InfoPanel.CPUFreq=Frequency
+InfoPanel.CPULoad=Load
+InfoPanel.CPULoadAvg=Load average
+InfoPanel.GPUTitle=GPU
+InfoPanel.GPUModel=Model
+InfoPanel.GPUDriver=Driver
+InfoPanel.Copied=Copied
+InfoPanel.UnitsHint= B: bytes ↔ human   C: copy row
 
 QuickView.Title= Quick view
 QuickView.NoSelection=<no selection>

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -203,7 +203,8 @@ InfoPanel.GPUTitle=GPU
 InfoPanel.GPUModel=Model
 InfoPanel.GPUDriver=Driver
 InfoPanel.Copied=Copied
-InfoPanel.UnitsHint= B: bytes ↔ human   C: copy row
+InfoPanel.CopiedRows=Copied rows
+InfoPanel.UnitsHint= B: units   Ins/Shift+↑↓: select   C: copy
 
 QuickView.Title= Quick view
 QuickView.NoSelection=<no selection>

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -108,6 +108,7 @@ PanelSettings.VimHotkeys=Включить &Vim-раскладку (j, k, dd, cc,
 PanelSettings.SyncPanelLoad=&Синхронная загрузка панелей (без кэша)
 PanelSettings.DefaultMode=Режим операций по &умолчанию:
 PanelSettings.PathDisplay=Отображение пути в прогрессе:
+PanelSettings.InfoPanelCPUGPU=Показывать CPU/GPU на &инфо-панели
 
 AppearanceSettings.Title= Внешний вид
 AppearanceSettings.Style=Стиль &оформления:
@@ -192,7 +193,17 @@ InfoPanel.MemShared=Общая память
 InfoPanel.MemBuffered=Буферная память
 InfoPanel.SwapTotal=Файл подкачки всего
 InfoPanel.SwapFree=Файл подкачки свободно
-InfoPanel.UnitsHint= B: байты ↔ человекочитаемый
+InfoPanel.CPUTitle=Процессор
+InfoPanel.CPUModel=Модель
+InfoPanel.CPUCores=Ядер / потоков
+InfoPanel.CPUFreq=Частота
+InfoPanel.CPULoad=Загрузка
+InfoPanel.CPULoadAvg=Средняя нагрузка
+InfoPanel.GPUTitle=Видеокарта
+InfoPanel.GPUModel=Модель
+InfoPanel.GPUDriver=Драйвер
+InfoPanel.Copied=Скопировано
+InfoPanel.UnitsHint= B: байты ↔ человекочитаемый   C: копировать
 
 QuickView.Title= Быстрый просмотр
 QuickView.NoSelection=<нет выделения>

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -202,6 +202,7 @@ InfoPanel.CPULoadAvg=Средняя нагрузка
 InfoPanel.GPUTitle=Видеокарта
 InfoPanel.GPUModel=Модель
 InfoPanel.GPUDriver=Драйвер
+InfoPanel.GPUWSLVirt=Виртуальная GPU WSL (имя хостовой не проброшено)
 InfoPanel.Copied=Скопировано
 InfoPanel.CopiedRows=Скопировано строк
 InfoPanel.UnitsHint= B: единицы   Ins/Shift+↑↓: пометить   C: копир

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -203,7 +203,8 @@ InfoPanel.GPUTitle=Видеокарта
 InfoPanel.GPUModel=Модель
 InfoPanel.GPUDriver=Драйвер
 InfoPanel.Copied=Скопировано
-InfoPanel.UnitsHint= B: байты ↔ человекочитаемый   C: копировать
+InfoPanel.CopiedRows=Скопировано строк
+InfoPanel.UnitsHint= B: единицы   Ins/Shift+↑↓: пометить   C: копир
 
 QuickView.Title= Быстрый просмотр
 QuickView.NoSelection=<нет выделения>


### PR DESCRIPTION
Continues the Ctrl+L info panel work from #235. This is the follow-up the earlier PR body listed under "Deferred to follow-ups → CPU section". Discussion picks up from #235 comments (maintainer ask: off-by-default option + let users copy the CPU / GPU strings; PDH via [unxed/pureffi](https://github.com/unxed/pureffi) is fine).

## Summary

Adds two optional sections to the Ctrl+L info panel — CPU and GPU — and a small navigation + copy affordance shared by the whole panel.

* **Opt-in.** Everything below hides behind a new checkbox in F9 → Panel settings, "Show CPU/GPU section on info panel", **off by default** (persisted to `[Panel] InfoPanelCPUGPU` via the debounced `RequestSaveConfig` plumbing added in #227). Existing users see zero change until they tick it.
* **CPU section:** Model, Cores/threads (physical/logical), Frequency (base), L1/L2/L3, Load.
* **GPU section:** Model + Driver per adapter; multi-GPU laptops render one entry per adapter, numbered.
* **Row cursor + copy.** Tab focuses the alt panel (same entry point QuickView already uses); ↑ / ↓ / Home / End walk copyable rows; **C** copies the current row.
* **Multi-row selection.** Shift+↑/↓ and Ins mirror the file panel's selection convention (toggle + move); C on a non-empty selection copies every selected row as `label: value` per line, in on-screen order.

## Sections

### CPU

Rendered under Memory. Every row is optional — populated only where the OS supplies the datum, others silently skipped.

* **Model** — brand string.
  * Linux: `/proc/cpuinfo` `model name`.
  * Windows: registry `HKLM\HARDWARE\DESCRIPTION\System\CentralProcessor\0\ProcessorNameString`.
  * macOS: `sysctl machdep.cpu.brand_string`.
* **Cores/threads** — `physical / logical` (e.g. `4 / 8`) when they differ, plain integer when equal (dedicated core-per-thread).
  * Linux: `/proc/cpuinfo` — physical cores counted as unique `(physical id, core id)` pairs, the same trick `lscpu` uses; falls back to `cpu cores` per-processor on single-socket kernels that omit `physical id`.
  * Windows: `GetLogicalProcessorInformation` (kernel32) — RelationProcessorCore counted.
  * macOS: `sysctl hw.physicalcpu`.
* **Frequency** — base clock, formatted as `2.50 GHz` (or `MHz` if < 1000).
  * Linux: `/proc/cpuinfo` `cpu MHz`, fallback `/sys/devices/system/cpu/cpu0/cpufreq/cpuinfo_max_freq`.
  * Windows: registry `~MHz` DWORD alongside `ProcessorNameString`.
  * macOS: `sysctl hw.cpufrequency`. **Skipped on Apple Silicon** where the key is absent by design (fixed-frequency P/E clusters with on-die scaling — no meaningful single number).
* **L1 / L2 / L3 / L4** — cache sizes; L1 sums the split I- and D-caches into one row.
  * Linux: `/sys/devices/system/cpu/cpu0/cache/index*/{level,size,type}`.
  * Windows: same `GetLogicalProcessorInformation` walk — RelationCache entries.
  * macOS: `sysctl hw.l1{i,d}cachesize`, `hw.l2cachesize`, `hw.l3cachesize`.
* **Load** — instantaneous percent (Windows / macOS-style), or 1/5/15-min load average (Linux).
  * **Windows: PDH via [unxed/pureffi](https://github.com/unxed/pureffi)** (already vendored under `replace github.com/ebitengine/purego => github.com/unxed/pureffi` in go.mod, no new dependency). Query is `\Processor Information(_Total)\% Processor Utility` — the same metric Task Manager shows since Win8, so numbers agree instead of drifting like the old `GetSystemTimes` % Processor Time path would. Fallback to `\Processor Information(_Total)\% Processor Time` if Utility is unavailable (some VMs / Server Core with disabled counter set). PDH counter names are queried through `PdhAddEnglishCounterW` so localized Windows still resolves them. Throttled to 500 ms — even with the panel redrawing constantly the syscall runs at most twice per second, and the query is only opened lazily on the first sample (nothing runs while the panel is closed).
  * Linux: `/proc/loadavg` — single tiny read per Show, kernel-computed.
  * macOS: `sysctl vm.loadavg` (decoded with the standard `FSCALE = 2048` constant).

### GPU

Rendered below CPU. Adapter enumeration is cached (runtime doesn't add/remove GPUs). Missing → section hidden entirely.

* **Model + Driver** per adapter.
* Multi-GPU (dGPU + iGPU): rows render numbered — `Model 1 / Driver 1 / Model 2 / Driver 2`.
* Sources:
  * **Linux**: `/sys/class/drm/card[0-9]*` filtered to base card devices (no HDMI-A-* connector entries). Model tries, in order: `device/label` (Chrome OS / some ThinkPads set it), PCI vendor+device IDs resolved through `/usr/share/hwdata/pci.ids` — the same DB `lspci` uses, no new dependency — and finally raw `VVVV:DDDD` hex as a last resort. NVIDIA proprietary driver is picked up first via `/proc/driver/nvidia/gpus/*/information`'s `Model` line (cleaner names than PCI ID lookup gives). Driver from `device/uevent` `DRIVER=` line — `i915` / `amdgpu` / `nouveau` / `nvidia` / `vmwgfx` / etc.
  * **Windows**: `EnumDisplayDevices`. **No `DISPLAY_DEVICE_ACTIVE` filter** — powered-down Optimus dGPUs still show up. Duplicates by DeviceString are collapsed. Driver comes from `DriverDesc` (fallback `ProviderName`) under the DeviceKey registry hop.
  * **macOS**: skipped. Apple Silicon shares GPU identity with the CPU (which is already rendered), and IOKit would need cgo. Follow-up if anyone wants a distinct row.
  * **WSL2**: Microsoft's `dxgkrnl` passthrough uses `/dev/dxg` instead of exposing anything under `/sys/class/drm`, so the normal Linux path finds nothing (same reason `lspci` / `glxinfo` don't). Fallback: if enumeration turns up empty and `/dev/dxg` exists, ask Windows for the real host adapter name(s) through WSL interop — `wmic.exe path win32_videocontroller get name /format:list` (~250 ms, preferred), falling back to `powershell.exe -Command "(Get-CimInstance Win32_VideoController).Name"` (~1.5 s) if wmic is missing (Microsoft has been sunsetting it since Server 2012 R2). Both binaries are on the interop PATH inside WSL by default, no `/mnt/c/...` hard-coding. 3-second timeout so a hung interop can't freeze the panel. Query runs once per session (already inside `sync.Once`). Driver stays `dxgkrnl` (that's the module we're actually talking to inside Linux). Last-ditch fallback if both interop paths fail: one row `Model = "WSL virtualised GPU (host name not exposed)"`.

### Row cursor + copy on C

Adds selection-inside-the-panel to the existing AltPanel focus flow.

* Tab flips focus to the info panel (same behaviour QuickView installs on Ctrl+Q + Tab); title recolours to signal focus, cursor bar appears on the first copyable row.
* ↑ / ↓ / Home / End — walk copyable rows. Section headers, blanks and wrapRow continuation lines are skipped.
* **C** copies the current row's raw value via `vtui.SetClipboard` — which already tries far2l IPC → OS clipboard → OSC 52 in order, so a single call covers every terminal case f4 supports. A toast confirms the copy.
* **Shift+↑/↓, Shift+Home/End, Ins** toggle selection on the current row, mirroring the file-panel convention exactly. Selected rows render in `ColPanelSelectedText`; cursor-on-selected escalates to `ColPanelSelectedCursor` (same "cursor-on-selected" contrast file entries get).
* C with a non-empty selection copies every selected row as `label: value` per line, in on-screen order — context survives the paste. Toast reports the count.
* Selection persists across rebuilds (which happen on every Show) via a `map[section+"|"+label]bool`. Section prefix disambiguates rows that share a label — CPU and GPU both use i18n key `.*Model` = "Model", the flat label-only key would light both up when you selected one. Selection is dropped when the panel itself is closed (Ctrl+L destroys the panel object).
* wrapRow-style rows (e.g. NTFS Flags spilling onto 2-3 hanging lines) light their continuation lines alongside the parent — the line break is a display artifact, not a selection boundary. Copy still emits one `label: value` line per parent row.

### Formatting

* Sizes use the existing formatBytes routing (`B` toggles human ↔ raw with thousand separators; unchanged from #235).
* Frequency: `X.XX GHz` for ≥ 1000 MHz, `N MHz` otherwise.
* Bottom-border hint updated to `B: units   Ins/Shift+↑↓: select   C: copy` (`B: единицы   Ins/Shift+↑↓: пометить   C: копир` in RU).

## Config

New `AppConfig.InfoPanelCPUGPU bool`, default false, persisted at `[Panel] InfoPanelCPUGPU = 0|1`. Toggled in F9 → Panel settings, dialog height bumped from 24 to 25 lines to fit the extra checkbox.

## i18n

New strings in `lang/en.lng` + `lang/ru.lng`:

* `InfoPanel.CPUTitle` / `.CPUModel` / `.CPUCores` / `.CPUFreq` / `.CPULoad` / `.CPULoadAvg`
* `InfoPanel.GPUTitle` / `.GPUModel` / `.GPUDriver` / `.GPUWSLVirt`
* `InfoPanel.Copied` / `.CopiedRows` — toast messages
* `InfoPanel.UnitsHint` — bottom hint rewritten to advertise the new keys
* `PanelSettings.InfoPanelCPUGPU` — settings checkbox

## Test plan

- [x] `go test ./...` passes.
- [x] `go build ./...` clean on linux; `GOOS=windows GOARCH=amd64 go build ./...` clean; `GOOS=darwin GOARCH=arm64 go build ./...` clean; `GOOS=darwin GOARCH=amd64 go build ./...` clean.
- [x] `gofmt -w -s` clean on all touched files.

### Automated

New tests, all in `info_panel_test.go`:

* `TestInfoPanel_CursorSkipsNonCopyable` — ↑/↓ never lands on a section header or blank.
* `TestInfoPanel_CopyCopiesValue` — C copies the current row's raw value (not the label) to `vtui.SetClipboard`.
* `TestInfoPanel_ProcessKey_UnfocusedIgnoresC` — C falls through when the panel isn't focused, so the file panel's fast-find still sees it.
* `TestInfoPanel_CPUSectionRespectsOption` — CPU rows only render when `AppConfig.InfoPanelCPUGPU` is on.
* `TestInfoPanel_ShiftUpDownSelectsAndCCopiesLabelValue` — Shift+Down chains, C on 2 selected rows produces `label: value\nlabel: value`, selection survives a rebuild.
* `TestInfoPanel_InsTogglesSelectionAndMoves` — Ins toggles current and advances by one.
* `TestInfoPanel_WrapRowContinuationInheritsSelection` — wrap continuation lines light up when the parent is selected (skips gracefully if the environment doesn't produce a wrapped row).

Existing `TestPanelsFrame_CtrlL_TogglesInfoPanel`, `TestInfoPanel_ShowRenders`, `TestPanelsFrame_B_TogglesInfoPanelUnits`, `TestFormatBytes_TogglesWithConfig`, `TestShortUsername`, `TestFormatBytesCommas` still pass.

### Manual (only what I actually ran)

**Windows 11** (native `f4.exe`, non-admin):

* Tick the option, Ctrl+L → CPU + GPU sections appear under Memory.
* CPU rendering (verified on-screen against Task Manager): `Model = 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz`, `Cores / threads = 4 / 8`, `Frequency = 2.50 GHz`, `L1 = 320.0 KiB`, `L2 = 5.0 MiB`, `L3 = 8.0 MiB`, `Load ≈ 12 %`. Task Manager tracked in the same ballpark — quantisation windows differ (Task Manager and PDH sample on their own schedules), so momentary peaks don't always align, but the average matches.
* GPU: `Model = Intel(R) Iris(R) Xe Graphics`, `Driver = Intel(R) Iris(R) Xe Graphics` (Intel ships the same string for DriverDesc and adapter name — expected).
* Tab focuses info panel; ↑/↓ navigate copyable rows only. `C` on a single row copies the raw value with a toast. Shift+Down through several rows selects them; `C` writes `Model: 11th Gen Intel(R) ...\nCores / threads: 4 / 8\n...` to the clipboard, verified by pasting elsewhere.
* Flags row (NTFS on `C:\Users`) wraps to 3 lines — selecting the row lights all three, `C` copies the full comma-list on one line.
* `B` still toggles units (regression check on the pre-existing shortcut).

**WSL Ubuntu** (`f4-linux` from the same tree):

* `/sys/class/drm` empty (no card entries), `/dev/dxg` present → interop path picks up `Intel(R) Iris(R) Xe Graphics` through `wmic.exe` (~250 ms), matches the Windows Device Manager string and what native `f4.exe` reports on the same host. `Driver = dxgkrnl` on both rows. Rest of the panel (CPU incl. loadavg from `/proc/loadavg`) unaffected.

### Not run (honest gaps)

* **Linux bare-metal** — GPU code path (`/sys/class/drm` + `pci.ids` lookup, `/proc/driver/nvidia`) written and cross-compiles cleanly, but I don't have a bare-metal Linux GPU to confirm the row shape end-to-end.
* **macOS** — CPU code path (`sysctl` calls + `vm.loadavg` decode) written and cross-compiles cleanly. `gpuInfo()` on macOS is intentionally an empty stub.
* **`% Processor Time` PDH fallback** — the primary `% Processor Utility` counter resolved fine on Win11; the fallback branch is exercised only when the primary path fails and I couldn't reproduce that on a real machine.
* **NVIDIA proprietary GPU** — the `/proc/driver/nvidia` branch is code-only, not confirmed against an actual NVIDIA + `nvidia` driver setup.
* ***BSD / illumos** — `cpu_info_other.go` and `gpu_info_other.go` are stubs (mirror `fs_info_other.go`) — surface `runtime.NumCPU()` for CPU cores, hide GPU. Same as before this PR for the FS/memory sections.

## Commits

Five atomic commits, each independently buildable:

1. **`InfoPanel: opt-in CPU and GPU sections, row cursor and copy on C`** — the base of the feature: per-OS CPU/GPU readers, InfoPanel rendering, opt-in checkbox, Tab-to-focus + ↑/↓/Home/End + single-row C copy, tests.
2. **`InfoPanel: Shift+Up/Down and Ins to select rows, C copies selection`** — multi-row selection, `label: value` per-line copy shape, selection persistence + rebuild tests.
3. **`InfoPanel: wrapRow continuation lines follow their parent's selection`** — Flags row on NTFS spans 2-3 lines; without this the highlight looked truncated. Tag continuation infoRows with parent (section, label) so the restore loop lights them alongside.
4. **`InfoPanel: WSL virtualised GPU fallback via /dev/dxg`** — Section no longer hidden on WSL2 where the normal `/sys/class/drm` path is empty by Microsoft design; one honest row instead of nothing.
5. **`InfoPanel: query real WSL host GPU name via wmic / PowerShell interop`** — Replaces the placeholder with the real host adapter name(s) via `wmic.exe` (or `powershell.exe` fallback). The generic placeholder from commit 4 only fires now when both interop paths fail.

## Deferred to follow-ups

* **macOS GPU row** — IOKit binding + cgo, worth its own PR if anyone asks.
* **CPU load on macOS** — right now `hw.cpufrequency` is skipped on Apple Silicon; a per-tick load figure would need a `host_processor_info` port similar to what `top` uses.
* **Real-time refresh** — values are pulled fresh on each Show (no goroutines/timers), so movement redraws refresh; no auto-refresh timer while the panel is idle. Same trade-off as #235.

Closes the CPU-section item from #235's follow-ups list; the earlier `feature/info-panel-cpu-section` branch is superseded.
