### PR TITLE
Apply theme colors to Hotkey Configurator and PlugRing

### DIFF
--- a/hotkeys_ui.go
+++ b/hotkeys_ui.go
@@ -52,6 +52,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		{Title: "When", Width: 12},
 		{Title: "Description", Width: 16},
 	})
+	useDialogTableColors(table)
 	table.ShowScrollBar = true
 
 	btnAssign := vtui.NewButton(0, 0, "&Assign")

--- a/hotkeys_ui_test.go
+++ b/hotkeys_ui_test.go
@@ -2,7 +2,23 @@ package main
 
 import (
 	"testing"
+
+	"github.com/unxed/vtui"
 )
+
+func TestDialogTableUsesThemePalette(t *testing.T) {
+	table := vtui.NewTable(0, 0, 20, 5, []vtui.TableColumn{{Title: "Value", Width: 20}})
+	useDialogTableColors(table)
+
+	if table.ColorTextIdx != vtui.ColDialogText ||
+		table.ColorSelectedTextIdx != vtui.ColDialogSelectedButton ||
+		table.ColorItemSelectTextIdx != vtui.ColDialogHighlightText ||
+		table.ColorItemSelectCursorIdx != vtui.ColDialogHighlightSelectedButton ||
+		table.ColorTitleIdx != vtui.ColDialogHighlightText ||
+		table.ColorBoxIdx != vtui.ColDialogBox {
+		t.Fatal("dialog table does not use the dialog theme palette")
+	}
+}
 
 func TestHotkeyRow(t *testing.T) {
 	row := hotkeyRow{

--- a/plugring_ui.go
+++ b/plugring_ui.go
@@ -56,13 +56,13 @@ func (r plugRingRow) GetCellText(col int) string {
 func (r plugRingRow) GetCellAttr(col int, def uint64) uint64 {
 	switch {
 	case r.header != "":
-		return vtui.SetRGBFore(def, 0x729FCF) // Blue
+		return themedForeground(def, vtui.ColDialogHighlightText)
 	case r.note != "":
-		return vtui.SetRGBFore(def, 0x888A85) // Grey
+		return vtui.DimColor(def)
 	case r.status == "Update":
-		return vtui.SetRGBFore(def, 0xFCE94F) // Yellow
+		return themedForeground(def, vtui.ColDialogHighlightText)
 	case r.status == "Installed":
-		return vtui.SetRGBFore(def, 0x8AE234) // Green
+		return themedForeground(def, vtui.ColDialogText)
 	}
 	return def
 }
@@ -121,6 +121,7 @@ func actionPlugRing(pf *PanelsFrame) {
 		{Title: "Author", Width: 10},
 		{Title: "Description", Width: w - 4 - 16 - 8 - 13 - 10 - 5}, // 5 is for borders and scrollbar
 	})
+	useDialogTableColors(table)
 	table.ShowScrollBar = true
 
 	btnInstall := vtui.NewButton(0, 0, "&Install/Update")

--- a/plugring_ui_test.go
+++ b/plugring_ui_test.go
@@ -27,3 +27,30 @@ func TestPlugRingDialog_Layout(t *testing.T) {
 	top.SetExitCode(-1)
 	vtui.FrameManager.Pop()
 }
+
+func TestPlugRingRowColorsFollowDialogTheme(t *testing.T) {
+	vtui.SetDefaultPalette()
+	oldHighlight := vtui.Palette[vtui.ColDialogHighlightText]
+	oldText := vtui.Palette[vtui.ColDialogText]
+	t.Cleanup(func() {
+		vtui.Palette[vtui.ColDialogHighlightText] = oldHighlight
+		vtui.Palette[vtui.ColDialogText] = oldText
+	})
+
+	vtui.Palette[vtui.ColDialogHighlightText] = vtui.SetRGBFore(oldHighlight, 0x123456)
+	vtui.Palette[vtui.ColDialogText] = vtui.SetRGBFore(oldText, 0xABCDEF)
+	selected := vtui.SetRGBBoth(0, 0xFFFFFF, 0x654321)
+
+	header := plugRingRow{header: "Category"}.GetCellAttr(0, selected)
+	if got := vtui.GetRGBFore(header); got != 0x123456 {
+		t.Fatalf("header foreground = %#x, want theme foreground", got)
+	}
+	if got := vtui.GetRGBBack(header); got != 0x654321 {
+		t.Fatalf("header background = %#x, want selected background", got)
+	}
+
+	installed := plugRingRow{status: "Installed"}.GetCellAttr(0, selected)
+	if got := vtui.GetRGBFore(installed); got != 0xABCDEF {
+		t.Fatalf("installed foreground = %#x, want dialog text foreground", got)
+	}
+}

--- a/themed_table.go
+++ b/themed_table.go
@@ -1,0 +1,24 @@
+package main
+
+import "github.com/unxed/vtui"
+
+// useDialogTableColors makes a table embedded in a dialog follow the dialog
+// palette instead of the panel-oriented ColTable palette.
+func useDialogTableColors(table *vtui.Table) {
+	table.ColorTextIdx = vtui.ColDialogText
+	table.ColorSelectedTextIdx = vtui.ColDialogSelectedButton
+	table.ColorItemSelectTextIdx = vtui.ColDialogHighlightText
+	table.ColorItemSelectCursorIdx = vtui.ColDialogHighlightSelectedButton
+	table.ColorTitleIdx = vtui.ColDialogHighlightText
+	table.ColorBoxIdx = vtui.ColDialogBox
+}
+
+// themedForeground applies only a theme color's foreground so row-specific
+// accents keep the normal or selected background supplied by the table.
+func themedForeground(attr uint64, paletteIdx int) uint64 {
+	themeAttr := vtui.Palette[paletteIdx]
+	if themeAttr&vtui.IsFgRGB != 0 {
+		return vtui.SetRGBFore(attr, vtui.GetRGBFore(themeAttr))
+	}
+	return vtui.SetIndexFore(attr, vtui.GetIndexFore(themeAttr))
+}


### PR DESCRIPTION
## Summary
- use the dialog palette for tables embedded in Hotkey Configurator and PlugRing
- replace hardcoded PlugRing status RGB values with colors derived from the active dialog theme
- preserve the selected-row background when applying themed foreground accents
- add regression tests for table palette mapping and PlugRing row colors

## Testing
- go test . -run 'Test(DialogTableUsesThemePalette|HotkeyRow|PlugRing)' -count=1 -timeout=180s
- go build -o f4.exe .