### PR TITLE
Fix declined update prompt persisting across restarts (fixes #374)

### DIFF
--- a/updater.go
+++ b/updater.go
@@ -39,6 +39,13 @@ var (
 	osExecutable = os.Executable
 	currentOS    = runtime.GOOS
 	currentArch  = runtime.GOARCH
+
+	// sessionDismissedUpdateKey remembers which update the user
+	// declined during the current f4 session, so an interval-driven
+	// auto-check does not re-prompt for the same version this run.
+	// The dismissal deliberately does NOT persist across restarts —
+	// see #374 — and a manual "Check for updates" always ignores it.
+	sessionDismissedUpdateKey string
 )
 
 func getCurrentVersion() string {
@@ -167,16 +174,31 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		return
 	}
 
+	// An update is available, but the user already said "no" to this
+	// exact release earlier in this session. Skip the auto-prompt so
+	// the next interval-driven check does not nag; a manual "Check
+	// for updates" from the settings dialog goes through regardless
+	// (see #374).
+	if !manual && sessionDismissedUpdateKey == updateKey {
+		vtui.DebugLog("UPDATER: skipping prompt — update %q dismissed this session", updateKey)
+		return
+	}
+
 	vtui.FrameManager.PostTask(func() {
 		msg := fmt.Sprintf("An update is available: %s\n\nDo you want to download and install it now?", displayVersion)
 		dlg := vtui.ShowMessage(" Auto Update ", msg, []string{"&Yes", "&No"})
 		dlg.OnResult = func(code int) {
 			if code == 0 {
 				performUpdate(pf, downloadURL, currentOS != "windows", release.TagName, updateKey)
-			} else {
-				AppConfig.LastUpdateVersion = updateKey
-				SaveConfig()
+				return
 			}
+			// User declined. Remember only for this session — the
+			// next restart (or a manual check) will offer it again.
+			// AppConfig.LastUpdateVersion is deliberately NOT touched
+			// here: that field is the "we already installed this
+			// version" marker and must survive across restarts, while
+			// a declined prompt must not (see #374).
+			sessionDismissedUpdateKey = updateKey
 		}
 	})
 }

--- a/updater_test.go
+++ b/updater_test.go
@@ -276,10 +276,20 @@ LoopJSON:
 	}
 }
 
