### PR TITLE
Panels: Ctrl+Ins and Ctrl+F on ".." use the current folder (fixes #289 note 4)

### DIFF
--- a/action_copyname_parent_test.go
+++ b/action_copyname_parent_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+func waitForCopyNameClipboard(t *testing.T, want string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := vtui.GetClipboard(); got == want {
+			return got
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return vtui.GetClipboard()
+}
+
+// seedPanelForCopyName wires up a PanelsFrame whose active panel points at
+// `path` and shows a `..` entry plus a couple of files, pushing it onto
+// FrameManager so withPF handlers find it.
+func seedPanelForCopyName(t *testing.T, path string) *PanelsFrame {
+	t.Helper()
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := setupMockPanelsFrame()
+	t.Cleanup(func() { pf.Close() })
+	pf.ResizeConsole(80, 25)
+
+	fsp := pf.getActivePanel()
+	fsp.vfs = vfs.NewOSVFS(path)
+	fsp.vfs.SetPath(path)
+
+	fsp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "a.txt"}},
+	}
+	fsp.Refresh()
+
+	vtui.FrameManager.Push(pf)
+	return pf
+}
+
+func TestAction_PanelCopyName_CursorOnFile(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pf := seedPanelForCopyName(t, tmp)
+	fsp := pf.getActivePanel()
+	fsp.SetCursorIndex(1) // "a.txt"
+	vtui.SetClipboard("")
+
+	if !RunAction("Panel.CopyName") {
+		t.Fatal("Panel.CopyName did not run")
+	}
+	if got := waitForCopyNameClipboard(t, "a.txt"); got != "a.txt" {
+		t.Errorf("clipboard = %q, want %q", got, "a.txt")
+	}
+}
+
+func TestAction_PanelCopyPath_CursorOnFile(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pf := seedPanelForCopyName(t, tmp)
+	fsp := pf.getActivePanel()
+	fsp.SetCursorIndex(1) // "a.txt"
+	vtui.SetClipboard("")
+
+	if !RunAction("Panel.CopyPath") {
+		t.Fatal("Panel.CopyPath did not run")
+	}
+	want := filepath.Join(tmp, "a.txt")
+	if got := waitForCopyNameClipboard(t, want); got != want {
+		t.Errorf("clipboard = %q, want %q", got, want)
+	}
+}
+
+func TestAction_PanelCopyPath_CursorOnParentUsesCurrentFolderPath(t *testing.T) {
+	tmp := t.TempDir()
+	inner := filepath.Join(tmp, "some-folder")
+	if err := os.Mkdir(inner, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pf := seedPanelForCopyName(t, inner)
+	fsp := pf.getActivePanel()
+	fsp.SetCursorIndex(0) // ".."
+	vtui.SetClipboard("")
+
+	if !RunAction("Panel.CopyPath") {
+		t.Fatal("Panel.CopyPath did not run")
+	}
+	if got := waitForCopyNameClipboard(t, inner); got != inner {
+		t.Errorf("cursor-on-.. clipboard = %q, want %q", got, inner)
+	}
+}
+
+func TestAction_PanelCopyName_CursorOnParentUsesCurrentFolderName(t *testing.T) {
+	// t.TempDir() returns a stable, existing dir; take its basename to know
+	// what the far2l "cursor on .. = current folder name" rule should yield.
+	tmp := t.TempDir()
+	inner := filepath.Join(tmp, "some-folder")
+	if err := os.Mkdir(inner, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pf := seedPanelForCopyName(t, inner)
+	fsp := pf.getActivePanel()
+	fsp.SetCursorIndex(0) // ".."
+	vtui.SetClipboard("")
+
+	if !RunAction("Panel.CopyName") {
+		t.Fatal("Panel.CopyName did not run")
+	}
+	want := "some-folder"
+	if got := waitForCopyNameClipboard(t, want); got != want {
+		t.Errorf("cursor-on-.. clipboard = %q, want %q", got, want)
+	}
+}

--- a/action_registry.go
+++ b/action_registry.go
@@ -585,10 +585,16 @@ func init() {
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
 				idx := fsp.GetCursorIndex()
-				if idx >= 0 && idx < len(fsp.entries) {
-					if entry := fsp.entries[idx]; entry.Name != ".." {
-						vtui.SetClipboard(fsp.vfs.Join(fsp.vfs.GetPath(), entry.Name))
-					}
+				if idx < 0 || idx >= len(fsp.entries) {
+					return
+				}
+				base := fsp.vfs.GetPath()
+				if entry := fsp.entries[idx]; entry.Name == ".." {
+					// far2l: cursor on ".." acts as the current folder itself
+					// (matches CreateFullPathName(".", …) in far2l's KEY_CTRLF branch).
+					vtui.SetClipboard(base)
+				} else {
+					vtui.SetClipboard(fsp.vfs.Join(base, entry.Name))
 				}
 			}
 		}),
@@ -605,11 +611,18 @@ func init() {
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
 				idx := fsp.GetCursorIndex()
-				if idx >= 0 && idx < len(fsp.entries) {
-					if entry := fsp.entries[idx]; entry.Name != ".." {
-						vtui.SetClipboard(entry.Name)
-					}
+				if idx < 0 || idx >= len(fsp.entries) {
+					return
 				}
+				name := fsp.entries[idx].Name
+				if name == ".." {
+					// far2l docs: with the cursor on ".." this hotkey
+					// treats it as the name of the current folder.
+					// Mirrors far2l's PointToName(GetCurDir()) branch
+					// in FileList::CopyNames() (FullPathName=false).
+					name = fsp.vfs.Base(fsp.vfs.GetPath())
+				}
+				vtui.SetClipboard(name)
 			}
 		}),
 	})


