### PR TITLE
Improve Fast Find matching and highlighting

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1758,7 +1758,7 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	const dialogHeight = 34
+	const dialogHeight = 33
 	dlg := vtui.NewCenteredDialog(60, dialogHeight, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
@@ -1810,11 +1810,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 	chkStayFocused.SetDisabled(AppConfig.NavigationMode != NavigationSearchFirst)
 	navigation.OnChange = func(selected int) {
 		chkStayFocused.SetDisabled(PanelNavigationMode(selected) != NavigationSearchFirst)
-	}
-
-	chkFastFindArrowsCancel := vtui.NewCheckbox(0, 0, Msg("PanelSettings.FastFindArrowsCancel"), false)
-	if AppConfig.FastFindArrowsCancel {
-		chkFastFindArrowsCancel.State = 1
 	}
 
 	chkSync := vtui.NewCheckbox(0, 0, Msg("PanelSettings.SyncPanelLoad"), false)
@@ -1874,7 +1869,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(lblNavigation)
 	dlg.AddItem(navigation)
 	dlg.AddItem(chkStayFocused)
-	dlg.AddItem(chkFastFindArrowsCancel)
 	dlg.AddItem(chkSync)
 	dlg.AddItem(chkAlwaysMenu)
 	dlg.AddItem(chkCPUGPU)
@@ -1897,8 +1891,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(navigation, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkStayFocused, vtui.Margins{Left: 2}, vtui.AlignLeft)
-	vbox.Add(chkFastFindArrowsCancel, vtui.Margins{}, vtui.AlignLeft)
-
 	vbox.Add(chkSync, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkAlwaysMenu, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkCPUGPU, vtui.Margins{Top: 1}, vtui.AlignLeft)
@@ -1937,7 +1929,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
 		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)
 		AppConfig.SearchCommandStayFocused = chkStayFocused.State == 1
-		AppConfig.FastFindArrowsCancel = chkFastFindArrowsCancel.State == 1
 		AppConfig.SyncPanelLoad = chkSync.State == 1
 		AppConfig.AlwaysShowMenuBar = chkAlwaysMenu.State == 1
 		AppConfig.InfoPanelCPUGPU = chkCPUGPU.State == 1

