### PR TITLE
Terminal: mouse-driven text selection with auto-copy (fixes #301)

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -158,6 +158,15 @@ type PanelsFrame struct {
 	lastPtyPath string
 	lastPtyVFS  vfs.VFS
 	closed      bool
+
+	// Terminal mouse-selection state. Kept in PanelsFrame because
+	// mouse routing lives here; the highlight and text extraction
+	// live on the TerminalView itself.
+	termSelDragging bool      // LMB is down after a drag-initiating click
+	termSelClickN   int       // 1 / 2 / 3 for triple-click detection
+	termSelClickAt  time.Time // time of the last click
+	termSelClickX   int
+	termSelClickY   int
 }
 
 func (pf *PanelsFrame) Left() Panel  { return pf.panels[0] }
@@ -2200,6 +2209,125 @@ func (pf *PanelsFrame) hitAltPanel(mx, my int) int {
 	return -1
 }
 
+// handleTerminalMouseSelection implements xterm-style text selection
+// over the terminal viewport when panels are hidden and no TUI has
+// grabbed the mouse via a tracking-mode escape. LMB starts / extends
+// a selection, dbl/triple-click selects word / line, Alt+LMB drag
+// switches to a rectangular block, releasing LMB auto-copies to the
+// clipboard, RMB pastes clipboard content into the PTY. Returns true
+// when it consumed the event.
+func (pf *PanelsFrame) handleTerminalMouseSelection(e *vtinput.InputEvent) bool {
+	if e.Type != vtinput.MouseEventType {
+		return false
+	}
+	tv := pf.termView
+	if tv == nil {
+		return false
+	}
+	mx, my := int(e.MouseX), int(e.MouseY)
+
+	// Right button: paste clipboard into the active PTY. Fires on
+	// button-down so the release doesn't paste a second time.
+	if e.ButtonState == vtinput.RightmostButtonPressed && e.KeyDown {
+		if !tv.InTerminalArea(mx, my) {
+			return false
+		}
+		if pty := pf.getActivePTY(); pty != nil {
+			text := vtui.GetClipboard()
+			if text != "" {
+				if tv.BracketedPasteMode {
+					pty.Write([]byte("\x1b[200~" + text + "\x1b[201~"))
+				} else {
+					pty.Write([]byte(text))
+				}
+			}
+		}
+		return true
+	}
+
+	// LMB fresh press — start / promote a selection. Guarded by
+	// KeyDown=true and no-MouseMoved so this fires only on the
+	// initial button-down (all hosts agree on that shape).
+	if e.ButtonState == vtinput.FromLeft1stButtonPressed &&
+		e.KeyDown && (e.MouseEventFlags&vtinput.MouseMoved) == 0 {
+		if !tv.InTerminalArea(mx, my) {
+			return false
+		}
+		alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
+
+		now := time.Now()
+		if pf.termSelClickN > 0 &&
+			now.Sub(pf.termSelClickAt) < 400*time.Millisecond &&
+			pf.termSelClickX == mx && pf.termSelClickY == my {
+			pf.termSelClickN++
+		} else {
+			pf.termSelClickN = 1
+		}
+		pf.termSelClickAt = now
+		pf.termSelClickX, pf.termSelClickY = mx, my
+
+		// A fresh click always drops the previous highlight, so the
+		// world resets before we start whatever this click resolves
+		// into (single/double/triple).
+		tv.ClearSelection()
+		switch pf.termSelClickN {
+		case 1:
+			tv.StartSelection(mx, my, alt)
+			pf.termSelDragging = true
+		case 2:
+			tv.SelectWordAt(mx, my)
+			pf.termSelDragging = false
+		default: // 3 or more
+			tv.SelectLineAt(my)
+			pf.termSelDragging = false
+			pf.termSelClickN = 0
+		}
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	// From here on we act only while a drag is in progress; separate
+	// motion-vs-release paths so we work across every backend:
+	//   * Windows console: every mouse event has KeyDown=true; release
+	//     is inferred from ButtonState transitioning to 0.
+	//   * Wayland: motion has KeyDown=false, ButtonState=held; release
+	//     KeyDown=false, ButtonState=0.
+	//   * X11/purex11: motion has KeyDown=false, ButtonState=0; release
+	//     KeyDown=false, ButtonState=held (X11 leaves the button code).
+	//   * tty SGR: motion KeyDown=true (button+motion bit); release
+	//     KeyDown=false, ButtonState=held.
+	if !pf.termSelDragging {
+		return false
+	}
+
+	// Drag — extend selection while the mouse moves with LMB held.
+	if (e.MouseEventFlags & vtinput.MouseMoved) != 0 {
+		tv.ExtendSelection(mx, my)
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	// Release — the button is no longer down under any of the four
+	// shapes above.
+	releasedWayland := e.ButtonState == 0
+	releasedElsewhere := !e.KeyDown
+	if releasedWayland || releasedElsewhere {
+		pf.termSelDragging = false
+		if !tv.SelectionIsEmpty() {
+			text := tv.ExtractSelection()
+			if text != "" {
+				// SetClipboard can hang for seconds behind far2l IPC
+				// or xclip/wl-copy — same treatment as the grabber.
+				go vtui.SetClipboard(text)
+			}
+		}
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	return false
+}
+
 func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 	// If panels are hidden, route relevant mouse events to PTY immediately
 	if !pf.showPanels {
@@ -2207,6 +2335,12 @@ func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 		if active != nil && (pf.termView.MouseTrackingMode != 0 || pf.termView.MouseSGRMode) {
 			seq := TranslateMouseInput(e)
 			active.Write([]byte(seq))
+			return true
+		}
+		// No TUI is grabbing the mouse — treat clicks/drags in the
+		// terminal viewport as text selection with auto-copy on
+		// release (xterm-style, and matches far2l's AdhocQuickEdit).
+		if pf.handleTerminalMouseSelection(e) {
 			return true
 		}
 		// If tracking is off, we still swallow clicks inside AltScreen to prevent hitting hidden panels

--- a/terminal_selection_test.go
+++ b/terminal_selection_test.go
@@ -1,0 +1,420 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// seedClipboard writes a value and polls back until vtui.GetClipboard
+// returns it, so later assertions aren't racing an async SetClipboard
+// goroutine that a preceding test may have left in flight against a
+// slow xclip/wl-copy fallback.
+func seedClipboard(t *testing.T, text string) {
+	t.Helper()
+	vtui.SetClipboard(text)
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if vtui.GetClipboard() == text {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+		vtui.SetClipboard(text) // re-assert against any concurrent writer
+	}
+	t.Fatalf("could not stabilise clipboard to %q; got %q", text, vtui.GetClipboard())
+}
+
+// seedRow writes a plain ASCII string into tv.Lines[row] starting at
+// column 0. Preserves existing right-side padding.
+func seedRow(tv *TerminalView, row int, text string) {
+	attr := DefaultTermAttr
+	for i, r := range text {
+		if i >= tv.Width {
+			return
+		}
+		tv.Lines[row][i] = vtui.CharInfo{Char: uint64(r), Attributes: attr}
+	}
+}
+
+func newSelectableTV(w, h int) *TerminalView {
+	tv := NewTerminalView(w, h)
+	tv.SetPosition(0, 0, w-1, h-1)
+	return tv
+}
+
+func TestTerminalSelection_ExtractStreamSingleRow(t *testing.T) {
+	tv := newSelectableTV(40, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "hello world")
+
+	tv.StartSelection(0, 0, false)
+	tv.ExtendSelection(4, 0)
+
+	if got := tv.ExtractSelection(); got != "hello" {
+		t.Errorf("single-row stream: got %q, want %q", got, "hello")
+	}
+}
+
+func TestTerminalSelection_ExtractStreamMultiRow(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "line one")
+	seedRow(tv, 1, "line two")
+	seedRow(tv, 2, "line three")
+
+	// Start mid-row 0, end mid-row 2 — stream picks up first row's
+	// tail, all of row 1, and row 2's head.
+	tv.StartSelection(5, 0, false)
+	tv.ExtendSelection(3, 2)
+
+	got := tv.ExtractSelection()
+	want := "one\nline two\nline"
+	if got != want {
+		t.Errorf("multi-row stream:\n got %q\nwant %q", got, want)
+	}
+}
+
+func TestTerminalSelection_ExtractBlock(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "abcdefghij")
+	seedRow(tv, 1, "0123456789")
+	seedRow(tv, 2, "ABCDEFGHIJ")
+
+	tv.StartSelection(2, 0, true) // block
+	tv.ExtendSelection(4, 2)
+
+	got := tv.ExtractSelection()
+	want := "cde\n234\nCDE"
+	if got != want {
+		t.Errorf("block: got %q, want %q", got, want)
+	}
+}
+
+func TestTerminalSelection_SelectWordAt(t *testing.T) {
+	tv := newSelectableTV(40, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "foo bar baz")
+
+	tv.SelectWordAt(5, 0) // click on the 'a' in "bar"
+	if got := tv.ExtractSelection(); got != "bar" {
+		t.Errorf("word at 'bar': got %q, want %q", got, "bar")
+	}
+
+	tv.SelectWordAt(3, 0) // click on space — must not activate
+	if got := tv.ExtractSelection(); got != "bar" {
+		t.Errorf("clicking whitespace should leave prior selection intact, got %q", got)
+	}
+}
+
+func TestTerminalSelection_SelectLineAt(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	seedRow(tv, 1, "hello    ") // padded
+
+	tv.SelectLineAt(1)
+	if got := tv.ExtractSelection(); got != "hello" {
+		t.Errorf("line select trims trailing spaces: got %q, want %q", got, "hello")
+	}
+}
+
+func TestTerminalSelection_ClearAndEmpty(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "hello")
+
+	if tv.HasSelection() {
+		t.Fatal("fresh TerminalView shouldn't have a selection")
+	}
+	tv.StartSelection(0, 0, false)
+	if !tv.HasSelection() {
+		t.Fatal("HasSelection should report true after StartSelection")
+	}
+	if !tv.SelectionIsEmpty() {
+		t.Fatal("SelectionIsEmpty should be true when start==end (bare click)")
+	}
+	tv.ExtendSelection(4, 0)
+	if tv.SelectionIsEmpty() {
+		t.Fatal("SelectionIsEmpty should be false after extending")
+	}
+	tv.ClearSelection()
+	if tv.HasSelection() {
+		t.Fatal("ClearSelection should drop the selection")
+	}
+}
+
+func TestTerminalSelection_HighlightInvertsCells(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	seedRow(tv, 0, "hello world")
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(20, 6)
+	vtui.FrameManager.Init(scr)
+	SetDefaultF4Palette()
+
+	tv.SetVisible(true)
+	tv.StartSelection(2, 0, false)
+	tv.ExtendSelection(4, 0)
+	tv.Show(scr)
+
+	baseFG := vtui.GetRGBFore(DefaultTermAttr)
+	baseBG := vtui.GetRGBBack(DefaultTermAttr)
+	for x := 2; x <= 4; x++ {
+		attr := scr.GetCell(x, 0).Attributes
+		if vtui.GetRGBFore(attr) != baseBG || vtui.GetRGBBack(attr) != baseFG {
+			t.Errorf("cell (%d,0) not inverted: fg=%06x bg=%06x, want fg=%06x bg=%06x",
+				x, vtui.GetRGBFore(attr), vtui.GetRGBBack(attr), baseBG, baseFG)
+		}
+	}
+	if attr := scr.GetCell(1, 0).Attributes; vtui.GetRGBFore(attr) == baseBG {
+		t.Error("cell (1,0) outside selection should not be inverted")
+	}
+	if attr := scr.GetCell(5, 0).Attributes; vtui.GetRGBFore(attr) == baseBG {
+		t.Error("cell (5,0) outside selection should not be inverted")
+	}
+}
+
+func TestTerminalSelection_InTerminalArea(t *testing.T) {
+	tv := newSelectableTV(20, 6)
+	defer tv.Close()
+	tv.SetPosition(10, 5, 29, 10) // move it off origin
+
+	cases := []struct {
+		x, y int
+		want bool
+	}{
+		{10, 5, true},
+		{29, 10, true},
+		{9, 5, false},
+		{30, 10, false},
+		{20, 4, false},
+		{20, 11, false},
+	}
+	for _, c := range cases {
+		if got := tv.InTerminalArea(c.x, c.y); got != c.want {
+			t.Errorf("InTerminalArea(%d,%d) = %v, want %v", c.x, c.y, got, c.want)
+		}
+	}
+}
+
+// panelsFrameWithMouseSelect returns a PanelsFrame configured for
+// hidden-panels terminal-selection tests: 80x25 grid, no mouse
+// tracking, no altScreen, a live termView, and a fake PTY.
+func panelsFrameWithMouseSelect(t *testing.T) (*PanelsFrame, *fakePTY) {
+	t.Helper()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	SetDefaultF4Palette()
+	pf := NewPanelsFrame()
+	pf.ResizeConsole(80, 25)
+	pf.showPanels = false
+	pf.termView.SetPosition(0, 0, 79, 22)
+	pty := &fakePTY{}
+	pf.pty = pty
+	return pf, pty
+}
+
+type fakePTY struct{ writes []byte }
+
+func (p *fakePTY) Read(b []byte) (int, error)            { return 0, nil }
+func (p *fakePTY) Write(b []byte) (int, error)           { p.writes = append(p.writes, b...); return len(b), nil }
+func (p *fakePTY) Close() error                          { return nil }
+func (p *fakePTY) SetSize(cols, rows int)                {}
+func (p *fakePTY) Wait() error                           { return nil }
+func (p *fakePTY) Run(name string, args ...string) error { return nil }
+func (p *fakePTY) IsBusy() bool                          { return false }
+
+// TestPanelsFrame_TerminalMouseSelect_Drag exercises the full click →
+// drag → release pipeline through PanelsFrame.ProcessMouse. Asserts
+// on selection state; the release-time clipboard write happens on a
+// goroutine and depends on external tools (xclip / wl-copy / far2l
+// IPC), so we don't assert on GetClipboard here — that path is
+// covered separately in the vtui clipboard tests.
+func TestPanelsFrame_TerminalMouseSelect_Drag(t *testing.T) {
+	pf, _ := panelsFrameWithMouseSelect(t)
+	tv := pf.termView
+	seedRow(tv, 0, "hello world")
+
+	// LMB down at (2, 0)
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      2, MouseY: 0,
+	})
+	if !tv.HasSelection() {
+		t.Fatal("expected HasSelection=true after LMB down")
+	}
+	if !pf.termSelDragging {
+		t.Fatal("expected termSelDragging=true after LMB down inside terminal area")
+	}
+	// Drag to (6, 0)
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.MouseMoved,
+		MouseX:          6, MouseY: 0,
+	})
+	if got := tv.ExtractSelection(); got != "llo w" {
+		t.Errorf("after drag: got %q, want %q", got, "llo w")
+	}
+
+	// Release button — drag flag drops, selection stays (xterm-style).
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: false,
+		ButtonState: 0,
+		MouseX:      6, MouseY: 0,
+	})
+	if pf.termSelDragging {
+		t.Fatal("release should clear termSelDragging")
+	}
+	if !tv.HasSelection() {
+		t.Fatal("release should keep the highlight (xterm-style)")
+	}
+	if got := tv.ExtractSelection(); got != "llo w" {
+		t.Errorf("post-release extract: got %q, want %q", got, "llo w")
+	}
+}
+
+// TestPanelsFrame_TerminalMouseSelect_ReleaseHostShapes locks in
+// support for the four distinct release-event shapes across our
+// backends. See the giant comment inside handleTerminalMouseSelection
+// for the taxonomy.
+func TestPanelsFrame_TerminalMouseSelect_ReleaseHostShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		release *vtinput.InputEvent
+	}{
+		{
+			"Wayland/Windows-console: ButtonState=0, KeyDown=false",
+			&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: false,
+				ButtonState: 0,
+				MouseX:      6, MouseY: 0,
+			},
+		},
+		{
+			"Windows-console: ButtonState=0, KeyDown=true (release inferred by ButtonState==0)",
+			&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: true,
+				ButtonState: 0,
+				MouseX:      6, MouseY: 0,
+			},
+		},
+		{
+			"X11/purex11/tty-SGR: ButtonState=LMB left in place, KeyDown=false",
+			&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: false,
+				ButtonState: vtinput.FromLeft1stButtonPressed,
+				MouseX:      6, MouseY: 0,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf, _ := panelsFrameWithMouseSelect(t)
+			tv := pf.termView
+			seedRow(tv, 0, "hello world")
+
+			pf.ProcessMouse(&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: true,
+				ButtonState: vtinput.FromLeft1stButtonPressed,
+				MouseX:      2, MouseY: 0,
+			})
+			pf.ProcessMouse(&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: true,
+				ButtonState:     vtinput.FromLeft1stButtonPressed,
+				MouseEventFlags: vtinput.MouseMoved,
+				MouseX:          6, MouseY: 0,
+			})
+			pf.ProcessMouse(tc.release)
+			if pf.termSelDragging {
+				t.Fatalf("release didn't clear termSelDragging: %+v", tc.release)
+			}
+			if got := tv.ExtractSelection(); got != "llo w" {
+				t.Fatalf("selection lost through release: got %q, want %q", got, "llo w")
+			}
+		})
+	}
+}
+
+// TestPanelsFrame_TerminalMouseSelect_DragHostShapes locks in support
+// for the two motion-event shapes we've seen: Wayland-style with the
+// button code still in ButtonState, and X11-style where motion carries
+// only the MouseMoved flag.
+func TestPanelsFrame_TerminalMouseSelect_DragHostShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		drag *vtinput.InputEvent
+	}{
+		{
+			"Wayland: ButtonState=LMB, KeyDown=false, MouseMoved",
+			&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: false,
+				ButtonState:     vtinput.FromLeft1stButtonPressed,
+				MouseEventFlags: vtinput.MouseMoved,
+				MouseX:          6, MouseY: 0,
+			},
+		},
+		{
+			"X11: ButtonState=0, KeyDown=false, MouseMoved",
+			&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: false,
+				ButtonState:     0,
+				MouseEventFlags: vtinput.MouseMoved,
+				MouseX:          6, MouseY: 0,
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pf, _ := panelsFrameWithMouseSelect(t)
+			tv := pf.termView
+			seedRow(tv, 0, "hello world")
+
+			pf.ProcessMouse(&vtinput.InputEvent{
+				Type: vtinput.MouseEventType, KeyDown: true,
+				ButtonState: vtinput.FromLeft1stButtonPressed,
+				MouseX:      2, MouseY: 0,
+			})
+			pf.ProcessMouse(tc.drag)
+			if got := tv.ExtractSelection(); got != "llo w" {
+				t.Fatalf("drag didn't extend: got %q, want %q", got, "llo w")
+			}
+		})
+	}
+}
+
+func TestPanelsFrame_TerminalMouseSelect_RightClickPastes(t *testing.T) {
+	pf, pty := panelsFrameWithMouseSelect(t)
+
+	seedClipboard(t, "pasted")
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState: vtinput.RightmostButtonPressed,
+		MouseX:      5, MouseY: 5,
+	})
+	if string(pty.writes) != "pasted" {
+		t.Errorf("RMB paste sent %q, want %q", string(pty.writes), "pasted")
+	}
+}
+
+func TestPanelsFrame_TerminalMouseSelect_RightClickPasteBracketed(t *testing.T) {
+	pf, pty := panelsFrameWithMouseSelect(t)
+	pf.termView.BracketedPasteMode = true
+
+	seedClipboard(t, "pasted")
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState: vtinput.RightmostButtonPressed,
+		MouseX:      5, MouseY: 5,
+	})
+	want := "\x1b[200~pasted\x1b[201~"
+	if string(pty.writes) != want {
+		t.Errorf("bracketed paste sent %q, want %q", string(pty.writes), want)
+	}
+}

