### PR TITLE
Compact settings dialogs — drop blank rows between checkboxes (fixes #298)

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1469,7 +1469,9 @@ func actionCopyInPlace(pf *PanelsFrame) {
 	})
 }
 func actionEditorSettings(pf *PanelsFrame) {
-	width, height := 78, 27
+	// Height sized so the 3×2 checkbox grid stacks tight (no blank
+	// rows between rows of the grid). See #298.
+	width, height := 78, 25
 	dlg := vtui.NewCenteredDialog(width, height, Msg("EditorSettings.Title"))
 	dlg.ShowClose = true
 
@@ -1610,17 +1612,17 @@ func actionEditorSettings(pf *PanelsFrame) {
 	rowTabSize.Add(editTabSize, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(rowTabSize, vtui.Margins{Top: 1}, vtui.AlignFill)
 
-	col1 := vtui.NewVBoxLayout(0, 0, (width-4)/2, 5)
+	col1 := vtui.NewVBoxLayout(0, 0, (width-4)/2, 3)
 	col1.Add(chkAutoIndent, vtui.Margins{}, vtui.AlignLeft)
-	col1.Add(chkEditorConfig, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	col1.Add(chkColorerBg, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	col1.Add(chkEditorConfig, vtui.Margins{}, vtui.AlignLeft)
+	col1.Add(chkColorerBg, vtui.Margins{}, vtui.AlignLeft)
 
-	col2 := vtui.NewVBoxLayout(0, 0, (width-4)/2, 5)
+	col2 := vtui.NewVBoxLayout(0, 0, (width-4)/2, 3)
 	col2.Add(chkCursorEOL, vtui.Margins{}, vtui.AlignLeft)
-	col2.Add(chkAuto, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	col2.Add(chkCrosshair, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	col2.Add(chkAuto, vtui.Margins{}, vtui.AlignLeft)
+	col2.Add(chkCrosshair, vtui.Margins{}, vtui.AlignLeft)
 
-	rowChecks := vtui.NewHBoxLayout(0, 0, width-4, 5)
+	rowChecks := vtui.NewHBoxLayout(0, 0, width-4, 3)
 	rowChecks.Add(col1, vtui.Margins{}, vtui.AlignFill)
 	rowChecks.Add(col2, vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(rowChecks, vtui.Margins{Top: 1}, vtui.AlignFill)
@@ -2056,7 +2058,11 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	const dialogHeight = 36
+	// Height sized so consecutive checkbox rows stack tightly without
+	// blank lines between them (see #298). Blank rows are kept only at
+	// transitions between widget kinds (checkbox↔combo↔radio↔button)
+	// so groups still read as groups.
+	const dialogHeight = 31
 	dlg := vtui.NewCenteredDialog(60, dialogHeight, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
@@ -2194,22 +2200,28 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(btnCancel)
 
 	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, dialogHeight-4)
+	// First checkbox cluster — stack tight, no blank rows between.
 	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkDirPrefix, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkSeparateExtensions, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkDirPrefix, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkSeparateExtensions, vtui.Margins{}, vtui.AlignLeft)
+	// Blank row before the scrollbar combo — transition to a different
+	// widget kind, worth the visual separator.
 	rowScrollbars := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowScrollbars.Add(lblScrollbars, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowScrollbars.Add(comboScrollbars, vtui.Margins{}, vtui.AlignFill)
-	vbox.Add(rowScrollbars, vtui.Margins{}, vtui.AlignFill)
+	vbox.Add(rowScrollbars, vtui.Margins{Top: 1}, vtui.AlignFill)
+	// Second checkbox cluster.
 	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkCmdAc, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkCmdAc, vtui.Margins{}, vtui.AlignLeft)
+	// Navigation radio group — its own visual island.
 	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(navigation, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkStayFocused, vtui.Margins{Left: 2}, vtui.AlignLeft)
+	// Third checkbox cluster.
 	vbox.Add(chkSync, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkAlwaysMenu, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkCPUGPU, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkEscToggle, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkAlwaysMenu, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkCPUGPU, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkEscToggle, vtui.Margins{}, vtui.AlignLeft)
 
 	rowMode := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowMode.Add(lblMode, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -2415,7 +2427,9 @@ func actionUpdateSettings(pf *PanelsFrame) {
 }
 
 func actionAppearanceSettings(pf *PanelsFrame) {
-	const width, height = 60, 21
+	// One row shaved by dropping the blank between the two trailing
+	// checkboxes (see #298).
+	const width, height = 60, 20
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
 	// Snapshot the whole palette (not just the style name) so a
@@ -2515,7 +2529,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	vbox.Add(rowTitle, vtui.Margins{Top: 1}, vtui.AlignFill)
 
 	vbox.Add(chkCursor, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkContrast, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkContrast, vtui.Margins{}, vtui.AlignLeft)
 
 	buttons := vtui.NewHBoxLayout(0, 0, width-4, 1)
 	buttons.HorizontalAlign = vtui.AlignCenter

--- a/style_test.go
+++ b/style_test.go
@@ -20,8 +20,11 @@ func TestAvailableColorStylesIncludesBuiltInsAndUserStyles(t *testing.T) {
 	}
 
 	styles := AvailableColorStyles()
-	if len(styles) != 4 {
-		t.Fatalf("expected 4 styles (Modern, Classic, Default Dark, Solarized); got %v", styleNames(styles))
+	// The built-in set grows with the repo (Fonokai landed after this
+	// test was first written); accept "the built-ins plus our
+	// Solarized" without pinning the exact count.
+	if len(styles) < 4 {
+		t.Fatalf("expected at least 4 styles (built-ins + user Solarized); got %v", styleNames(styles))
 	}
 	if styles[0].Name != "Modern" || styles[1].Name != "Classic" {
 		t.Fatalf("first two styles should be Modern and Classic, got %v", styleNames(styles[:2]))


### PR DESCRIPTION
Fixes #298.

The Panel/Editor/Appearance settings dialogs put an empty row before every checkbox, which meant every new option grew the dialog by two rows instead of one. #298 shows the Panel Settings dialog nearly running out of vertical space with that spacing, while the far/far2l reference stacks its option checkboxes one-per-line without gaps.

### Changes

Compact three dialogs the same way — remove the blank row between consecutive checkboxes of the same visual group, keep the blank row at transitions between widget kinds (checkbox↔combo, checkbox↔radio, before the button row) so groups still read as groups:

- **actionPanelSettings** — 3-item, 2-item and 4-item checkbox clusters each stack tight; dialog height drops from 36 to 31 rows.
- **actionEditorSettings** — the 3×2 checkbox grid stacks tight (col1/col2/rowChecks height 5 → 3); dialog height 27 → 25.
- **actionAppearanceSettings** — the two trailing checkboxes stack tight; dialog height 21 → 20.

`actionConfirmationsSettings` already used this pattern and needed no changes. `actionUpdateSettings` has no checkbox cluster. Non-settings dialogs (attributes, file-op progress, etc.) intentionally use blank rows to separate framed sub-groups and are left alone.

### Test

Guarded by the existing `TestAllDialogs_LayoutValidation`, which independently checks that every widget fits inside its frame after the layout runs — an earlier attempt at these heights that was one row too small (I initially set Panel Settings height to 30) was caught by that test.

### Drive-by

Separate first commit: `TestAvailableColorStylesIncludesBuiltInsAndUserStyles` still hard-codes `len(styles) == 4` on plain main and fails after fonokai.ini brought the built-in count to five. Same fix as #388 (`>= 4`), carried here so this branch builds in isolation. Will resolve trivially at merge time.