### PR TITLE
Fix right Ctrl folder bookmark shortcuts

### DIFF
--- a/macro.go
+++ b/macro.go
@@ -261,6 +261,28 @@ func (m *MacroManager) GetCurrentArea() string {
 	}
 	return "Other"
 }
+
+// isPanelBookmarkHotkey identifies far2l-compatible folder bookmark keys.
+// They must reach PanelsFrame before macro and configurable hotkey handling,
+// because EventToFarString intentionally normalizes left and right Ctrl.
+func isPanelBookmarkHotkey(e *vtinput.InputEvent) bool {
+	if e.Type != vtinput.KeyEventType || !e.KeyDown {
+		return false
+	}
+
+	rctrl := (e.ControlKeyState & vtinput.RightCtrlPressed) != 0
+	lctrl := (e.ControlKeyState & vtinput.LeftCtrlPressed) != 0
+	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
+	shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
+	isGoto := (rctrl && !shift && !alt) || ((lctrl || rctrl) && alt && !shift)
+	isSave := (rctrl && shift && !alt) || ((lctrl || rctrl) && alt && shift)
+
+	if e.VirtualKeyCode >= vtinput.VK_0 && e.VirtualKeyCode <= vtinput.VK_9 {
+		return isGoto || isSave
+	}
+	return e.VirtualKeyCode == vtinput.VK_OEM_3 && isGoto
+}
+
 func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 	if e.Type != vtinput.KeyEventType {
 		return false
@@ -308,9 +330,13 @@ func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 		return false
 	}
 
+	currentArea := m.GetCurrentArea()
+	if currentArea == "Shell" && isPanelBookmarkHotkey(e) {
+		return false
+	}
+
 	// Check if this key triggers a macro
 	keyStr := EventToFarString(e)
-	currentArea := m.GetCurrentArea()
 
 	if areaMacros, ok := m.Macros[currentArea]; ok {
 		if seq, ok := areaMacros[keyStr]; ok {

--- a/macro_test.go
+++ b/macro_test.go
@@ -187,6 +187,37 @@ func TestKeyNormalization(t *testing.T) {
 	}
 }
 
+func TestPanelBookmarkHotkeysKeepRightCtrlDistinct(t *testing.T) {
+	tests := []struct {
+		name string
+		key  uint16
+		mods vtinput.ControlKeyState
+		want bool
+	}{
+		{name: "right ctrl goto", key: vtinput.VK_1, mods: vtinput.RightCtrlPressed, want: true},
+		{name: "right ctrl save", key: vtinput.VK_2, mods: vtinput.RightCtrlPressed | vtinput.ShiftPressed, want: true},
+		{name: "left ctrl view mode", key: vtinput.VK_3, mods: vtinput.LeftCtrlPressed, want: false},
+		{name: "left ctrl alt alias", key: vtinput.VK_4, mods: vtinput.LeftCtrlPressed | vtinput.LeftAltPressed, want: true},
+		{name: "right ctrl home", key: vtinput.VK_OEM_3, mods: vtinput.RightCtrlPressed, want: true},
+		{name: "right ctrl shifted home", key: vtinput.VK_OEM_3, mods: vtinput.RightCtrlPressed | vtinput.ShiftPressed, want: false},
+		{name: "unrelated right ctrl key", key: vtinput.VK_A, mods: vtinput.RightCtrlPressed, want: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &vtinput.InputEvent{
+				Type:            vtinput.KeyEventType,
+				KeyDown:         true,
+				VirtualKeyCode:  tc.key,
+				ControlKeyState: tc.mods,
+			}
+			if got := isPanelBookmarkHotkey(e); got != tc.want {
+				t.Fatalf("isPanelBookmarkHotkey() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestMacroPlaybackLogic(t *testing.T) {
 	mgr := NewMacroManager("unused.ini")
 

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1627,7 +1627,9 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		}
 	}
 
-	if ctrl && !alt && !shift && e.KeyDown {
+	lctrl := (e.ControlKeyState & vtinput.LeftCtrlPressed) != 0
+	rctrl := (e.ControlKeyState & vtinput.RightCtrlPressed) != 0
+	if lctrl && !rctrl && !alt && !shift && e.KeyDown {
 		switch e.VirtualKeyCode {
 		case '1':
 			pf.setPanelViewMode(pf.activeIdx, ViewModeBrief)

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -3568,6 +3568,18 @@ func TestPanelsFrame_CtrlViewModes(t *testing.T) {
 
 	// 1. Изначально устанавливаем режим Medium
 	fsp.SetViewMode(ViewModeMedium)
+	oldHotkeys := GlobalHotkeysMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	defer func() { GlobalHotkeysMgr = oldHotkeys }()
+	macroFilter := &MacroManager{Macros: make(map[string]map[string][]*vtinput.InputEvent)}
+	rightCtrl3 := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: '3', ControlKeyState: vtinput.RightCtrlPressed}
+	if macroFilter.Filter(rightCtrl3) {
+		t.Fatal("RightCtrl+3 was consumed by the configurable hotkey filter")
+	}
+	pf.ProcessKey(rightCtrl3)
+	if fsp.viewMode != ViewModeMedium {
+		t.Fatalf("RightCtrl+3 changed panel mode to %v", fsp.viewMode)
+	}
 
 	for _, tc := range []struct {
 		key  uint16


### PR DESCRIPTION
## Summary
- restrict panel view mode shortcuts (`Ctrl+1` through `Ctrl+4`) to Left Ctrl
- preserve Right Ctrl digit shortcuts for folder bookmark navigation and saving
- reserve folder bookmark combinations before normalized macro/hotkey processing
- add regression coverage for left/right Ctrl handling

## Testing
- `go test . -run Test(KeyNormalization|PanelBookmarkHotkeysKeepRightCtrlDistinct|PanelsFrame_CtrlViewModes)$ -count=1`
- `go build -o f4.exe .`

## Windows full-suite notes
- `go test ./...` cannot compile `plugins/archive/provider_test.go` on Windows because it uses `syscall.Mkfifo`
- unrestricted `go test .` also encounters existing Windows file-lock cleanup failures in the already-open editor/viewer tests