+// TestUpdater_UserDeclinesUpdate pins the fix for #374: declining an
+// update must NOT persist across sessions. Concretely:
+//   - AppConfig.LastUpdateVersion must stay untouched (that field is the
+//     "we already installed this version" marker and would suppress the
+//     prompt on every subsequent restart, which is the reported bug).
+//   - sessionDismissedUpdateKey must be set, so a follow-up automatic
+//     check within the same run does not re-prompt for the same version.
 func TestUpdater_UserDeclinesUpdate(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	oldCfg := AppConfig
 	defer func() { AppConfig = oldCfg }()
+	oldDismissed := sessionDismissedUpdateKey
+	defer func() { sessionDismissedUpdateKey = oldDismissed }()
+	sessionDismissedUpdateKey = ""
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := githubRelease{
@@ -330,9 +340,119 @@ Loop:
 		t.Fatal("Update prompt dialog not found")
 	}
 
-	// Verify that LastUpdateVersion was updated so we don't prompt again for this version
-	if AppConfig.LastUpdateVersion != "v100.0.0" {
-		t.Errorf("Expected LastUpdateVersion to be 'v100.0.0' after decline, got %q", AppConfig.LastUpdateVersion)
+	if AppConfig.LastUpdateVersion != "" {
+		t.Errorf("declining the prompt must NOT persist across restarts (see #374); LastUpdateVersion=%q, want empty",
+			AppConfig.LastUpdateVersion)
+	}
+	if sessionDismissedUpdateKey != "v100.0.0" {
+		t.Errorf("declining the prompt must arm the session-level dismiss; sessionDismissedUpdateKey=%q, want %q",
+			sessionDismissedUpdateKey, "v100.0.0")
+	}
+}
+
+// TestUpdater_ManualCheckIgnoresSessionDismiss guards the second half
+// of #374: after the user declined once, an explicit "Check for
+// updates" from the settings dialog must still offer the update.
+// The session-level dismissal only silences the automatic prompt.
+func TestUpdater_ManualCheckIgnoresSessionDismiss(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	oldDismissed := sessionDismissedUpdateKey
+	defer func() { sessionDismissedUpdateKey = oldDismissed }()
+	// Simulate the user having declined the same release earlier.
+	sessionDismissedUpdateKey = "v100.0.0"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := githubRelease{
+			TagName:     "v100.0.0",
+			PublishedAt: "2030-01-01T00:00:00Z",
+			Assets: []githubAsset{
+				{Name: "f4-linux-amd64.tar.gz", BrowserDownloadURL: "http://mock"},
+				{Name: "f4-windows-amd64.zip", BrowserDownloadURL: "http://mock"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	origAPIURL := githubAPIURL
+	githubAPIURL = ts.URL + "/repos/unxed/f4/releases"
+	defer func() { githubAPIURL = origAPIURL }()
+
+	AppConfig.UpdateChannel = 0
+	AppConfig.LastUpdateVersion = ""
+
+	CheckForUpdates(nil, true) // manual == true
+
+	timeout := time.After(2 * time.Second)
+	sawPrompt := false
+	for !sawPrompt {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			top := vtui.FrameManager.GetTopFrame()
+			if top != nil && top.GetTitle() == " Auto Update " {
+				sawPrompt = true
+			}
+		case <-timeout:
+			t.Fatal("manual check must re-offer the update even after a session-level dismiss (see #374)")
+		}
+	}
+}
+
+// TestUpdater_AutoCheckSkipsSessionDismiss is the other side of the
+// same coin: within one session, an interval-driven automatic check
+// must NOT re-prompt for a version the user already declined this
+// run. This keeps the manual override useful without introducing the
+// #374 spam.
+func TestUpdater_AutoCheckSkipsSessionDismiss(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	oldDismissed := sessionDismissedUpdateKey
+	defer func() { sessionDismissedUpdateKey = oldDismissed }()
+	sessionDismissedUpdateKey = "v100.0.0"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := githubRelease{
+			TagName:     "v100.0.0",
+			PublishedAt: "2030-01-01T00:00:00Z",
+			Assets: []githubAsset{
+				{Name: "f4-linux-amd64.tar.gz", BrowserDownloadURL: "http://mock"},
+				{Name: "f4-windows-amd64.zip", BrowserDownloadURL: "http://mock"},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	origAPIURL := githubAPIURL
+	githubAPIURL = ts.URL + "/repos/unxed/f4/releases"
+	defer func() { githubAPIURL = origAPIURL }()
+
+	AppConfig.UpdateChannel = 0
+	AppConfig.LastUpdateVersion = ""
+	// Force shouldCheck() to allow the auto path to reach the dismiss guard.
+	AppConfig.UpdateInterval = 1
+	AppConfig.LastUpdateCheck = 0
+
+	CheckForUpdates(nil, false) // manual == false
+
+	// Give the goroutine a chance to reach the guard and return without
+	// pushing a task; a leaking prompt would enqueue one within ~200ms.
+	timeout := time.After(500 * time.Millisecond)
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			top := vtui.FrameManager.GetTopFrame()
+			if top != nil && top.GetTitle() == " Auto Update " {
+				t.Fatal("auto check must respect the session-level dismiss (see #374)")
+			}
+		case <-timeout:
+			return
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #374.

`CheckForUpdates` wrote `AppConfig.LastUpdateVersion` in two different situations that share nothing but the field name:

- After a **successful install** — meaning "this version is now on disk", which correctly suppresses future prompts for the same version.
- When the user clicked **"No"** on the prompt — meaning "not right now", but reusing the same field made this look identical to "already installed".

The second write is the bug reported in #374: one declined prompt silenced every subsequent check — both interval-driven auto-checks after a restart and explicit "Check for updates" from the settings dialog — because `release.TagName == LastUpdateVersion`, so `CheckForUpdates` decided "You are using the latest version" and returned. The user only saw the offer again once a newer release landed and the tags no longer matched.

### Fix

Split the two meanings:

- `LastUpdateVersion` stays what it always was on paper: written **only** when `performUpdate` finishes successfully.
- A new in-memory `sessionDismissedUpdateKey` remembers the just-declined update for the rest of this run, so a follow-up auto-check within the interval doesn't nag for the same version.
- Manual checks (from the settings dialog) **ignore** the session-level dismiss on purpose — the user explicitly asked, offer the update.

Because `sessionDismissedUpdateKey` is not persisted, restarting f4 gives the user the offer again, which matches the behaviour every other well-mannered auto-updater has and matches the reporter's mental model — mitek1977-coder's option B in the ticket comments.

### Tests

- `TestUpdater_UserDeclinesUpdate` rewritten to lock the new contract in place — declining leaves `LastUpdateVersion` empty and arms `sessionDismissedUpdateKey`. The old assertion was pinning the buggy behaviour.
- `TestUpdater_ManualCheckIgnoresSessionDismiss` guards the manual override: a manual check after a session-level dismiss must still surface the prompt.
- `TestUpdater_AutoCheckSkipsSessionDismiss` guards the other half: within one session, the interval-driven check must NOT re-prompt for a version already declined this run.