### PR TITLE
Editor: route Ctrl+[/Ctrl+] through visualLeftFSP / visualRightFSP (follow-up to #297)

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -798,12 +798,12 @@ func (ev *EditorView) ProcessKey(e *vtinput.InputEvent) bool {
 	if ctrl && !alt && !shift {
 		switch {
 		case e.VirtualKeyCode == vtinput.VK_OEM_4 || e.Char == '[':
-			if s := panelPathForEditor(0); s != "" {
+			if s := leftPanelPathForEditor(); s != "" {
 				ev.insertTextAtCursor([]byte(s))
 			}
 			return true
 		case e.VirtualKeyCode == vtinput.VK_OEM_6 || e.Char == ']':
-			if s := panelPathForEditor(1); s != "" {
+			if s := rightPanelPathForEditor(); s != "" {
 				ev.insertTextAtCursor([]byte(s))
 			}
 			return true
@@ -2698,19 +2698,30 @@ func findPanelsFrameAnyScreen() *PanelsFrame {
 	return nil
 }
 
-// panelPathForEditor returns the on-disk path of file panel [idx]
-// (0=left, 1=right), or "" if the panels frame or the panel isn't
-// available (headless test, panels hidden). Same source PanelsFrame
-// uses for its own Ctrl+[/Ctrl+] command-line binds.
-func panelPathForEditor(idx int) string {
+// leftPanelPathForEditor / rightPanelPathForEditor return the
+// on-screen visually-left / visually-right file panel's path, or
+// "" if the panels frame isn't available. Deliberately uses the
+// same visualLeftFSP / visualRightFSP resolvers PanelsFrame uses
+// for its own Ctrl+[/Ctrl+] command-line binds, so after Ctrl+U
+// the editor stays in lock-step with the panel behaviour instead
+// of routing by stale slot index.
+func leftPanelPathForEditor() string {
 	pf := findPanelsFrameAnyScreen()
 	if pf == nil {
 		return ""
 	}
-	if idx < 0 || idx >= len(pf.panels) {
+	if fsp := pf.visualLeftFSP(); fsp != nil {
+		return fsp.vfs.GetPath()
+	}
+	return ""
+}
+
+func rightPanelPathForEditor() string {
+	pf := findPanelsFrameAnyScreen()
+	if pf == nil {
 		return ""
 	}
-	if fsp, ok := pf.panels[idx].(*FileSystemPanel); ok && fsp != nil {
+	if fsp := pf.visualRightFSP(); fsp != nil {
 		return fsp.vfs.GetPath()
 	}
 	return ""


### PR DESCRIPTION
Follow-up to #297.

## Why

#297 made \`PanelsFrame\` resolve Ctrl+[/Ctrl+] targets by on-screen X-position instead of slot index so those command-line binds keep pointing at the visually-left / visually-right panel after Ctrl+U (\`CmSwapPanels\`). The editor's Ctrl+[/Ctrl+] helpers (added in #296) were intentionally left resolving by slot index in that PR, to keep the panel and editor behaviours identical to each other and to what shipped before either PR landed.

With #297 merged, the panel side now uses \`visualLeftFSP()\` / \`visualRightFSP()\` while the editor still uses \`panelPathForEditor(0/1)\` on the raw \`pf.panels\` slots. Under Ctrl+U the two sides diverge — the command-line pair points correctly, the editor pair inverts.

## Change

Replace \`panelPathForEditor(idx int)\` with two direction-named helpers that call the same PanelsFrame accessors merged in #297:

\`\`\`go
leftPanelPathForEditor()  → pf.visualLeftFSP().vfs.GetPath()
rightPanelPathForEditor() → pf.visualRightFSP().vfs.GetPath()
\`\`\`

Call sites in \`EditorView.ProcessKey\` updated accordingly.

## Test plan

- [x] \`go test ./...\` passes (\`TestPlugRing_InstallAndRemove_EndToEnd\` fails identically on \`main\` — pre-existing).
- [x] \`go build ./...\` clean on linux; \`GOOS=windows GOARCH=amd64 go build ./...\` clean; \`GOOS=darwin GOARCH=arm64 go build ./...\` clean.
- [x] \`gofmt -w -s\` clean on touched files.

### Automated

No new tests — \`TestPanelsFrame_VisualLeftRightFollowSwap\` from #297 already covers the resolvers this routes through, and the editor helpers are one-line pass-throughs. Existing \`TestEditorView_InsertTextAtCursor\` and \`TestEditorView_DeleteSpacersForward\` still green.

### Manual

Editor Ctrl+[ / Ctrl+] before and after Ctrl+U — the inserted paths track the visually-left / visually-right side in both states, matching the command-line binds.