### PR TITLE
Make panel scrollbars optional

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1758,7 +1758,7 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	const dialogHeight = 33
+	const dialogHeight = 34
 	dlg := vtui.NewCenteredDialog(60, dialogHeight, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
@@ -1777,6 +1777,11 @@ func actionPanelSettings(pf *PanelsFrame) {
 	chkSeparateExtensions := vtui.NewCheckbox(0, 0, Msg("PanelSettings.SeparateExtensions"), false)
 	if AppConfig.SeparateFileExtensions {
 		chkSeparateExtensions.State = 1
+	}
+
+	chkShowScrollbars := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowScrollbars"), false)
+	if AppConfig.ShowPanelScrollbars {
+		chkShowScrollbars.State = 1
 	}
 
 	chkPaths := vtui.NewCheckbox(0, 0, Msg("PanelSettings.SavePaths"), false)
@@ -1864,6 +1869,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(chkHidden)
 	dlg.AddItem(chkHighlight)
 	dlg.AddItem(chkSeparateExtensions)
+	dlg.AddItem(chkShowScrollbars)
 	dlg.AddItem(chkPaths)
 	dlg.AddItem(chkCmdAc)
 	dlg.AddItem(lblNavigation)
@@ -1886,6 +1892,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkHighlight, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkSeparateExtensions, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkShowScrollbars, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkCmdAc, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
@@ -1925,6 +1932,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.ShowHiddenFiles = chkHidden.State == 1
 		AppConfig.HighlightDir = chkHighlight.State == 1
 		AppConfig.SeparateFileExtensions = chkSeparateExtensions.State == 1
+		AppConfig.ShowPanelScrollbars = chkShowScrollbars.State == 1
 		AppConfig.SavePanelPaths = chkPaths.State == 1
 		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
 		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)

--- a/config.go
+++ b/config.go
@@ -71,6 +71,7 @@ type F4Config struct {
 	ShowHiddenFiles          bool
 	HighlightDir             bool
 	SeparateFileExtensions   bool
+	ShowPanelScrollbars      bool
 	SavePanelPaths           bool
 	InfoPanelBytes           bool // Ctrl+L info panel: true = raw bytes, false = human (GiB/MiB…)
 	InfoPanelCPUGPU          bool // Ctrl+L info panel: show CPU and GPU sections (off by default)
@@ -147,6 +148,7 @@ var AppConfig = F4Config{
 	ShowHiddenFiles:          true,
 	HighlightDir:             true,
 	SeparateFileExtensions:   false,
+	ShowPanelScrollbars:      false,
 	SavePanelPaths:           true,
 	InfoPanelBytes:           false,
 	InfoPanelCPUGPU:          false,
@@ -249,6 +251,7 @@ func LoadConfig() {
 	}
 	AppConfig.HighlightDir = ini.GetString("Panel", "HighlightDir", "1") == "1"
 	AppConfig.SeparateFileExtensions = ini.GetString("Panel", "SeparateFileExtensions", "0") == "1"
+	AppConfig.ShowPanelScrollbars = ini.GetString("Panel", "ShowPanelScrollbars", "0") == "1"
 	AppConfig.SavePanelPaths = ini.GetString("Panel", "SavePanelPaths", "1") == "1"
 	AppConfig.InfoPanelBytes = ini.GetString("Panel", "InfoPanelBytes", "0") == "1"
 	AppConfig.InfoPanelCPUGPU = ini.GetString("Panel", "InfoPanelCPUGPU", "0") == "1"
@@ -370,6 +373,7 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("ShowHiddenFiles = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowHiddenFiles]))
 	sb.WriteString(fmt.Sprintf("HighlightDir = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.HighlightDir]))
 	sb.WriteString(fmt.Sprintf("SeparateFileExtensions = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SeparateFileExtensions]))
+	sb.WriteString(fmt.Sprintf("ShowPanelScrollbars = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowPanelScrollbars]))
 	sb.WriteString(fmt.Sprintf("SavePanelPaths = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SavePanelPaths]))
 	sb.WriteString(fmt.Sprintf("InfoPanelBytes = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelBytes]))
 	sb.WriteString(fmt.Sprintf("InfoPanelCPUGPU = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelCPUGPU]))

--- a/config_test.go
+++ b/config_test.go
@@ -34,6 +34,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.EditorColorerBackground = false
 	AppConfig.CommandLineAutoComplete = false
 	AppConfig.SeparateFileExtensions = true
+	AppConfig.ShowPanelScrollbars = true
 	AppConfig.MacroRecordFormat = 1
 
 	// 2. Save
@@ -46,6 +47,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.EditorCrosshair = false
 	AppConfig.EditorColorerBackground = true
 	AppConfig.SeparateFileExtensions = false
+	AppConfig.ShowPanelScrollbars = false
 	AppConfig.MacroRecordFormat = 0
 
 	// 4. Load
@@ -76,8 +78,36 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	if !AppConfig.SeparateFileExtensions {
 		t.Error("LoadConfig failed to restore SeparateFileExtensions")
 	}
+	if !AppConfig.ShowPanelScrollbars {
+		t.Error("LoadConfig failed to restore ShowPanelScrollbars")
+	}
 	if AppConfig.MacroRecordFormat != 1 {
 		t.Error("LoadConfig failed to restore MacroRecordFormat")
+	}
+}
+
+func TestConfig_PanelScrollbarsDisabledByDefault(t *testing.T) {
+	tmpDir := t.TempDir()
+	userIniPath := filepath.Join(tmpDir, "settings.ini")
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	origUserPathFunc := getUserConfigIniPath
+	origPathsFunc := getConfigIniPaths
+	oldCfg := AppConfig
+	defer func() {
+		getUserConfigIniPath = origUserPathFunc
+		getConfigIniPaths = origPathsFunc
+		AppConfig = oldCfg
+	}()
+	getUserConfigIniPath = func() string { return userIniPath }
+	getConfigIniPaths = func() []string { return []string{userIniPath} }
+
+	AppConfig.ShowPanelScrollbars = true
+	LoadConfig()
+	if AppConfig.ShowPanelScrollbars {
+		t.Fatal("panel scrollbars must be disabled when the setting is absent")
 	}
 }
 

--- a/file_panel.go
+++ b/file_panel.go
@@ -905,7 +905,7 @@ func (fp *FileSystemPanel) initScrollBar() {
 }
 
 func (fp *FileSystemPanel) syncScrollBar() bool {
-	if fp.scrollBar == nil {
+	if fp.scrollBar == nil || !AppConfig.ShowPanelScrollbars {
 		return false
 	}
 	height, _, maxTop, virtualMax, virtualValue := fp.panelScrollMetrics()
@@ -994,7 +994,7 @@ func (fp *FileSystemPanel) drawCursorSeparators(scr *vtui.ScreenBuf) {
 }
 
 func (fp *FileSystemPanel) processScrollBarMouse(e *vtinput.InputEvent) bool {
-	if fp.scrollBar == nil {
+	if fp.scrollBar == nil || !AppConfig.ShowPanelScrollbars {
 		return false
 	}
 	// Releases must reach ScrollBar so it can stop dragging and auto-repeat.

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -1093,6 +1093,10 @@ func TestFileSystemPanel_DragAutoScrollStopsOnRelease(t *testing.T) {
 }
 
 func TestFileSystemPanel_ScrollBarMetricsAllViewModes(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelScrollbars = true
+
 	for _, tc := range []struct {
 		name    string
 		mode    ViewMode
@@ -1140,6 +1144,9 @@ func TestFileSystemPanel_ScrollBarMetricsAllViewModes(t *testing.T) {
 func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelScrollbars = true
 
 	fp := newPanelScrollTestFixture(ViewModeMedium, 0)
 	capacity := fp.table.ViewHeight * fp.gridColumnCount()
@@ -1210,6 +1217,10 @@ func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 }
 
 func TestFileSystemPanel_ScrollBarHiddenWhenGridFits(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelScrollbars = true
+
 	fp := newPanelScrollTestFixture(ViewModeBrief, 0)
 	fp.entries = make([]*fileEntry, fp.table.ViewHeight*fp.gridColumnCount())
 	fp.table.TopPos = 4
@@ -1225,6 +1236,31 @@ func TestFileSystemPanel_ScrollBarHiddenWhenGridFits(t *testing.T) {
 	dataY := fp.table.Y1 + fp.table.MarginTop
 	if got := scr.GetCell(fp.X2, dataY).Char; got != 0 {
 		t.Fatalf("scrollbar drawn for fitting Brief grid: %q", rune(got))
+	}
+}
+
+func TestFileSystemPanel_ScrollBarDisabledByDefault(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelScrollbars = false
+
+	fp := newPanelScrollTestFixture(ViewModeDetailed, 50)
+	if fp.syncScrollBar() {
+		t.Fatal("disabled panel scrollbar reported itself visible")
+	}
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(40, 12)
+	fp.drawScrollBar(scr)
+	y := fp.table.Y1 + fp.table.MarginTop
+	if got := scr.GetCell(fp.X2, y).Char; got != 0 {
+		t.Fatalf("disabled panel scrollbar drew %q", rune(got))
+	}
+	if fp.processScrollBarMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		MouseX: int16(fp.X2), MouseY: int16(y),
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}) {
+		t.Fatal("disabled panel scrollbar handled mouse input")
 	}
 }
 

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -108,6 +108,7 @@ PanelSettings.Title= Panel settings
 PanelSettings.ShowHidden=Show &hidden and system files
 PanelSettings.HighlightDir=H&ighlight folders
 PanelSettings.SeparateExtensions=Align file &extensions to the right
+PanelSettings.ShowScrollbars=Show panel scroll&bars
 PanelSettings.SavePaths=Save panel &paths on exit
 PanelSettings.KeepCursor=Don't touch terminal &cursor style
 PanelSettings.Navigation=&Navigation:

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -108,6 +108,7 @@ PanelSettings.Title= Настройки панелей
 PanelSettings.ShowHidden=Показывать &скрытые и системные файлы
 PanelSettings.HighlightDir=В&ыделять папки цветом
 PanelSettings.SeparateExtensions=Выравнивать &расширения файлов по правому краю
+PanelSettings.ShowScrollbars=Показывать полосы про&крутки панелей
 PanelSettings.SavePaths=Сохранять &пути панелей при выходе
 PanelSettings.KeepCursor=Не трогать стиль &курсора терминала
 PanelSettings.Navigation=&Навигация:


### PR DESCRIPTION
## Summary
- add a localized panel setting for showing panel scrollbars
- keep panel scrollbars disabled by default and persist the choice as `ShowPanelScrollbars`
- disable both scrollbar rendering and mouse handling when the option is off
- preserve keyboard, wheel, and drag auto-scroll behavior

## Testing
- `go test . -run ^(TestConfig_(SaveAndLoad|PanelScrollbarsDisabledByDefault)|TestFileSystemPanel_.*ScrollBar.*)$ -count=50`
- `go test . -run ^(TestConfig_.*|TestFileSystemPanel_.*)$ -count=5`
- `go build -o f4.exe .`