### PR TITLE
Actions: Appearance Cancel snapshots the whole palette (preserves farcolors.ini overrides)

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -2043,7 +2043,12 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	const width, height = 60, 19
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
-	originalStyle := AppConfig.ColorStyle
+	// Snapshot the whole palette (not just the style name) so a
+	// Cancel restores every runtime tweak — farcolors.ini overrides
+	// loaded at startup, Colorer editor-background pushes, anything
+	// else that touched vtui.Palette. Re-applying originalStyle
+	// alone would wipe those.
+	originalPalette := append([]uint64(nil), vtui.Palette...)
 
 	styles := AvailableColorStyles()
 	names := make([]string, len(styles))
@@ -2176,8 +2181,8 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	}
 
 	dlg.OnResult = func(code int) {
-		if code < 0 {
-			_ = ApplyColorStyle(originalStyle)
+		if code < 0 && len(originalPalette) == len(vtui.Palette) {
+			copy(vtui.Palette, originalPalette)
 		}
 		vtui.FrameManager.Redraw()
 	}

--- a/actions_test.go
+++ b/actions_test.go
@@ -1491,6 +1491,65 @@ func TestActionAppearanceSettings_SaveCursor(t *testing.T) {
 	}
 }
 
+// TestActionAppearanceSettings_CancelPreservesPalette locks in the
+// fix: farcolors.ini overrides applied at startup were wiped when
+// the user opened Appearance settings and pressed Cancel, because
+// the dialog restored via ApplyColorStyle(originalStyle) — a clean
+// re-apply of the named base style with no room for runtime
+// overrides. Snapshot-and-copy the whole palette instead, so
+// Cancel returns exactly what was on screen before the dialog
+// opened, regardless of where the tweak came from.
+func TestActionAppearanceSettings_CancelPreservesPalette(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	// Simulate a farcolors.ini override: bump one palette slot to
+	// a sentinel value the base style would never produce. If Cancel
+	// restores by name it clobbers this back to the style default;
+	// if it restores by palette snapshot the sentinel survives.
+	const sentinel uint64 = 0xDEADBEEFCAFE0001
+	origAtIdx := vtui.Palette[ColPanelText]
+	vtui.Palette[ColPanelText] = sentinel
+	defer func() { vtui.Palette[ColPanelText] = origAtIdx }()
+
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	// Trigger live preview: pick a style different from the current
+	// one so ApplyColorStyle actually runs and overwrites the
+	// sentinel. Any built-in style other than the current one works.
+	var combo *vtui.ComboBox
+	for _, itm := range top.GetChildren() {
+		if c, ok := itm.(*vtui.ComboBox); ok {
+			combo = c
+			break
+		}
+	}
+	if combo == nil {
+		t.Fatal("style combobox not found in Appearance dialog")
+	}
+	// Pick the *other* end of the list — different from whatever
+	// index the config currently points to.
+	target := 0
+	if combo.Menu.SelectPos == 0 && len(combo.Menu.Items) > 1 {
+		target = len(combo.Menu.Items) - 1
+	}
+	combo.Menu.OnAction(target)
+	if vtui.Palette[ColPanelText] == sentinel {
+		t.Fatal("test setup: live preview didn't overwrite the sentinel — need a different palette slot or style pair")
+	}
+
+	clickDialogButton(t, top, "Cancel")
+
+	if got := vtui.Palette[ColPanelText]; got != sentinel {
+		t.Errorf("Cancel dropped the override: palette[ColPanelText]=%016x, want sentinel %016x", got, sentinel)
+	}
+}
+
 func TestPanelsFrame_RunAdvancedProgressTask(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()


### PR DESCRIPTION
## Repro

Video (user report): https://t.me/f4chat_ru/991

1. Drop a customised \`farcolors.ini\` next to \`settings.ini\` (on Windows \`C:\\Users\\<user>\\AppData\\Roaming\\f4\\farcolors.ini\`) so custom colors override the base style at startup.
2. Launch f4 — the custom colors are visible.
3. Open F9 → Options → Appearance settings.
4. Press **Cancel** (no field touched).
5. All custom colors from \`farcolors.ini\` are gone — the palette drops back to the base style's defaults until the next f4 restart.

## Cause

\`actionAppearanceSettings\` remembered \`originalStyle := AppConfig.ColorStyle\` on open (the style *name*, e.g. \`"Modern"\`) and, on Cancel, called \`ApplyColorStyle(originalStyle)\` to \"undo\" any live preview. That call re-applies the clean named style — but the \`farcolors.ini\` layer is loaded at startup **on top of** the style (see \`main.go:362-367\` — \`InitColors(legacyIni)\` runs after \`ApplyColorStyle(AppConfig.ColorStyle)\`), so re-applying the style-by-name silently drops every override.

So \"Cancel\" was effectively \"reset every runtime palette tweak\", not \"leave things alone\".

## Fix

Snapshot \`vtui.Palette\` (a plain \`[]uint64\`) when the dialog opens and \`copy()\` it back on Cancel. Robust regardless of where the tweak came from — \`farcolors.ini\` overrides, Colorer editor-background pushes, anything else that touched Palette after startup, all survive Cancel.

\`\`\`go
originalPalette := append([]uint64(nil), vtui.Palette...)
...
dlg.OnResult = func(code int) {
    if code < 0 && len(originalPalette) == len(vtui.Palette) {
        copy(vtui.Palette, originalPalette)
    }
    vtui.FrameManager.Redraw()
}
\`\`\`

## Test plan

- [x] \`go test ./...\` passes (\`TestPlugRing_InstallAndRemove_EndToEnd\` fails identically on \`main\` — pre-existing).
- [x] \`go build ./...\` clean on linux; \`GOOS=windows GOARCH=amd64 go build ./...\` clean; \`GOOS=darwin GOARCH=arm64 go build ./...\` clean.
- [x] \`gofmt -w -s\` clean on touched files.

### Automated

* \`TestActionAppearanceSettings_CancelPreservesPalette\` — writes a sentinel into \`vtui.Palette[ColPanelText]\` (simulating a farcolors.ini override), opens the dialog, triggers live preview via the combobox to prove it does overwrite, presses Cancel, asserts the sentinel is back.
* Existing \`TestActionAppearanceSettings_SaveCursor\` still green (OK branch unchanged).

### Manual

Reproduced with a real \`farcolors.ini\` in \`~/.config/f4/\` (WSL Ubuntu, \`f4-linux\`): before the fix Cancel dropped the custom colors as the video shows; after the fix Cancel leaves the palette exactly as it was on dialog open, including custom overrides.

## Open follow-up (deliberately out of scope)

The **OK branch with a *changed* style** still has the same underlying problem: switching from \"Modern\" to \"Classic\" via the combobox applies the new base style but doesn't re-layer \`farcolors.ini\` on top, so custom overrides get lost even after OK. That case is trickier because \"user picked a new style\" plausibly means \"start from that style's defaults\" — do the user's per-color overrides survive a style switch, or is picking a new style a fresh slate? Worth its own PR and its own conversation. This PR fixes Cancel only, which unambiguously should be a no-op.