### PR TITLE
Hotkeys: fix Ctrl+letter lookup on Wayland/X11 gui backends

### DIFF
--- a/macro.go
+++ b/macro.go
@@ -109,11 +109,12 @@ func EventToFarString(e *vtinput.InputEvent) string {
 	} else if vk >= vtinput.VK_F1 && vk <= vtinput.VK_F24 {
 		sb.WriteString(fmt.Sprintf("F%d", vk-vtinput.VK_F1+1))
 	} else if vk >= 'A' && vk <= 'Z' {
-		if !mods.Contains(vtinput.ShiftPressed) && e.Char >= 'a' && e.Char <= 'z' {
-			sb.WriteRune(e.Char)
-		} else {
-			sb.WriteRune(rune(vk))
-		}
+		// Hotkey key strings are always uppercase for A-Z ("CtrlV",
+		// "ShiftA"). Wayland/X11 gui backends deliver Ctrl+letter events
+		// with Char set to the lowercase typed letter — writing e.Char
+		// here would produce "Ctrlv" and miss every default binding
+		// (Ctrl+V paste, Ctrl+A select-all, Ctrl+O toggle-panels, …).
+		sb.WriteRune(rune(vk))
 	} else if vk >= '0' && vk <= '9' {
 		sb.WriteRune(rune(vk))
 	} else if e.Char > 32 && e.Char < 127 {

--- a/macro_ctrlletter_test.go
+++ b/macro_ctrlletter_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+)
+
+// TestEventToFarString_CtrlLetter_LowercaseChar guards against a regression
+// where the Wayland/X11 gui backends deliver Ctrl+letter events with Char
+// set to the lowercase typed letter. EventToFarString must ignore that and
+// produce the canonical uppercase form used by every default binding —
+// otherwise Ctrl+V paste, Ctrl+A select-all, Ctrl+O toggle-panels, and
+// every other Ctrl+letter shortcut silently fail on gui-linux.
+func TestEventToFarString_CtrlLetter_LowercaseChar(t *testing.T) {
+	cases := []struct {
+		name string
+		vk   uint16
+		char rune
+		mods vtinput.ControlKeyState
+		want string
+	}{
+		{"Ctrl+V (Wayland, lowercase Char)", vtinput.VK_V, 'v', vtinput.LeftCtrlPressed, "CtrlV"},
+		{"Ctrl+A (Wayland, lowercase Char)", vtinput.VK_A, 'a', vtinput.LeftCtrlPressed, "CtrlA"},
+		{"Ctrl+O (Wayland, lowercase Char)", vtinput.VK_O, 'o', vtinput.LeftCtrlPressed, "CtrlO"},
+		{"Alt+F (Wayland, lowercase Char)", vtinput.VK_F, 'f', vtinput.LeftAltPressed, "AltF"},
+		{"Ctrl+Shift+Z (uppercase Char)", vtinput.VK_Z, 'Z', vtinput.LeftCtrlPressed | vtinput.ShiftPressed, "CtrlShiftZ"},
+		{"Ctrl+V (tty, no Char)", vtinput.VK_V, 0, vtinput.LeftCtrlPressed, "CtrlV"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := &vtinput.InputEvent{
+				Type:            vtinput.KeyEventType,
+				KeyDown:         true,
+				VirtualKeyCode:  tc.vk,
+				Char:            tc.char,
+				ControlKeyState: tc.mods,
+			}
+			if got := EventToFarString(e); got != tc.want {
+				t.Errorf("EventToFarString = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`EventToFarString` echoed the input event's `Char` field verbatim for A-Z when Shift wasn't held. The Wayland and X11 gui backends deliver `Ctrl+letter` events with `Char` set to the **lowercase** typed letter (e.g. `Ctrl+V` arrives as `VK=VK_V, Char='v'`), so the produced hotkey key came out as `"Ctrlv"` — while every default binding is registered under the canonical uppercase form (`"CtrlV"`, `"CtrlA"`, `"CtrlO"`, …).

Net effect on gui-linux: every `Ctrl+letter` shortcut silently missed the hotkey manager. Ctrl+V paste in the editor did nothing (looks like a hang), Ctrl+A select-all didn't fire, Ctrl+O toggle-panels was dead, Ctrl+H toggle-hidden from #329 didn't work, and so on. The tty and Windows paths were fine because their events don't set `Char` for Ctrl-combos.

Fix: for A-Z always emit `rune(VK)` — the `Char` field is irrelevant to the hotkey lookup path.

Sample debug log entry that made the bug visible (from a Wayland/WSL session):

```
FM_DISPATCH: Received event: Key{VK:VK_V Scan:0x0 Char:'v' DOWN Mods:Ctrl Src:}
FM_DISPATCH: TopFrame.ProcessKey handled=false
```

No `HOTKEY: Executing action Editor.Paste …` line — because the produced key `"Ctrlv"` never matched the registered `"CtrlV"` binding.

## Test plan

- [x] New table-driven test `TestEventToFarString_CtrlLetter_LowercaseChar` covers:
  - Ctrl+V / Ctrl+A / Ctrl+O with `Char` set to lowercase (the Wayland shape) — now produce `"CtrlV"`, `"CtrlA"`, `"CtrlO"`
  - Alt+F with lowercase `Char` — produces `"AltF"`
  - Ctrl+Shift+Z with uppercase `Char` (already worked) — still produces `"CtrlShiftZ"`
  - Ctrl+V with `Char=0` (the tty shape) — still produces `"CtrlV"`
- [x] Existing `TestMacro*` / `TestHotkey*` / `TestAction*` unaffected.
- [x] `gofmt -w -s .` clean.
- [x] `go build ./...` clean.
