### PR TITLE
Make editor and viewer close immediately

### DIFF
--- a/colorer_plugin.go
+++ b/colorer_plugin.go
@@ -244,7 +244,6 @@ func releaseColorerSession(session *colorer.Session, configsDir string) {
 	if session == nil {
 		return
 	}
-	session.Reset()
 	colorerPoolMu.Lock()
 	if colorerIdle == nil {
 		colorerIdle = session
@@ -253,7 +252,10 @@ func releaseColorerSession(session *colorer.Session, configsDir string) {
 		return
 	}
 	colorerPoolMu.Unlock()
-	session.Close()
+	// Destroying a WASM runtime can be noticeably slower than closing the
+	// editor frame. This session is no longer reachable, so release it away
+	// from the UI thread.
+	go session.Close()
 }
 
 // ResetColorerSessions drops the pooled session, so that the next opened file

--- a/editor_view.go
+++ b/editor_view.go
@@ -198,7 +198,7 @@ type editorState struct {
 
 func (ev *EditorView) Close() {
 	if GlobalFileState != nil && ev.filePath != "" {
-		GlobalFileState.SaveEditorState(ev.filePath, ev.CursorLine, ev.CursorPos, ev.ScrollTopRow, ev.ScrollLeft, ev.WordWrap)
+		GlobalFileState.SaveEditorStateAsync(ev.filePath, ev.CursorLine, ev.CursorPos, ev.ScrollTopRow, ev.ScrollLeft, ev.WordWrap)
 	}
 	if ev.indexCancel != nil {
 		ev.indexCancel()

--- a/file_state.go
+++ b/file_state.go
@@ -21,11 +21,13 @@ type FileState struct {
 }
 
 type F4FileStateProvider struct {
-	mu    sync.Mutex
-	path  string
-	Limit int
-	Order []string
-	Data  map[string]*FileState
+	mu      sync.Mutex
+	writeMu sync.Mutex
+	saveWG  sync.WaitGroup
+	path    string
+	Limit   int
+	Order   []string
+	Data    map[string]*FileState
 }
 
 func NewF4FileStateProvider() *F4FileStateProvider {
@@ -60,17 +62,29 @@ func (fs *F4FileStateProvider) load() {
 }
 
 func (fs *F4FileStateProvider) save() {
+	fs.writeMu.Lock()
+	defer fs.writeMu.Unlock()
+
 	fs.mu.Lock()
-	defer fs.mu.Unlock()
-	os.MkdirAll(filepath.Dir(fs.path), 0755)
 	type DiskFormat struct {
 		Order []string
 		Data  map[string]*FileState
 	}
-	df := DiskFormat{Order: fs.Order, Data: fs.Data}
+	df := DiskFormat{
+		Order: append([]string(nil), fs.Order...),
+		Data:  make(map[string]*FileState, len(fs.Data)),
+	}
+	for path, state := range fs.Data {
+		copy := *state
+		df.Data[path] = &copy
+	}
+	statePath := fs.path
+	fs.mu.Unlock()
+
+	os.MkdirAll(filepath.Dir(statePath), 0755)
 	file, err := json.MarshalIndent(df, "", "  ")
 	if err == nil {
-		os.WriteFile(fs.path, file, 0644)
+		os.WriteFile(statePath, file, 0644)
 	}
 }
 
@@ -107,6 +121,16 @@ func (fs *F4FileStateProvider) touch(path string) *FileState {
 }
 
 func (fs *F4FileStateProvider) SaveEditorState(path string, line, pos, top, left int, wrap bool) {
+	fs.updateEditorState(path, line, pos, top, left, wrap)
+	fs.save()
+}
+
+func (fs *F4FileStateProvider) SaveEditorStateAsync(path string, line, pos, top, left int, wrap bool) {
+	fs.updateEditorState(path, line, pos, top, left, wrap)
+	fs.saveAsync()
+}
+
+func (fs *F4FileStateProvider) updateEditorState(path string, line, pos, top, left int, wrap bool) {
 	fs.mu.Lock()
 	state := fs.touch(path)
 	state.EditorLine = line
@@ -115,15 +139,38 @@ func (fs *F4FileStateProvider) SaveEditorState(path string, line, pos, top, left
 	state.EditorLeft = left
 	state.EditorWrap = wrap
 	fs.mu.Unlock()
-	fs.save()
 }
 
 func (fs *F4FileStateProvider) SaveViewerState(path string, offset int64, wrap, hex bool) {
+	fs.updateViewerState(path, offset, wrap, hex)
+	fs.save()
+}
+
+func (fs *F4FileStateProvider) SaveViewerStateAsync(path string, offset int64, wrap, hex bool) {
+	fs.updateViewerState(path, offset, wrap, hex)
+	fs.saveAsync()
+}
+
+func (fs *F4FileStateProvider) updateViewerState(path string, offset int64, wrap, hex bool) {
 	fs.mu.Lock()
 	state := fs.touch(path)
 	state.ViewerOffset = offset
 	state.ViewerWrap = wrap
 	state.ViewerHex = hex
 	fs.mu.Unlock()
-	fs.save()
+}
+
+func (fs *F4FileStateProvider) saveAsync() {
+	fs.saveWG.Add(1)
+	go func() {
+		defer fs.saveWG.Done()
+		fs.save()
+	}()
+}
+
+// Flush waits for state writes queued by editor and viewer close operations.
+// Application shutdown uses it so an immediate exit cannot lose the last
+// cursor or viewer position.
+func (fs *F4FileStateProvider) Flush() {
+	fs.saveWG.Wait()
 }

--- a/file_state_test.go
+++ b/file_state_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -60,5 +61,25 @@ func TestF4FileStateProvider_SaveAndRestore(t *testing.T) {
 	}
 	if stateV.ViewerOffset != 500 || stateV.ViewerWrap != false || stateV.ViewerHex != true {
 		t.Errorf("Incorrect saved viewer state: %+v", stateV)
+	}
+}
+
+func TestF4FileStateProvider_AsyncSaveUpdatesMemoryAndDisk(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "file_states_async.json")
+	fs := &F4FileStateProvider{
+		path:  dbPath,
+		Limit: 10,
+		Data:  make(map[string]*FileState),
+	}
+
+	fs.SaveEditorStateAsync("main.go", 12, 7, 3, 1, true)
+	state := fs.GetState("main.go")
+	if state == nil || state.EditorLine != 12 || state.EditorPos != 7 {
+		t.Fatalf("async save did not update in-memory state immediately: %+v", state)
+	}
+
+	fs.Flush()
+	if _, err := os.Stat(dbPath); err != nil {
+		t.Fatalf("async state was not persisted after Flush: %v", err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 
 	defer func() {
 		SaveSession() // Гарантирует сохранение размеров и путей при любом выходе
+		if GlobalFileState != nil {
+			GlobalFileState.Flush()
+		}
 		if r := recover(); r != nil {
 			vtui.DebugLog("FATAL PANIC IN MAIN: %v", r)
 			crashPath := vtui.RecordCrash(r, nil)

--- a/viewer_view.go
+++ b/viewer_view.go
@@ -816,7 +816,7 @@ func (vv *ViewerView) ResizeConsole(w, h int) { vv.SetPosition(0, 0, w-1, h-2) }
 
 func (vv *ViewerView) Close() {
 	if GlobalFileState != nil && vv.path != "" {
-		GlobalFileState.SaveViewerState(vv.path, vv.TopOffset, vv.WrapMode, vv.HexMode)
+		GlobalFileState.SaveViewerStateAsync(vv.path, vv.TopOffset, vv.WrapMode, vv.HexMode)
 	}
 	if vv.backend != nil {
 		vv.backend.Close()


### PR DESCRIPTION
## Summary
- avoid the redundant Colorer session reset when returning a session to the pool
- destroy excess Colorer WASM sessions outside the UI thread
- update editor/viewer state in memory immediately and persist `file_states.json` asynchronously
- flush pending state writes during application shutdown
- add coverage for immediate in-memory updates and eventual persistence

The key-down frame cleanup itself is now provided by `vtui v0.1.104` through unxed/vtui#13, so this change contains no F4-specific event-loop workaround.

## Testing
- `go test . -run Test(Editor|Viewer|Hotkey|F4FileStateProvider|Colorer) -count=1`
- `go build -o f4.exe .`