### PR DESCRIPTION
## Summary

`Panel.CopyName` (Ctrl+Ins) and `Panel.CopyPath` (Ctrl+F) previously silently skipped the `..` entry — cursor sitting on it produced no clipboard write.

### Panel.CopyName (Ctrl+Ins) — direct far2l docs note 4

Per the far2l docs note that

> Ctrl+Ins, Alt+Shift+Ins and Ctrl+Alt+Ins treat the `..` name as the name of the current folder

Panel.CopyName now emits the **last path component** of the panel's current directory, mirroring far2l's `PointToName(GetCurDir())` branch in `FileList::CopyNames()` with `FullPathName=false`:

```cpp
if (TestParentFolderName(strQuotedName)) {
    ...
    GetCurDir(strQuotedName);
    strQuotedName = PointToName(strQuotedName);
}
```

`fsp.vfs.Base(fsp.vfs.GetPath())` is the equivalent of `PointToName(GetCurDir())` in f4/vtui terms.

### Panel.CopyPath (Ctrl+F) — parallel treatment

Panel.CopyPath is not in the docs note but shares the exact same shape (single cursor entry, no fallback to marked list, copied to clipboard) — so leaving its `..` case as a no-op would create a jarring inconsistency between the two "single-entry copy" shortcuts.

It gets the parallel treatment: cursor on `..` emits the **full path** of the current folder itself, mirroring far2l's `KEY_CTRLF` branch which builds `CreateFullPathName(".", …)` after truncating `".."` to `"."`.

### Companion PR

The other two hotkeys listed in the same far2l note — Alt+Shift+Ins and Ctrl+Alt+Ins — already carry the same behaviour on PR #330 (`sogonov/feature/hotkeys-marked-to-clipboard`); this PR closes the two single-entry shortcuts that were quietly no-op'ing on `..`.

## Test plan

- [x] `TestAction_PanelCopyName_CursorOnFile` — regression guard: cursor on a regular file still copies its plain name.
- [x] `TestAction_PanelCopyName_CursorOnParentUsesCurrentFolderName` — cursor on `..` in a sub-folder yields the sub-folder's basename.
- [x] `TestAction_PanelCopyPath_CursorOnFile` — regression guard: cursor on a file still yields `filepath.Join(panelPath, name)`.
- [x] `TestAction_PanelCopyPath_CursorOnParentUsesCurrentFolderPath` — cursor on `..` in a sub-folder yields the sub-folder's full path.
- [x] `gofmt -w -s .` clean.
- [x] `go build ./...` clean.
