### PR TITLE
Grabber: Alt+Ins screen grabber for keyboard-driven copy (part of #301)

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -725,6 +725,17 @@ func (ev *EditorView) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
+
+	// Alt+Ins — global screen grabber (far/far2l parity). Handled here
+	// so it works even when the editor is the top frame.
+	if e.Type == vtinput.KeyEventType && e.KeyDown && e.VirtualKeyCode == vtinput.VK_INSERT && alt {
+		ctrl := (e.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
+		shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
+		if !ctrl && !shift {
+			OpenGrabber()
+			return true
+		}
+	}
 	// 1. Processing Bracketed Paste (events arrive outside KeyDown)
 	if e.Type == vtinput.PasteEventType {
 		if e.PasteStart {

--- a/grabber.go
+++ b/grabber.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// GrabberFrame is the modal, full-screen "screen grabber" reached via
+// Alt+Ins (same as far/far2l). It freezes a snapshot of whatever is
+// currently on screen, lets the user drive a text cursor with the
+// keyboard, extend a rectangular selection with Shift-modified
+// navigation, and copy the selected text to the clipboard on
+// Enter / Ctrl+Ins. Esc cancels without touching the clipboard.
+//
+// A single-cell selection collapses onto the cursor when navigation
+// runs without Shift, matching far2l's _reset_area semantics.
+type GrabberFrame struct {
+	vtui.BaseFrame
+	mu      sync.Mutex
+	snap    [][]vtui.CharInfo
+	snapW   int
+	snapH   int
+	curX    int
+	curY    int
+	anchorX int
+	anchorY int
+	hasSnap bool
+
+	// Held-modifier tracking. Some GUI hosts (e.g. gogpu) don't
+	// reliably carry ShiftPressed/etc in ControlKeyState on
+	// non-character keys, so we keep our own bookkeeping via
+	// VK_SHIFT / VK_CONTROL / VK_MENU key events and OR it with
+	// whatever the event's mask reports.
+	shiftHeld bool
+	ctrlHeld  bool
+	altHeld   bool
+}
+
+// NewGrabberFrame constructs an empty grabber. The screen snapshot is
+// taken on the first Show(scr) pass — that's the earliest moment we
+// see the ScreenBuf with the pre-grabber render already applied by
+// the frames beneath us.
+func NewGrabberFrame() *GrabberFrame {
+	g := &GrabberFrame{}
+	g.Modal = true
+	g.SetVisible(true)
+	w := vtui.FrameManager.GetScreenSize()
+	h := vtui.FrameManager.GetScreenHeight()
+	g.SetPosition(0, 0, w-1, h-1)
+	return g
+}
+
+// OpenGrabber pushes a fresh grabber onto the active screen's stack.
+// Callers wire this to Alt+Ins in every frame that could hold input
+// focus (PanelsFrame, EditorView, ViewerView, …).
+func OpenGrabber() {
+	vtui.FrameManager.Push(NewGrabberFrame())
+	vtui.FrameManager.Redraw()
+}
+
+// rect returns the normalized selection rectangle in snapshot
+// coordinates: left ≤ right, top ≤ bottom, inclusive on both sides.
+func (g *GrabberFrame) rect() (l, r, t, b int) {
+	l, r = g.anchorX, g.curX
+	if l > r {
+		l, r = r, l
+	}
+	t, b = g.anchorY, g.curY
+	if t > b {
+		t, b = b, t
+	}
+	return
+}
+
+func (g *GrabberFrame) snapshot(scr *vtui.ScreenBuf) {
+	w, h := scr.Width(), scr.Height()
+	g.snapW, g.snapH = w, h
+	g.snap = make([][]vtui.CharInfo, h)
+	for y := 0; y < h; y++ {
+		row := make([]vtui.CharInfo, w)
+		for x := 0; x < w; x++ {
+			row[x] = scr.GetCell(x, y)
+		}
+		g.snap[y] = row
+	}
+	g.clampCursor()
+	g.hasSnap = true
+}
+
+func (g *GrabberFrame) clampCursor() {
+	if g.snapW == 0 || g.snapH == 0 {
+		return
+	}
+	if g.curX < 0 {
+		g.curX = 0
+	}
+	if g.curY < 0 {
+		g.curY = 0
+	}
+	if g.curX > g.snapW-1 {
+		g.curX = g.snapW - 1
+	}
+	if g.curY > g.snapH-1 {
+		g.curY = g.snapH - 1
+	}
+	if g.anchorX < 0 {
+		g.anchorX = 0
+	}
+	if g.anchorY < 0 {
+		g.anchorY = 0
+	}
+	if g.anchorX > g.snapW-1 {
+		g.anchorX = g.snapW - 1
+	}
+	if g.anchorY > g.snapH-1 {
+		g.anchorY = g.snapH - 1
+	}
+}
+
+// Show paints the grabber overlay. On the first pass we snapshot the
+// underlying render, then on every pass we blit the snapshot back
+// (covering whatever the underlying frames drew this cycle) and
+// invert cells inside the selection rect.
+func (g *GrabberFrame) Show(scr *vtui.ScreenBuf) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if !g.hasSnap || scr.Width() != g.snapW || scr.Height() != g.snapH {
+		g.snapshot(scr)
+		g.SetPosition(0, 0, g.snapW-1, g.snapH-1)
+	}
+
+	for y := 0; y < g.snapH; y++ {
+		scr.Write(0, y, g.snap[y])
+	}
+
+	l, r, t, b := g.rect()
+	for y := t; y <= b; y++ {
+		for x := l; x <= r; x++ {
+			ci := g.snap[y][x]
+			ci.Attributes = invertAttrColors(ci.Attributes)
+			scr.Write(x, y, []vtui.CharInfo{ci})
+		}
+	}
+
+	scr.SetCursorPos(g.curX, g.curY)
+	scr.SetCursorVisible(true)
+	scr.SetCursorShape(vtui.CursorShapeBlock)
+}
+
+func (g *GrabberFrame) moveCursor(dx, dy int, extend bool) {
+	if g.snapW == 0 || g.snapH == 0 {
+		return
+	}
+	nx := g.curX + dx
+	ny := g.curY + dy
+	if nx < 0 {
+		nx = 0
+	}
+	if ny < 0 {
+		ny = 0
+	}
+	if nx > g.snapW-1 {
+		nx = g.snapW - 1
+	}
+	if ny > g.snapH-1 {
+		ny = g.snapH - 1
+	}
+	g.curX, g.curY = nx, ny
+	if !extend {
+		g.anchorX, g.anchorY = nx, ny
+	}
+}
+
+func (g *GrabberFrame) jump(x, y int, extend bool) {
+	if g.snapW == 0 || g.snapH == 0 {
+		return
+	}
+	if x < 0 {
+		x = 0
+	}
+	if y < 0 {
+		y = 0
+	}
+	if x > g.snapW-1 {
+		x = g.snapW - 1
+	}
+	if y > g.snapH-1 {
+		y = g.snapH - 1
+	}
+	g.curX, g.curY = x, y
+	if !extend {
+		g.anchorX, g.anchorY = x, y
+	}
+}
+
+// copyText extracts the current selection from the snapshot: one
+// screen row per output line, trailing spaces trimmed, wide-char
+// filler cells skipped so CJK/emoji don't emit stray U+FFFF runes.
+func (g *GrabberFrame) copyText() string {
+	l, r, t, b := g.rect()
+	var sb strings.Builder
+	for y := t; y <= b; y++ {
+		line := make([]rune, 0, r-l+1)
+		for x := l; x <= r; x++ {
+			ci := g.snap[y][x]
+			if ci.Char == vtui.WideCharFiller {
+				continue
+			}
+			ch := rune(ci.Char)
+			if ch == 0 {
+				ch = ' '
+			}
+			line = append(line, ch)
+		}
+		sb.WriteString(strings.TrimRight(string(line), " "))
+		if y < b {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+func (g *GrabberFrame) copyAndExit() {
+	text := g.copyText()
+	if text != "" {
+		// vtui.SetClipboard can take up to ~4s when Far2lEnabled=true
+		// (two 2s waits for IPC replies) and can block for a similar
+		// stretch when it shells out to wl-copy/xclip on Linux. Do
+		// the write off the UI goroutine so the grabber closes
+		// instantly and the app stays responsive; the clipboard
+		// eventually settles in the background.
+		go vtui.SetClipboard(text)
+	}
+	g.SetExitCode(1)
+}
+
+func (g *GrabberFrame) cancel() {
+	g.SetExitCode(-1)
+}
+
+func (g *GrabberFrame) ProcessKey(e *vtinput.InputEvent) bool {
+	if e.Type != vtinput.KeyEventType {
+		return true
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Track modifier hold state ourselves — gui hosts sometimes
+	// omit ShiftPressed/etc from ControlKeyState on non-character
+	// key events, and X11-based hosts deliver the modifier as its
+	// left/right VK variant rather than the generic one.
+	switch e.VirtualKeyCode {
+	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT:
+		g.shiftHeld = e.KeyDown
+		return true
+	case vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL:
+		g.ctrlHeld = e.KeyDown
+		return true
+	case vtinput.VK_MENU, vtinput.VK_LMENU, vtinput.VK_RMENU:
+		g.altHeld = e.KeyDown
+		return true
+	}
+
+	if !e.KeyDown {
+		return true
+	}
+
+	ctrl := g.ctrlHeld || (e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed)) != 0
+	shift := g.shiftHeld || (e.ControlKeyState&vtinput.ShiftPressed) != 0
+	alt := g.altHeld || (e.ControlKeyState&(vtinput.LeftAltPressed|vtinput.RightAltPressed)) != 0
+
+	// Alt+Ins on an already-open grabber toggles it off.
+	if e.VirtualKeyCode == vtinput.VK_INSERT && alt {
+		g.cancel()
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	// Big-step deltas match far2l: Ctrl+←/→ = ±10 cols, Ctrl+↑/↓ = ±5 rows.
+	const bigX, bigY = 10, 5
+
+	switch e.VirtualKeyCode {
+	case vtinput.VK_ESCAPE:
+		g.cancel()
+	case vtinput.VK_LEFT:
+		if ctrl {
+			g.moveCursor(-bigX, 0, shift)
+		} else {
+			g.moveCursor(-1, 0, shift)
+		}
+	case vtinput.VK_RIGHT:
+		if ctrl {
+			g.moveCursor(bigX, 0, shift)
+		} else {
+			g.moveCursor(1, 0, shift)
+		}
+	case vtinput.VK_UP:
+		if ctrl {
+			g.moveCursor(0, -bigY, shift)
+		} else {
+			g.moveCursor(0, -1, shift)
+		}
+	case vtinput.VK_DOWN:
+		if ctrl {
+			g.moveCursor(0, bigY, shift)
+		} else {
+			g.moveCursor(0, 1, shift)
+		}
+	case vtinput.VK_HOME:
+		if ctrl {
+			g.jump(0, 0, shift)
+		} else {
+			g.jump(0, g.curY, shift)
+		}
+	case vtinput.VK_END:
+		if ctrl {
+			g.jump(g.snapW-1, g.snapH-1, shift)
+		} else {
+			g.jump(g.snapW-1, g.curY, shift)
+		}
+	case vtinput.VK_PRIOR:
+		g.jump(g.curX, 0, shift)
+	case vtinput.VK_NEXT:
+		g.jump(g.curX, g.snapH-1, shift)
+	case vtinput.VK_A:
+		g.anchorX, g.anchorY = 0, 0
+		g.curX, g.curY = g.snapW-1, g.snapH-1
+	case vtinput.VK_U:
+		g.anchorX, g.anchorY = g.curX, g.curY
+	case vtinput.VK_RETURN:
+		g.copyAndExit()
+	case vtinput.VK_INSERT:
+		if ctrl {
+			g.copyAndExit()
+		}
+	}
+	vtui.FrameManager.Redraw()
+	return true
+}
+
+func (g *GrabberFrame) ProcessMouse(e *vtinput.InputEvent) bool {
+	// Consume everything — mouse-driven grabber selection is a follow-up.
+	return true
+}
+
+func (g *GrabberFrame) GetType() vtui.FrameType                { return vtui.TypeUser + 4 }
+func (g *GrabberFrame) GetTitle() string                       { return "Screen Grabber" }
+func (g *GrabberFrame) IsModal() bool                          { return true }
+func (g *GrabberFrame) HasShadow() bool                        { return false }
+func (g *GrabberFrame) HandleCommand(cmd int, args any) bool   { return false }
+func (g *GrabberFrame) HandleBroadcast(cmd int, args any) bool { return false }
+func (g *GrabberFrame) Valid(cmd int) bool                     { return true }
+func (g *GrabberFrame) GetKeyLabels() *vtui.KeySet             { return nil }
+
+// invertAttrColors swaps foreground and background colors in a cell
+// attribute word, preserving other flags (bold, dim, underline, …).
+// Physical swap instead of the CommonLvbReverse flag — GUI renderers
+// (X11, Wayland, gogpu) don't inspect that flag, so relying on it
+// leaves the selection invisible outside the tty backend.
+func invertAttrColors(attr uint64) uint64 {
+	fgIsRGB := attr&vtui.IsFgRGB != 0
+	bgIsRGB := attr&vtui.IsBgRGB != 0
+
+	var fgRGB, bgRGB uint32
+	var fgIdx, bgIdx uint8
+	if fgIsRGB {
+		fgRGB = vtui.GetRGBFore(attr)
+	} else {
+		fgIdx = vtui.GetIndexFore(attr)
+	}
+	if bgIsRGB {
+		bgRGB = vtui.GetRGBBack(attr)
+	} else {
+		bgIdx = vtui.GetIndexBack(attr)
+	}
+
+	result := attr
+	if bgIsRGB {
+		result = vtui.SetRGBFore(result, bgRGB)
+	} else {
+		result = vtui.SetIndexFore(result, bgIdx)
+	}
+	if fgIsRGB {
+		result = vtui.SetRGBBack(result, fgRGB)
+	} else {
+		result = vtui.SetIndexBack(result, fgIdx)
+	}
+	return result
+}
+
+func (g *GrabberFrame) ResizeConsole(w, h int) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.SetPosition(0, 0, w-1, h-1)
+	// Force resnapshot on next Show — the frozen buffer no longer
+	// matches the physical screen.
+	g.hasSnap = false
+}

--- a/grabber_test.go
+++ b/grabber_test.go
@@ -1,0 +1,310 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// waitForClipboard polls the clipboard until it matches want or the
+// deadline expires. copyAndExit fires SetClipboard on a goroutine
+// to keep the UI responsive, so tests must be tolerant of a small delay.
+func waitForClipboard(t *testing.T, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := vtui.GetClipboard(); got == want {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return vtui.GetClipboard()
+}
+
+const (
+	testGrabberW = 40
+	testGrabberH = 6
+)
+
+// setupGrabberScreen initialises the FrameManager with a silent 40x6
+// screen and paints a couple of predictable rows so extraction tests
+// can assert against known text.
+func setupGrabberScreen(t *testing.T) *vtui.ScreenBuf {
+	t.Helper()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(testGrabberW, testGrabberH)
+	vtui.FrameManager.Init(scr)
+	SetDefaultF4Palette()
+	attr := vtui.SetRGBBoth(0, 0xFFFFFF, 0x000000)
+	scr.FillRect(0, 0, testGrabberW-1, testGrabberH-1, ' ', attr)
+	scr.Write(0, 0, vtui.StringToCharInfo("hello world", attr))
+	scr.Write(0, 1, vtui.StringToCharInfo("second line trailing spaces      ", attr))
+	scr.Write(0, 2, vtui.StringToCharInfo("third", attr))
+	return scr
+}
+
+func keyDown(vk uint16, mods vtinput.ControlKeyState) *vtinput.InputEvent {
+	return &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vk,
+		ControlKeyState: mods,
+	}
+}
+
+func TestGrabber_SnapshotOnFirstShow(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	if !g.hasSnap {
+		t.Fatal("expected snapshot to be taken on first Show")
+	}
+	if g.snapW != testGrabberW || g.snapH != testGrabberH {
+		t.Fatalf("snapshot dims %dx%d, want %dx%d", g.snapW, g.snapH, testGrabberW, testGrabberH)
+	}
+	if rune(g.snap[0][0].Char) != 'h' {
+		t.Fatalf("snap[0][0]=%v, want 'h'", g.snap[0][0].Char)
+	}
+	// Cursor starts collapsed at (0,0) — anchor==cur.
+	if g.curX != 0 || g.curY != 0 || g.anchorX != 0 || g.anchorY != 0 {
+		t.Fatalf("initial cursor/anchor = (%d,%d)/(%d,%d), want origin",
+			g.curX, g.curY, g.anchorX, g.anchorY)
+	}
+}
+
+func TestGrabber_PlainArrowCollapsesSelection(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	// Extend right by 3 with Shift.
+	for i := 0; i < 3; i++ {
+		g.ProcessKey(keyDown(vtinput.VK_RIGHT, vtinput.ShiftPressed))
+	}
+	if g.curX != 3 || g.anchorX != 0 {
+		t.Fatalf("after Shift+Right×3: cur=%d anchor=%d, want cur=3 anchor=0", g.curX, g.anchorX)
+	}
+
+	// Plain Right must move AND collapse anchor to cursor.
+	g.ProcessKey(keyDown(vtinput.VK_RIGHT, 0))
+	if g.curX != 4 || g.anchorX != 4 {
+		t.Fatalf("after plain Right: cur=%d anchor=%d, want both 4", g.curX, g.anchorX)
+	}
+}
+
+func TestGrabber_SelectAllAndReset(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	g.ProcessKey(keyDown(vtinput.VK_A, vtinput.LeftCtrlPressed))
+	if g.anchorX != 0 || g.anchorY != 0 || g.curX != testGrabberW-1 || g.curY != testGrabberH-1 {
+		t.Fatalf("Ctrl+A: anchor=(%d,%d) cur=(%d,%d), want (0,0)/(%d,%d)",
+			g.anchorX, g.anchorY, g.curX, g.curY, testGrabberW-1, testGrabberH-1)
+	}
+
+	g.ProcessKey(keyDown(vtinput.VK_U, vtinput.LeftCtrlPressed))
+	if g.anchorX != g.curX || g.anchorY != g.curY {
+		t.Fatalf("Ctrl+U: anchor=(%d,%d) cur=(%d,%d), expected collapsed",
+			g.anchorX, g.anchorY, g.curX, g.curY)
+	}
+}
+
+func TestGrabber_CopyTextTrimsTrailingSpaces(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	// Select the full first row: (0,0) → (W-1, 0).
+	g.ProcessKey(keyDown(vtinput.VK_END, vtinput.ShiftPressed))
+	got := g.copyText()
+	if got != "hello world" {
+		t.Fatalf("row-0 copy = %q, want %q", got, "hello world")
+	}
+
+	// Now select the first three rows via Ctrl+A then Shift+Home to
+	// bring cursor back... simpler: manually set state.
+	g.anchorX, g.anchorY = 0, 0
+	g.curX, g.curY = testGrabberW-1, 2
+	got = g.copyText()
+	wantLines := []string{"hello world", "second line trailing spaces", "third"}
+	if got != strings.Join(wantLines, "\n") {
+		t.Fatalf("multiline copy = %q, want %q", got, strings.Join(wantLines, "\n"))
+	}
+}
+
+func TestGrabber_EnterCopiesAndExits(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	// Select "hello world" on row 0.
+	g.anchorX, g.anchorY = 0, 0
+	g.curX, g.curY = 10, 0
+	// Clear whatever the runtime clipboard held from prior tests.
+	vtui.SetClipboard("")
+
+	g.ProcessKey(keyDown(vtinput.VK_RETURN, 0))
+	if !g.IsDone() {
+		t.Fatal("Enter should mark grabber Done")
+	}
+	if got := waitForClipboard(t, "hello world"); got != "hello world" {
+		t.Fatalf("clipboard = %q, want %q", got, "hello world")
+	}
+}
+
+func TestGrabber_CtrlInsCopiesAndExits(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	g.anchorX, g.anchorY = 0, 0
+	g.curX, g.curY = 4, 0
+	vtui.SetClipboard("")
+
+	g.ProcessKey(keyDown(vtinput.VK_INSERT, vtinput.LeftCtrlPressed))
+	if !g.IsDone() {
+		t.Fatal("Ctrl+Ins should mark grabber Done")
+	}
+	if got := waitForClipboard(t, "hello"); got != "hello" {
+		t.Fatalf("clipboard = %q, want %q", got, "hello")
+	}
+}
+
+func TestGrabber_EscCancelsWithoutClipboard(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	vtui.SetClipboard("sentinel")
+	g.anchorX, g.anchorY = 0, 0
+	g.curX, g.curY = 4, 0
+
+	g.ProcessKey(keyDown(vtinput.VK_ESCAPE, 0))
+	if !g.IsDone() {
+		t.Fatal("Esc should mark grabber Done")
+	}
+	if got := vtui.GetClipboard(); got != "sentinel" {
+		t.Fatalf("clipboard = %q, want unchanged %q", got, "sentinel")
+	}
+}
+
+func TestGrabber_AltInsToggleCloses(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	g.ProcessKey(keyDown(vtinput.VK_INSERT, vtinput.LeftAltPressed))
+	if !g.IsDone() {
+		t.Fatal("Alt+Ins on open grabber should close it")
+	}
+}
+
+func TestGrabber_JumpKeys(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	g.ProcessKey(keyDown(vtinput.VK_END, 0))
+	if g.curX != testGrabberW-1 || g.curY != 0 {
+		t.Fatalf("End: cur=(%d,%d), want (%d,0)", g.curX, g.curY, testGrabberW-1)
+	}
+	g.ProcessKey(keyDown(vtinput.VK_NEXT, 0))
+	if g.curY != testGrabberH-1 {
+		t.Fatalf("PgDn: curY=%d, want %d", g.curY, testGrabberH-1)
+	}
+	g.ProcessKey(keyDown(vtinput.VK_HOME, vtinput.LeftCtrlPressed))
+	if g.curX != 0 || g.curY != 0 {
+		t.Fatalf("Ctrl+Home: cur=(%d,%d), want (0,0)", g.curX, g.curY)
+	}
+	g.ProcessKey(keyDown(vtinput.VK_END, vtinput.LeftCtrlPressed))
+	if g.curX != testGrabberW-1 || g.curY != testGrabberH-1 {
+		t.Fatalf("Ctrl+End: cur=(%d,%d), want (%d,%d)", g.curX, g.curY, testGrabberW-1, testGrabberH-1)
+	}
+}
+
+func TestGrabber_ShiftTrackedViaVKShift(t *testing.T) {
+	// Table-driven: X11 hosts deliver Shift as VK_LSHIFT/VK_RSHIFT,
+	// Windows console tends to send the generic VK_SHIFT.
+	for _, shiftVK := range []uint16{vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT} {
+		scr := setupGrabberScreen(t)
+		g := NewGrabberFrame()
+		g.Show(scr)
+
+		g.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true,
+			VirtualKeyCode: shiftVK,
+		})
+		g.ProcessKey(keyDown(vtinput.VK_RIGHT, 0))
+		g.ProcessKey(keyDown(vtinput.VK_RIGHT, 0))
+		if g.curX != 2 || g.anchorX != 0 {
+			t.Fatalf("shift VK=0x%x extend: cur=%d anchor=%d, want cur=2 anchor=0",
+				shiftVK, g.curX, g.anchorX)
+		}
+
+		g.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: false,
+			VirtualKeyCode: shiftVK,
+		})
+		g.ProcessKey(keyDown(vtinput.VK_RIGHT, 0))
+		if g.curX != 3 || g.anchorX != 3 {
+			t.Fatalf("shift VK=0x%x post-release arrow: cur=%d anchor=%d, want both 3",
+				shiftVK, g.curX, g.anchorX)
+		}
+	}
+}
+
+func TestGrabber_ShowHighlightsSelectionRect(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	baseAttr := scr.GetCell(2, 0).Attributes
+	baseFG := vtui.GetRGBFore(baseAttr)
+	baseBG := vtui.GetRGBBack(baseAttr)
+	if baseFG == baseBG {
+		t.Fatal("test setup: base fg and bg must differ so a swap is observable")
+	}
+
+	g.anchorX, g.anchorY = 1, 0
+	g.curX, g.curY = 3, 0
+	g.Show(scr)
+
+	// Inside the rect: fg/bg swapped.
+	for x := 1; x <= 3; x++ {
+		cell := scr.GetCell(x, 0).Attributes
+		if vtui.GetRGBFore(cell) != baseBG || vtui.GetRGBBack(cell) != baseFG {
+			t.Errorf("cell (%d,0) not color-swapped: fg=%06x bg=%06x, want fg=%06x bg=%06x",
+				x, vtui.GetRGBFore(cell), vtui.GetRGBBack(cell), baseBG, baseFG)
+		}
+	}
+	// Outside the rect: colors unchanged.
+	for _, x := range []int{0, 4} {
+		cell := scr.GetCell(x, 0).Attributes
+		if vtui.GetRGBFore(cell) != baseFG || vtui.GetRGBBack(cell) != baseBG {
+			t.Errorf("cell (%d,0) was modified but should be outside selection", x)
+		}
+	}
+}
+
+func TestGrabber_InvertAttrColorsRGB(t *testing.T) {
+	// White on black → black on white, other flags preserved.
+	src := vtui.SetRGBBoth(vtui.ForegroundIntensity, 0xFFFFFF, 0x000000)
+	got := invertAttrColors(src)
+	if vtui.GetRGBFore(got) != 0x000000 {
+		t.Errorf("fg after swap = %06x, want 000000", vtui.GetRGBFore(got))
+	}
+	if vtui.GetRGBBack(got) != 0xFFFFFF {
+		t.Errorf("bg after swap = %06x, want FFFFFF", vtui.GetRGBBack(got))
+	}
+	if got&vtui.ForegroundIntensity == 0 {
+		t.Error("style flags must survive the color swap")
+	}
+	if got&vtui.IsFgRGB == 0 || got&vtui.IsBgRGB == 0 {
+		t.Error("RGB flags must be set on both slots")
+	}
+}

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1009,6 +1009,14 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
 	shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
 
+	// Alt+Ins opens the screen grabber — matches far/far2l's
+	// non-remappable global hotkey. Intercepted before the AltScreen
+	// raw-forwarding branch so the grabber still opens over mc/htop.
+	if e.KeyDown && e.VirtualKeyCode == vtinput.VK_INSERT && alt && !ctrl && !shift {
+		OpenGrabber()
+		return true
+	}
+
 	// Raw input mode check at the very top. If an interactive AltScreen app is active (e.g. mc, htop),
 	// we forward ALL keys to PTY, except workspace switcher keys (Ctrl+Tab in standard mode, Ctrl+Shift+Tab in advanced).
 	if !pf.showPanels && pf.termView.UseAltScreen {

--- a/viewer_view.go
+++ b/viewer_view.go
@@ -443,8 +443,15 @@ func (vv *ViewerView) ProcessKey(e *vtinput.InputEvent) bool {
 
 	ctrl := (e.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
 	shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
+	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
 	if e.VirtualKeyCode == vtinput.VK_TAB && ctrl {
 		return false
+	}
+
+	// Alt+Ins — global screen grabber (far/far2l parity).
+	if e.VirtualKeyCode == vtinput.VK_INSERT && alt && !ctrl && !shift {
+		OpenGrabber()
+		return true
 	}
 
 	//height := int64(vv.Y2 - vv.Y1 + 1)


### PR DESCRIPTION
## Summary

Implements far2l's screen grabber (Alt+Ins). Freezes the current screen, drives a text cursor with the keyboard, extends a rectangular selection with Shift-modified navigation, copies to the clipboard on Enter / Ctrl+Ins, Esc cancels. Works over panels, editor, viewer, and full-screen TUIs (mc, htop) in the built-in terminal.

Partial coverage of #301 — the issue asked for mouse selection in the built-in terminal *and* the grabber gives you a way to select from anywhere by keyboard as a first step. Mouse-in-terminal selection stays as a separate PR.

## Key bindings (mirrored from far2l `grabber.cpp`)

| Key | Action |
|---|---|
| arrows / Ctrl+arrows | move cursor (±1 / ±10 cols, ±5 rows) |
| Home / End | jump to row edges (Ctrl+ = screen corners) |
| PgUp / PgDn | jump to top / bottom edge |
| Shift+navigation | extend selection |
| Ctrl+A / A | select entire screen |
| Ctrl+U / U | collapse selection to cursor |
| Enter / Ctrl+Ins | copy and exit |
| Esc | cancel |
| Alt+Ins | toggle grabber off |

## Wiring

Alt+Ins is intercepted in:
* `PanelsFrame.ProcessKey` — *before* the AltScreen raw-forward branch, so the grabber opens over mc/htop
* `EditorView.ProcessKey`
* `ViewerView.ProcessKey`

## Notable implementation choices

* **Lazy snapshot.** The frozen buffer is captured on the first ``Show(scr)`` pass, not in the constructor — that way it reflects whatever the underlying frames rendered *this frame*, not whatever was left in the ScreenBuf before.
* **Selection highlight physically swaps fg↔bg** in the ``CharInfo`` rather than OR-ing ``CommonLvbReverse``. GUI renderers (X11/Wayland/gogpu) ignore that flag, so relying on it makes the selection invisible outside the tty backend. Physical swap works in both.
* **Local modifier tracking.** X11-based hosts deliver Shift as ``VK_LSHIFT`` / ``VK_RSHIFT`` rather than the generic ``VK_SHIFT``, and some GUI hosts don't populate ``ControlKeyState`` on non-character keys. Grabber tracks ``VK_SHIFT``/``VK_LSHIFT``/``VK_RSHIFT`` (and Ctrl/Alt equivalents) explicitly *and* ORs the state with ``ControlKeyState`` — belt-and-suspenders.
* **Async clipboard write.** ``vtui.SetClipboard`` runs on a goroutine — inside far2l terminal the two ``WaitForFar2lReply`` calls inside ``SetFar2lClipboard`` can add up to ~4 s of UI freeze; ``wl-copy``/``xclip`` on Linux can also stall. Grabber closes instantly and the write settles in the background.

## Tests

12 unit tests in ``grabber_test.go`` cover snapshotting, area normalisation, plain-arrow collapse, Shift-arrow extend, table-driven Shift-VK variants, Ctrl+A / Ctrl+U, jump keys, copy trims trailing spaces, Enter / Ctrl+Ins copy path, Esc leaves clipboard untouched, Alt+Ins toggles off, ``Show`` inverts colours inside the rect and leaves cells outside untouched, and the ``invertAttrColors`` helper preserves style flags.

## Follow-ups (deliberately out of scope)

* Mouse-driven selection inside the grabber
* HTML clipboard payload with per-cell colour attributes (far2l does both plain and HTML)
* ``Ctrl+Grey+`` — copy and *append* to clipboard
* ``Opt.CleanAscii`` / ``NoGraphics`` / ``NoBoxes`` text filters
* KeyBar hints specific to the grabber (currently inherits from the underlying frame)

## Test plan

- [x] ``go build ./...``
- [x] ``go test -run TestGrabber ./...`` — all 12 pass
- [x] ``gofmt -w -s`` on all touched files
- [x] Manual smoke test on Windows tty
- [x] Manual smoke test on Linux tty (wezterm, inside far2l terminal on WSL) — Alt+Ins opens grabber over panels / editor / viewer / mc / htop; Shift+arrow extends; Enter copies
- [x] Manual smoke test on Linux gui (X11) — same as above, colour-swap highlight visible
- [ ] Not smoke-tested on macOS