### PR TITLE
fix: resolve commands via App Paths registry when PATH lookup fails

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1500,6 +1500,10 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 				}
 
 				if isWindowsShell {
+					cmd = resolveWindowsCommand(cmd)
+				}
+
+				if isWindowsShell {
 					// Use a combined command for reliable excision in AnsiParser: cd /d "path" & command
 					if path != "" {
 						fullWireCmd = fmt.Sprintf("cd /d \"%s\" & %s\r", path, cmd)

--- a/resolve_command_other.go
+++ b/resolve_command_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// resolveWindowsCommand is a no-op on non-Windows platforms.
+func resolveWindowsCommand(cmd string) string {
+	return cmd
+}

--- a/resolve_command_windows.go
+++ b/resolve_command_windows.go
@@ -1,0 +1,130 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+const appPathsKeyPath = `Software\Microsoft\Windows\CurrentVersion\App Paths`
+
+// resolveWindowsCommand rewrites the first token of cmd to the full path
+// registered in the "App Paths" registry key, but only when the program is
+// NOT resolvable by the regular search (current dir / PATH / PATHEXT) that
+// cmd.exe itself uses. Commands found normally are passed through untouched,
+// so the registry is queried only as a fallback.
+func resolveWindowsCommand(cmd string) string {
+	start, end, name, ok := findCmdToken(cmd)
+	if !ok || name == "" {
+		return cmd
+	}
+
+	// Already a path (relative or absolute): cmd.exe handles it itself.
+	if strings.ContainsAny(name, `\/`) {
+		return cmd
+	}
+
+	// Resolve exactly as cmd.exe would (PATH + PATHEXT). If found, cmd will
+	// run it without any help from us.
+	if _, err := exec.LookPath(name); err == nil {
+		return cmd
+	}
+
+	// Fallback: cmd.exe ignores App Paths, so try it ourselves. Wrap in
+	// double quotes verbatim (no escaping) so the path reaches cmd unchanged.
+	if full := appPathLookup(name); full != "" {
+		return cmd[:start] + `"` + full + `"` + cmd[end:]
+	}
+	return cmd
+}
+
+// findCmdToken returns the byte range of the first command-line token and its
+// unquoted value. A leading double or single quote is honoured.
+func findCmdToken(cmd string) (start, end int, name string, ok bool) {
+	start = -1
+	for i := 0; i < len(cmd); i++ {
+		if cmd[i] == ' ' || cmd[i] == '\t' {
+			continue
+		}
+		start = i
+		break
+	}
+	if start < 0 {
+		return -1, -1, "", false
+	}
+
+	if cmd[start] == '"' || cmd[start] == '\'' {
+		quote := cmd[start]
+		close := -1
+		for i := start + 1; i < len(cmd); i++ {
+			if cmd[i] == quote {
+				close = i
+				break
+			}
+		}
+		if close < 0 {
+			close = len(cmd) - 1
+		}
+		return start, close + 1, cmd[start+1 : close], true
+	}
+
+	end = start
+	for end < len(cmd) && cmd[end] != ' ' && cmd[end] != '\t' {
+		end++
+	}
+	return start, end, cmd[start:end], true
+}
+
+// appPathLookup searches the App Paths registry (HKCU first, then HKLM) for
+// name, trying each PATHEXT variant. It returns the (default) value of the
+// matching subkey, i.e. the full path to the executable.
+func appPathLookup(name string) string {
+	roots := []registry.Key{registry.CURRENT_USER, registry.LOCAL_MACHINE}
+
+	exts := appPathExts()
+	variants := []string{name}
+	for _, ext := range exts {
+		if !strings.HasSuffix(strings.ToLower(name), strings.ToLower(ext)) {
+			variants = append(variants, name+ext)
+		}
+	}
+
+	for _, variant := range variants {
+		subKey := filepath.Join(appPathsKeyPath, variant)
+		for _, root := range roots {
+			k, err := registry.OpenKey(root, subKey, registry.QUERY_VALUE)
+			if err != nil {
+				continue
+			}
+			value, _, err := k.GetStringValue("")
+			k.Close()
+			if err == nil && value != "" {
+				return value
+			}
+		}
+	}
+	return ""
+}
+
+func appPathExts() []string {
+	var out []string
+	for _, ext := range strings.Split(os.Getenv("PATHEXT"), ";") {
+		ext = strings.TrimSpace(ext)
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		out = append(out, ext)
+	}
+	if len(out) == 0 {
+		out = []string{".COM", ".EXE", ".BAT", ".CMD"}
+	}
+	return out
+}


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h2 style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 10px; padding: 0px; font-size: 15px; font-weight: 600; color: rgb(22, 22, 22); line-height: 22.5px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Summary</h2><p style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 12px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(92, 92, 92); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 440; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Fixes launching of programs registered only via the Windows<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">App Paths</code><span> </span>registry key (e.g.<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">n</code><span> </span>→<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">notepad.exe</code>) from the F4 command line.</p><h2 style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 10px; padding: 0px; font-size: 15px; font-weight: 600; color: rgb(22, 22, 22); line-height: 22.5px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Problem</h2><p style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 12px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(92, 92, 92); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 440; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">F4 runs typed commands by writing them into the embedded<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">cmd.exe</code><span> </span>PTY (<code data-inline-code-kind="path" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(38, 63, 169); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.420176 0.172062 267.776 / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">panels_frame.go</code>).<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">cmd.exe</code><span> </span>searches only current dir +<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">PATH</code><span> </span>+<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">PATHEXT</code><span> </span>and<span> </span><strong style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; color: rgb(22, 22, 22); -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">does not</strong><span> </span>consult<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">HKCU/HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths</code>. Far3 runs commands via<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">CreateProcess</code>/<code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">ShellExecuteEx</code>, which do honor<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">App Paths</code><span> </span>— hence the difference.</p><h2 style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 10px; padding: 0px; font-size: 15px; font-weight: 600; color: rgb(22, 22, 22); line-height: 22.5px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Changes</h2><ul style="box-sizing: border-box; border: 0px solid; margin: 8px 0px 12px; padding: 0px; list-style: outside disc; margin-inline-start: 0px; padding-inline-start: 32px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(92, 92, 92); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 440; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 8px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><strong style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; color: rgb(22, 22, 22); -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><code data-inline-code-kind="path" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(38, 63, 169); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.420176 0.172062 267.776 / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">resolve_command_windows.go</code></strong><span> </span>(new):<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">resolveWindowsCommand</code><span> </span>— extracts the first token, checks it has no path part, resolves it with<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">exec.LookPath</code><span> </span>(exactly the same search<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">cmd.exe</code><span> </span>uses). Only when that fails, looks up<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">App Paths</code><span> </span>(<code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">HKCU</code><span> </span>→<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">HKLM</code>, trying every<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">PATHEXT</code><span> </span>variant) and replaces the token with the quoted full path.</li><li style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 8px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><strong style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; color: rgb(22, 22, 22); -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><code data-inline-code-kind="path" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(38, 63, 169); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.420176 0.172062 267.776 / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">resolve_command_other.go</code></strong><span> </span>(new): no-op for non-Windows builds.</li><li style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 8px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><strong style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; color: rgb(22, 22, 22); -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><code data-inline-code-kind="path" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(38, 63, 169); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.420176 0.172062 267.776 / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">panels_frame.go</code></strong>: call<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">resolveWindowsCommand</code><span> </span>before building the wire command for the Windows shell.</li></ul><h2 style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 10px; padding: 0px; font-size: 15px; font-weight: 600; color: rgb(22, 22, 22); line-height: 22.5px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Behavior</h2>
Command | Result
-- | --
n (App Paths) | rewritten to "C:\windows\notepad.exe"
notepad, dir, copy ..., C:\tools\x.exe | unchanged — registry never touched

<p style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 12px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(92, 92, 92); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 440; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">The registry is queried only as a<span> </span><strong style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 0px; font-weight: 500; color: rgb(22, 22, 22); -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">fallback</strong><span> </span>when the normal PATH search already failed, so there is no added latency for regular commands.</p><h2 style="box-sizing: border-box; border: 0px solid; margin: 24px 0px 10px; padding: 0px; font-size: 15px; font-weight: 600; color: rgb(22, 22, 22); line-height: 22.5px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Testing</h2><ul style="box-sizing: border-box; border: 0px solid; margin: 8px 0px 12px; padding: 0px; list-style: outside disc; margin-inline-start: 0px; padding-inline-start: 32px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision; color: rgb(92, 92, 92); font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, sans-serif; font-size: 14px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 440; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(255, 255, 255); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><li style="box-sizing: border-box; border: 0px solid; margin: 0px 0px 8px; padding: 0px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;"><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">go build</code><span> </span>and<span> </span><code style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(22, 22, 22); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.200192 0.00000992829 none / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">go vet</code><span> </span>pass on<span> </span><code data-inline-code-kind="path" style="box-sizing: border-box; border: 0px solid; margin: 0px; padding: 2px 4px; font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, &quot;Liberation Mono&quot;, &quot;Courier New&quot;, monospace; font-feature-settings: normal; font-variation-settings: normal; font-size: 1em; color: rgb(38, 63, 169); font-weight: 500; background: none 0% 0% / auto repeat scroll padding-box border-box oklch(0.420176 0.172062 267.776 / 0.08); direction: ltr; unicode-bidi: isolate; border-radius: 4px; -webkit-font-smoothing: antialiased; text-rendering: geometricprecision;">windows/amd64</code>; no new vet warnings.</li></ul><!--EndFragment-->
</body>
</html>