### PR TITLE
Improve right mouse panel selection

### DIFF
--- a/file_panel.go
+++ b/file_panel.go
@@ -232,6 +232,8 @@ type FileSystemPanel struct {
 	wide                bool
 	cursorIdx           int
 	lastRightClickedIdx int
+	rightDragActive     bool
+	rightDragSelect     bool
 
 	loadCtx            context.Context
 	cancelLoad         context.CancelFunc
@@ -419,6 +421,71 @@ func (fp *FileSystemPanel) SetViewMode(mode ViewMode) {
 	fp.wide = false
 	fp.configureCellSelection()
 	fp.Resize(fp.X2-fp.X1+1, fp.Y2-fp.Y1+1)
+}
+
+// mouseEntryIndex returns the entry under the mouse. Multi-column panel modes
+// are filled from top to bottom and then from left to right, so the visual
+// column contributes a full table height to the entry index.
+func (fp *FileSystemPanel) mouseEntryIndex(mouseX, mouseY int) int {
+	if mouseX < fp.table.X1 || mouseX > fp.table.X2 {
+		return -1
+	}
+
+	row := mouseY - (fp.table.Y1 + fp.table.MarginTop)
+	if row < 0 || row >= fp.table.ViewHeight {
+		return -1
+	}
+
+	column := 0
+	if fp.gridColumnCount() > 1 {
+		column = -1
+		columnX := fp.table.X1
+		for i, tableColumn := range fp.table.Columns {
+			if mouseX >= columnX && mouseX < columnX+tableColumn.Width {
+				column = i
+				break
+			}
+			columnX += tableColumn.Width + 1 // one-character separator
+		}
+		if column < 0 {
+			return -1
+		}
+	}
+
+	idx := fp.table.TopPos + row + column*fp.table.ViewHeight
+	if idx < 0 || idx >= len(fp.entries) {
+		return -1
+	}
+	return idx
+}
+
+func (fp *FileSystemPanel) processRightDrag(idx int) {
+	if !fp.rightDragActive {
+		fp.rightDragActive = true
+		fp.rightDragSelect = !fp.entries[idx].Selected
+		fp.lastRightClickedIdx = idx
+		fp.SetItemSelected(idx, fp.rightDragSelect)
+		return
+	}
+
+	from := fp.lastRightClickedIdx
+	step := 1
+	if idx < from {
+		step = -1
+	}
+	for current := from; ; current += step {
+		fp.SetItemSelected(current, fp.rightDragSelect)
+		if current == idx {
+			break
+		}
+	}
+	fp.lastRightClickedIdx = idx
+}
+
+func (fp *FileSystemPanel) setAllItemsSelected(state bool) {
+	for idx := range fp.entries {
+		fp.SetItemSelected(idx, state)
+	}
 }
 
 func (fp *FileSystemPanel) SetWide(wide bool) {
@@ -1472,6 +1539,7 @@ func (fp *FileSystemPanel) ProcessMouse(e *vtinput.InputEvent) bool {
 
 	if e.ButtonState == 0 {
 		fp.lastRightClickedIdx = -1
+		fp.rightDragActive = false
 	}
 
 	if fp.fastFindMode && e.ButtonState != 0 {
@@ -1550,6 +1618,33 @@ func (fp *FileSystemPanel) ProcessMouse(e *vtinput.InputEvent) bool {
 		}
 	}
 
+	if e.ButtonState == vtinput.RightmostButtonPressed && e.KeyDown {
+		idx := fp.mouseEntryIndex(int(e.MouseX), int(e.MouseY))
+		if idx >= 0 {
+			fp.SetCursorIndex(idx)
+			if fp.entries[idx].Name == ".." {
+				return true
+			}
+			if e.MouseEventFlags&vtinput.DoubleClick != 0 {
+				// Windows reports the second press as a double-click. The first
+				// press has already established whether this is a select or
+				// deselect operation, so propagate its result to the whole panel.
+				state := fp.entries[idx].Selected
+				fp.setAllItemsSelected(state)
+				fp.rightDragActive = true
+				fp.rightDragSelect = state
+				fp.lastRightClickedIdx = idx
+				fp.Refresh()
+				return true
+			}
+			fp.processRightDrag(idx)
+			fp.Refresh()
+			return true
+		}
+		// Keep the drag captured while the pointer temporarily leaves a file row.
+		return fp.rightDragActive
+	}
+
 	handled := fp.table.ProcessMouse(e)
 	if handled {
 		// Sync absolute index from table's visual selection
@@ -1570,19 +1665,6 @@ func (fp *FileSystemPanel) ProcessMouse(e *vtinput.InputEvent) bool {
 				fp.SetCursorIndex(len(fp.entries) - 1)
 			} else {
 				fp.cursorIdx = newIdx
-			}
-		}
-	}
-
-	if e.ButtonState != 0 && e.KeyDown {
-		idx := fp.GetCursorIndex()
-		if idx < len(fp.entries) {
-			if e.ButtonState == vtinput.RightmostButtonPressed {
-				if fp.entries[idx].Name != ".." && fp.lastRightClickedIdx != idx {
-					fp.ToggleSelection(idx)
-					fp.lastRightClickedIdx = idx
-				}
-				return true
 			}
 		}
 	}

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -935,6 +935,147 @@ func TestFileSystemPanel_RightClick_ResetOnRelease(t *testing.T) {
 		t.Error("Item should have been unselected after button release and re-click")
 	}
 }
+
+func TestFileSystemPanel_RightDragAppliesToSkippedRows(t *testing.T) {
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	fp.SetViewMode(ViewModeDetailed)
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "f1"}},
+		{VFSItem: vfs.VFSItem{Name: "f2"}},
+		{VFSItem: vfs.VFSItem{Name: "f3"}},
+		{VFSItem: vfs.VFSItem{Name: "f4"}},
+	}
+	fp.Refresh()
+
+	dataY := fp.table.Y1 + fp.table.MarginTop
+	rightDown := func(idx int) {
+		fp.ProcessMouse(&vtinput.InputEvent{
+			Type: vtinput.MouseEventType, KeyDown: true,
+			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			ButtonState: vtinput.RightmostButtonPressed,
+		})
+	}
+	release := func(idx int) {
+		fp.ProcessMouse(&vtinput.InputEvent{
+			Type:   vtinput.MouseEventType,
+			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+		})
+	}
+
+	// Only the endpoints emit events; f2 and f3 must still be selected.
+	rightDown(1)
+	rightDown(4)
+	for idx := 1; idx <= 4; idx++ {
+		if !fp.entries[idx].Selected {
+			t.Errorf("entry %d was skipped while selecting", idx)
+		}
+	}
+
+	release(4)
+
+	// Starting a new drag on a selected item fixes the operation to deselect,
+	// including skipped rows while moving in the opposite direction.
+	rightDown(4)
+	rightDown(1)
+	for idx := 1; idx <= 4; idx++ {
+		if fp.entries[idx].Selected {
+			t.Errorf("entry %d was skipped while deselecting", idx)
+		}
+	}
+}
+
+func TestFileSystemPanel_RightDragTracksGridColumn(t *testing.T) {
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	fp.SetViewMode(ViewModeMedium)
+
+	height := fp.table.ViewHeight
+	fp.entries = make([]*fileEntry, height*2)
+	for idx := range fp.entries {
+		fp.entries[idx] = &fileEntry{VFSItem: vfs.VFSItem{Name: fmt.Sprintf("f%d", idx)}}
+	}
+	fp.Refresh()
+
+	startIdx := height - 2
+	endIdx := height + 1
+	dataY := fp.table.Y1 + fp.table.MarginTop
+	leftX := fp.table.X1
+	rightX := fp.table.X1 + fp.table.Columns[0].Width + 1
+
+	fp.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		MouseX: int16(leftX), MouseY: int16(dataY + height - 2),
+		ButtonState: vtinput.RightmostButtonPressed,
+	})
+	fp.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		MouseX: int16(rightX), MouseY: int16(dataY + 1),
+		ButtonState: vtinput.RightmostButtonPressed,
+	})
+
+	if fp.GetCursorIndex() != endIdx {
+		t.Fatalf("cursor index = %d, want %d", fp.GetCursorIndex(), endIdx)
+	}
+	for idx := startIdx; idx <= endIdx; idx++ {
+		if !fp.entries[idx].Selected {
+			t.Errorf("grid entry %d was skipped", idx)
+		}
+	}
+}
+
+func TestFileSystemPanel_RightDoubleClickAppliesToWholePanel(t *testing.T) {
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	fp.SetViewMode(ViewModeDetailed)
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "f1"}},
+		{VFSItem: vfs.VFSItem{Name: "f2"}},
+		{VFSItem: vfs.VFSItem{Name: "f3"}},
+	}
+	fp.Refresh()
+
+	dataY := fp.table.Y1 + fp.table.MarginTop
+	rightClick := func(idx int, flags uint32) {
+		fp.ProcessMouse(&vtinput.InputEvent{
+			Type: vtinput.MouseEventType, KeyDown: true,
+			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			ButtonState: vtinput.RightmostButtonPressed, MouseEventFlags: flags,
+		})
+	}
+	release := func(idx int) {
+		fp.ProcessMouse(&vtinput.InputEvent{
+			Type:   vtinput.MouseEventType,
+			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+		})
+	}
+
+	// The first press selects f1; the second press spreads that state to all.
+	rightClick(1, 0)
+	release(1)
+	rightClick(1, vtinput.DoubleClick)
+	for idx := 1; idx < len(fp.entries); idx++ {
+		if !fp.entries[idx].Selected {
+			t.Errorf("entry %d was not selected by right double-click", idx)
+		}
+	}
+	if fp.entries[0].Selected {
+		t.Error("parent directory entry must not be selected")
+	}
+
+	release(1)
+
+	// Starting on selected f2 makes the first press deselect it; the second
+	// press spreads deselection to the whole panel.
+	rightClick(2, 0)
+	release(2)
+	rightClick(2, vtinput.DoubleClick)
+	for idx := 1; idx < len(fp.entries); idx++ {
+		if fp.entries[idx].Selected {
+			t.Errorf("entry %d was not deselected by right double-click", idx)
+		}
+	}
+}
+
 func TestFileSystemPanel_IncrementalInteraction(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(t.TempDir()))


### PR DESCRIPTION
## Summary
- keep a fixed select/deselect mode throughout a right-button drag
- apply selection to intermediate entries skipped by fast mouse movement
- handle right-button dragging correctly in multi-column panel modes
- select or deselect the entire panel with a right double-click

## Testing
- `go test . -run TestFileSystemPanel_(ProcessMouse|RightClick_ResetOnRelease|RightDragAppliesToSkippedRows|RightDragTracksGridColumn|RightDoubleClickAppliesToWholePanel)$ -count=1`
- `go build -o f4.exe .`

The full Windows test suite still contains unrelated platform-specific failures, including `syscall.Mkfifo` in `plugins/archive`.