### PR TITLE
PanelsFrame: swallow mouse clicks landing on alt panels

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1816,6 +1816,29 @@ func (pf *PanelsFrame) HandleBroadcast(cmd int, args any) bool {
 	return pf.BaseFrame.HandleBroadcast(cmd, args)
 }
 
+// hitAltPanel returns the index (0 or 1) of the alt panel whose
+// on-screen area contains (mx, my), or -1 if none. Respects the
+// per-side hidden flags so a click over a hidden slot doesn't
+// accidentally target its ghost alt panel.
+func (pf *PanelsFrame) hitAltPanel(mx, my int) int {
+	for i, a := range pf.altPanels {
+		if a == nil {
+			continue
+		}
+		if i == 0 && !pf.showLeftPanel {
+			continue
+		}
+		if i == 1 && !pf.showRightPanel {
+			continue
+		}
+		x1, y1, x2, y2 := a.GetPosition()
+		if mx >= x1 && mx <= x2 && my >= y1 && my <= y2 {
+			return i
+		}
+	}
+	return -1
+}
+
 func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 	// If panels are hidden, route relevant mouse events to PTY immediately
 	if !pf.showPanels {
@@ -1847,22 +1870,9 @@ func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 	// Wheel events fall through to the wheel branch and its
 	// normal alt-panel-first routing.
 	if pf.showPanels && e.ButtonState != 0 {
-		for i, a := range pf.altPanels {
-			if a == nil {
-				continue
-			}
-			if i == 0 && !pf.showLeftPanel {
-				continue
-			}
-			if i == 1 && !pf.showRightPanel {
-				continue
-			}
-			x1, y1, x2, y2 := a.GetPosition()
-			if mx < x1 || mx > x2 || my < y1 || my > y2 {
-				continue
-			}
-			// Click on an alt panel activates its side, same as a
-			// click on a file panel does.
+		if i := pf.hitAltPanel(mx, my); i >= 0 {
+			// Click on an alt panel activates its side, same as
+			// a click on a file panel does.
 			if pf.activeIdx != i {
 				pf.activeIdx = i
 				pf.lastKey = 0
@@ -1871,7 +1881,7 @@ func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 			// Give the alt panel a chance to handle it (future
 			// row-picking, etc.); return true either way — the
 			// event does not fall through.
-			a.ProcessMouse(e)
+			pf.altPanels[i].ProcessMouse(e)
 			return true
 		}
 	}

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1838,6 +1838,44 @@ func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// Alt panels (Ctrl+L info / Ctrl+Q quick view / …) share the
+	// same screen slot as the file panel underneath — the file
+	// panel is not drawn, but it still exists logically at the
+	// same coordinates. Swallow any button event landing on an
+	// alt panel so a double-click or the global middle-click →
+	// Enter branch below can't launch a file the user can't see.
+	// Wheel events fall through to the wheel branch and its
+	// normal alt-panel-first routing.
+	if pf.showPanels && e.ButtonState != 0 {
+		for i, a := range pf.altPanels {
+			if a == nil {
+				continue
+			}
+			if i == 0 && !pf.showLeftPanel {
+				continue
+			}
+			if i == 1 && !pf.showRightPanel {
+				continue
+			}
+			x1, y1, x2, y2 := a.GetPosition()
+			if mx < x1 || mx > x2 || my < y1 || my > y2 {
+				continue
+			}
+			// Click on an alt panel activates its side, same as a
+			// click on a file panel does.
+			if pf.activeIdx != i {
+				pf.activeIdx = i
+				pf.lastKey = 0
+				vtui.FrameManager.Redraw()
+			}
+			// Give the alt panel a chance to handle it (future
+			// row-picking, etc.); return true either way — the
+			// event does not fall through.
+			a.ProcessMouse(e)
+			return true
+		}
+	}
+
 	// Global middle-click (wheel click) intercept for PanelsFrame.
 	// When panels are shown, clicking the middle mouse button anywhere on screen
 	// triggers the Enter handler, launching the selected file in the active panel.

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -483,6 +483,132 @@ func TestPanelsFrame_ProcessMouse_DoubleClickFile(t *testing.T) {
 	}
 }
 
+// TestPanelsFrame_ProcessMouse_AltPanelSwallowsClicks makes sure a
+// click on an alt panel (Ctrl+L / Ctrl+Q) does NOT fall through to
+// the file panel underneath — otherwise a double-click can launch
+// a file the user can't even see. Also verifies that a click on
+// the passive-side alt panel activates that side.
+func TestPanelsFrame_ProcessMouse_AltPanelSwallowsClicks(t *testing.T) {
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	tmp := t.TempDir()
+	runnablePath := filepath.Join(tmp, "run.sh")
+	os.WriteFile(runnablePath, []byte("echo"), 0755)
+
+	// Left panel holds the runnable; right is active by default.
+	fsp := pf.panels[0].(*FileSystemPanel)
+	fsp.SetViewMode(ViewModeDetailed)
+	fsp.vfs.SetPath(tmp)
+	fsp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "run.sh", IsDir: false}},
+	}
+	fsp.Refresh()
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	// Ctrl+L installs an info panel on the passive (left) slot.
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_L,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if pf.altPanels[0] == nil {
+		t.Fatal("Ctrl+L should install alt panel on the left slot")
+	}
+	priorActive := pf.activeIdx // right (1) from setupMockPanelsFrame
+
+	// Double-click at (5,3) — coordinates that would hit run.sh
+	// if the file panel underneath received the event.
+	handled := pf.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		MouseX:          5,
+		MouseY:          3,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.DoubleClick,
+	})
+	if !handled {
+		t.Error("click on alt panel must return handled=true")
+	}
+	// Drain any incidental tasks (ReadDirectory etc); if the file
+	// panel handled the double-click, panels would be hidden.
+	timeout := time.After(200 * time.Millisecond)
+drain:
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			break drain
+		}
+	}
+	if !pf.showPanels {
+		t.Error("double-click on alt panel must NOT launch the file underneath")
+	}
+	if pf.activeIdx == priorActive {
+		t.Errorf("click on passive-side alt panel should activate that side; activeIdx stayed %d", pf.activeIdx)
+	}
+}
+
+// TestPanelsFrame_ProcessMouse_MiddleClickOverAltPanel confirms the
+// global middle-click → Enter branch is also swallowed when the
+// click lands on an alt panel; otherwise the file under the alt
+// still gets launched despite the fix.
+func TestPanelsFrame_ProcessMouse_MiddleClickOverAltPanel(t *testing.T) {
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "run.sh"), []byte("echo"), 0755)
+	fsp := pf.panels[0].(*FileSystemPanel)
+	fsp.SetViewMode(ViewModeDetailed)
+	fsp.vfs.SetPath(tmp)
+	fsp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "run.sh", IsDir: false}},
+	}
+	fsp.Refresh()
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_L,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if pf.altPanels[0] == nil {
+		t.Fatal("Ctrl+L should install alt panel")
+	}
+
+	handled := pf.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      5,
+		MouseY:      3,
+		ButtonState: vtinput.FromLeft2ndButtonPressed,
+	})
+	if !handled {
+		t.Error("middle-click on alt panel must be handled=true")
+	}
+	timeout := time.After(200 * time.Millisecond)
+drain:
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			break drain
+		}
+	}
+	if !pf.showPanels {
+		t.Error("middle-click on alt panel must NOT trigger Enter → launch on the file underneath")
+	}
+}
+
 func TestPanelsFrame_KeyHandling(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()


### PR DESCRIPTION
## Problem

Alt panels (Ctrl+L info, Ctrl+Q quick view) share the same screen slot as the file panel underneath — only the alt is drawn, but the file panel still exists logically at the same coordinates and its \`ProcessMouse\` still runs on any event at those coordinates.

Result: a mouse click on an alt panel falls through to the invisible file panel underneath. A double-click launches whatever file happens to be at those coordinates — invisible to the user because the alt panel is drawn on top. Middle-click has the same problem via the global middle-click → Enter intercept in \`PanelsFrame.ProcessMouse\`.

## Fix

Hit-test alt panels before the wheel handler and the global middle-click → Enter branch in \`PanelsFrame.ProcessMouse\`. If a button event lands on an alt panel:

* Activate that side — matches how clicking a file panel does.
* Let the alt panel handle it via \`ProcessMouse\` (QuickView already uses this path for wheel scrolling; info panel and future alts can pick up row selection later — this PR is intentionally passive on that front).
* Return \`true\` — the event does not fall through.

Wheel events keep the existing routing (active-alt-first, then active file panel, then arrow-key fallback), so scroll still works over both slots.

## Commits

1. **\`PanelsFrame: swallow mouse clicks landing on alt panels\`** — the actual fix, plus two tests.
2. **\`PanelsFrame: extract hitAltPanel helper\`** — pure cleanup, no behaviour change.

## Test plan

- [x] \`go test ./...\` passes.
- [x] \`go build ./...\` clean on linux; \`GOOS=windows GOARCH=amd64 go build ./...\` clean; \`GOOS=darwin GOARCH=arm64 go build ./...\` clean.
- [x] \`gofmt -w -s\` clean on touched files.

### Automated (new)

* \`TestPanelsFrame_ProcessMouse_AltPanelSwallowsClicks\` — double-click at coordinates over a runnable file under a Ctrl+L info panel; verifies panels stay visible (file not launched) and the clicked side becomes active.
* \`TestPanelsFrame_ProcessMouse_MiddleClickOverAltPanel\` — same guarantee for the global middle-click → Enter branch.

### Manual (WSL Ubuntu, native \`f4-linux\`)

* Ctrl+L on right panel → info panel appears on left. Double-click anywhere in it → panels stay, no file launched, active side flips to left.
* Same with Ctrl+Q (quick view) — quick view scrolling by wheel still works (wheel branch unchanged).
* Middle-click on info panel → also swallowed (previously invoked Enter on active side).