### PR TITLE
Hotkeys: dispatch keybar mouse clicks through the action registry

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -1477,6 +1477,14 @@ func (ev *EditorView) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// Injected-event fallback: KeyBar mouse clicks reach ProcessKey via
+	// InjectEvents, which skips FrameManager.EventFilter and therefore the
+	// hotkey manager. Route them through the same lookup so clicking F2/F7/
+	// F10/… on the bottom bar triggers the configured Editor action.
+	if MacroMgr.LookupHotkey(e) {
+		return true
+	}
+
 	return false
 }
 

--- a/keybar_injected_test.go
+++ b/keybar_injected_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// TestKeyBarClick_DispatchesHotkeyAction guards the regression introduced by
+// the KeyBind refactor (commit 5b91218): mouse clicks on the F-key bar reach
+// PanelsFrame via FrameManager.InjectEvents, which sets is_injected=true and
+// therefore skips FrameManager.EventFilter — the MacroMgr.Filter path where
+// configured hotkey actions (F3=View, F4=Edit, F5=Copy, …) are dispatched.
+// Before the fix, the injected VK_F5 fell through PanelsFrame.ProcessKey
+// unhandled, so clicking F5 in the bottom bar did nothing.
+func TestKeyBarClick_DispatchesHotkeyAction(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	if GlobalHotkeysMgr == nil {
+		GlobalHotkeysMgr = NewHotkeyManager("")
+	}
+	if MacroMgr == nil {
+		MacroMgr = NewMacroManager("")
+	}
+
+	// Register a probe action bound to F5 in the Shell area, overriding
+	// whatever the registry ships with. This isolates the test from the
+	// actual File.Copy handler (which would try to open dialogs).
+	called := false
+	RegisterAction(Action{
+		Name: "Test.KeyBarF5Probe",
+		Area: "Shell",
+		Handler: func() bool {
+			called = true
+			return true
+		},
+	})
+	prev := GlobalHotkeysMgr.GetAction("Shell", "F5")
+	GlobalHotkeysMgr.Bind("Shell", "F5", "Test.KeyBarF5Probe")
+	defer func() {
+		if prev == "" {
+			GlobalHotkeysMgr.Unbind("Shell", "F5")
+		} else {
+			GlobalHotkeysMgr.Bind("Shell", "F5", prev)
+		}
+	}()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+
+	// Simulate what vtui's KeyBar.ProcessMouse synthesizes on an F5 click:
+	// a KeyEvent that reaches ProcessKey directly (via InjectEvents),
+	// bypassing MacroMgr.Filter.
+	ev := &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F5,
+	}
+	if !pf.ProcessKey(ev) {
+		t.Fatal("PanelsFrame.ProcessKey returned false for injected F5; the KeyBar click would silently disappear")
+	}
+	if !called {
+		t.Fatal("Injected F5 did not invoke the bound Shell action; KeyBar mouse click still broken")
+	}
+}

--- a/macro.go
+++ b/macro.go
@@ -424,6 +424,36 @@ func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 	return false
 }
 
+// LookupHotkey runs the configured action for e in the current area without
+// touching macro-recording or macro-playback state. Frames use it as a
+// fallback for synthesized key events that bypass FrameManager.EventFilter —
+// notably mouse clicks on the F-key bar, which InjectEvents into the queue
+// with is_injected=true and therefore never reach Filter above. Returns true
+// when the key is bound (including to "None", which is a deliberate silence).
+func (m *MacroManager) LookupHotkey(e *vtinput.InputEvent) bool {
+	if m == nil || e == nil || e.Type != vtinput.KeyEventType || !e.KeyDown {
+		return false
+	}
+	hm := GlobalHotkeysMgr
+	if hm == nil {
+		return false
+	}
+	keyStr := EventToFarString(e)
+	if keyStr == "" {
+		return false
+	}
+	area := m.GetCurrentArea()
+	actionName := hm.GetAction(area, keyStr)
+	if actionName == "" {
+		return false
+	}
+	if strings.EqualFold(actionName, "none") {
+		return true
+	}
+	vtui.DebugLog("HOTKEY: Injected %s → action %s in area %s", keyStr, actionName, area)
+	return RunAction(actionName)
+}
+
 func (m *MacroManager) showAssignDialog() {
 	m.Assigning = true
 	frame := NewMacroAssignFrame(m)

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1667,7 +1667,18 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		}
 	}
 
