### PR TITLE
Fix nil pointer crash on switching viewer codepage

### DIFF
--- a/viewer_backend.go
+++ b/viewer_backend.go
@@ -40,7 +40,9 @@ func NewViewerBackend(ctx context.Context, v vfs.VFS, path string) (*ViewerBacke
 }
 
 func (b *ViewerBackend) Close() error {
-	b.cancelCtx()
+	if b.cancelCtx != nil {
+		b.cancelCtx()
+	}
 	return b.file.Close()
 }
 

--- a/viewer_view.go
+++ b/viewer_view.go
@@ -719,17 +719,19 @@ func (vv *ViewerView) ReloadWithCodepage(cpID int) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
 
 	size := f.Size()
 	var backend *ViewerBackend
 	if cpID == 65001 {
+		bCtx, bCancel := context.WithCancel(context.Background())
 		backend = &ViewerBackend{
-			file: f,
-			size: size,
-			ctx:  context.Background(),
+			file:      f,
+			size:      size,
+			ctx:       bCtx,
+			cancelCtx: bCancel,
 		}
 	} else {
+		defer f.Close()
 		fullData := make([]byte, size)
 		_, _ = f.ReadAt(context.Background(), fullData, 0)
 		decoded, err := vfs.DecodeBytes(fullData, cpID)
@@ -738,17 +740,22 @@ func (vv *ViewerView) ReloadWithCodepage(cpID int) {
 			cpID = 65001
 		}
 		memFile := &vfs.MemoryReadAtCloser{Data: decoded}
+		bCtx, bCancel := context.WithCancel(context.Background())
 		backend = &ViewerBackend{
-			file: memFile,
-			size: int64(len(decoded)),
-			ctx:  context.Background(),
+			file:      memFile,
+			size:      int64(len(decoded)),
+			ctx:       bCtx,
+			cancelCtx: bCancel,
 		}
 	}
 
-	vv.backend.Close()
+	oldBackend := vv.backend
 	vv.backend = backend
 	vv.Codepage = cpID
 	vv.TopOffset = 0
+	if oldBackend != nil {
+		oldBackend.Close()
+	}
 	vtui.FrameManager.Redraw()
 }
 


### PR DESCRIPTION
ReloadWithCodepage created ViewerBackend without cancelCtx,
so closing it on the second code page switch hit a nil
pointer dereference (b.cancelCtx()). Initialize cancelCtx via
context.WithCancel and guard Close() against a nil cancelCtx.

обнаружено переключил во вьюере system ansi , потом на system oem

Корень бага: ReloadWithCodepage (viewer_view.go) создавал новый ViewerBackend без cancelCtx:

backend = &ViewerBackend{
	file: f,
	size: size,
	ctx:  context.Background(),
	// cancelCtx == nil
}
а Close() (viewer_backend.go:43) первым делом делает b.cancelCtx() → при втором переключении кодовой страницы бэкенд, созданный на первом, падает по nil-указателю.

Что исправлено:

viewer_view.go — ReloadWithCodepage теперь задаёт cancelCtx через context.WithCancel (как в NewViewerView), закрывает старый бэкенд только если он не nil, и не закрывает f в UTF-8-ветке (файл живёт в бэкенде).
viewer_backend.go — защитный if b.cancelCtx != nil в Close().
Проверка:

go build — успешно.
go test -run "ViewerBackend|Codepage" — ok.