### PR TITLE
Panels: Shift-nav range selection, ESC toggle panels (issue #289)

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1700,7 +1700,7 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	dlg := vtui.NewCenteredDialog(60, 27, Msg("PanelSettings.Title"))
+	dlg := vtui.NewCenteredDialog(60, 28, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
 	chkHidden := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowHidden"), false)
@@ -1755,6 +1755,12 @@ func actionPanelSettings(pf *PanelsFrame) {
 		chkCPUGPU.State = 1
 	}
 
+	chkEscToggle := vtui.NewCheckbox(0, 0, Msg("PanelSettings.EscTogglePanels"), false)
+	chkEscToggle.State = 0
+	if AppConfig.EscTogglePanels {
+		chkEscToggle.State = 1
+	}
+
 	modes := []string{Msg("Op.Queue"), Msg("Op.Background"), Msg("Op.Foreground")}
 	comboMode := vtui.NewComboBox(0, 0, 30, modes)
 	comboMode.DropdownOnly = true
@@ -1782,6 +1788,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(chkSync)
 	dlg.AddItem(chkAlwaysMenu)
 	dlg.AddItem(chkCPUGPU)
+	dlg.AddItem(chkEscToggle)
 	dlg.AddItem(lblMode)
 	dlg.AddItem(comboMode)
 	dlg.AddItem(lblPath)
@@ -1789,7 +1796,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
 
-	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 54-4, 27-4)
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 54-4, 28-4)
 	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkHighlight, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkSeparateExtensions, vtui.Margins{Top: 1}, vtui.AlignLeft)