--- a/terminal_view.go
+++ b/terminal_view.go
@@ -81,6 +81,18 @@ type TerminalView struct {
 
 	OnTitleChange func(string)
 	OnBusyChange  func(bool)
+
+	// --- Mouse-driven text selection over the visible viewport ---
+	// Coordinates are absolute (screen) columns/rows, chosen so the
+	// highlight stays visually anchored while PTY output scrolls the
+	// underlying grid — matches xterm-style selection semantics.
+	selActive  bool
+	selStartX  int
+	selStartY  int
+	selEndX    int
+	selEndY    int
+	selBlock   bool
+	showOffset int // last vertical "visual gravity" offset applied in Show
 }
 
 func NewTerminalView(w, h int) *TerminalView {
@@ -861,6 +873,7 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 			offset = (tv.Height - 1) - lowestRow
 		}
 	}
+	tv.showOffset = offset
 
 	for y, line := range buf {
 		if y >= tv.Height {
@@ -878,6 +891,10 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 
 	tv.kittyDrawPlacements(scr, offset)
 
+	if tv.selActive {
+		tv.paintSelectionHighlight(scr)
+	}
+
 	if tv.IsVisible() && tv.IsFocused() {
 		cursorDrawY := tv.Y1 + tv.CursorY + offset
 		if tv.UseAltScreen {
@@ -888,6 +905,306 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 			scr.SetCursorVisible(true)
 		}
 	}
+}
+
+// selectionScreenRect returns the normalised screen-coordinate
+// rectangle currently painted as selection, clamped to the terminal's
+// visible area. Ok is false when there's no active selection.
+func (tv *TerminalView) selectionScreenRect() (x1, y1, x2, y2 int, ok bool) {
+	if !tv.selActive {
+		return 0, 0, 0, 0, false
+	}
+	x1, x2 = tv.selStartX, tv.selEndX
+	if x1 > x2 {
+		x1, x2 = x2, x1
+	}
+	y1, y2 = tv.selStartY, tv.selEndY
+	if y1 > y2 {
+		y1, y2 = y2, y1
+	}
+	if x1 < tv.X1 {
+		x1 = tv.X1
+	}
+	if y1 < tv.Y1 {
+		y1 = tv.Y1
+	}
+	if x2 > tv.X1+tv.Width-1 {
+		x2 = tv.X1 + tv.Width - 1
+	}
+	if y2 > tv.Y1+tv.Height-1 {
+		y2 = tv.Y1 + tv.Height - 1
+	}
+	if x1 > x2 || y1 > y2 {
+		return 0, 0, 0, 0, false
+	}
+	return x1, y1, x2, y2, true
+}
+
+// paintSelectionHighlight inverts fg↔bg for every cell inside the
+// selection area. Stream selections span from the start column on the
+// first row to the end column on the last row, filling middle rows
+// edge-to-edge; block selections are strict rectangles.
+func (tv *TerminalView) paintSelectionHighlight(scr *vtui.ScreenBuf) {
+	x1, y1, x2, y2, ok := tv.selectionScreenRect()
+	if !ok {
+		return
+	}
+	rowLeft := func(y int) int {
+		if tv.selBlock {
+			return x1
+		}
+		if y == y1 && !singleRow(y1, y2) {
+			return normalizedStart(tv.selStartX, tv.selStartY, tv.selEndX, tv.selEndY, true)
+		}
+		if y == y1 && singleRow(y1, y2) {
+			return x1
+		}
+		return tv.X1
+	}
+	rowRight := func(y int) int {
+		if tv.selBlock {
+			return x2
+		}
+		if y == y2 && !singleRow(y1, y2) {
+			return normalizedStart(tv.selStartX, tv.selStartY, tv.selEndX, tv.selEndY, false)
+		}
+		if y == y2 && singleRow(y1, y2) {
+			return x2
+		}
+		return tv.X1 + tv.Width - 1
+	}
+	for y := y1; y <= y2; y++ {
+		l, r := rowLeft(y), rowRight(y)
+		if l < tv.X1 {
+			l = tv.X1
+		}
+		if r > tv.X1+tv.Width-1 {
+			r = tv.X1 + tv.Width - 1
+		}
+		for x := l; x <= r; x++ {
+			ci := scr.GetCell(x, y)
+			ci.Attributes = invertAttrColors(ci.Attributes)
+			scr.Write(x, y, []vtui.CharInfo{ci})
+		}
+	}
+}
+
+func singleRow(y1, y2 int) bool { return y1 == y2 }
+
+// normalizedStart returns the column that starts / ends a stream
+// selection across multiple rows. When returnStart is true it returns
+// the left edge on the row that owns the top-most anchor; otherwise
+// it returns the right edge on the row that owns the bottom-most.
+func normalizedStart(sx, sy, ex, ey int, returnStart bool) int {
+	topX, botX := sx, ex
+	if sy > ey {
+		topX, botX = ex, sx
+	}
+	if returnStart {
+		return topX
+	}
+	return botX
+}
+
+// HasSelection reports whether the terminal currently owns a
+// user-driven text selection over its viewport.
+func (tv *TerminalView) HasSelection() bool {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	return tv.selActive
+}
+
+// StartSelection begins a new selection anchored at the given
+// screen-absolute cell. block controls stream vs. rectangular mode.
+func (tv *TerminalView) StartSelection(x, y int, block bool) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	tv.selActive = true
+	tv.selBlock = block
+	tv.selStartX, tv.selStartY = x, y
+	tv.selEndX, tv.selEndY = x, y
+}
+
+// ExtendSelection moves the loose end of an active selection.
+func (tv *TerminalView) ExtendSelection(x, y int) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	if !tv.selActive {
+		return
+	}
+	tv.selEndX, tv.selEndY = x, y
+}
+
+// ClearSelection drops the highlight without touching the clipboard.
+func (tv *TerminalView) ClearSelection() {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	tv.selActive = false
+}
+
+// SelectionIsEmpty reports whether the current selection covers a
+// single cell (i.e. a click without drag).
+func (tv *TerminalView) SelectionIsEmpty() bool {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	return !tv.selActive || (tv.selStartX == tv.selEndX && tv.selStartY == tv.selEndY)
+}
+
+// gridRowForScreenY maps a screen-absolute Y to the index into
+// tv.Lines / tv.AltLines that is currently visible at that row, or
+// -1 if the row falls outside the visible viewport.
+func (tv *TerminalView) gridRowForScreenY(y int) int {
+	off := 0
+	if !tv.UseAltScreen {
+		off = tv.showOffset
+	}
+	logical := y - tv.Y1 - off
+	if logical < 0 || logical >= tv.Height {
+		return -1
+	}
+	return logical
+}
+
+// ExtractSelection returns the plain-text content of the current
+// selection, read from the terminal's own grid. Trailing spaces on
+// stream-selected rows are trimmed; block selections keep alignment.
+// WideCharFiller cells are skipped so wide glyphs don't emit stray
+// runes.
+func (tv *TerminalView) ExtractSelection() string {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	if !tv.selActive {
+		return ""
+	}
+	x1, y1, x2, y2, ok := tv.selectionScreenRect()
+	if !ok {
+		return ""
+	}
+
+	buf := tv.Lines
+	if tv.UseAltScreen {
+		buf = tv.AltLines
+	}
+
+	var sb strings.Builder
+	for y := y1; y <= y2; y++ {
+		gy := tv.gridRowForScreenY(y)
+		if gy < 0 || gy >= len(buf) {
+			if y < y2 {
+				sb.WriteByte('\n')
+			}
+			continue
+		}
+		row := buf[gy]
+
+		var l, r int
+		if tv.selBlock {
+			l, r = x1, x2
+		} else if y1 == y2 {
+			l, r = x1, x2
+		} else if y == y1 {
+			l = normalizedStart(tv.selStartX, tv.selStartY, tv.selEndX, tv.selEndY, true)
+			r = tv.X1 + tv.Width - 1
+		} else if y == y2 {
+			l = tv.X1
+			r = normalizedStart(tv.selStartX, tv.selStartY, tv.selEndX, tv.selEndY, false)
+		} else {
+			l = tv.X1
+			r = tv.X1 + tv.Width - 1
+		}
+		if l < tv.X1 {
+			l = tv.X1
+		}
+		if r > tv.X1+tv.Width-1 {
+			r = tv.X1 + tv.Width - 1
+		}
+
+		var line []rune
+		for x := l; x <= r; x++ {
+			ci := row[x-tv.X1]
+			if ci.Char == vtui.WideCharFiller {
+				continue
+			}
+			ch := rune(ci.Char)
+			if ch == 0 {
+				ch = ' '
+			}
+			line = append(line, ch)
+		}
+		if !tv.selBlock {
+			sb.WriteString(strings.TrimRight(string(line), " "))
+		} else {
+			sb.WriteString(string(line))
+		}
+		if y < y2 {
+			sb.WriteByte('\n')
+		}
+	}
+	return sb.String()
+}
+
+// SelectWordAt sets a selection covering the whitespace-delimited
+// word under the given screen cell. If the cell is whitespace,
+// nothing changes.
+func (tv *TerminalView) SelectWordAt(x, y int) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	gy := tv.gridRowForScreenY(y)
+	if gy < 0 {
+		return
+	}
+	buf := tv.Lines
+	if tv.UseAltScreen {
+		buf = tv.AltLines
+	}
+	if gy >= len(buf) {
+		return
+	}
+	row := buf[gy]
+	col := x - tv.X1
+	if col < 0 || col >= len(row) {
+		return
+	}
+	isWord := func(ch uint64) bool {
+		if ch == 0 || ch == vtui.WideCharFiller {
+			return false
+		}
+		return ch != ' '
+	}
+	if !isWord(row[col].Char) {
+		return
+	}
+	left := col
+	for left > 0 && isWord(row[left-1].Char) {
+		left--
+	}
+	right := col
+	for right < len(row)-1 && isWord(row[right+1].Char) {
+		right++
+	}
+	tv.selActive = true
+	tv.selBlock = false
+	tv.selStartX, tv.selStartY = tv.X1+left, y
+	tv.selEndX, tv.selEndY = tv.X1+right, y
+}
+
+// SelectLineAt selects the whole visible row at the given screen Y.
+func (tv *TerminalView) SelectLineAt(y int) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	if tv.gridRowForScreenY(y) < 0 {
+		return
+	}
+	tv.selActive = true
+	tv.selBlock = false
+	tv.selStartX, tv.selStartY = tv.X1, y
+	tv.selEndX, tv.selEndY = tv.X1+tv.Width-1, y
+}
+
+// InTerminalArea reports whether a screen cell falls inside the
+// terminal's visible viewport.
+func (tv *TerminalView) InTerminalArea(x, y int) bool {
+	return x >= tv.X1 && x <= tv.X1+tv.Width-1 && y >= tv.Y1 && y <= tv.Y1+tv.Height-1
 }
 
 func (tv *TerminalView) Resize(w, h int) {


### PR DESCRIPTION
## Summary

Fixes #301. When panels are hidden and no TUI has taken the mouse via a tracking-mode escape, the terminal viewport becomes a source you can select from with the mouse, xterm-style:

| Gesture | Action |
|---|---|
| LMB-drag | stream selection over one or more rows |
| Alt+LMB-drag | rectangular / block selection across columns |
| Double-click | select whitespace-delimited word |
| Triple-click | select entire visible row (trailing spaces trimmed) |
| LMB release | auto-copy the selection to the clipboard |
| RMB | paste clipboard content into the PTY (wrapped in `\e[200~` / `\e[201~` when the app has bracketed-paste on) |

Fresh clicks always drop the previous highlight; releasing keeps the highlight visible until the next click (again, xterm convention).

Companion / independent from #305 (the Alt+Ins keyboard grabber) — either can land first. Both PRs define an `invertAttrColors` helper; this PR puts it in `attr_util.go`, #305 has it inline in `grabber.go`. Whoever lands second should drop its copy.

## Implementation notes

* **Selection state on `TerminalView`.** Owns the grid, so it owns the highlight. Stored in absolute screen coordinates so the selection stays visually anchored while PTY output scrolls the underlying rows (matches xterm).
* **Highlight physically swaps fg↔bg** via `invertAttrColors`. `CommonLvbReverse` is only honoured by the tty renderer, so relying on it makes the selection invisible in the X11/Wayland/gogpu backends — same lesson learned in #305.
* **`TerminalView.showOffset`** caches the "visual gravity" shift applied during `Show` so extraction can map absolute screen Y back to the underlying `tv.Lines` row without duplicating the offset formula.
* **`SetClipboard` runs on a goroutine.** It can hang for seconds behind far2l IPC (up to ~4 s per `WaitForFar2lReply`) or a slow `xclip` / `wl-copy` on Linux; blocking the UI on a mouse release is the difference between "instant" and "frozen".

## Cross-backend mouse-event shape

Detecting drag and release is fussy because every backend describes them slightly differently. Fresh-press is uniform (`KeyDown=true`, `ButtonState=LMB`, no `MouseMoved`) but from there:

| Backend | Motion event | Release event |
|---|---|---|
| Windows console | `KeyDown=true` | `ButtonState=0`, `KeyDown=true` |
| Wayland | `KeyDown=false`, `ButtonState=held` | `ButtonState=0`, `KeyDown=false` |
| X11 / purex11 | `KeyDown=false`, `ButtonState=0` | `ButtonState=held`, `KeyDown=false` |
| tty SGR | `KeyDown=true` (button + motion bit) | `ButtonState=held`, `KeyDown=false` |

So we key drag off the `MouseMoved` bit alone (regardless of `KeyDown` / `ButtonState`) and treat any subsequent event where the button is no longer held (`ButtonState == 0 || !KeyDown`) as release. Table-driven tests lock in every shape above.

## Tests

15 unit tests in `terminal_selection_test.go`:
* Stream extraction — single row, multi row (with tail/head/full-row middles)
* Block extraction
* Word / line selection (word skips whitespace start cells; line trims trailing spaces)
* Selection state — `HasSelection`, `SelectionIsEmpty`, `ClearSelection`
* `Show` highlight physically inverts cells inside the rect and leaves those outside alone
* `InTerminalArea` hit test (also with the terminal moved off origin)
* Full press → drag → release pipeline through `PanelsFrame.ProcessMouse`
* Table-driven release across all four host shapes
* Table-driven drag across Wayland and X11 shapes
* RMB paste (plain + bracketed)

## Follow-ups (deliberately out of scope)

* Shift-override to steal selection from TUI apps that have taken the mouse (xterm convention; far2l explicitly doesn't do this)
* Scrollback selection when `Ctrl+O` opens the terminal log viewer — separate PR should give the viewer its own mouse selection
* HTML clipboard payload with per-cell attributes (far2l does both plain and HTML in its grabber)

## Test plan

- [x] `go build ./...`
- [x] `go test -run 'TestTerminalSelection|TestPanelsFrame_TerminalMouseSelect' ./...` — 15 pass
- [x] `gofmt -w -s` on all touched files
- [x] Manual smoke test on Windows console — drag / dbl-click / triple-click / Alt-drag / release copies / RMB pastes
- [x] Manual smoke test on Linux gui (X11) — same
- [x] Manual smoke test on Linux tty (wezterm-inside-far2l on WSL) — same
- [ ] Not smoke-tested on macOS
- [ ] Not smoke-tested on Wayland (only X11)