### PR TITLE
PanelsFrame: resolve Ctrl+[/Ctrl+] targets by on-screen X-position

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -159,8 +159,49 @@ type PanelsFrame struct {
 	closed      bool
 }
 
-func (pf *PanelsFrame) Left() Panel    { return pf.panels[0] }
-func (pf *PanelsFrame) Right() Panel   { return pf.panels[1] }
+func (pf *PanelsFrame) Left() Panel  { return pf.panels[0] }
+func (pf *PanelsFrame) Right() Panel { return pf.panels[1] }
+
+// visualLeftFSP / visualRightFSP return the file panels resolved by
+// their on-screen X-position rather than slot index. The Ctrl+U
+// panel swap re-assigns pf.panels[0]/[1] but keeps the two frames
+// where the user sees them, so index-based routing sends Ctrl+[/]
+// to the wrong side after a swap. Sizing keeps both panels
+// horizontal-adjacent (see ResizeConsole), so a simple min-X pick
+// is enough — no need to check a bounding box.
+func (pf *PanelsFrame) visualLeftFSP() *FileSystemPanel {
+	a, _ := pf.panels[0].(*FileSystemPanel)
+	b, _ := pf.panels[1].(*FileSystemPanel)
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	xA, _, _, _ := a.GetPosition()
+	xB, _, _, _ := b.GetPosition()
+	if xA <= xB {
+		return a
+	}
+	return b
+}
+
+func (pf *PanelsFrame) visualRightFSP() *FileSystemPanel {
+	a, _ := pf.panels[0].(*FileSystemPanel)
+	b, _ := pf.panels[1].(*FileSystemPanel)
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	xA, _, _, _ := a.GetPosition()
+	xB, _, _, _ := b.GetPosition()
+	if xA > xB {
+		return a
+	}
+	return b
+}
 func (pf *PanelsFrame) Active() Panel  { return pf.panels[pf.activeIdx] }
 func (pf *PanelsFrame) Passive() Panel { return pf.panels[1-pf.activeIdx] }
 