-	// 4. Fallback: pass to CommandLine (handles text, Backspace, Delete, etc.)
+	// 4. Injected-event fallback: synthesized key events (a KeyBar mouse
+	// click, InjectEvents from a widget) bypass FrameManager.EventFilter
+	// and therefore skip the hotkey manager the F-key actions moved into
+	// after the KeyBind refactor. Route them through the same lookup so
+	// clicking F3/F4/F5/… on the bottom bar still triggers View/Edit/Copy.
+	// Real key events reach ProcessKey only when Filter already declined
+	// them, so re-checking here is a no-op for those.
+	if MacroMgr.LookupHotkey(e) {
+		return true
+	}
+
+	// 5. Fallback: pass to CommandLine (handles text, Backspace, Delete, etc.)
 	if (!pf.searchFirstMode() || pf.commandLineFocused || !pf.showPanels) && pf.cmdLine.ProcessKey(e) {
 		pf.cmdLine.SetFocus(true)
 		return true

--- a/viewer_view.go
+++ b/viewer_view.go
@@ -554,6 +554,14 @@ func (vv *ViewerView) ProcessKey(e *vtinput.InputEvent) bool {
 		return true
 	}
 
+	// Injected-event fallback: KeyBar mouse clicks reach ProcessKey via
+	// InjectEvents, which skips FrameManager.EventFilter and therefore the
+	// hotkey manager. Route them through the same lookup so clicking F2/F5/
+	// F7/… on the bottom bar triggers the configured Viewer action.
+	if MacroMgr.LookupHotkey(e) {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
### Bug

After the KeyBind refactor merged in `5b91218`, clicking F1–F12 in the bottom key bar mostly stopped working. F3, F4, F5, F6, F7, F8, F10, F11 (and normal-mode F2) silently did nothing. Only F9 and fast-find F2 kept firing.

### Root cause

The refactor moved those F-keys from a `switch` inside `PanelsFrame.ProcessKey` into action-registry entries dispatched by `MacroMgr.Filter`, which is wired as `FrameManager.EventFilter`.

`vtui.KeyBar.ProcessMouse` synthesises a `KeyEventType` and posts it via `FrameManager.InjectEvents`. Inside `frameManager.dispatchEvent`, injected events skip `EventFilter`:

```go
if !is_injected && fm.EventFilter != nil && fm.EventFilter(ev) { ... }
```

That bypass exists so macro playback (which also uses `InjectEvents`) cannot re-trigger itself. But it also means the synthesised F-key never reaches the hotkey manager — it lands in `PanelsFrame.ProcessKey` unhandled and disappears.

F9 kept working only because it is still hardcoded in `ProcessKey`; fast-find F2 for the same reason.

### Fix

- `macro.go`: new `MacroManager.LookupHotkey(e)` — the hotkey-manager lookup plus `RunAction`, without touching macro-recording/playback state. Safe to call for any event.
- `panels_frame.go`, `editor_view.go`, `viewer_view.go`: each `ProcessKey` calls `MacroMgr.LookupHotkey(e)` as a last-resort fallback (right before `return false`). Real events already went through `Filter`, so the extra lookup is a no-op for them; injected events finally take the same dispatch path a real F-key press would.
- Cannot fix at the source (KeyBar / dispatchEvent) — `vtui` is a versioned external module.

### Regression test

`keybar_injected_test.go` binds F5 in the `Shell` area to a probe action, then calls `PanelsFrame.ProcessKey` with the exact synthesised event `KeyBar.ProcessMouse` injects (`KeyEventType`, `KeyDown`, `VirtualKeyCode: VK_F5`). It fails on `main` without the fix and passes with it.

### Manual check

Run `f4`, click F3 / F4 / F5 / F6 / F7 / F8 / F10 in the bottom bar — each should trigger View / Edit / Copy / Move / MkDir / Delete / Quit as it did before the refactor. F9 and fast-find F2 should keep working as before.