### PR TITLE
User menu: multi-line command field via MultiLineEdit (fixes #342)

### DIFF
--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -701,24 +701,24 @@ func showEditItemDialog(s *userMenuState, current *vtui.VMenu, items []UserMenuI
 
 	hotkey := ""
 	label := ""
-	cmdText := ""
+	var cmdLines []string
 	if !isCreate && idx >= 0 && idx < len(items) {
 		it := items[idx]
 		hotkey = it.HotKey
 		label = it.Label
 		if !isSubmenu {
-			sep := "; "
-			if runtime.GOOS == "windows" {
-				sep = " & "
-			}
-			cmdText = strings.Join(it.Commands, sep)
+			cmdLines = append([]string(nil), it.Commands...)
 		}
 	}
 
+	// Number of visible rows in the multiline command field. Six matches
+	// FAR's edit-menu-item dialog and comfortably shows short scripts.
+	const cmdRowsVisible = 6
 	width := 56
 	height := 11
 	if !isSubmenu {
-		height = 14
+		// Extra rows for the multiline command box + one for its label row.
+		height = 11 + cmdRowsVisible + 1
 	}
 
 	dlg := vtui.NewCenteredDialog(width, height, title)
@@ -726,9 +726,10 @@ func showEditItemDialog(s *userMenuState, current *vtui.VMenu, items []UserMenuI
 
 	editHotkey := vtui.NewEdit(0, 0, 10, hotkey)
 	editLabel := vtui.NewEdit(0, 0, 36, label)
-	var editCommand *vtui.Edit
+	var editCommand *vtui.MultiLineEdit
 	if !isSubmenu {
-		editCommand = vtui.NewEdit(0, 0, 36, cmdText)
+		editCommand = vtui.NewMultiLineEdit(0, 0, width-4, cmdRowsVisible, "")
+		editCommand.SetLines(cmdLines)
 	}
 
 	makeRow := func(labelText string, edit vtui.UIElement) *vtui.HBoxLayout {
@@ -745,7 +746,16 @@ func showEditItemDialog(s *userMenuState, current *vtui.VMenu, items []UserMenuI
 	vbox.Add(makeRow("Hot &key:", editHotkey), vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(makeRow("&Label:", editLabel), vtui.Margins{Top: 1}, vtui.AlignFill)
 	if !isSubmenu {
-		vbox.Add(makeRow("&Command:", editCommand), vtui.Margins{Top: 1}, vtui.AlignFill)
+		// Multi-line command box: label sits on its own row above the box
+		// (FAR's edit-menu-item dialog layout) so the multi-row edit
+		// doesn't leave the label floating next to just its first row.
+		cmdLabel := vtui.NewLabel(0, 0, "&Command:", editCommand)
+		dlg.AddItem(cmdLabel)
+		dlg.AddItem(editCommand)
+		cmdBox := vtui.NewHBoxLayout(0, 0, width-4, cmdRowsVisible)
+		cmdBox.Add(editCommand, vtui.Margins{}, vtui.AlignFill)
+		vbox.Add(cmdLabel, vtui.Margins{Top: 1}, vtui.AlignLeft)
+		vbox.Add(cmdBox, vtui.Margins{}, vtui.AlignFill)
 	}
 
 	btnOk := vtui.NewButton(0, 0, "&Save")
@@ -774,16 +784,19 @@ func showEditItemDialog(s *userMenuState, current *vtui.VMenu, items []UserMenuI
 
 		var cmds []string
 		if !isSubmenu && editCommand != nil {
-			cText := editCommand.GetText()
-			if cText != "" {
-				sep := "; "
-				if runtime.GOOS == "windows" {
-					sep = " & "
+			for _, ln := range editCommand.GetLines() {
+				ln = strings.TrimRight(ln, " \t\r")
+				// Drop leading/trailing blank rows but keep interior ones,
+				// because a blank line inside a script can still be
+				// intentional (visual grouping in a shell block).
+				if ln == "" && len(cmds) == 0 {
+					continue
 				}
-				cmds = strings.Split(cText, sep)
-				for i, cmd := range cmds {
-					cmds[i] = strings.TrimSpace(cmd)
-				}
+				cmds = append(cmds, ln)
+			}
+			// Drop trailing blank lines.
+			for len(cmds) > 0 && strings.TrimSpace(cmds[len(cmds)-1]) == "" {
+				cmds = cmds[:len(cmds)-1]
 			}
 		}
 

--- a/user_menu_ui_test.go
+++ b/user_menu_ui_test.go
@@ -333,3 +333,118 @@ func TestUserMenu_InteractiveEdit(t *testing.T) {
 		t.Errorf("Expected updated label 'new label', got %q", s.rootItems[0].Label)
 	}
 }
+
+// TestUserMenu_EditItemMultilineCommand covers issue #342: the Command
+// field is a MultiLineEdit, so editing an item with several commands
+// preserves them one-per-line on save and lets the user append more.
+func TestUserMenu_EditItemMultilineCommand(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	s := &userMenuState{
+		pf:         pf,
+		mode:       MenuModeLocal,
+		sourcePath: filepath.Join(t.TempDir(), farMenuFileName),
+		rootTitle:  "Local Menu",
+		rootItems: []UserMenuItem{
+			{HotKey: "1", Label: "build", Commands: []string{"go build ./...", "go vet ./..."}},
+		},
+	}
+
+	showEditItemDialog(s, vtui.NewVMenu("dummy"), s.rootItems, 0, false, false)
+
+	dlg := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var editCmd *vtui.MultiLineEdit
+	var btnSave *vtui.Button
+	for _, child := range dlg.GetChildren() {
+		if mle, ok := child.(*vtui.MultiLineEdit); ok {
+			editCmd = mle
+		}
+		if b, ok := child.(*vtui.Button); ok && strings.Contains(b.GetText(), "Save") {
+			btnSave = b
+		}
+	}
+	if editCmd == nil {
+		t.Fatal("MultiLineEdit for Command field not found")
+	}
+	if btnSave == nil {
+		t.Fatal("Save button not found")
+	}
+
+	// The dialog opened with the existing commands rendered on separate
+	// rows (no "; " join), so the user immediately sees the full script.
+	if got := editCmd.GetLines(); len(got) != 2 || got[0] != "go build ./..." || got[1] != "go vet ./..." {
+		t.Errorf("initial lines = %v, want [go build ./..., go vet ./...]", got)
+	}
+
+	// Append a third command via SetLines (simulating typing).
+	editCmd.SetLines([]string{"go build ./...", "go vet ./...", "go test ./..."})
+	btnSave.OnClick()
+
+	got := s.rootItems[0].Commands
+	want := []string{"go build ./...", "go vet ./...", "go test ./..."}
+	if len(got) != len(want) {
+		t.Fatalf("commands after save = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("commands[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestUserMenu_EditItemStripsBlankLines guards the save-path helper:
+// blank rows at the top/bottom of the multi-line box shouldn't reach
+// the ini file as empty Command entries; interior blank lines survive
+// (visual grouping inside a shell script).
+func TestUserMenu_EditItemStripsBlankLines(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	s := &userMenuState{
+		pf:         pf,
+		mode:       MenuModeLocal,
+		sourcePath: filepath.Join(t.TempDir(), farMenuFileName),
+		rootTitle:  "Local Menu",
+		rootItems: []UserMenuItem{
+			{HotKey: "1", Label: "cmd", Commands: []string{"echo a"}},
+		},
+	}
+
+	showEditItemDialog(s, vtui.NewVMenu("dummy"), s.rootItems, 0, false, false)
+	dlg := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var editCmd *vtui.MultiLineEdit
+	var btnSave *vtui.Button
+	for _, child := range dlg.GetChildren() {
+		if mle, ok := child.(*vtui.MultiLineEdit); ok {
+			editCmd = mle
+		}
+		if b, ok := child.(*vtui.Button); ok && strings.Contains(b.GetText(), "Save") {
+			btnSave = b
+		}
+	}
+
+	editCmd.SetLines([]string{"", "", "echo a", "", "echo b", "", ""})
+	btnSave.OnClick()
+
+	got := s.rootItems[0].Commands
+	want := []string{"echo a", "", "echo b"}
+	if len(got) != len(want) {
+		t.Fatalf("commands after save = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("commands[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #342. The Edit Menu Item / Create Menu Item dialog reached via F2 → Add/Edit always squeezed the entire command list into a single-line `Edit` joined by `"; "` (or `" & "` on Windows). Long scripts didn't fit horizontally, and the separator convention wasn't discoverable — most users assumed the box only takes one command. FAR presents this as a proper multi-line edit box; this PR does the same.

## Changes

- Bumps [`github.com/unxed/vtui`](https://github.com/unxed/vtui) to `v0.1.108` which introduces `MultiLineEdit` ([`unxed/vtui#17`](https://github.com/unxed/vtui/pull/17)).
- **`showEditItemDialog`**:
  - `Command:` field is now a `vtui.MultiLineEdit`, six visible rows (matches FAR's edit-menu-item layout).
  - **Load**: `SetLines(it.Commands)` directly — each stored command lands on its own row.
  - **Save**: `GetLines()` → strip leading/trailing blank rows, keep interior blanks (they can be intentional in a shell script for visual grouping).
  - The `Command:` label sits on its own row above the multi-row box so it isn't left floating next to just the first row.
  - Dialog height grows by `cmdRowsVisible + 1` for the extra content. Submenu height is unchanged (no Command field there).

The persisted `main_menu.ini` format (`Command0=`, `Command1=`, …) is already multi-command native — **no data-format migration needed**.

## Test plan

- [x] `TestUserMenu_EditItemMultilineCommand` — open the dialog on an item with two commands, verify both come back on separate rows, add a third, save, assert `Commands[]` has three entries in order.
- [x] `TestUserMenu_EditItemStripsBlankLines` — leading/trailing blank rows in the box are stripped on save, interior blank rows survive.
- [x] `TestUserMenu_InteractiveEdit` — existing test, still edits Label successfully (regression guard on the dialog structure).
- [x] `TestUserMenu*` full suite green.
- [x] `gofmt -w -s .` clean.
- [x] `go build ./...` clean.