--- a/colors.go
+++ b/colors.go
@@ -28,6 +28,7 @@ const (
 	ColPanelBox
 	ColPanelScrollbar
 	ColPanelDir
+	ColPanelFastFindNoMatch
 
 	ColCommandLinePrompt
 	ColCommandLineInactivePrompt
@@ -83,6 +84,7 @@ func SetDefaultF4Palette() {
 	vtui.Palette[ColPanelSelectedTitle] = vtui.Palette[ColPanelTitle]
 	vtui.Palette[ColPanelTotalInfo] = vtui.Palette[ColPanelText]
 	vtui.Palette[ColPanelDir] = vtui.SetRGBBoth(0, 0xFFFFFF, blue)
+	vtui.Palette[ColPanelFastFindNoMatch] = vtui.SetRGBBoth(0, 0xD75F5F, blue)
 	vtui.Palette[ColPanelSelectedInfo] = vtui.Palette[ColPanelSelectedText]
 	vtui.Palette[ColPanelScrollbar] = vtui.Palette[ColPanelBox]
 
@@ -139,6 +141,7 @@ var colorMap = map[string]int{
 	"Panel.Box":                        ColPanelBox,
 	"Panel.Scrollbar":                  ColPanelScrollbar,
 	"Panel.Dir":                        ColPanelDir,
+	"Panel.FastFindNoMatch":            ColPanelFastFindNoMatch,
 	"Dialog.Text":                      vtui.ColDialogText,
 	"Dialog.Highlight":                 vtui.ColDialogHighlightText,
 	"Dialog.Box":                       vtui.ColDialogBox,
@@ -234,7 +237,7 @@ func ExportColors(path string) error {
 			name: "Panel",
 			keys: []string{
 				"Panel.Box", "Panel.Cursor", "Panel.Cursor.Selected", "Panel.Cursor.Inactive",
-				"Panel.Cursor.Inactive.Selected", "Panel.Dir",
+				"Panel.Cursor.Inactive.Selected", "Panel.Dir", "Panel.FastFindNoMatch",
 				"Panel.Scrollbar", "Panel.Text", "Panel.Text.Highlight", "Panel.Text.Info",
 				"Panel.Text.Selected", "Panel.Title", "Panel.Title.Column", "Panel.Title.Selected",
 				"Table.Box", "Scrollbar",

--- a/config.go
+++ b/config.go
@@ -80,7 +80,6 @@ type F4Config struct {
 	CommandLineAutoComplete  bool
 	NavigationMode           PanelNavigationMode
 	SearchCommandStayFocused bool
-	FastFindArrowsCancel     bool
 	SyncPanelLoad            bool
 	EditorAutoComplete       bool
 	EditorAutoCompleteMask   string
@@ -157,7 +156,6 @@ var AppConfig = F4Config{
 	CommandLineAutoComplete:  true,
 	NavigationMode:           NavigationClassic,
 	SearchCommandStayFocused: false,
-	FastFindArrowsCancel:     false,
 	SyncPanelLoad:            false,
 	EditorAutoComplete:       true,
 	EditorAutoCompleteMask:   "*.go;*.c;*.cpp;*.h;*.hpp;*.py;*.js;*.ts;*.rs;*.java;*.sh;*.txt;*.md;*.html;*.css;*.json",
@@ -266,7 +264,6 @@ func LoadConfig() {
 		AppConfig.NavigationMode = NavigationClassic
 	}
 	AppConfig.SearchCommandStayFocused = ini.GetString("Panel", "SearchCommandStayFocused", "0") == "1"
-	AppConfig.FastFindArrowsCancel = ini.GetString("Panel", "FastFindArrowsCancel", "0") == "1"
 	AppConfig.SyncPanelLoad = ini.GetString("Panel", "SyncPanelLoad", "0") == "1"
 	fmt.Sscanf(ini.GetString("Panel", "DefaultFileOpMode", "0"), "%d", &AppConfig.DefaultFileOpMode)
 	AppConfig.ConfirmCopy = ini.GetString("System", "ConfirmCopy", "1") == "1"
@@ -381,7 +378,6 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("CommandLineAutoComplete = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.CommandLineAutoComplete]))
 	sb.WriteString(fmt.Sprintf("NavigationMode = %s\n", AppConfig.NavigationMode.String()))
 	sb.WriteString(fmt.Sprintf("SearchCommandStayFocused = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SearchCommandStayFocused]))
-	sb.WriteString(fmt.Sprintf("FastFindArrowsCancel = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.FastFindArrowsCancel]))
 	// Keep the legacy key synchronized for older f4 versions and shared configs.
 	sb.WriteString(fmt.Sprintf("VimHotkeys = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.NavigationMode == NavigationVim]))
 	sb.WriteString(fmt.Sprintf("SyncPanelLoad = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SyncPanelLoad]))

--- a/config_test.go
+++ b/config_test.go
@@ -34,7 +34,6 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.EditorColorerBackground = false
 	AppConfig.CommandLineAutoComplete = false
 	AppConfig.SeparateFileExtensions = true
-	AppConfig.FastFindArrowsCancel = true
 	AppConfig.MacroRecordFormat = 1
 
 	// 2. Save
@@ -47,7 +46,6 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.EditorCrosshair = false
 	AppConfig.EditorColorerBackground = true
 	AppConfig.SeparateFileExtensions = false
-	AppConfig.FastFindArrowsCancel = false
 	AppConfig.MacroRecordFormat = 0
 
 	// 4. Load
@@ -77,9 +75,6 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if !AppConfig.SeparateFileExtensions {
 		t.Error("LoadConfig failed to restore SeparateFileExtensions")
-	}
-	if !AppConfig.FastFindArrowsCancel {
-		t.Error("LoadConfig failed to restore FastFindArrowsCancel")
 	}
 	if AppConfig.MacroRecordFormat != 1 {
 		t.Error("LoadConfig failed to restore MacroRecordFormat")

--- a/file_panel.go
+++ b/file_panel.go
@@ -35,6 +35,11 @@ type panelEntryRow struct {
 	entry *fileEntry
 }
 
+type panelMatchSpan struct {
+	start int
+	width int
+}
+
 func (r *panelEntryRow) GetCellText(col int) string {
 	if col == 0 && len(r.fp.table.Columns) > 0 {
 		return formatPanelFileName(r.entry, r.fp.table.Columns[0].Width)
@@ -114,6 +119,110 @@ func formatPanelFileName(entry *fileEntry, width int) string {
 	left := runewidth.Truncate(entry.displayName(base), width-extensionFieldWidth-1, "")
 	padding := width - runewidth.StringWidth(left) - extensionFieldWidth
 	return left + strings.Repeat(" ", padding) + extensionText
+}
+
+func clippedPanelMatchSpan(start, width, cellWidth int) (panelMatchSpan, bool) {
+	if start < 0 {
+		width += start
+		start = 0
+	}
+	if start >= cellWidth || width <= 0 {
+		return panelMatchSpan{}, false
+	}
+	if start+width > cellWidth {
+		width = cellWidth - start
+	}
+	return panelMatchSpan{start: start, width: width}, width > 0
+}
+
+func panelFileNameMatchSpans(entry *fileEntry, width, matchStartRunes, matchedRunes int) []panelMatchSpan {
+	if matchStartRunes < 0 || matchedRunes <= 0 || width <= 0 {
+		return nil
+	}
+	nameRunes := []rune(entry.Name)
+	if matchStartRunes >= len(nameRunes) {
+		return nil
+	}
+	matchEndRunes := matchStartRunes + matchedRunes
+	if matchEndRunes > len(nameRunes) {
+		matchEndRunes = len(nameRunes)
+	}
+	prefixWidth := 0
+	if entry.Name != ".." {
+		prefixWidth = runewidth.StringWidth(entry.displayName(""))
+	}
+
+	if !AppConfig.SeparateFileExtensions || entry.IsDir || entry.Name == ".." {
+		if span, ok := clippedPanelMatchSpan(
+			prefixWidth+runewidth.StringWidth(string(nameRunes[:matchStartRunes])),
+			runewidth.StringWidth(string(nameRunes[matchStartRunes:matchEndRunes])), width,
+		); ok {
+			return []panelMatchSpan{span}
+		}
+		return nil
+	}
+
+	base, extension := splitFileExtension(entry.Name)
+	if extension == "" {
+		if span, ok := clippedPanelMatchSpan(
+			prefixWidth+runewidth.StringWidth(string(nameRunes[:matchStartRunes])),
+			runewidth.StringWidth(string(nameRunes[matchStartRunes:matchEndRunes])), width,
+		); ok {
+			return []panelMatchSpan{span}
+		}
+		return nil
+	}
+
+	baseRunes := []rune(base)
+	extensionRunes := []rune(extension)
+	extensionFieldWidth := runewidth.StringWidth(extension)
+	if extensionFieldWidth < 3 {
+		extensionFieldWidth = 3
+	}
+
+	spans := make([]panelMatchSpan, 0, 2)
+	baseMatchStart := matchStartRunes
+	if baseMatchStart < 0 {
+		baseMatchStart = 0
+	}
+	baseMatchEnd := matchEndRunes
+	if baseMatchEnd > len(baseRunes) {
+		baseMatchEnd = len(baseRunes)
+	}
+	if baseMatchStart < baseMatchEnd && extensionFieldWidth < width {
+		leftWidth := width - extensionFieldWidth - 1
+		if span, ok := clippedPanelMatchSpan(
+			prefixWidth+runewidth.StringWidth(string(baseRunes[:baseMatchStart])),
+			runewidth.StringWidth(string(baseRunes[baseMatchStart:baseMatchEnd])), leftWidth,
+		); ok {
+			spans = append(spans, span)
+		}
+	}
+
+	// The separating dot is intentionally hidden when extensions are aligned.
+	// Continue highlighting at the right-aligned extension after that dot.
+	extensionNameStart := len(baseRunes) + 1
+	extensionMatchStart := matchStartRunes - extensionNameStart
+	if extensionMatchStart < 0 {
+		extensionMatchStart = 0
+	}
+	extensionMatchEnd := matchEndRunes - extensionNameStart
+	if extensionMatchEnd > len(extensionRunes) {
+		extensionMatchEnd = len(extensionRunes)
+	}
+	if extensionMatchStart < extensionMatchEnd {
+		extensionStart := width - extensionFieldWidth
+		if extensionStart < 0 {
+			extensionStart = 0
+		}
+		if span, ok := clippedPanelMatchSpan(
+			extensionStart+runewidth.StringWidth(string(extensionRunes[:extensionMatchStart])),
+			runewidth.StringWidth(string(extensionRunes[extensionMatchStart:extensionMatchEnd])), width,
+		); ok {
+			spans = append(spans, span)
+		}
+	}
+	return spans
 }
 
 func (m *mediumRow) IsColSelected(col int) bool {
@@ -1421,6 +1530,7 @@ func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 		fp.table.SetFocus(fp.IsFocused())
 	}
 	fp.table.Show(scr)
+	fp.drawFastFindMatches(scr)
 	fp.drawCursorSeparators(scr)
 	fp.drawScrollBar(scr)
 
@@ -1547,10 +1657,96 @@ func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 			searchStr = string(runes[1:])
 		}
 
-		p.DrawString(fx1+2, fy1+1, searchStr, vtui.Palette[vtui.ColDialogText])
+		searchColor := vtui.Palette[ColPanelFastFindNoMatch]
+		if fp.fastFindHasMatches() {
+			searchColor = vtui.Palette[vtui.ColMenuHighlight]
+		}
+		searchAttr := fastFindMatchAttr(vtui.Palette[vtui.ColDialogText], searchColor)
+		p.DrawString(fx1+2, fy1+1, searchStr, searchAttr)
 
 		scr.SetCursorPos(fx1+2+runewidth.StringWidth(searchStr), fy1+1)
 		scr.SetCursorVisible(true)
+	}
+}
+
+func (fp *FileSystemPanel) fastFindMatch(name string) (startRunes, matchedRunes int, ok bool) {
+	if !fp.fastFindMode || fp.fastFindStr == "" {
+		return 0, 0, false
+	}
+	queryText := fp.fastFindStr
+	anywhere := strings.HasPrefix(queryText, "*")
+	if anywhere {
+		queryText = strings.TrimPrefix(queryText, "*")
+	}
+	if queryText == "" {
+		return 0, 0, anywhere
+	}
+	nameLower := strings.ToLower(name)
+	for _, query := range []string{
+		strings.ToLower(queryText),
+		strings.ToLower(vtui.GlobalXlator.TranscodeString(queryText)),
+	} {
+		if query == "" {
+			continue
+		}
+		byteOffset := strings.Index(nameLower, query)
+		if byteOffset >= 0 && (anywhere || byteOffset == 0) {
+			return len([]rune(nameLower[:byteOffset])), len([]rune(query)), true
+		}
+	}
+	return 0, 0, false
+}
+
+func (fp *FileSystemPanel) fastFindHasMatches() bool {
+	for _, entry := range fp.entries {
+		if _, _, ok := fp.fastFindMatch(entry.Name); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func fastFindMatchAttr(baseAttr, matchAttr uint64) uint64 {
+	if matchAttr&vtui.IsFgRGB != 0 {
+		return vtui.SetRGBFore(baseAttr, vtui.GetRGBFore(matchAttr))
+	}
+	return vtui.SetIndexFore(baseAttr, vtui.GetIndexFore(matchAttr))
+}
+
+func (fp *FileSystemPanel) drawFastFindMatches(scr *vtui.ScreenBuf) {
+	if !fp.fastFindMode || fp.fastFindStr == "" || !fp.table.IsVisible() {
+		return
+	}
+	height := fp.table.ViewHeight
+	if height <= 0 {
+		return
+	}
+	columns := fp.gridColumnCount()
+	matchAttr := vtui.Palette[vtui.ColMenuHighlight]
+
+	for rowOffset := 0; rowOffset < height; rowOffset++ {
+		row := fp.table.TopPos + rowOffset
+		y := fp.table.Y1 + fp.table.MarginTop + rowOffset
+		x := fp.table.X1
+		for column := 0; column < columns && column < len(fp.table.Columns); column++ {
+			entryIndex := row
+			if columns > 1 {
+				entryIndex += column * height
+			}
+			cellWidth := fp.table.Columns[column].Width
+			if entryIndex >= 0 && entryIndex < len(fp.entries) {
+				entry := fp.entries[entryIndex]
+				matchStart, matchedRunes, _ := fp.fastFindMatch(entry.Name)
+				for _, span := range panelFileNameMatchSpans(entry, cellWidth, matchStart, matchedRunes) {
+					for cellOffset := 0; cellOffset < span.width; cellOffset++ {
+						cell := scr.GetCell(x+span.start+cellOffset, y)
+						cell.Attributes = fastFindMatchAttr(cell.Attributes, matchAttr)
+						scr.Write(x+span.start+cellOffset, y, []vtui.CharInfo{cell})
+					}
+				}
+			}
+			x += cellWidth + 1
+		}
 	}
 }
 
@@ -1670,7 +1866,7 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 	}
 
 	if fp.fastFindMode {
-		if AppConfig.FastFindArrowsCancel && (e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN) {
+		if e.VirtualKeyCode == vtinput.VK_UP || e.VirtualKeyCode == vtinput.VK_DOWN {
 			fp.fastFindMode = false
 			fp.fastFindStr = ""
 			vtui.FrameManager.Redraw()
@@ -1687,6 +1883,20 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 		case vtinput.VK_ESCAPE:
 			fp.fastFindMode = false
 			fp.fastFindStr = ""
+			vtui.FrameManager.Redraw()
+			return true
+		}
+		if e.VirtualKeyCode == vtinput.VK_F2 && !shift && !ctrl && !alt {
+			if strings.HasPrefix(fp.fastFindStr, "*") {
+				fp.fastFindStr = strings.TrimPrefix(fp.fastFindStr, "*")
+			} else {
+				fp.fastFindStr = "*" + fp.fastFindStr
+			}
+			if fp.fastFindStr == "" {
+				fp.fastFindMode = false
+			} else {
+				fp.doFastFind(0)
+			}
 			vtui.FrameManager.Redraw()
 			return true
 		}
@@ -1982,6 +2192,7 @@ func (fp *FileSystemPanel) ProcessMouse(e *vtinput.InputEvent) bool {
 
 	if fp.fastFindMode && e.ButtonState != 0 {
 		fp.fastFindMode = false
+		fp.fastFindStr = ""
 		vtui.FrameManager.Redraw()
 	}
 
@@ -2214,17 +2425,22 @@ func (fp *FileSystemPanel) doFastFind(dir int) {
 	if fp.fastFindStr == "" {
 		return
 	}
-	searchLower := strings.ToLower(fp.fastFindStr)
-	searchXlat := strings.ToLower(vtui.GlobalXlator.TranscodeString(fp.fastFindStr))
 	startIdx := fp.GetCursorIndex()
 
 	checkMatch := func(i int) bool {
-		nameLower := strings.ToLower(fp.entries[i].Name)
-		return strings.HasPrefix(nameLower, searchLower) || strings.HasPrefix(nameLower, searchXlat)
+		_, _, ok := fp.fastFindMatch(fp.entries[i].Name)
+		return ok
 	}
 
 	if dir == 0 {
-		for i := 0; i < len(fp.entries); i++ {
+		for i := startIdx; i < len(fp.entries); i++ {
+			if checkMatch(i) {
+				fp.SetCursorIndex(i)
+				fp.Refresh()
+				return
+			}
+		}
+		for i := 0; i < startIdx; i++ {
 			if checkMatch(i) {
 				fp.SetCursorIndex(i)
 				fp.Refresh()

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -904,6 +904,124 @@ func newPanelScrollTestFixture(mode ViewMode, entryCount int) *FileSystemPanel {
 	return fp
 }
 
+func TestPanelFileNameMatchSpans_AlignedExtension(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.SeparateFileExtensions = true
+
+	entry := &fileEntry{VFSItem: vfs.VFSItem{Name: "report.json"}}
+	spans := panelFileNameMatchSpans(entry, 16, 0, len([]rune("report.jso")))
+	if len(spans) != 2 {
+		t.Fatalf("match spans = %#v, want base and extension spans", spans)
+	}
+	if spans[0] != (panelMatchSpan{start: 0, width: 6}) {
+		t.Fatalf("base span = %#v, want start 0 width 6", spans[0])
+	}
+	if spans[1] != (panelMatchSpan{start: 12, width: 3}) {
+		t.Fatalf("extension span = %#v, want start 12 width 3", spans[1])
+	}
+}
+
+func TestPanelFileNameMatchSpans_Anywhere(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.SeparateFileExtensions = true
+
+	entry := &fileEntry{VFSItem: vfs.VFSItem{Name: "report.json"}}
+	if got := panelFileNameMatchSpans(entry, 16, 2, 4); len(got) != 1 || got[0] != (panelMatchSpan{start: 2, width: 4}) {
+		t.Fatalf("middle-of-name spans = %#v, want start 2 width 4", got)
+	}
+	if got := panelFileNameMatchSpans(entry, 16, 8, 3); len(got) != 1 || got[0] != (panelMatchSpan{start: 13, width: 3}) {
+		t.Fatalf("middle-of-extension spans = %#v, want start 13 width 3", got)
+	}
+}
+
+func TestFileSystemPanel_DrawFastFindMatches(t *testing.T) {
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.SeparateFileExtensions = false
+
+	fp := NewFileSystemPanel(0, 0, 40, 12, vfs.NewOSVFS(t.TempDir()))
+	fp.viewMode = ViewModeDetailed
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "alpha.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "beta.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "alpine.txt"}},
+	}
+	fp.Resize(40, 12)
+	fp.Refresh()
+	fp.table.SetFocus(true)
+	fp.fastFindMode = true
+	fp.fastFindStr = "alp"
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(40, 12)
+	fp.table.Show(scr)
+	y := fp.table.Y1 + fp.table.MarginTop
+	beforeCursor := scr.GetCell(fp.table.X1, y).Attributes
+	beforeNonMatch := scr.GetCell(fp.table.X1, y+1).Attributes
+
+	fp.drawFastFindMatches(scr)
+	matchColor := vtui.GetRGBFore(vtui.Palette[vtui.ColMenuHighlight])
+	for _, row := range []int{0, 2} {
+		for x := 0; x < 3; x++ {
+			cell := scr.GetCell(fp.table.X1+x, y+row)
+			if got := vtui.GetRGBFore(cell.Attributes); got != matchColor {
+				t.Fatalf("row %d match cell %d foreground = %#06x, want %#06x", row, x, got, matchColor)
+			}
+		}
+	}
+	afterCursor := scr.GetCell(fp.table.X1, y).Attributes
+	if vtui.GetRGBBack(afterCursor) != vtui.GetRGBBack(beforeCursor) {
+		t.Fatalf("match highlight changed cursor background: before %#x after %#x", beforeCursor, afterCursor)
+	}
+	if got := scr.GetCell(fp.table.X1, y+1).Attributes; got != beforeNonMatch {
+		t.Fatalf("non-matching row color changed: before %#x after %#x", beforeNonMatch, got)
+	}
+}
+
+func TestFileSystemPanel_DrawFastFindMatchesInEveryGridColumn(t *testing.T) {
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.SeparateFileExtensions = false
+
+	for _, mode := range []ViewMode{ViewModeBrief, ViewModeMedium} {
+		fp := NewFileSystemPanel(0, 0, 60, 12, vfs.NewOSVFS(t.TempDir()))
+		fp.viewMode = mode
+		fp.Resize(60, 12)
+		height := fp.table.ViewHeight
+		count := height * fp.gridColumnCount()
+		fp.entries = make([]*fileEntry, count)
+		for idx := range fp.entries {
+			fp.entries[idx] = &fileEntry{VFSItem: vfs.VFSItem{Name: fmt.Sprintf("other-%d", idx)}}
+		}
+		for column := 0; column < fp.gridColumnCount(); column++ {
+			fp.entries[column*height].Name = fmt.Sprintf("match-%d", column)
+		}
+		fp.Refresh()
+		fp.fastFindMode = true
+		fp.fastFindStr = "match"
+
+		scr := vtui.NewSilentScreenBuf()
+		scr.AllocBuf(60, 12)
+		fp.table.Show(scr)
+		fp.drawFastFindMatches(scr)
+		wantForeground := vtui.GetRGBFore(vtui.Palette[vtui.ColMenuHighlight])
+		x := fp.table.X1
+		y := fp.table.Y1 + fp.table.MarginTop
+		for column, tableColumn := range fp.table.Columns {
+			if got := vtui.GetRGBFore(scr.GetCell(x, y).Attributes); got != wantForeground {
+				t.Fatalf("mode %v column %d foreground = %#06x, want %#06x", mode, column, got, wantForeground)
+			}
+			x += tableColumn.Width + 1
+		}
+	}
+}
+
 func TestFileSystemPanel_DragAutoScrollContinuesAndStops(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	for _, mode := range []ViewMode{ViewModeBrief, ViewModeMedium, ViewModeDetailed, ViewModeWide} {
@@ -1628,9 +1746,6 @@ func TestFileSystemPanel_NavigateDown_CursorReset(t *testing.T) {
 }
 func TestFileSystemPanel_FastFind(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	oldFastFindArrowsCancel := AppConfig.FastFindArrowsCancel
-	defer func() { AppConfig.FastFindArrowsCancel = oldFastFindArrowsCancel }()
-	AppConfig.FastFindArrowsCancel = false
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(t.TempDir()))
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: ".."}},
@@ -1683,72 +1798,66 @@ func TestFileSystemPanel_FastFind(t *testing.T) {
 	if fp.fastFindStr != "c" {
 		t.Errorf("Expected search string 'c' after backspace, got %q", fp.fastFindStr)
 	}
-	if fp.GetSelectedName() != "cherry" {
-		t.Errorf("Cursor should jump back to 'cherry', got %q", fp.GetSelectedName())
-	}
-
-	// 4. Down arrow (next match)
-	fp.ProcessKey(&vtinput.InputEvent{
-		Type:           vtinput.KeyEventType,
-		KeyDown:        true,
-		VirtualKeyCode: vtinput.VK_DOWN,
-	})
 	if fp.GetSelectedName() != "cat" {
-		t.Errorf("Down arrow should jump to 'cat', got %q", fp.GetSelectedName())
+		t.Errorf("Cursor should stay on the current matching 'cat', got %q", fp.GetSelectedName())
 	}
 
-	// 5. Up arrow (prev match)
-	fp.ProcessKey(&vtinput.InputEvent{
-		Type:           vtinput.KeyEventType,
-		KeyDown:        true,
-		VirtualKeyCode: vtinput.VK_UP,
-	})
-	if fp.GetSelectedName() != "cherry" {
-		t.Errorf("Up arrow should jump back to 'cherry', got %q", fp.GetSelectedName())
-	}
-
-	// 6. Ctrl+Enter finds the next match and keeps Fast Find active.
+	// 4. Ctrl+Enter finds the next match and keeps Fast Find active.
 	fp.ProcessKey(&vtinput.InputEvent{
 		Type:            vtinput.KeyEventType,
 		KeyDown:         true,
 		VirtualKeyCode:  vtinput.VK_RETURN,
 		ControlKeyState: vtinput.LeftCtrlPressed,
 	})
-	if fp.GetSelectedName() != "cat" {
-		t.Errorf("Ctrl+Enter should jump to 'cat', got %q", fp.GetSelectedName())
+	if fp.GetSelectedName() != "cherry" {
+		t.Errorf("Ctrl+Enter should wrap to 'cherry', got %q", fp.GetSelectedName())
 	}
 	if !fp.fastFindMode || fp.fastFindStr != "c" {
 		t.Fatal("Ctrl+Enter should keep Fast Find active")
 	}
 
-	// 7. Ctrl+Shift+Enter finds the previous match.
+	// 5. Ctrl+Shift+Enter finds the previous match.
 	fp.ProcessKey(&vtinput.InputEvent{
 		Type:            vtinput.KeyEventType,
 		KeyDown:         true,
 		VirtualKeyCode:  vtinput.VK_RETURN,
 		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed,
 	})
-	if fp.GetSelectedName() != "cherry" {
-		t.Errorf("Ctrl+Shift+Enter should jump back to 'cherry', got %q", fp.GetSelectedName())
+	if fp.GetSelectedName() != "cat" {
+		t.Errorf("Ctrl+Shift+Enter should wrap back to 'cat', got %q", fp.GetSelectedName())
 	}
 
-	// 8. With the option enabled, Down cancels Fast Find and performs
-	// ordinary one-row navigation instead of jumping to the next match.
-	AppConfig.FastFindArrowsCancel = true
+	// 6. Down closes Fast Find and performs ordinary one-row navigation.
+	fp.SetCursorIndex(3) // cherry
 	fp.ProcessKey(&vtinput.InputEvent{
 		Type:           vtinput.KeyEventType,
 		KeyDown:        true,
 		VirtualKeyCode: vtinput.VK_DOWN,
 	})
 	if got := fp.GetSelectedName(); got != "dog" {
-		t.Errorf("Down with FastFindArrowsCancel selected %q, want dog", got)
+		t.Errorf("Down after closing Fast Find selected %q, want dog", got)
 	}
 	if fp.fastFindMode || fp.fastFindStr != "" {
-		t.Fatal("Down with FastFindArrowsCancel should close Fast Find")
+		t.Fatal("Down should close Fast Find")
 	}
-	AppConfig.FastFindArrowsCancel = false
 
-	// 9. Escape to cancel
+	// 7. Up follows the same rule and moves to the previous ordinary item.
+	fp.SetCursorIndex(5) // cat
+	fp.fastFindMode = true
+	fp.fastFindStr = "c"
+	fp.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_UP,
+	})
+	if got := fp.GetSelectedName(); got != "dog" {
+		t.Errorf("Up after closing Fast Find selected %q, want dog", got)
+	}
+	if fp.fastFindMode || fp.fastFindStr != "" {
+		t.Fatal("Up should close Fast Find")
+	}
+
+	// 8. Escape to cancel.
 	fp.fastFindMode = true
 	fp.fastFindStr = "c"
 	fp.ProcessKey(&vtinput.InputEvent{
@@ -1774,11 +1883,14 @@ func TestFileSystemPanel_FastFind(t *testing.T) {
 }
 func TestFileSystemPanel_FastFind_Rendering(t *testing.T) {
 	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
 	scr := vtui.NewSilentScreenBuf()
 	scr.AllocBuf(80, 25)
 	vtui.FrameManager.Init(scr)
 
 	fp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(t.TempDir()))
+	fp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "test-file.txt"}}}
+	fp.Refresh()
 	fp.fastFindMode = true
 	fp.fastFindStr = "test"
 
@@ -1809,6 +1921,34 @@ func TestFileSystemPanel_FastFind_Rendering(t *testing.T) {
 	}
 	if !foundText {
 		t.Error("FastFind search string 'test' not found in ScreenBuf")
+	}
+
+	inputX, inputY := fp.X1+11, fp.Y2-1
+	matchingAttr := scr.GetCell(inputX, inputY).Attributes
+	if got, want := vtui.GetRGBFore(matchingAttr), vtui.GetRGBFore(vtui.Palette[vtui.ColMenuHighlight]); got != want {
+		t.Fatalf("matching query foreground = %#06x, want %#06x", got, want)
+	}
+	if got, want := vtui.GetRGBBack(matchingAttr), vtui.GetRGBBack(vtui.Palette[vtui.ColDialogText]); got != want {
+		t.Fatalf("matching query background = %#06x, want dialog background %#06x", got, want)
+	}
+
+	fp.fastFindStr = "*test"
+	fp.Show(scr)
+	if got := scr.GetCell(inputX, inputY).Char; got != '*' {
+		t.Fatalf("anywhere-mode marker = %q, want '*'", rune(got))
+	}
+	if got := scr.GetCell(inputX+1, inputY).Char; got != 't' {
+		t.Fatalf("query after anywhere-mode marker starts with %q, want 't'", rune(got))
+	}
+
+	fp.fastFindStr = "missing"
+	fp.Show(scr)
+	missingAttr := scr.GetCell(inputX, inputY).Attributes
+	if got, want := vtui.GetRGBFore(missingAttr), vtui.GetRGBFore(vtui.Palette[ColPanelFastFindNoMatch]); got != want {
+		t.Fatalf("missing query foreground = %#06x, want %#06x", got, want)
+	}
+	if got, want := vtui.GetRGBBack(missingAttr), vtui.GetRGBBack(vtui.Palette[vtui.ColDialogText]); got != want {
+		t.Fatalf("missing query background = %#06x, want dialog background %#06x", got, want)
 	}
 }
 
@@ -1882,6 +2022,35 @@ func TestFileSystemPanel_FastFind_XLat(t *testing.T) {
 
 	if fp.GetSelectedName() != "заметка.txt" {
 		t.Errorf("XLat FastFind (reverse) failed: expected 'заметка.txt', got %q", fp.GetSelectedName())
+	}
+}
+
+func TestFileSystemPanel_FastFindStartsAtCurrentItem(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(t.TempDir()))
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "match-before.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "other.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "match-after.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "tail.txt"}},
+	}
+	fp.Refresh()
+	fp.fastFindMode = true
+	fp.fastFindStr = "match"
+
+	fp.SetCursorIndex(1)
+	fp.doFastFind(0)
+	if got := fp.GetSelectedName(); got != "match-after.txt" {
+		t.Fatalf("search from middle selected %q, want match-after.txt", got)
+	}
+	fp.doFastFind(0)
+	if got := fp.GetSelectedName(); got != "match-after.txt" {
+		t.Fatalf("search moved away from matching current item to %q", got)
+	}
+	fp.SetCursorIndex(3)
+	fp.doFastFind(0)
+	if got := fp.GetSelectedName(); got != "match-before.txt" {
+		t.Fatalf("wrapped search selected %q, want match-before.txt", got)
 	}
 }
 

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -115,7 +115,6 @@ PanelSettings.NavigationClassic=&Classic
 PanelSettings.NavigationVim=&Vim (j, k, dd, cc, mm)
 PanelSettings.NavigationSearch=&Search by default
 PanelSettings.SearchStayFocused=Stay in the command &line after Enter
-PanelSettings.FastFindArrowsCancel=&Arrow keys cancel fast find
 PanelSettings.SyncPanelLoad=S&ynchronous panel loading (disable cache/chunking)
 PanelSettings.DefaultMode=Default operation &mode:
 PanelSettings.PathDisplay=File path in progress:

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -115,7 +115,6 @@ PanelSettings.NavigationClassic=&Классическая
 PanelSettings.NavigationVim=&Vim (j, k, dd, cc, mm)
 PanelSettings.NavigationSearch=&Поиск по умолчанию
 PanelSettings.SearchStayFocused=Оставаться в командной &строке после Enter
-PanelSettings.FastFindArrowsCancel=&Стрелки отменяют быстрый поиск
 PanelSettings.SyncPanelLoad=&Синхронная загрузка панелей (без кэша)
 PanelSettings.DefaultMode=Режим операций по &умолчанию:
 PanelSettings.PathDisplay=Отображение пути в прогрессе:

--- a/navigation_mode_test.go
+++ b/navigation_mode_test.go
@@ -211,6 +211,68 @@ func TestClassicFastFindEscapeDoesNotHidePanels(t *testing.T) {
 	}
 }
 
+func TestClassicFastFindF2TogglesAnywhereMatching(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.NavigationMode = NavigationClassic
+
+	pf, left, _ := newSearchFirstTestFrame(t)
+	left.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "inside-target.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "target-prefix.txt"}},
+	}
+	left.Refresh()
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		Char:            't',
+		VirtualKeyCode:  'T',
+		ControlKeyState: vtinput.LeftAltPressed,
+	})
+	if got := left.GetSelectedName(); got != "target-prefix.txt" {
+		t.Fatalf("prefix Fast Find selected %q, want target-prefix.txt", got)
+	}
+
+	f2 := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_F2}
+	if !pf.ProcessKey(f2) || left.fastFindStr != "*t" {
+		t.Fatal("F2 did not enable anywhere matching in Fast Find")
+	}
+	if got := left.GetSelectedName(); got != "target-prefix.txt" {
+		t.Fatalf("anywhere Fast Find moved away from current match to %q", got)
+	}
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_RETURN,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if got := left.GetSelectedName(); got != "inside-target.txt" {
+		t.Fatalf("next anywhere match selected %q, want inside-target.txt", got)
+	}
+	if !pf.ProcessKey(f2) || left.fastFindStr != "t" {
+		t.Fatal("second F2 did not restore prefix matching")
+	}
+	if got := left.GetSelectedName(); got != "target-prefix.txt" {
+		t.Fatalf("restored prefix Fast Find selected %q, want target-prefix.txt", got)
+	}
+
+	pf.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_ESCAPE})
+	left.SetCursorIndex(0)
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		Char:            '*',
+		ControlKeyState: vtinput.LeftAltPressed,
+	})
+	pf.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, Char: 't', VirtualKeyCode: 'T'})
+	if left.fastFindStr != "*t" {
+		t.Fatalf("manually entered anywhere query = %q, want *t", left.fastFindStr)
+	}
+	if got := left.GetSelectedName(); got != "inside-target.txt" {
+		t.Fatalf("manual leading star selected %q, want inside-target.txt", got)
+	}
+}
+
 func TestSearchFirstFocusToggleAcceptsGUITextOnlyGraveEvents(t *testing.T) {
 	oldCfg := AppConfig
 	defer func() { AppConfig = oldCfg }()

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1088,12 +1088,13 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		}
 	}
 
-	// Fast Find owns Esc and Ctrl+Enter before in-frame hotkeys and command-line
-	// handling. Delegate both to the panel's normal Fast Find handler.
+	// Fast Find owns Esc, F2 and Ctrl+Enter before in-frame hotkeys and
+	// command-line handling. Delegate them to the panel's normal handler.
 	if pf.showPanels && e.KeyDown {
 		if fsp := pf.getActivePanel(); fsp != nil && fsp.fastFindMode {
 			isFindEnter := e.VirtualKeyCode == vtinput.VK_RETURN && ctrl && !alt
-			if plainEscape || isFindEnter {
+			isFindModeToggle := e.VirtualKeyCode == vtinput.VK_F2 && !ctrl && !alt && !shift
+			if plainEscape || isFindEnter || isFindModeToggle {
 				return fsp.ProcessKey(e)
 			}
 		}

--- a/styles/far2l_dark.ini
+++ b/styles/far2l_dark.ini
@@ -9,6 +9,7 @@ Panel.Cursor.Selected = foreground:#FCE94F | background:#06989A
 Panel.Cursor.Inactive = foreground:#D3D7CF | background:#555753
 Panel.Cursor.Inactive.Selected = foreground:#FCE94F | background:#555753
 Panel.Dir = foreground:#EEEEEC | background:#2E3436
+Panel.FastFindNoMatch = foreground:#CC6666 | background:#2E3436
 Panel.Scrollbar = foreground:#34E2E2 | background:#2E3436
 Panel.Text = foreground:#34E2E2 | background:#2E3436
 Panel.Text.Highlight = foreground:#D3D7CF | background:#3465A4

--- a/styles/modern.ini
+++ b/styles/modern.ini
@@ -9,6 +9,7 @@ Panel.Cursor.Selected = foreground:#F1EC0E | background:#3B6290
 Panel.Cursor.Inactive = foreground:#D0D0D0 | background:#555753
 Panel.Cursor.Inactive.Selected = foreground:#F1EC0E | background:#555753
 Panel.Dir = foreground:#FFFFFF | background:#232323
+Panel.FastFindNoMatch = foreground:#C45B5B | background:#232323
 Panel.Scrollbar = foreground:#5A5A5A | background:#232323
 Panel.Text = foreground:#AAAAAA | background:#232323
 Panel.Text.Highlight = foreground:#8A8A8A | background:#232323


### PR DESCRIPTION
## Summary
- highlight every visible Fast Find match in panel file names using the same theme color as history search, while preserving cursor and selection backgrounds
- color the Fast Find query like matching text, and use a muted red color when no entries match
- support `*query` substring matching, with F2 adding or removing the leading `*`
- start matching at the current panel item, continue forward, and wrap only after reaching the end
- make Up/Down close Fast Find and perform ordinary panel navigation; keep result navigation on Ctrl+Enter and Ctrl+Shift+Enter
- remove the obsolete configurable arrow-key behavior from panel settings and configuration

## Testing
- `go test . -run Test.*(FastFind|PanelFileNameMatchSpans|Config_SaveAndLoad|HistorySearch) -count=50`
- `go build -o f4.exe .`