@@ -1800,6 +1807,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	vbox.Add(chkSync, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkAlwaysMenu, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkCPUGPU, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkEscToggle, vtui.Margins{Top: 1}, vtui.AlignLeft)
 
 	rowMode := vtui.NewHBoxLayout(0, 0, 54-4, 1)
 	rowMode.Add(lblMode, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -1831,6 +1839,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.SyncPanelLoad = chkSync.State == 1
 		AppConfig.AlwaysShowMenuBar = chkAlwaysMenu.State == 1
 		AppConfig.InfoPanelCPUGPU = chkCPUGPU.State == 1
+		AppConfig.EscTogglePanels = chkEscToggle.State == 1
 		AppConfig.DefaultFileOpMode = comboMode.Menu.SelectPos
 		AppConfig.FileOpPathDisplay = comboPath.Menu.SelectPos
 		SaveConfig()

--- a/config.go
+++ b/config.go
@@ -73,6 +73,7 @@ type F4Config struct {
 	SavePanelPaths           bool
 	InfoPanelBytes           bool // Ctrl+L info panel: true = raw bytes, false = human (GiB/MiB…)
 	InfoPanelCPUGPU          bool // Ctrl+L info panel: show CPU and GPU sections (off by default)
+	EscTogglePanels          bool // ESC toggles panels visibility (Far ships this as a macro; on by default)
 	KeepTerminalCursor       bool
 	AnnounceKittyTerm        bool // introduce the built-in terminal as kitty, so that image tools use the graphics protocol
 	CommandLineAutoComplete  bool
@@ -142,6 +143,7 @@ var AppConfig = F4Config{
 	SavePanelPaths:           true,
 	InfoPanelBytes:           false,
 	InfoPanelCPUGPU:          false,
+	EscTogglePanels:          true,
 	KeepTerminalCursor:       false,
 	AnnounceKittyTerm:        true,
 	CommandLineAutoComplete:  true,
@@ -238,6 +240,7 @@ func LoadConfig() {
 	AppConfig.SavePanelPaths = ini.GetString("Panel", "SavePanelPaths", "1") == "1"
 	AppConfig.InfoPanelBytes = ini.GetString("Panel", "InfoPanelBytes", "0") == "1"
 	AppConfig.InfoPanelCPUGPU = ini.GetString("Panel", "InfoPanelCPUGPU", "0") == "1"
+	AppConfig.EscTogglePanels = ini.GetString("Panel", "EscTogglePanels", "1") == "1"
 	AppConfig.KeepTerminalCursor = ini.GetString("Panel", "KeepTerminalCursor", "0") == "1"
 	AppConfig.CommandLineAutoComplete = ini.GetString("Panel", "CommandLineAutoComplete", "1") == "1"
 	AppConfig.VimHotkeys = ini.GetString("Panel", "VimHotkeys", "0") == "1"
@@ -336,6 +339,7 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("SavePanelPaths = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SavePanelPaths]))
 	sb.WriteString(fmt.Sprintf("InfoPanelBytes = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelBytes]))
 	sb.WriteString(fmt.Sprintf("InfoPanelCPUGPU = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelCPUGPU]))
+	sb.WriteString(fmt.Sprintf("EscTogglePanels = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.EscTogglePanels]))
 	sb.WriteString(fmt.Sprintf("KeepTerminalCursor = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.KeepTerminalCursor]))
 	sb.WriteString(fmt.Sprintf("CommandLineAutoComplete = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.CommandLineAutoComplete]))
 	sb.WriteString(fmt.Sprintf("VimHotkeys = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.VimHotkeys]))

--- a/file_panel.go
+++ b/file_panel.go
@@ -255,6 +255,16 @@ type FileSystemPanel struct {
 	// detect a directory switch so selectedItems can be dropped
 	// (selection is per-directory, matches far/far2l).
 	lastLoadedPath string
+
+	// shiftSessionActive / shiftSessionMode implement FAR-style
+	// Shift+nav selection. The mode (select vs deselect) is
+	// decided on the first Shift+nav from the state of the row
+	// under the cursor and held until Shift is released, so all
+	// following Shift+nav keys in the same "session" apply that
+	// same mode. Any event other than a Shift+nav key closes
+	// the session — the next Shift+nav starts a new one.
+	shiftSessionActive bool
+	shiftSessionMode   bool // true = select, false = deselect
 }
 
 func NewFileSystemPanel(x, y, w, h int, vfs vfs.VFS) *FileSystemPanel {
@@ -1127,6 +1137,32 @@ func (fp *FileSystemPanel) Resize(w, h int) {
 	fp.Refresh()
 }
 
+// isShiftSelectNavKey reports whether a virtual key is a navigation
+// key that participates in the Shift+nav selection session. The set
+// mirrors the nav switch below so any change stays in sync.
+func isShiftSelectNavKey(vk uint16) bool {
+	switch vk {
+	case vtinput.VK_UP, vtinput.VK_DOWN, vtinput.VK_LEFT, vtinput.VK_RIGHT,
+		vtinput.VK_PRIOR, vtinput.VK_NEXT, vtinput.VK_HOME, vtinput.VK_END:
+		return true
+	}
+	return false
+}
+
+// shiftSelectDirection returns +1 for keys that move the cursor
+// forward (Down/Right/PgDn/End) and -1 for backward (Up/Left/
+// PgUp/Home). Used to look past a ".." starting row so
+// session-mode detection can still see a real, selectable row.
+func shiftSelectDirection(vk uint16) int {
+	switch vk {
+	case vtinput.VK_DOWN, vtinput.VK_RIGHT, vtinput.VK_NEXT, vtinput.VK_END:
+		return 1
+	case vtinput.VK_UP, vtinput.VK_LEFT, vtinput.VK_PRIOR, vtinput.VK_HOME:
+		return -1
+	}
+	return 0
+}
+
 func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 	if !e.KeyDown {
 		return false
@@ -1136,6 +1172,13 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
 	ctrl := (e.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
+
+	// Close the shift-selection session on anything other than a
+	// Shift+nav key so the next Shift+nav re-decides its mode
+	// from the row under the cursor.
+	if !(shift && isShiftSelectNavKey(e.VirtualKeyCode)) {
+		fp.shiftSessionActive = false
+	}
 
 	if fp.fastFindMode {
 		switch e.VirtualKeyCode {
@@ -1205,32 +1248,60 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 
 	case vtinput.VK_UP, vtinput.VK_DOWN, vtinput.VK_LEFT, vtinput.VK_RIGHT, vtinput.VK_PRIOR, vtinput.VK_NEXT, vtinput.VK_HOME, vtinput.VK_END:
-		// Shift+nav: two flavours share this block.
+		// FAR-style Shift+nav selection.
 		//
-		//   * Single-step (Up/Down): FAR's per-tap toggle-current
-		//     semantic. Each tap toggles the row under the cursor,
-		//     then moves — holding Shift and tapping Down N times
-		//     naturally toggles N sequential rows.
+		// The session concept unifies "select" and "deselect"
+		// across every navigation key: the first Shift+nav decides
+		// the mode from the state of the row under the cursor
+		// (unselected → we're selecting; selected → we're
+		// deselecting), and every subsequent Shift+nav in the same
+		// session applies that same mode. Releasing Shift (or any
+		// non-nav key) closes the session; the next Shift+nav
+		// starts a new one, potentially with the opposite mode.
 		//
-		//   * Multi-step (Left/Right in grid, PgUp/PgDn, Home/End):
-		//     the cursor covers many rows in one keystroke, so a
-		//     per-tap toggle would leave a dashed selection. Simpler
-		//     and closer to what users expect: mark every row the
-		//     cursor sweeps over as selected. Additive — repeated
-		//     swipes grow the selection instead of flipping it.
-		//     Starting on a non-selectable row (".." parent-dir) is
-		//     handled naturally because SetItemSelected skips it.
-		//
-		// Deselect stays with Ins (single row) and the panel-wide
-		// mask/invert commands; Shift-swipe intentionally only adds.
+		// Range width is per-key: Up/Down affect just the starting
+		// row (session grows by one row per tap); Left/Right in
+		// grid, PgUp/PgDn, Home/End paint the whole [start..new]
+		// sweep. ".." is skipped inside SetItemSelected.
 		startIdx := fp.GetCursorIndex()
+
+		if shift {
+			if !fp.shiftSessionActive {
+				fp.shiftSessionActive = true
+				// Decide session mode from the state of the row
+				// under the cursor. If it's ".." (never selectable),
+				// look past it in the direction of movement to
+				// find the first real row — otherwise the ".."
+				// start would always resolve to "select" and users
+				// couldn't clear a selection with Shift+End/etc
+				// from the top of the list.
+				modeIdx := startIdx
+				if startIdx >= 0 && startIdx < len(fp.entries) &&
+					fp.entries[startIdx].Name == ".." {
+					if dir := shiftSelectDirection(e.VirtualKeyCode); dir != 0 {
+						for i := startIdx + dir; i >= 0 && i < len(fp.entries); i += dir {
+							if fp.entries[i].Name != ".." {
+								modeIdx = i
+								break
+							}
+						}
+					}
+				}
+				if modeIdx >= 0 && modeIdx < len(fp.entries) &&
+					fp.entries[modeIdx].Name != ".." &&
+					fp.entries[modeIdx].Selected {
+					fp.shiftSessionMode = false
+				} else {
+					fp.shiftSessionMode = true
+				}
+			}
+			fp.SetItemSelected(startIdx, fp.shiftSessionMode)
+		}
+
 		isMultiStep := false
 		switch e.VirtualKeyCode {
 		case vtinput.VK_LEFT, vtinput.VK_RIGHT, vtinput.VK_PRIOR, vtinput.VK_NEXT, vtinput.VK_HOME, vtinput.VK_END:
 			isMultiStep = true
-		}
-		if shift && !isMultiStep {
-			fp.ToggleSelection(startIdx)
 		}
 
 		idx := startIdx
@@ -1278,7 +1349,7 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 				lo, hi = hi, lo
 			}
 			for i := lo; i <= hi; i++ {
-				fp.SetItemSelected(i, true)
+				fp.SetItemSelected(i, fp.shiftSessionMode)
 			}
 		}
 		return handled

--- a/file_panel.go
+++ b/file_panel.go
@@ -1187,17 +1187,41 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 
 	case vtinput.VK_UP, vtinput.VK_DOWN, vtinput.VK_LEFT, vtinput.VK_RIGHT, vtinput.VK_PRIOR, vtinput.VK_NEXT, vtinput.VK_HOME, vtinput.VK_END:
-		if shift {
-			idx := fp.GetCursorIndex()
-			fp.ToggleSelection(idx)
+		// Shift+nav: two flavours share this block.
+		//
+		//   * Single-step (Up/Down): FAR's per-tap toggle-current
+		//     semantic. Each tap toggles the row under the cursor,
+		//     then moves — holding Shift and tapping Down N times
+		//     naturally toggles N sequential rows.
+		//
+		//   * Multi-step (Left/Right in grid, PgUp/PgDn, Home/End):
+		//     the cursor covers many rows in one keystroke, so a
+		//     per-tap toggle would leave a dashed selection. Simpler
+		//     and closer to what users expect: mark every row the
+		//     cursor sweeps over as selected. Additive — repeated
+		//     swipes grow the selection instead of flipping it.
+		//     Starting on a non-selectable row (".." parent-dir) is
+		//     handled naturally because SetItemSelected skips it.
+		//
+		// Deselect stays with Ins (single row) and the panel-wide
+		// mask/invert commands; Shift-swipe intentionally only adds.
+		startIdx := fp.GetCursorIndex()
+		isMultiStep := false
+		switch e.VirtualKeyCode {
+		case vtinput.VK_LEFT, vtinput.VK_RIGHT, vtinput.VK_PRIOR, vtinput.VK_NEXT, vtinput.VK_HOME, vtinput.VK_END:
+			isMultiStep = true
+		}
+		if shift && !isMultiStep {
+			fp.ToggleSelection(startIdx)
 		}
 
-		idx := fp.GetCursorIndex()
+		idx := startIdx
 		H := fp.table.ViewHeight
 		if H <= 0 {
 			H = 1
 		}
 
+		handled := false
 		if columns := fp.gridColumnCount(); columns > 1 {
 			switch e.VirtualKeyCode {
 			case vtinput.VK_UP:
@@ -1220,15 +1244,26 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 				return false
 			}
 			fp.SetCursorIndex(idx)
-			return true
+			handled = true
 		} else {
 			// In Detailed mode, we let the table handle navigation but sync our index back
-			handled := fp.table.ProcessKey(e)
-			if handled {
+			if fp.table.ProcessKey(e) {
 				fp.cursorIdx = fp.table.SelectPos
+				handled = true
 			}
-			return handled
 		}
+
+		if shift && handled && isMultiStep {
+			newIdx := fp.GetCursorIndex()
+			lo, hi := startIdx, newIdx
+			if lo > hi {
+				lo, hi = hi, lo
+			}
+			for i := lo; i <= hi; i++ {
+				fp.SetItemSelected(i, true)
+			}
+		}
+		return handled
 
 	case vtinput.VK_RETURN:
 		idx := fp.GetCursorIndex()

--- a/file_panel.go
+++ b/file_panel.go
@@ -250,6 +250,11 @@ type FileSystemPanel struct {
 
 	isCheckingRefresh bool
 	currentTitle      string
+
+	// lastLoadedPath is the path readDirectoryEx last saw; used to
+	// detect a directory switch so selectedItems can be dropped
+	// (selection is per-directory, matches far/far2l).
+	lastLoadedPath string
 }
 
 func NewFileSystemPanel(x, y, w, h int, vfs vfs.VFS) *FileSystemPanel {
@@ -556,6 +561,19 @@ func (fp *FileSystemPanel) readDirectoryEx(keepEntries bool) {
 
 	// 1. Устанавливаем флаг, но НЕ обновляем UI немедленно, чтобы избежать мерцания
 	path := fp.vfs.GetPath()
+
+	// Drop persistent selection when we've navigated to a different
+	// directory. Without this the map (keyed by bare filename)
+	// silently re-applies to any incoming entry with a matching
+	// name — e.g. .claude selected in ~/f4 would come back
+	// pre-selected in ~/scc or ~. Same rule far/far2l use:
+	// selection is per-directory.
+	if fp.lastLoadedPath != "" && fp.lastLoadedPath != path {
+		for k := range fp.selectedItems {
+			delete(fp.selectedItems, k)
+		}
+	}
+	fp.lastLoadedPath = path
 
 	if fp.pendingSelection == "" {
 		oldName := fp.getRawSelectedName()

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -626,6 +626,122 @@ func TestFileSystemPanel_ShiftMultiStepSwipe(t *testing.T) {
 	}
 }
 
+// TestFileSystemPanel_ShiftSessionModeDecidedOnFirstKey covers
+// FAR-style session semantic: the first Shift+nav decides "select"
+// or "deselect" based on the starting row, every subsequent Shift+
+// nav in the same session applies that same mode, and any non-
+// Shift-nav event closes the session so the next Shift+nav re-
+// decides.
+func TestFileSystemPanel_ShiftSessionModeDecidedOnFirstKey(t *testing.T) {
+	tmp := t.TempDir()
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		os.WriteFile(filepath.Join(tmp, n), []byte(n), 0644)
+	}
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(tmp))
+	fp.viewMode = ViewModeDetailed
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "a"}},
+		{VFSItem: vfs.VFSItem{Name: "b"}},
+		{VFSItem: vfs.VFSItem{Name: "c"}},
+		{VFSItem: vfs.VFSItem{Name: "d"}},
+		{VFSItem: vfs.VFSItem{Name: "e"}},
+	}
+	fp.Refresh()
+
+	shiftDown := &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_DOWN,
+		ControlKeyState: vtinput.ShiftPressed,
+	}
+	plainDown := &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_DOWN,
+	}
+
+	// Session 1: start on unselected "a" (idx 1) → session picks
+	// "select" mode. Two Shift+Down keystrokes should select "a"
+	// and "b" one after another.
+	fp.SetCursorIndex(1)
+	fp.ProcessKey(shiftDown)
+	fp.ProcessKey(shiftDown)
+	if !fp.entries[1].Selected || !fp.entries[2].Selected {
+		t.Errorf("session-1 select: a=%v b=%v, want both true",
+			fp.entries[1].Selected, fp.entries[2].Selected)
+	}
+	if fp.entries[3].Selected {
+		t.Error("session-1 select: 'c' must not be selected yet — cursor stopped at 'c'")
+	}
+
+	// Plain Down closes the session. Cursor moves from c to d
+	// without selecting anything.
+	fp.ProcessKey(plainDown)
+	if fp.shiftSessionActive {
+		t.Error("plain Down must close the shift-selection session")
+	}
+
+	// Session 2: cursor now on "d". Move it back to "b" (still
+	// selected from session 1) to prove the mode re-decides.
+	fp.SetCursorIndex(2)
+	fp.ProcessKey(shiftDown)
+	// b was selected → session mode = deselect. b should be
+	// unselected now, cursor moved to c.
+	if fp.entries[2].Selected {
+		t.Error("session-2 first Shift+Down on selected 'b' should deselect it")
+	}
+	// Another Shift+Down: c was selected? no, c wasn't selected
+	// after session 1. deselect on an already-unselected row is
+	// a no-op — still unselected.
+	fp.ProcessKey(shiftDown)
+	if fp.entries[3].Selected {
+		t.Error("session-2 mode is deselect; 'c' must stay unselected")
+	}
+}
+
+// TestFileSystemPanel_ShiftSessionDeselectFromParentDir covers the
+// asymmetric case: cursor on ".." (unselectable) and everything
+// below already selected. Session mode has to look past ".." at
+// the first real row in the direction of movement; otherwise
+// Shift+End would always start in "select" mode and there'd be
+// no way to clear the panel selection from that position.
+func TestFileSystemPanel_ShiftSessionDeselectFromParentDir(t *testing.T) {
+	tmp := t.TempDir()
+	for _, n := range []string{"a", "b", "c"} {
+		os.WriteFile(filepath.Join(tmp, n), []byte(n), 0644)
+	}
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(tmp))
+	fp.viewMode = ViewModeDetailed
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "a"}},
+		{VFSItem: vfs.VFSItem{Name: "b"}},
+		{VFSItem: vfs.VFSItem{Name: "c"}},
+	}
+	// Pre-select everything by hand — this is the state the user
+	// would land in after a first Shift+End sweep.
+	fp.entries[1].Selected = true
+	fp.entries[2].Selected = true
+	fp.entries[3].Selected = true
+	fp.selectedItems = map[string]bool{"a": true, "b": true, "c": true}
+	fp.Refresh()
+
+	// Cursor on ".." (idx 0). Shift+End should look past ".." to
+	// "a" (selected) and pick "deselect" mode, then clear a..c.
+	fp.SetCursorIndex(0)
+	fp.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_END,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	for _, want := range []string{"a", "b", "c"} {
+		for _, e := range fp.entries {
+			if e.Name == want && e.Selected {
+				t.Errorf("Shift+End from '..': expected %q deselected", want)
+			}
+		}
+	}
+}
+
 // TestFileSystemPanel_ShiftRangeSkipsParentDir makes sure the ".."
 // row is never selected by a shift-sweep, matching the same rule
 // SetItemSelected / ToggleSelection already enforce for Ins.

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -652,6 +652,62 @@ func TestFileSystemPanel_ShiftRangeSkipsParentDir(t *testing.T) {
 	}
 }
 
+// TestFileSystemPanel_SelectionClearedOnDirChange guards against
+// the map[filename]→selected persisting between directories: a
+// row with the same name in a sibling dir used to inherit the
+// old selection. readDirectoryEx now drops the map when the path
+// changes.
+func TestFileSystemPanel_SelectionClearedOnDirChange(t *testing.T) {
+	// Two sibling directories, each with a file named "same".
+	parent := t.TempDir()
+	a := filepath.Join(parent, "a")
+	b := filepath.Join(parent, "b")
+	os.MkdirAll(a, 0755)
+	os.MkdirAll(b, 0755)
+	os.WriteFile(filepath.Join(a, "same"), []byte("a"), 0644)
+	os.WriteFile(filepath.Join(b, "same"), []byte("b"), 0644)
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(a))
+	fp.viewMode = ViewModeDetailed
+	// Simulate a completed load of directory `a` with "same" selected.
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "same"}},
+	}
+	fp.selectedItems = map[string]bool{"same": true}
+	fp.entries[1].Selected = true
+	fp.lastLoadedPath = a
+
+	// Now navigate to sibling `b`. readDirectoryEx should notice
+	// the path changed and drop the persistent selection so the
+	// "same" file in `b` starts unselected.
+	fp.vfs.SetPath(b)
+	fp.ReadDirectory()
+
+	// Drain any async loader tasks the ReadDirectory scheduled.
+	timeout := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			break drain
+		}
+	}
+
+	for _, e := range fp.entries {
+		if e.Name == "same" && e.Selected {
+			t.Error(`"same" in sibling directory should NOT inherit selection from previous dir`)
+		}
+	}
+	if fp.selectedItems["same"] {
+		t.Error("selectedItems should have been cleared on directory change")
+	}
+}
+
 func TestFileSystemPanel_ProcessMouse(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
 	fp.SetViewMode(ViewModeDetailed)

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -542,7 +542,12 @@ func TestFileSystemPanel_MultiSelect(t *testing.T) {
 		t.Errorf("Cursor should move to 2, got %d", fp.GetCursorIndex())
 	}
 
-	// 3. Select file2.txt via Shift+Down
+	// 3. Shift+Down at cursor=2 (file2.txt).
+	//    Single-step Up/Down keep FAR's per-tap semantics: only the
+	//    starting row is toggled; the cursor moves to the next row
+	//    but that row is left alone (the next tap decides what to
+	//    do with it). Range-paint is reserved for multi-step jumps
+	//    (Home/End/PgUp/PgDn/Left/Right in grid mode).
 	fp.ProcessKey(&vtinput.InputEvent{
 		Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN, ControlKeyState: vtinput.ShiftPressed,
 	})
@@ -550,11 +555,100 @@ func TestFileSystemPanel_MultiSelect(t *testing.T) {
 	if !fp.entries[2].Selected {
 		t.Error("file2.txt (index 2) should be selected after Shift+Down")
 	}
+	if fp.entries[3].Selected {
+		t.Error("file3.txt (index 3) must NOT be selected — Shift+Down is single-step, next row is left alone")
+	}
+	if fp.GetCursorIndex() != 3 {
+		t.Errorf("Cursor should move to 3, got %d", fp.GetCursorIndex())
+	}
 
-	// 4. Verify results
+	// 4. Verify results — file1 (from Ins) + file2 (from Shift+Down).
 	names := fp.GetSelectedNames()
 	if len(names) != 2 || names[0] != "file1.txt" || names[1] != "file2.txt" {
 		t.Errorf("GetSelectedNames returned wrong result: %v", names)
+	}
+}
+
+// TestFileSystemPanel_ShiftMultiStepSwipe covers the long-jump
+// shift keys: they select every row the cursor sweeps over. It's
+// additive — starting on ".." works (nothing to toggle, we just
+// paint from there onward), and a second swipe over already-
+// selected rows grows the selection instead of flipping it off.
+func TestFileSystemPanel_ShiftMultiStepSwipe(t *testing.T) {
+	tmp := t.TempDir()
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		os.WriteFile(filepath.Join(tmp, n), []byte(n), 0644)
+	}
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(tmp))
+	fp.viewMode = ViewModeDetailed
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "a"}},
+		{VFSItem: vfs.VFSItem{Name: "b"}},
+		{VFSItem: vfs.VFSItem{Name: "c"}},
+		{VFSItem: vfs.VFSItem{Name: "d"}},
+		{VFSItem: vfs.VFSItem{Name: "e"}},
+	}
+	fp.Refresh()
+
+	// Cursor on ".." (idx 0). Shift+End should still paint a..e —
+	// starting on an unselectable row is not a reason to skip the
+	// sweep. This exact scenario used to return zero selections.
+	fp.SetCursorIndex(0)
+	fp.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_END,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	for _, want := range []string{"a", "b", "c", "d", "e"} {
+		for _, e := range fp.entries {
+			if e.Name == want && !e.Selected {
+				t.Errorf(`Shift+End starting on "..": expected %q selected`, want)
+			}
+		}
+	}
+
+	// Repeating the sweep from "e" back with Shift+Home must NOT
+	// deselect anything — swipes are additive. Everything from ".."
+	// (skipped) through "a" is already selected, and the return
+	// trip leaves the selection intact.
+	fp.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_HOME,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	for _, want := range []string{"a", "b", "c", "d", "e"} {
+		for _, e := range fp.entries {
+			if e.Name == want && !e.Selected {
+				t.Errorf("Shift+Home return sweep must not deselect %q", want)
+			}
+		}
+	}
+}
+
+// TestFileSystemPanel_ShiftRangeSkipsParentDir makes sure the ".."
+// row is never selected by a shift-sweep, matching the same rule
+// SetItemSelected / ToggleSelection already enforce for Ins.
+func TestFileSystemPanel_ShiftRangeSkipsParentDir(t *testing.T) {
+	tmp := t.TempDir()
+	os.WriteFile(filepath.Join(tmp, "a"), []byte("a"), 0644)
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(tmp))
+	fp.viewMode = ViewModeDetailed
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "a"}},
+	}
+	fp.Refresh()
+
+	// Cursor on "a"; Shift+Home should not select ".."
+	fp.SetCursorIndex(1)
+	fp.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode:  vtinput.VK_HOME,
+		ControlKeyState: vtinput.ShiftPressed,
+	})
+	if fp.entries[0].Selected {
+		t.Error(`Shift-sweep must not select the ".." parent-dir row`)
 	}
 }
 

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -113,6 +113,7 @@ PanelSettings.SyncPanelLoad=S&ynchronous panel loading (disable cache/chunking)
 PanelSettings.DefaultMode=Default operation &mode:
 PanelSettings.PathDisplay=File path in progress:
 PanelSettings.InfoPanelCPUGPU=Show CPU/GPU section on i&nfo panel
