### PR TITLE
Restore F-key actions when panels are hidden (fixes #354)

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -251,15 +251,16 @@ func init() {
 		Handler:     withPF(func(pf *PanelsFrame) { actionEditFile(pf) }),
 	})
 	RegisterAction(Action{
-		Name:        "File.New",
-		Area:        "Shell",
-		Label:       "New File",
-		LabelKey:    "Action.File.New",
-		Description: "Create and open a new file in editor",
-		DescKey:     "Action.File.New.Desc",
-		DefaultKeys: []string{"ShiftF4"},
-		MenuPath:    "Files",
-		Handler:     withPF(func(pf *PanelsFrame) { actionNewFile(pf) }),
+		Name:         "File.New",
+		Area:         "Shell",
+		Label:        "New File",
+		LabelKey:     "Action.File.New",
+		Description:  "Create and open a new file in editor",
+		DescKey:      "Action.File.New.Desc",
+		DefaultKeys:  []string{"ShiftF4:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		MenuPath:     "Files",
+		Handler:      withPF(func(pf *PanelsFrame) { actionNewFile(pf) }),
 	})
 	RegisterAction(Action{
 		Name:        "File.Copy",
@@ -306,15 +307,16 @@ func init() {
 		Handler:     withPF(func(pf *PanelsFrame) { actionRename(pf) }),
 	})
 	RegisterAction(Action{
-		Name:        "File.MakeDir",
-		Area:        "Shell",
-		Label:       "Make Folder",
-		LabelKey:    "Menu.Files.MkDir",
-		Description: "Create a new directory",
-		DescKey:     "Action.File.MakeDir.Desc",
-		DefaultKeys: []string{"F7"},
-		MenuPath:    "Files",
-		Handler:     withPF(func(pf *PanelsFrame) { actionMkDir(pf) }),
+		Name:         "File.MakeDir",
+		Area:         "Shell",
+		Label:        "Make Folder",
+		LabelKey:     "Menu.Files.MkDir",
+		Description:  "Create a new directory",
+		DescKey:      "Action.File.MakeDir.Desc",
+		DefaultKeys:  []string{"F7:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		MenuPath:     "Files",
+		Handler:      withPF(func(pf *PanelsFrame) { actionMkDir(pf) }),
 	})
 	RegisterAction(Action{
 		Name:        "File.Delete",
@@ -457,15 +459,16 @@ func init() {
 	})
 
 	RegisterAction(Action{
-		Name:        "Panel.UserMenu",
-		Area:        "Shell",
-		Label:       "User Menu",
-		LabelKey:    "Action.Panel.UserMenu",
-		Description: "Show the user menu",
-		DescKey:     "Action.Panel.UserMenu.Desc",
-		DefaultKeys: []string{"F2"},
-		MenuPath:    "Commands",
-		Handler:     withPF(func(pf *PanelsFrame) { ShowUserMenu(pf) }),
+		Name:         "Panel.UserMenu",
+		Area:         "Shell",
+		Label:        "User Menu",
+		LabelKey:     "Action.Panel.UserMenu",
+		Description:  "Show the user menu",
+		DescKey:      "Action.Panel.UserMenu.Desc",
+		DefaultKeys:  []string{"F2:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		MenuPath:     "Commands",
+		Handler:      withPF(func(pf *PanelsFrame) { ShowUserMenu(pf) }),
 	})
 	RegisterAction(Action{
 		Name:        "Panel.FileAssociations",
@@ -915,14 +918,15 @@ func init() {
 		Handler:             withPF(func(pf *PanelsFrame) { vtui.FrameManager.EmitCommand(CmPlugRing, nil) }),
 	})
 	RegisterAction(Action{
-		Name:        "App.SaveSettings",
-		Area:        "Shell",
-		Label:       "Save Settings",
-		LabelKey:    "Action.App.SaveSettings",
-		Description: "Save settings and session",
-		DescKey:     "Action.App.SaveSettings.Desc",
-		DefaultKeys: []string{"ShiftF9"},
-		MenuPath:    "Options",
+		Name:         "App.SaveSettings",
+		Area:         "Shell",
+		Label:        "Save Settings",
+		LabelKey:     "Action.App.SaveSettings",
+		Description:  "Save settings and session",
+		DescKey:      "Action.App.SaveSettings.Desc",
+		DefaultKeys:  []string{"ShiftF9:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		MenuPath:     "Options",
 		Handler: withPF(func(pf *PanelsFrame) {
 			SaveConfig()
 			SaveSession()
@@ -1048,12 +1052,13 @@ func init() {
 		}),
 	})
 	RegisterAction(Action{
-		Name:        "Panel.TogglePassivePanel",
-		Area:        "Shell",
-		Label:       "Toggle Passive Panel",
-		Description: "Show or hide the passive panel",
-		DescKey:     "Action.Panel.TogglePassivePanel.Desc",
-		DefaultKeys: []string{"CtrlP"},
+		Name:         "Panel.TogglePassivePanel",
+		Area:         "Shell",
+		Label:        "Toggle Passive Panel",
+		Description:  "Show or hide the passive panel",
+		DescKey:      "Action.Panel.TogglePassivePanel.Desc",
+		DefaultKeys:  []string{"CtrlP:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
 		Handler: withPF(func(pf *PanelsFrame) {
 			pf.exitWide()
 			if pf.activeIdx == 0 {
@@ -1350,22 +1355,24 @@ func init() {
 		Handler:     withPF(func(pf *PanelsFrame) { vtui.FrameManager.EmitCommand(CmSortUnsorted, nil) }),
 	})
 	RegisterAction(Action{
-		Name:        "Panel.LeftDriveMenu",
-		Area:        "Shell",
-		Label:       "Left Drive Menu",
-		Description: "Show the drive menu for the left panel",
-		DescKey:     "Action.Panel.LeftDriveMenu.Desc",
-		DefaultKeys: []string{"AltF1", "CtrlShiftLeft"},
-		Handler:     withPF(func(pf *PanelsFrame) { pf.showDriveMenu(0) }),
+		Name:         "Panel.LeftDriveMenu",
+		Area:         "Shell",
+		Label:        "Left Drive Menu",
+		Description:  "Show the drive menu for the left panel",
+		DescKey:      "Action.Panel.LeftDriveMenu.Desc",
+		DefaultKeys:  []string{"AltF1:NoAltScreenApp", "CtrlShiftLeft:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		Handler:      withPF(func(pf *PanelsFrame) { pf.showDriveMenu(0) }),
 	})
 	RegisterAction(Action{
-		Name:        "Panel.RightDriveMenu",
-		Area:        "Shell",
-		Label:       "Right Drive Menu",
-		Description: "Show the drive menu for the right panel",
-		DescKey:     "Action.Panel.RightDriveMenu.Desc",
-		DefaultKeys: []string{"AltF2", "CtrlShiftRight"},
-		Handler:     withPF(func(pf *PanelsFrame) { pf.showDriveMenu(1) }),
+		Name:         "Panel.RightDriveMenu",
+		Area:         "Shell",
+		Label:        "Right Drive Menu",
+		Description:  "Show the drive menu for the right panel",
+		DescKey:      "Action.Panel.RightDriveMenu.Desc",
+		DefaultKeys:  []string{"AltF2:NoAltScreenApp", "CtrlShiftRight:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		Handler:      withPF(func(pf *PanelsFrame) { pf.showDriveMenu(1) }),
 	})
 	RegisterAction(Action{
 		Name:        "Panel.EnterDirectory",
@@ -1433,13 +1440,14 @@ func init() {
 		}),
 	})
 	RegisterAction(Action{
-		Name:        "App.Quit",
-		Area:        "Shell",
-		Label:       "Quit",
-		Description: "Quit f4",
-		DescKey:     "Action.App.Quit.Desc",
-		DefaultKeys: []string{"F10"},
-		Handler:     func() bool { return vtui.FrameManager.EmitCommand(vtui.CmQuit, nil) },
+		Name:         "App.Quit",
+		Area:         "Shell",
+		Label:        "Quit",
+		Description:  "Quit f4",
+		DescKey:      "Action.App.Quit.Desc",
+		DefaultKeys:  []string{"F10:NoAltScreenApp"},
+		DefaultAreas: []string{"Terminal"},
+		Handler:      func() bool { return vtui.FrameManager.EmitCommand(vtui.CmQuit, nil) },
 	})
 	RegisterAction(Action{
 		Name:        "Debug.DummyOperation",

--- a/fkeys_hidden_panels_test.go
+++ b/fkeys_hidden_panels_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// TestHotkeys_ShellActionsBoundInTerminalArea guards the fix for issue #354.
+// With panels hidden (area="Terminal") the file-manager F-keys used to
+// fall through, so F2/F7/Shift+F4/Shift+F9/F10/Alt+F1/Alt+F2/Ctrl+P did
+// nothing. They now carry DefaultAreas: []string{"Terminal"} with a
+// NoAltScreenApp condition so they fire in the panels-hidden idle
+// terminal but stay out of the way of full-screen apps.
+func TestHotkeys_ShellActionsBoundInTerminalArea_Issue354(t *testing.T) {
+	hm := NewHotkeyManager("")
+
+	cases := []struct {
+		key    string
+		action string
+	}{
+		{"F2", "Panel.UserMenu"},
+		{"F7", "File.MakeDir"},
+		{"F10", "App.Quit"},
+		{"ShiftF4", "File.New"},
+		{"ShiftF9", "App.SaveSettings"},
+		{"AltF1", "Panel.LeftDriveMenu"},
+		{"AltF2", "Panel.RightDriveMenu"},
+		{"CtrlP", "Panel.TogglePassivePanel"},
+	}
+	for _, tc := range cases {
+		got, ok := hm.Bindings["Terminal"][tc.key]
+		if !ok {
+			t.Errorf("Terminal area missing binding for %s (expected %s:NoAltScreenApp)", tc.key, tc.action)
+			continue
+		}
+		want := tc.action + ":NoAltScreenApp"
+		if got != want {
+			t.Errorf("Terminal/%s = %q, want %q", tc.key, got, want)
+		}
+	}
+}
+
+// TestHotkeys_ShellActions_TerminalArea_GatedByAltScreen ensures the
+// Terminal-area bindings do NOT fire when a full-screen application
+// (mc, htop, vim, less) is active — those keys belong to the app.
+// The gate is NoAltScreenApp, which returns true when panels are
+// shown OR no AltScreen mode is engaged.
+func TestHotkeys_ShellActions_TerminalArea_GatedByAltScreen_Issue354(t *testing.T) {
+	// Reset the global frame manager and register a hidden-panels PanelsFrame
+	// with an AltScreen app active — that's the state where the condition must fail.
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	pf.showPanels = false
+	pf.termView.UseAltScreen = true
+	vtui.FrameManager.Push(pf)
+
+	if GlobalHotkeysMgr == nil {
+		GlobalHotkeysMgr = NewHotkeyManager("")
+	}
+
+	// With AltScreen active the condition NoAltScreenApp is false, so
+	// the Terminal-area binding must resolve to "" (fall-through to PTY).
+	if got := GlobalHotkeysMgr.GetAction("Terminal", "F2"); got != "" {
+		t.Errorf("Terminal F2 with AltScreen active: got %q, want empty (must fall through to app)", got)
+	}
+	if got := GlobalHotkeysMgr.GetAction("Terminal", "F10"); got != "" {
+		t.Errorf("Terminal F10 with AltScreen active: got %q, want empty (must fall through to app)", got)
+	}
+
+	// Clear AltScreen — condition now passes and the actions surface.
+	pf.termView.UseAltScreen = false
+	if got := GlobalHotkeysMgr.GetAction("Terminal", "F2"); got != "Panel.UserMenu" {
+		t.Errorf("Terminal F2 without AltScreen: got %q, want Panel.UserMenu", got)
+	}
+	if got := GlobalHotkeysMgr.GetAction("Terminal", "F10"); got != "App.Quit" {
+		t.Errorf("Terminal F10 without AltScreen: got %q, want App.Quit", got)
+	}
+}
+
+// TestPanelsFrame_F2_OpensUserMenu_WhenPanelsHidden is the end-to-end
+// half of the issue #354 fix: with panels hidden, pressing F2 must
+// push the user-menu frame onto the top of the stack.
+func TestPanelsFrame_F2_OpensUserMenu_WhenPanelsHidden_Issue354(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	pf.showPanels = false
+	pf.termView.UseAltScreen = false
+
+	before := topFrameType()
+
+	pressKey(pf, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F2,
+	})
+
+	after := topFrameType()
+	if after == before {
+		t.Fatalf("F2 with hidden panels did not push a new top frame (still %v)", after)
+	}
+	if after != vtui.TypeMenu {
+		t.Errorf("F2 with hidden panels pushed frame of type %v, want VMenu (Panel.UserMenu)", after)
+	}
+}
+
+// TestPanelsFrame_CtrlL_RevealsHiddenPassivePanel_Issue354 exercises
+// the second bug from issue #354: with the passive panel hidden
+// (Ctrl+F1 or Ctrl+F2), Ctrl+L installed the InfoPanel into the
+// invisible slot and looked like a no-op. It must now un-hide the
+// slot so the info panel is actually visible.
+func TestPanelsFrame_CtrlL_RevealsHiddenPassivePanel_Issue354(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	// setupMockPanelsFrame gives activeIdx=1 (right). Hide the passive
+	// left panel — the state a user reaches via Ctrl+F1 in real life.
+	pf.showLeftPanel = false
+
+	pressKey(pf, &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_L,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+
+	if pf.altPanels[0] == nil {
+		t.Fatal("Ctrl+L must install InfoPanel on the passive (left) slot")
+	}
+	if _, ok := pf.altPanels[0].(*InfoPanel); !ok {
+		t.Errorf("expected *InfoPanel on left slot, got %T", pf.altPanels[0])
+	}
+	if !pf.showLeftPanel {
+		t.Error("Ctrl+L must un-hide the passive slot — otherwise the info panel is invisible")
+	}
+	if pf.activeIdx != 1 {
+		t.Errorf("Ctrl+L must not move active side; got activeIdx=%d, want 1", pf.activeIdx)
+	}
+}
+
+// topFrameType returns the type of the top frame across all screens
+// (or -1 if none) — small helper for the F2 assertion above.
+func topFrameType() vtui.FrameType {
+	if vtui.FrameManager == nil {
+		return -1
+	}
+	top := vtui.FrameManager.GetTopFrame()
+	if top == nil {
+		return -1
+	}
+	return top.GetType()
+}

--- a/help_keys_test.go
+++ b/help_keys_test.go
@@ -50,10 +50,11 @@ func TestGenerateKeysHelpTopic_PanelNav(t *testing.T) {
 
 	for _, want := range []string{
 		"F3             - Open file in viewer",
-		"Ctrl+O / Esc   - Show or hide panels",
-		// Alt+F1 gained Ctrl+Shift+Left as an alias (#351); keysFor
-		// sorts and joins the aliases, so the "Alt+F1 / …" prefix is
-		// what generateKeysHelpTopic now emits.
+		// Panel.Toggle picked up Del and NumDel as aliases (#351), and
+		// keysFor sorts + joins them alphabetically, so the emitted
+		// prefix is now "Ctrl+O / Del / Esc / NumDel".
+		"Ctrl+O / Del / Esc / NumDel - Show or hide panels",
+		// Alt+F1 gained Ctrl+Shift+Left as an alias (same PR).
 		"Alt+F1 / Ctrl+Shift+Left - Show the drive menu for the left panel",
 		"Ctrl+PgUp      - Go to parent directory",
 		"Shift+Enter    - Open current file in the system file manager",

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2813,6 +2813,14 @@ func (pf *PanelsFrame) toggleAltPanel(kind string, factory func(src *FileSystemP
 				tryClose(pf.altPanels[opp])
 			}
 			pf.altPanels[opp] = factory(fsp)
+			// If the opposite side is currently hidden (Ctrl+F1/F2), un-hide
+			// it — otherwise the alt panel installs into an invisible slot
+			// and Ctrl+L / Ctrl+Q look like a no-op.
+			if opp == 0 {
+				pf.showLeftPanel = true
+			} else {
+				pf.showRightPanel = true
+			}
 		}
 	}
 	pf.ResizeConsole(pf.lastW, pf.lastH)


### PR DESCRIPTION
Fixes #354.

## What breaks today

With Ctrl+O the panels get hidden and the input area flips from **Shell** to **Terminal**. Every file-manager action registered only in **Shell** silently stops working:

- **F2** — user menu
- **F7** — make folder
- **Shift+F4** — new file
- **Shift+F9** — save settings (on Windows this even reaches the console system menu instead of doing nothing)
- **F10** — quit
- **Alt+F1** / **Alt+F2** — left / right drive menus
- **Ctrl+P** — toggle passive panel

Second, unrelated bug from the same report: with one panel hidden (Ctrl+F1/F2), **Ctrl+L** (and Ctrl+Q) installs the info/quick-view panel into the invisible slot and looks like a no-op.

## The fix

**Terminal-area bindings.** Add `DefaultAreas: []string{"Terminal"}` to those Shell actions and gate them with the existing `NoAltScreenApp` condition. The condition returns true when panels are shown OR no full-screen app is engaged, so:
- Shell-area binding is unaffected (condition is transparent when panels are shown).
- Terminal-area binding fires when the terminal is idle / running a plain command.
- A full-screen app (mc, htop, vim, less) keeps its F-keys — matches the same policy `Panel.Toggle` (Ctrl+O) already uses.

**Ctrl+L with one panel hidden.** In `toggleAltPanel`, when placing the alt panel on the opposite side, un-hide that side too. Mirrors Far Manager, where Ctrl+L reveals the hidden passive slot.

## Tests

New `fkeys_hidden_panels_test.go` covers:
- Every listed key resolves in the Terminal area to `<Action>:NoAltScreenApp`.
- With AltScreen active the condition drops the binding (Terminal-area lookup returns empty) — mc / htop / vim still get their F-keys.
- Pressing **F2** with hidden panels pushes the user-menu frame.
- **Ctrl+L** with the passive side hidden installs the InfoPanel AND un-hides the slot.

Full test suite passes locally.