### PR TITLE
Fix more illogical dialog palettes (follow-up to #379)

### DIFF
--- a/file_associations_dispatch_test.go
+++ b/file_associations_dispatch_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
 
@@ -393,4 +394,47 @@ func TestFileAssociation_LangKeysResolve(t *testing.T) {
 	}
 	// Silence "runtime unused" if this is the only reference.
 	_ = runtime.GOOS
+}
+
+// TestFileAssociation_DeleteConfirmIsWarning is the regression guard
+// for the associations-editor half of #379: the delete-entry
+// confirmation is destructive and must render on the red WarnDialog
+// palette, matching the file-manager delete confirmation.
+func TestFileAssociation_DeleteConfirmIsWarning(t *testing.T) {
+	withTempAssociations(t, []FileAssoc{
+		{
+			Mask:        "*.md",
+			Description: "Markdown",
+			Commands:    [assocKindCount]string{AssocExecute: "cat !.!"},
+			Enabled:     [assocKindCount]bool{AssocExecute: true},
+		},
+	})
+	pf, _ := setupPanelWithFile(t, "readme.md")
+	ShowFileAssociations(pf)
+
+	top := vtui.FrameManager.GetTopFrame()
+	umf, ok := top.(*userMenuFrame)
+	if !ok {
+		t.Fatalf("expected *userMenuFrame on top after ShowFileAssociations, got %T", top)
+	}
+	umf.VMenu.SetSelectPos(0)
+
+	// Simulate the Del keypress the editor listens for.
+	handled := umf.VMenu.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_DELETE,
+	})
+	if !handled {
+		t.Fatal("Del was not consumed by the associations editor")
+	}
+
+	top = vtui.FrameManager.GetTopFrame()
+	dlg, ok := top.(*vtui.Window)
+	if !ok {
+		t.Fatalf("expected confirmation dialog (*Window) on top, got %T", top)
+	}
+	if !dlg.IsWarning {
+		t.Error("Delete-association confirmation must render on the WarnDialog palette (see #379)")
+	}
 }

--- a/file_associations_editor.go
+++ b/file_associations_editor.go
@@ -127,6 +127,8 @@ func (s *assocEditorState) openList(selected int) {
 			dlg := vtui.ShowMessageOn(menu, " "+Msg("FileAssoc.DeleteTitle")+" ",
 				fmt.Sprintf(Msg("FileAssoc.DeleteConfirm"), assocDisplayLabel(it)),
 				[]string{"&Delete", "Cancel"})
+			// Destructive — render on the WarnDialog palette (see #379).
+			dlg.IsWarning = true
 			dlg.OnResult = func(code int) {
 				if code != 0 {
 					return

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -2246,6 +2246,12 @@ func (pf *PanelsFrame) HandleCommand(cmd int, args any) bool {
 				msg = fmt.Sprintf("There are %d active background operations!\nIf you exit, they will be aborted.\n\n%s", active, msg)
 			}
 			dlg := vtui.ShowMessage(Msg("Quit.Title"), msg, []string{Msg("Quit.Btn"), Msg("vtui.Cancel")})
+			// When background operations would be aborted the exit is
+			// genuinely destructive — flip to the WarnDialog palette.
+			// Plain "confirm on exit" stays on the neutral palette.
+			if active > 0 {
+				dlg.IsWarning = true
+			}
 			dlg.OnResult = func(code int) {
 				if code == 0 {
 					SaveSession()

--- a/plugring_ui.go
+++ b/plugring_ui.go
@@ -385,6 +385,9 @@ func actionRemovePlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRin
 	}
 
 	dlg := vtui.ShowMessageOn(parent, " Remove Plugin ", fmt.Sprintf("Do you want to completely remove %s?", item.Name), []string{"&Remove", "Cancel"})
+	// Destructive — wipes the plugin directory. Render on the WarnDialog
+	// palette so the confirmation reads as an alarm.
+	dlg.IsWarning = true
 	dlg.OnResult = func(code int) {
 		if code == 0 {
 			// Grants belong to the plugin, not to its id. Leaving them

--- a/queue_manager.go
+++ b/queue_manager.go
@@ -546,7 +546,11 @@ func (qf *QueueFrame) ProcessKey(e *vtinput.InputEvent) bool {
 			t.mu.Unlock()
 
 			if isErr && errMsg != nil {
-				vtui.ShowMessageOn(qf, " Error Details ", errMsg.Error(), []string{"&Ok"})
+				// "Error Details" is an error dialog — the plain "Error"
+				// title would auto-detect as a warning, but this one does
+				// not match the legacy whitelist. Flip explicitly (#379).
+				dlg := vtui.ShowMessageOn(qf, " Error Details ", errMsg.Error(), []string{"&Ok"})
+				dlg.IsWarning = true
 			}
 			return true
 		}

--- a/user_menu_ui.go
+++ b/user_menu_ui.go
@@ -636,6 +636,8 @@ func (s *userMenuState) deleteAt(current *vtui.VMenu, items []UserMenuItem) {
 	dlg := vtui.ShowMessage(" User menu ",
 		fmt.Sprintf("Delete menu item:\n\n  %s", label),
 		[]string{"&Delete", "Cancel"})
+	// Destructive — render on the WarnDialog palette (see #379).
+	dlg.IsWarning = true
 	dlg.OnResult = func(code int) {
 		if code == 0 {
 			apply()


### PR DESCRIPTION
Follow-up sweep of the same class of mismatch fixed by #385: dialogs whose colour disagreed with what they actually did. All five sites are untouched by that PR because their titles fall outside vtui's legacy `Warning`/`Error`/`Confirm` whitelist, so they never picked up the warning palette on their own.

### Changes

- **plugring_ui.go** — `Remove Plugin` confirmation wipes the plugin directory. Mark as warning.
- **file_associations_editor.go** — `Delete association` confirmation is destructive. Mark as warning.
- **user_menu_ui.go** — `Delete menu item` confirmation is destructive. Mark as warning.
- **panels_frame.go** — `Quit` confirmation stays neutral for the plain "confirm on exit" case, but flips to warning when there are active background operations that would be aborted.
- **queue_manager.go** — `Error Details` popup reports a task error. The plain `Error` title would auto-detect as a warning, but this compound title didn't. Set `IsWarning` explicitly.

Each site uses the minimal pattern of setting `dlg.IsWarning = true` on the window returned by the existing `ShowMessage` / `ShowMessageOn` call, so this PR is **independent** of the `ShowMessageEx` API introduced in #385 for a different pair of dialogs — no vtui bump needed. Bases on `main`, not on #385; can be merged in either order.

### Test

`TestFileAssociation_DeleteConfirmIsWarning` locks in the associations-editor case end-to-end (open editor → Del → assert confirmation dialog carries `IsWarning`). The other four sites are one-line palette flips with no surrounding logic to regress; they piggyback on the existing manual smoke tests.