+PanelSettings.EscTogglePanels=&Esc toggles panels visibility
 
 AppearanceSettings.Title= Appearance settings
 AppearanceSettings.Style=Application &style:

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -113,6 +113,7 @@ PanelSettings.SyncPanelLoad=&Синхронная загрузка панеле�
 PanelSettings.DefaultMode=Режим операций по &умолчанию:
 PanelSettings.PathDisplay=Отображение пути в прогрессе:
 PanelSettings.InfoPanelCPUGPU=Показывать CPU/GPU на &инфо-панели
+PanelSettings.EscTogglePanels=&Esc переключает видимость панелей
 
 AppearanceSettings.Title= Внешний вид
 AppearanceSettings.Style=Стиль &оформления:

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1005,7 +1005,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	//   * panels hidden → the terminal must be in a non-interactive
 	//     state (no AltScreen, no busy PTY), so we don't steal ESC
 	//     from a running app (vim, less, htop, …).
-	if e.VirtualKeyCode == vtinput.VK_ESCAPE && !alt && !ctrl && !shift && e.KeyDown {
+	if AppConfig.EscTogglePanels && e.VirtualKeyCode == vtinput.VK_ESCAPE && !alt && !ctrl && !shift && e.KeyDown {
 		if pf.showPanels && pf.cmdLine.IsEmpty() {
 			pf.exitWide()
 			pf.showPanels = false

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -999,20 +999,22 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// ESC toggles panels visibility — mirrors the "hide panels"
 	// macro shipped with FAR. Only fires when there's nothing more
-	// contextual for ESC to do:
-	//   * panels visible → command line must be empty (otherwise
-	//     the ESC-clears-cmdline handler below still wins);
-	//   * panels hidden → the terminal must be in a non-interactive
-	//     state (no AltScreen, no busy PTY), so we don't steal ESC
-	//     from a running app (vim, less, htop, …).
-	if AppConfig.EscTogglePanels && e.VirtualKeyCode == vtinput.VK_ESCAPE && !alt && !ctrl && !shift && e.KeyDown {
-		if pf.showPanels && pf.cmdLine.IsEmpty() {
+	// contextual for ESC to do. Both branches require an empty
+	// command line so ESC still clears typed input / resets the
+	// history-navigation position (the ESC-clears-cmdline handler
+	// further down keeps working on a non-empty line):
+	//   * panels visible + empty cmdLine → hide panels;
+	//   * panels hidden + empty cmdLine + quiet terminal (no
+	//     AltScreen, no busy PTY) → show panels back. Busy/AltScreen
+	//     leaves ESC to the running app (vim, less, htop, …).
+	if AppConfig.EscTogglePanels && e.VirtualKeyCode == vtinput.VK_ESCAPE && !alt && !ctrl && !shift && e.KeyDown && pf.cmdLine.IsEmpty() {
+		if pf.showPanels {
 			pf.exitWide()
 			pf.showPanels = false
 			vtui.FrameManager.HardRefresh()
 			return true
 		}
-		if !pf.showPanels && !pf.termView.UseAltScreen && !pf.isPtyBusy() {
+		if !pf.termView.UseAltScreen && !pf.isPtyBusy() {
 			pf.exitWide()
 			pf.showPanels = true
 			if !pf.showLeftPanel && !pf.showRightPanel {

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -997,6 +997,34 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// ESC toggles panels visibility — mirrors the "hide panels"
+	// macro shipped with FAR. Only fires when there's nothing more
+	// contextual for ESC to do:
+	//   * panels visible → command line must be empty (otherwise
+	//     the ESC-clears-cmdline handler below still wins);
+	//   * panels hidden → the terminal must be in a non-interactive
+	//     state (no AltScreen, no busy PTY), so we don't steal ESC
+	//     from a running app (vim, less, htop, …).
+	if e.VirtualKeyCode == vtinput.VK_ESCAPE && !alt && !ctrl && !shift && e.KeyDown {
+		if pf.showPanels && pf.cmdLine.IsEmpty() {
+			pf.exitWide()
+			pf.showPanels = false
+			vtui.FrameManager.HardRefresh()
+			return true
+		}
+		if !pf.showPanels && !pf.termView.UseAltScreen && !pf.isPtyBusy() {
+			pf.exitWide()
+			pf.showPanels = true
+			if !pf.showLeftPanel && !pf.showRightPanel {
+				pf.showLeftPanel = true
+				pf.showRightPanel = true
+			}
+			vtui.FrameManager.HardRefresh()
+			pf.RefreshAll()
+			return true
+		}
+	}
+
 	// Ctrl+F1 toggles left panel
 	if e.VirtualKeyCode == vtinput.VK_F1 && ctrl && !alt && !shift && e.KeyDown {
 		pf.exitWide()

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2955,6 +2955,14 @@ func (pf *PanelsFrame) Clone() *PanelsFrame {
 			for k, v := range fsp.selectedItems {
 				cloneFsp.selectedItems[k] = v
 			}
+			// Copying selectedItems without copying the path they
+			// belong to would trip readDirectoryEx's "path changed
+			// → drop selection" guard: the clone's fsp was
+			// constructed against CWD, so its lastLoadedPath is
+			// CWD, and the SetPath above moves it elsewhere. Bring
+			// the tag over so the clone's next load recognises
+			// the map as belonging to the current directory.
+			cloneFsp.lastLoadedPath = fsp.lastLoadedPath
 
 			// Copy entries immediately so the visual state is valid before async reload
 			cloneFsp.entries = make([]*fileEntry, len(fsp.entries))

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -610,6 +610,57 @@ drain:
 	}
 }
 
+// TestPanelsFrame_EscTogglesPanels exercises the FAR-style ESC
+// toggle: hides visible panels when the command line is empty,
+// shows hidden panels back if no interactive terminal app is
+// running. Non-empty command line keeps the existing ESC-clears-
+// cmdLine behaviour.
+func TestPanelsFrame_EscTogglesPanels(t *testing.T) {
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	sendEsc := func() bool {
+		return pf.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true,
+			VirtualKeyCode: vtinput.VK_ESCAPE,
+		})
+	}
+
+	// Panels visible, cmdLine empty → ESC hides.
+	if !pf.showPanels {
+		t.Fatal("precondition: panels should start visible")
+	}
+	if !sendEsc() {
+		t.Error("ESC on visible panels + empty cmdLine should be handled")
+	}
+	if pf.showPanels {
+		t.Error("ESC should hide panels when cmdLine is empty")
+	}
+
+	// Panels hidden, quiet PTY → ESC brings them back.
+	if !sendEsc() {
+		t.Error("ESC on hidden panels + quiet PTY should be handled")
+	}
+	if !pf.showPanels {
+		t.Error("ESC should show panels back on the second press")
+	}
+
+	// Panels visible with a typed command → ESC falls through to
+	// the clear-cmdLine handler and panels stay put.
+	pf.cmdLine.InsertString("something")
+	if !sendEsc() {
+		t.Error("ESC with a non-empty cmdLine should still be handled (clears it)")
+	}
+	if !pf.showPanels {
+		t.Error("ESC with a typed command must NOT hide the panels — only clear the line")
+	}
+	if !pf.cmdLine.IsEmpty() {
+		t.Error("ESC with a typed command should have cleared the command line")
+	}
+}
+
 func TestPanelsFrame_KeyHandling(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -621,6 +621,10 @@ func TestPanelsFrame_EscTogglesPanels(t *testing.T) {
 	pf.ResizeConsole(80, 25)
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
+	old := AppConfig.EscTogglePanels
+	defer func() { AppConfig.EscTogglePanels = old }()
+	AppConfig.EscTogglePanels = true
+
 	sendEsc := func() bool {
 		return pf.ProcessKey(&vtinput.InputEvent{
 			Type: vtinput.KeyEventType, KeyDown: true,
@@ -658,6 +662,28 @@ func TestPanelsFrame_EscTogglesPanels(t *testing.T) {
 	}
 	if !pf.cmdLine.IsEmpty() {
 		t.Error("ESC with a typed command should have cleared the command line")
+	}
+}
+
+// TestPanelsFrame_EscTogglePanels_RespectsOption confirms the
+// shortcut can be turned off — with EscTogglePanels=false, ESC
+// on visible panels + empty cmdLine is a no-op instead of hiding.
+func TestPanelsFrame_EscTogglePanels_RespectsOption(t *testing.T) {
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	old := AppConfig.EscTogglePanels
+	defer func() { AppConfig.EscTogglePanels = old }()
+	AppConfig.EscTogglePanels = false
+
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_ESCAPE,
+	})
+	if !pf.showPanels {
+		t.Error("with EscTogglePanels=false, ESC must not hide the panels")
 	}
 }
 


### PR DESCRIPTION
Addresses the Panels bullets from #289:

* **перемещение с нажатым Shift должно выделять все файлы** — Shift+navigation now paints the whole swept range, not just the starting row. Works uniformly for Up/Down/Left/Right/PgUp/PgDn/Home/End.
* **ESC — включение/выключение панелей** — ESC toggles panel visibility (Ctrl+O analog).

## What each commit does

1. **`FilePanel: Shift+navigation with additive multi-step selection`** — first cut: Shift+multi-step (Left/Right/PgUp/PgDn/Home/End) paints the whole swept range as \"selected\"; Shift+Up/Down keep FAR's per-tap toggle-current-only. Also drops the ".." parent-dir special-case worry (SetItemSelected already skips it).
2. **`FilePanel: drop persistent selection when the directory changes`** — pre-existing bug on main: \`selectedItems\` (map keyed by bare filename) survived across directory changes, so a file selected in ~/f4 (say \`.claude\`) came back pre-selected in ~/scc and ~. Fixed by tagging the map with \`lastLoadedPath\` in \`readDirectoryEx\`; \`Clone()\` copies the tag alongside \`selectedItems\` so cloning a workspace doesn't trigger the drop.
3. **`FilePanel: Shift+nav session mode — unified select/deselect`** — user feedback loop: after a Shift+swipe the mode was always \"add\"; couldn't shift-deselect. Introduces session semantics: while Shift is held, the mode (select vs deselect) is decided on the first Shift+nav from the state of the row under the cursor, and every subsequent Shift+nav in the same session applies that same mode. Releasing Shift or pressing any non-nav key closes the session; the next Shift+nav re-decides. Uniform across all nav keys. \".\" starting row falls back to the first real row in the direction of movement, so Shift+End from \".\" over a fully selected list correctly picks deselect.
4. **`PanelsFrame: ESC toggles panels visibility`** — mirrors FAR's shipped-with-standard-install ESC macro. Guarded so ESC still goes to a running interactive app (vim, less, htop) when panels are hidden and the terminal is busy, and still clears the command line when it has a typed command.
5. **`PanelsFrame: gate ESC-toggle behind AppConfig.EscTogglePanels`** — same shortcut is a macro in FAR, so it's opt-outable there. Same choice here: new \`AppConfig.EscTogglePanels bool\`, default \`true\` (matches FAR's stock macro), persisted to \`[Panel] EscTogglePanels\`. New checkbox in F9 → Panel settings.

## Test plan

- [x] \`go test ./...\` passes (\`TestPlugRing_InstallAndRemove_EndToEnd\` fails identically on \`main\` — pre-existing, not this PR).
- [x] \`go build ./...\` clean on linux; \`GOOS=windows GOARCH=amd64 go build ./...\` clean; \`GOOS=darwin GOARCH=arm64 go build ./...\` clean.
- [x] \`gofmt -w -s\` clean on touched files.

### Automated (new)

* \`TestFileSystemPanel_MultiSelect\` — single-step Shift+Down toggles only the starting row.
* \`TestFileSystemPanel_ShiftMultiStepSwipe\` — start on \".\" still paints the sweep; return sweep over already-selected rows doesn't deselect (additive within a session).
* \`TestFileSystemPanel_ShiftRangeSkipsParentDir\` — \".\" is never in the selection.
* \`TestFileSystemPanel_ShiftSessionModeDecidedOnFirstKey\` — full flow: session-1 selects across two taps; plain Down closes it; session-2 starting on a selected row switches into deselect mode.
* \`TestFileSystemPanel_ShiftSessionDeselectFromParentDir\` — \".\" start looks past to the next real row so Shift+End can clear a pre-selected list.
* \`TestFileSystemPanel_SelectionClearedOnDirChange\` — sibling directories with same filename don't inherit selection.
* \`TestPanelsFrame_Clone_SelectionPreservation\` — regression guard (existed on main): the dir-clear commit doesn't strip selection out of a fresh workspace clone.
* \`TestPanelsFrame_EscTogglesPanels\` — hide/show/hide-with-typed-command flow.
* \`TestPanelsFrame_EscTogglePanels_RespectsOption\` — the flag actually turns the shortcut off.

### Manual

Tested end-to-end in WSL Ubuntu (\`f4-linux\`) and native Windows 10 (\`f4.exe\`), including the whole Shift+nav interaction loop across Up/Down/PgUp/PgDn/Home/End/Left/Right (grid), directory switches, workspace clone, ESC-hide with and without a typed command, ESC-restore, and ESC-passthrough into a busy PTY (\`sleep 30\` inside f4's terminal keeps ESC away from the panels toggle).