@@ -1292,7 +1333,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// Ctrl+[ - Insert left panel path into command line (Far compatible)
 	if (e.VirtualKeyCode == vtinput.VK_OEM_4 || e.Char == '[') && ctrl && !alt && !shift && e.KeyDown {
-		if fsp, ok := pf.panels[0].(*FileSystemPanel); ok && fsp != nil {
+		if fsp := pf.visualLeftFSP(); fsp != nil {
 			pf.insertPathToCmdLine(fsp.vfs.GetPath())
 			return true
 		}
@@ -1300,7 +1341,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// Ctrl+] - Insert right panel path into command line (Far compatible)
 	if (e.VirtualKeyCode == vtinput.VK_OEM_6 || e.Char == ']') && ctrl && !alt && !shift && e.KeyDown {
-		if fsp, ok := pf.panels[1].(*FileSystemPanel); ok && fsp != nil {
+		if fsp := pf.visualRightFSP(); fsp != nil {
 			pf.insertPathToCmdLine(fsp.vfs.GetPath())
 			return true
 		}

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -1337,6 +1337,47 @@ func TestPanelsFrame_SwapPanels(t *testing.T) {
 	}
 }
 
+// TestPanelsFrame_VisualLeftRightFollowSwap makes sure resolving
+// panels by on-screen X-position keeps Ctrl+[/Ctrl+] pointing at
+// the visually-left and visually-right sides after CmSwapPanels
+// re-slots the underlying panels array.
+func TestPanelsFrame_VisualLeftRightFollowSwap(t *testing.T) {
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	pathL := filepath.Join(t.TempDir(), "left")
+	pathR := filepath.Join(t.TempDir(), "right")
+	os.MkdirAll(pathL, 0755)
+	os.MkdirAll(pathR, 0755)
+
+	fspL := pf.panels[0].(*FileSystemPanel)
+	fspR := pf.panels[1].(*FileSystemPanel)
+	fspL.vfs.SetPath(pathL)
+	fspR.vfs.SetPath(pathR)
+
+	// Baseline: unswapped — visual-left is the panel we set to
+	// pathL, visual-right the one at pathR.
+	if got := pf.visualLeftFSP(); got != fspL {
+		t.Errorf("visualLeftFSP baseline: got %p, want left (%p)", got, fspL)
+	}
+	if got := pf.visualRightFSP(); got != fspR {
+		t.Errorf("visualRightFSP baseline: got %p, want right (%p)", got, fspR)
+	}
+
+	// Swap. panels[0] now points at fspR, but that panel gets
+	// moved to X=0 by ResizeConsole (see TestPanelsFrame_SwapPanels
+	// step 3), so it's the visually-left one now.
+	pf.HandleCommand(CmSwapPanels, nil)
+
+	if got := pf.visualLeftFSP(); got != fspR {
+		t.Errorf("visualLeftFSP after swap: got %p, want fspR (%p)", got, fspR)
+	}
+	if got := pf.visualRightFSP(); got != fspL {
+		t.Errorf("visualRightFSP after swap: got %p, want fspL (%p)", got, fspL)
+	}
+}
+
 func TestPanelsFrame_WideFollowsSwapAndClone(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()


### PR DESCRIPTION
Small pre-existing bug surfaced during testing of #296.

## The bug

Ctrl+[ / Ctrl+] on the command line insert the wrong panel's path after \`Ctrl+U\` (CmSwapPanels): Ctrl+[ ends up inserting the visually-*right* panel's path and Ctrl+] the visually-*left* one — opposite the FAR \"[ = left, ] = right\" convention every muscle memory expects.

## Why

Both handlers routed by slot index:

\`\`\`go
// panels_frame.go
if (e.VirtualKeyCode == vtinput.VK_OEM_4 || e.Char == '[') && ctrl && ... {
    if fsp, ok := pf.panels[0].(*FileSystemPanel); ok && fsp != nil { ... }
}
if (e.VirtualKeyCode == vtinput.VK_OEM_6 || e.Char == ']') && ctrl && ... {
    if fsp, ok := pf.panels[1].(*FileSystemPanel); ok && fsp != nil { ... }
}
\`\`\`

\`CmSwapPanels\` re-assigns \`pf.panels[0]\` and \`pf.panels[1]\` to each other, then \`ResizeConsole\` moves the frames so the visually-left one goes back to X=0 and the visually-right one to X=leftW. The **slot indices stay swapped**. Result: after a swap the handlers still pick by slot, but the slots point at the opposite side of the screen.

## Fix

Two tiny helpers on \`PanelsFrame\`:

\`\`\`go
func (pf *PanelsFrame) visualLeftFSP() *FileSystemPanel  // min-X of the two panels
func (pf *PanelsFrame) visualRightFSP() *FileSystemPanel // max-X of the two panels
\`\`\`

Both Ctrl+[ / Ctrl+] handlers switch to those. **No behavioural change in the unswapped case** — \`panels[0].X1 = 0 <= panels[1].X1\`, so \`visualLeftFSP()\` returns \`panels[0]\` exactly like before.

The invariant this leans on — the two file panels stay horizontally adjacent, no vertical stacking — is already enforced by \`ResizeConsole\`, so a min-X comparison is enough; no bounding-box test needed.

## Test plan

- [x] \`go test ./...\` passes (\`TestPlugRing_InstallAndRemove_EndToEnd\` fails identically on \`main\` — pre-existing, not this PR).
- [x] \`go build ./...\` clean on linux; \`GOOS=windows GOARCH=amd64 go build ./...\` clean; \`GOOS=darwin GOARCH=arm64 go build ./...\` clean.
- [x] \`gofmt -w -s\` clean on touched files.

### Automated

* \`TestPanelsFrame_VisualLeftRightFollowSwap\` — new. Set left/right to distinct paths, assert baseline pick, run \`CmSwapPanels\`, assert the picks *follow* the on-screen position (the visually-left panel is now the one that used to be right).
* \`TestPanelsFrame_SwapPanels\` — pre-existing, still green (it doesn't assert bracket routing, just the swap mechanics).

### Manual (WSL Ubuntu, \`f4-linux\`)

* Fresh start (no swap): Ctrl+[ on the command line inserts the visually-left path, Ctrl+] the visually-right — as it should.
* After Ctrl+U: Ctrl+[ still inserts the visually-left panel, Ctrl+] the visually-right (previously they inverted).

## Follow-up

#296 (editor Ctrl+[/Ctrl+]) intentionally mirrored the old slot-index routing so the panel and editor behaviours stayed consistent. Once both this PR and #296 are merged, the editor helpers (\`panelPathForEditor\`) should switch to the same \`visualLeftFSP\` / \`visualRightFSP\` accessors — small mechanical change, not attempted here to keep this PR focused on the panel-side bug.