### PR TITLE
Fix illogical plugin dialog palettes (follow-up to #379)

### DIFF
--- a/plugins/id3editor/plugin.go
+++ b/plugins/id3editor/plugin.go
@@ -46,14 +46,17 @@ func (p *ID3EditorPlugin) handleEdit(app vfs.App) {
 
 	names := app.GetSelectedNames()
 	if len(names) == 0 {
-		vtui.ShowMessage(" Warning ", vtui.Msg("ID3Editor.SelectFile"), []string{"&Ok"})
+		// Neutral hint ("select a file first"), not an alarm — a
+		// non-whitelist title keeps this on the info palette. See #379.
+		vtui.ShowMessage(" ID3 Editor ", vtui.Msg("ID3Editor.SelectFile"), []string{"&Ok"})
 		return
 	}
 
 	name := names[0]
 	ext := strings.ToLower(filepath.Ext(name))
 	if ext != ".mp3" {
-		vtui.ShowMessage(" Warning ", vtui.Msg("ID3Editor.OnlyMP3"), []string{"&Ok"})
+		// Same rationale as the SelectFile hint above.
+		vtui.ShowMessage(" ID3 Editor ", vtui.Msg("ID3Editor.OnlyMP3"), []string{"&Ok"})
 		return
 	}
 

--- a/plugins/visren/dialog.go
+++ b/plugins/visren/dialog.go
@@ -685,6 +685,9 @@ func (d *Dialog) restoreNormalView() {
 func (d *Dialog) onRename() {
 	if d.undoMode {
 		confirm := vtui.ShowMessageOn(d, " "+tr("VisRen.Undo", "Undo")+" ", tr("VisRen.UndoQuestion", "Undo the recorded rename operation?"), []string{"&Yes", "&No", "Cancel"})
+		// Destructive — renames files back — render on the WarnDialog
+		// palette so the confirmation reads as an alarm. See #379.
+		confirm.IsWarning = true
 		confirm.OnResult = func(choice int) {
 			switch choice {
 			case 0:
@@ -831,6 +834,9 @@ func (d *Dialog) clearUndoLog() {
 		return
 	}
 	confirm := vtui.ShowMessageOn(d, " "+tr("VisRen.Undo", "Undo")+" ", tr("VisRen.ClearLog", "Clear the rename log?"), []string{"&Yes", "&No"})
+	// Destructive — wipes the undo history, taking away the ability to
+	// undo the last rename. Render on the WarnDialog palette. See #379.
+	confirm.IsWarning = true
 	confirm.OnResult = func(code int) {
 		if code == 0 {
 			d.plugin.setUndo("", nil)


### PR DESCRIPTION
Same class of colour/semantics mismatch as #385 and #386, but in the in-tree plugins:

### Changes

- **plugins/id3editor** — the "Please select a file" and "Only MP3 files are supported" hints were shown with title ` Warning `, which triggers vtui's legacy warning-palette inference — they came up red for what are ordinary neutral prompts. Retitle to ` ID3 Editor ` so the info palette wins.
- **plugins/visren** — the "Undo the recorded rename operation?" and "Clear the rename log?" confirmations are destructive (rename files back / wipe the undo history) but were shown on the neutral palette. Mark them as warnings via `confirm.IsWarning = true`.

Uses the minimal `dlg.IsWarning = true` pattern where a warning is being added, and a title change where a warning is being removed — so this PR is **independent** of the `ShowMessageEx` API from #385 and the in-tree follow-up in #386. No vtui bump needed and can be merged in any order.

### Test

No new unit tests — the changes are one-line palette flips with no surrounding logic to regress, and both the id3editor and visren test suites would need noticeable mock-setup to reach the affected code paths. Full `go test ./...` on the whole repo passes locally.