### PR TITLE
plugins/netfox/fishplus: PowerShell helper for Windows peers

### DIFF
--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -72,8 +72,17 @@ type FishDialer func(ctx context.Context) (io.Writer, io.Reader, io.Closer, erro
 type fishConn struct {
 	client *fishplus.Client
 	ka     *fishplus.Keepalive
-	dial   FishDialer
-	closer io.Closer
+	// dial and opts describe how to bring the primary shell flavor up. A
+	// site the first attempt cannot reach — a Windows peer whose sshd
+	// answers "exec /bin/sh" with a PowerShell parse error — is served by
+	// dialAlt/optsAlt instead. Once a fallback succeeds it becomes the
+	// primary, so every reconnect after the first goes straight to the
+	// flavor that actually works.
+	dial    FishDialer
+	opts    fishplus.HandshakeOptions
+	dialAlt FishDialer
+	optsAlt fishplus.HandshakeOptions
+	closer  io.Closer
 
 	mu     sync.Mutex
 	refs   int
@@ -112,7 +121,8 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 		c.mu.Unlock()
 		return fresh, nil
 	}
-	dial := c.dial
+	dial, opts := c.dial, c.opts
+	dialAlt, optsAlt := c.dialAlt, c.optsAlt
 	c.mu.Unlock()
 
 	if dial == nil {
@@ -122,13 +132,8 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 	// Dialling and the handshake happen outside the lock: both take as long as
 	// the network takes, and holding the lock would stall every other view of
 	// this connection for that whole time.
-	stdin, stdout, closer, err := dial(ctx)
+	sess, usedAlt, closer, err := establishWithFallback(ctx, dial, opts, dialAlt, optsAlt)
 	if err != nil {
-		return nil, err
-	}
-	sess := fishplus.NewSession(stdin, stdout, closer)
-	if err := sess.Handshake(ctx); err != nil {
-		sess.Close()
 		return nil, err
 	}
 	client := fishplus.NewClient(sess)
@@ -157,6 +162,12 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 	c.client = client
 	c.ka = fishplus.StartKeepalive(client, fishplus.DefaultKeepaliveInterval)
 	c.closer = closer
+	if usedAlt {
+		// The fallback answered where the primary did not. Promote it so
+		// every reconnect after this one goes straight to what works, and
+		// the primary is only tried again if the new primary also fails.
+		c.dial, c.opts, c.dialAlt, c.optsAlt = c.dialAlt, c.optsAlt, c.dial, c.opts
+	}
 	c.mu.Unlock()
 
 	oldKA.Stop()
@@ -208,14 +219,28 @@ func NewFishVFSOnStreamWithOptions(ctx context.Context, parent vfs.VFS, stdin io
 // that a site that cannot be reached fails at open time rather than at the
 // first request.
 func NewFishVFSOnDialer(ctx context.Context, parent vfs.VFS, dial FishDialer, title string) (*FishVFS, error) {
+	return NewFishVFSOnDialers(ctx, parent, dial, fishplus.HandshakeOptions{}, nil, fishplus.HandshakeOptions{}, title)
+}
+
+// NewFishVFSOnDialers is NewFishVFSOnDialer with a fallback: a peer the
+// first (dial, opts) pair cannot bring a helper up on is retried with the
+// second pair. Meant for sites where the shell flavor is not known at
+// open time — a POSIX login shell wins the common case, and a PowerShell
+// peer answers only after the retry. Once the fallback succeeds it is
+// promoted to primary, so every reconnect after the first goes straight
+// to the flavor that actually works. A nil dialAlt means no fallback.
+func NewFishVFSOnDialers(ctx context.Context, parent vfs.VFS, dial FishDialer, opts fishplus.HandshakeOptions, dialAlt FishDialer, optsAlt fishplus.HandshakeOptions, title string) (*FishVFS, error) {
 	if dial == nil {
 		return nil, ErrNoDialer
 	}
-	stdin, stdout, closer, err := dial(ctx)
+	sess, usedAlt, closer, err := establishWithFallback(ctx, dial, opts, dialAlt, optsAlt)
 	if err != nil {
 		return nil, err
 	}
-	return newFishVFSOnStream(ctx, parent, stdin, stdout, closer, title, dial, fishplus.HandshakeOptions{})
+	if usedAlt {
+		dial, opts, dialAlt, optsAlt = dialAlt, optsAlt, dial, opts
+	}
+	return newFishVFSFromSession(parent, sess, closer, title, dial, opts, dialAlt, optsAlt), nil
 }
 
 func newFishVFSOnStream(ctx context.Context, parent vfs.VFS, stdin io.Writer, stdout io.Reader, closer io.Closer, title string, dial FishDialer, opts fishplus.HandshakeOptions) (*FishVFS, error) {
@@ -224,23 +249,111 @@ func newFishVFSOnStream(ctx context.Context, parent vfs.VFS, stdin io.Writer, st
 		sess.Close()
 		return nil, err
 	}
+	return newFishVFSFromSession(parent, sess, closer, title, dial, opts, nil, fishplus.HandshakeOptions{}), nil
+}
+
+// newFishVFSFromSession wraps an already-handshaked session in a FishVFS,
+// used by every construction path so the wrapper stays in one place.
+func newFishVFSFromSession(parent vfs.VFS, sess *fishplus.Session, closer io.Closer, title string, dial FishDialer, opts fishplus.HandshakeOptions, dialAlt FishDialer, optsAlt fishplus.HandshakeOptions) *FishVFS {
 	client := fishplus.NewClient(sess)
-	cwd, err := client.Pwd(ctx)
+	cwd, err := client.Pwd(context.Background())
 	if err != nil || !path.IsAbs(cwd) {
 		cwd = "/"
 	}
 	return &FishVFS{
 		parent: parent,
 		conn: &fishConn{
-			client: client,
-			refs:   1,
-			ka:     fishplus.StartKeepalive(client, fishplus.DefaultKeepaliveInterval),
-			dial:   dial,
-			closer: closer,
+			client:  client,
+			refs:    1,
+			ka:      fishplus.StartKeepalive(client, fishplus.DefaultKeepaliveInterval),
+			dial:    dial,
+			opts:    opts,
+			dialAlt: dialAlt,
+			optsAlt: optsAlt,
+			closer:  closer,
 		},
 		path:  cwd,
 		title: title,
-	}, nil
+	}
+}
+
+// establishSession dials, brings up the helper with the given handshake
+// options, and returns a session that is ready to serve requests. The
+// closer returned is the one the dialer supplied; it is closed with the
+// session on failure and stored on fishConn on success.
+func establishSession(ctx context.Context, dial FishDialer, opts fishplus.HandshakeOptions) (*fishplus.Session, io.Closer, error) {
+	stdin, stdout, closer, err := dial(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	sess := fishplus.NewSession(stdin, stdout, closer)
+	if err := sess.HandshakeWithOptions(ctx, opts); err != nil {
+		sess.Close()
+		return nil, nil, err
+	}
+	return sess, closer, nil
+}
+
+// establishWithFallback tries the primary (dial, opts) pair first and
+// falls back to (dialAlt, optsAlt) only when the primary handshake fails
+// — that is, after the transport already answered. A dial-level failure
+// is returned as-is: the network cannot be worked around by trying a
+// different shell. A nil dialAlt disables the fallback, which is what
+// callers with a known-good flavor pass. The bool report tells the caller
+// which pair produced the session so it can promote the fallback for
+// future reconnects.
+func establishWithFallback(ctx context.Context, dial FishDialer, opts fishplus.HandshakeOptions, dialAlt FishDialer, optsAlt fishplus.HandshakeOptions) (*fishplus.Session, bool, io.Closer, error) {
+	sess, closer, err := establishSession(ctx, dial, opts)
+	if err == nil {
+		return sess, false, closer, nil
+	}
+	// A dial failure — no route, refused, auth — has no shell flavor to
+	// try. Only a handshake failure means the transport is fine but the
+	// far side did not recognize the bootstrap; only then is the fallback
+	// worth trying.
+	if _, isRemoteErr := err.(*fishplus.RemoteError); !isRemoteErr && !isHandshakeFailure(err) {
+		return nil, false, nil, err
+	}
+	if dialAlt == nil {
+		return nil, false, nil, err
+	}
+	sessAlt, closerAlt, errAlt := establishSession(ctx, dialAlt, optsAlt)
+	if errAlt != nil {
+		// The original error is more informative — the alt was a guess,
+		// the primary is what the caller configured.
+		return nil, false, nil, err
+	}
+	return sessAlt, true, closerAlt, nil
+}
+
+// isHandshakeFailure recognizes the errors HandshakeWithOptions raises
+// when the far side answered but did not speak the expected protocol.
+// A read that failed because the transport is broken should not trigger
+// a shell-flavor retry, since neither flavor would fare any better.
+func isHandshakeFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	// The far side hung up while the bootstrap was being uploaded or
+	// waited for. That is what a Windows peer does with the POSIX attempt:
+	// sshd resolves the exec request to powershell.exe -c "exec /bin/sh",
+	// PowerShell fails to parse it, prints to stderr — which the dialer
+	// discards — and exits, closing the channel. Measured against a real
+	// sshd this arrives as EOF within half a second, and it is the most
+	// direct evidence there is that this flavor is the wrong one.
+	//
+	// The dial already succeeded by the time this runs, so an EOF here is
+	// a shell that would not stay, not a network that will not carry.
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	msg := err.Error()
+	// The two phrases parseBanner / HandshakeWithOptions build for
+	// "answered but wrong": one for the banner shape, one for the version.
+	return strings.Contains(msg, "unexpected banner") ||
+		strings.Contains(msg, "remote speaks protocol") ||
+		strings.Contains(msg, "never reported being ready") ||
+		strings.Contains(msg, "bad terminator")
 }
 
 // sshShell ties the lifetime of the remote shell and of the connection that
@@ -280,6 +393,34 @@ func (s *sshShell) OpenPty(cols, rows int) (any, error) {
 // account's login shell may well be csh, fish or something else that does not
 // speak the POSIX syntax the helper is written in.
 func sshFishDialer(host, port, user, pass string, timeout int) FishDialer {
+	return sshFishDialerWith(host, port, user, pass, timeout, func(s *ssh.Session) error {
+		return s.Start("exec /bin/sh")
+	})
+}
+
+// sshFishDialerPwsh is the fallback for a Windows peer. It asks sshd to
+// run "powershell.exe -NoLogo -NoProfile" rather than sess.Shell(): the
+// exec request resolves through the DefaultShell of the peer, which is
+// cmd.exe on a stock OpenSSH-Server-Windows install, so a bare shell
+// request would land the helper in cmd — which does not understand a
+// single line of PowerShell. Routing through
+// "cmd.exe /c powershell.exe -NoLogo -NoProfile" instead lets cmd fork
+// PowerShell for us; a peer whose DefaultShell is already powershell.exe
+// or pwsh pays for a nested launch (~200 ms) but the same helper runs
+// on both. No pseudo-terminal is requested for the same reason as the
+// POSIX side: a ConPTY would echo every request back and inject VT
+// sequences.
+func sshFishDialerPwsh(host, port, user, pass string, timeout int) FishDialer {
+	return sshFishDialerWith(host, port, user, pass, timeout, func(s *ssh.Session) error {
+		return s.Start("powershell.exe -NoLogo -NoProfile")
+	})
+}
+
+// sshFishDialerWith is what both flavors share. The only thing they
+// disagree about is how they ask sshd to give them the shell: exec+cmd
+// on POSIX (which bypasses an exotic login shell), plain shell on
+// Windows (which respects DefaultShell).
+func sshFishDialerWith(host, port, user, pass string, timeout int, startShell func(*ssh.Session) error) FishDialer {
 	return func(ctx context.Context) (io.Writer, io.Reader, io.Closer, error) {
 		// DialSSH carries a timeout of its own and cannot be interrupted, so
 		// the context is honoured where it can be: before the dial, and again
@@ -316,7 +457,7 @@ func sshFishDialer(host, port, user, pass string, timeout int) FishDialer {
 			return nil, nil, nil, err
 		}
 		sess.Stderr = io.Discard
-		if err := sess.Start("exec /bin/sh"); err != nil {
+		if err := startShell(sess); err != nil {
 			shell.Close()
 			return nil, nil, nil, err
 		}
@@ -340,7 +481,17 @@ func NewFishVFS(parent vfs.VFS, host, port, user, pass string, timeout int) (*Fi
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), sshTimeout(timeout))
 	defer cancel()
-	v, err := NewFishVFSOnDialer(ctx, parent, sshFishDialer(host, port, user, pass, timeout), title)
+	// The primary flavor is POSIX (exec /bin/sh + line bootstrap): the
+	// bulk of hosts a panel opens are Linux or a BSD, and the client's
+	// existing tests exercise that path in every commit. A Windows peer
+	// with sshd's DefaultShell set to powershell.exe answers the POSIX
+	// bootstrap with a parse error; the fallback dialer catches that,
+	// asks sshd for a plain shell (which resolves to PowerShell on
+	// Windows), and delivers the base64-encoded helper.ps1 through it.
+	v, err := NewFishVFSOnDialers(ctx, parent,
+		sshFishDialer(host, port, user, pass, timeout), fishplus.HandshakeOptions{},
+		sshFishDialerPwsh(host, port, user, pass, timeout), fishplus.HandshakeOptions{Bootstrap: fishplus.BootstrapBase64LinePwsh},
+		title)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/netfox/fishplus/WINDOWS_PORT.md
+++ b/plugins/netfox/fishplus/WINDOWS_PORT.md
@@ -1,0 +1,396 @@
+# FISH+ Windows / PowerShell backend — design notes
+
+Working notes for the port. Not documentation for users. Discard when the
+port lands, or fold into the package doc if any of it turns out to have
+long-term value.
+
+## Scope and non-goals
+
+**In:** a helper for a plain PowerShell 5.1+ session reached over SSH
+(`OpenSSH-Server` on Windows, subsystem `sftp` unused, shell is
+`powershell.exe` or `pwsh.exe`). Same wire protocol v1 as `helper.sh`.
+Same client, same VFS, same test lab pattern.
+
+**Out (this pass):**
+- `cmd.exe`-only hosts. `cmd`'s scripting is a much worse target than PS
+  and virtually every Windows box with OpenSSH-Server also has PS.
+- WSL/Git-Bash on Windows. Those already work through `helper.sh`.
+- ACL-preserving copy/move, Windows-specific attributes (readonly,
+  hidden, archive) beyond a reasonable rwx projection.
+- Anything that requires elevation.
+
+## What the wire protocol actually requires from the backend
+
+From `helper.sh` (v1 — the only version):
+
+1. **Line-oriented request stream.** One line per request:
+   `<ID> <cmd> [<a1> <a2> <a3>]`. Path lines follow, raw or
+   `~<base64>` if they contain LF/CR/tab or start with `~`.
+2. **Line-oriented reply stream ending in a terminator.**
+   `.<TOKEN> <ID> ok|err [flat-message]`. Payload is any lines the
+   command emits before the terminator.
+3. **One-shot greeting.** The helper's first line after `printf '\n'` is
+   the terminator for id `0`, carrying `FISHPLUS <PROTO><space-feats>` on
+   ok, or an error message.
+4. **Binary frame primitive.** `#<n>\n` followed by exactly n raw bytes.
+   Used by `read` (server → client) and `write`/`patch raw` (client →
+   server). Bytes are literal, not encoded.
+5. **Line boundary is LF.** `IFS= read -r` on the server, and the client
+   is a Go program that will read `\n`-terminated lines. CRLF from the
+   server would either break parsing (if the client is strict) or leave
+   `\r` in every parsed field (if it's lax).
+6. **UTF-8 filenames must survive round-trip.** The whole protocol is
+   byte-transparent for paths; `~base64` handles bytes that would break
+   the line channel.
+
+The Windows backend must respect all six. The riskiest ones under
+PowerShell are (4) — PS pipeline is text — and (5)/(6) — PS 5.1
+defaults to the OEM code page for stdout.
+
+## PowerShell command mapping
+
+One row per wire command. `PS API` is what the helper.ps1 body will
+call; where an idiom needs a wrapper, the wrapper name goes in the
+`helper.ps1 fn` column and the details land in a later section.
+
+| Wire cmd  | POSIX (`helper.sh`)      | PowerShell approach                                          | helper.ps1 fn      |
+| --------- | ------------------------ | ------------------------------------------------------------ | ------------------ |
+| `noop`    | just terminator          | just terminator                                              | inline             |
+| `pwd`     | `pwd`                    | `$PWD.Path`                                                  | inline             |
+| `ping`    | echo path                | echo path                                                    | inline             |
+| `enum`    | find/stat/ls listing     | `Get-ChildItem -Force -LiteralPath`                          | `f4_list`          |
+| `isdirs`  | `[ -d ]` per path        | `[System.IO.Directory]::Exists($p)`                          | `f4_cmd_isdirs`    |
+| `info`    | find/stat entry (follow) | `[IO.FileInfo]` after `Resolve-Path`                         | `f4_cmd_info`      |
+| `linfo`   | same, no follow          | `[IO.FileSystemInfo]` no resolve; check `ReparsePoint` attr  | `f4_cmd_info -L`   |
+| `rdlink`  | `readlink`               | `(Get-Item -LiteralPath $p).Target`                          | `f4_cmd_rdlink`    |
+| `mkdir`   | `mkdir -p`               | `New-Item -Type Directory -Force`                            | inline             |
+| `rm`      | `rm -f`                  | `Remove-Item -LiteralPath -Force`                            | inline             |
+| `rmdir`   | `rmdir`                  | `[IO.Directory]::Delete($p, $false)`                         | inline             |
+| `rmtree`  | `rm -rf`                 | `Remove-Item -Recurse -Force`                                | inline             |
+| `mv`      | `mv -f`                  | `Move-Item -Force` (`Rename-Item` if same dir)               | inline             |
+| `cp`      | `cp -R -f`               | `Copy-Item -Recurse -Force`                                  | inline             |
+| `chmod`   | `chmod <octal>`          | project owner-write bit onto `ReadOnly` attribute; ignore rest | `f4_cmd_chmod`   |
+| `chown`   | `chown u:g`              | **not implemented** — reply `err "chown unsupported"`; the client already handles servers without chown | inline |
+| `read`    | dd/head/tail             | `FileStream.Seek + Read` → raw bytes to stdout               | `f4_read_range`   |
+| `write`   | dd raw / base64          | `FileStream.Seek + Write` (raw or `[Convert]::FromBase64String`) | `f4_write_run`  |
+| `trunc`   | `truncate`               | `FileStream.SetLength`                                       | inline             |
+| `patch`   | segments + writes        | segments as `FileStream` reads from src, writes to dst       | `f4_cmd_patch`     |
+| `utime`   | `touch -t`/`-d`          | `[IO.File]::SetLastWriteTimeUtc` / `SetLastAccessTimeUtc`    | `f4_cmd_utime`     |
+| `grep`    | `grep -abo` + awk        | streaming reader over the file, byte-offset per match        | `f4_cmd_grep`      |
+| `lidx`    | awk pass                 | streaming reader over the file, byte offset per line         | `f4_cmd_lidx`      |
+| `ffind`   | `find` + optional grep   | `Get-ChildItem -Recurse -Include` + optional `Select-String` | `f4_cmd_ffind`     |
+| `jstart`  | subshell `&`             | `Start-ThreadJob` writing to files under a job dir           | `f4_cmd_jstart`    |
+| `jpoll`   | wc/tail/head over files  | same shape, `[IO.File]` reads                                | `f4_cmd_jpoll`     |
+| `jkill`   | `kill`                   | `Stop-Job` + `Stop-Process` of children                      | `f4_cmd_jkill`     |
+| `jdrop`   | kill + `rm -rf`          | same                                                         | `f4_cmd_jdrop`     |
+| `jlist`   | glob                     | `Get-ChildItem` of job dir                                   | `f4_cmd_jlist`     |
+| `mode`    | switch listing backend   | one backend only (`Get-ChildItem`); accept `getchilditem`, reject others | inline |
+| `rmode`   | switch read strategy     | one strategy only (`filestream`); accept it, reject others  | inline             |
+| `wmode`   | switch write strategy    | one strategy only (`filestream`); accept it, reject others  | inline             |
+| `feats`   | echo feature list        | same, precomputed at startup                                 | inline             |
+| `exit`    | clean jobs, break        | same                                                         | inline             |
+
+Notable simplifications vs `helper.sh`:
+
+- **Single backend per capability.** No probes for `dd` variants, `head -c`
+  quirks, GNU vs BSD stat. .NET is a stable substrate: one code path.
+  The features string still gets advertised (client-facing contract), but
+  the values are constants: `mode:getchilditem read:filestream write:filestream`.
+- **Uniform binary framing.** `.NET FileStream` reads and writes exact
+  byte counts by contract; no equivalent of the `ddbytes`/`b64`
+  fallback dance.
+- **Symlinks are `ReparsePoint`.** They exist on Windows but need SeCreateSymbolicLink;
+  the helper treats them as-is on read, refuses `mkdir -s` operations
+  the protocol doesn't have anyway.
+
+## Feature string the Windows helper advertises
+
+```
+FISHPLUS 1 base64 grep sed awk wc head tail touch date sha256sum \
+         findbin jobs mode:getchilditem read:filestream write:filestream
+```
+
+Rationale: everything the client uses `feats` to gate is either always
+available under .NET (read/write/find/hash/utime/jobs) or is meaningless
+on Windows (`chown`, `truncate` as a separate binary — trunc is inline).
+`sha256sum` here means "the helper can hash", not "the coreutils
+binary is on PATH".
+
+`chown` is deliberately absent. `chmod` is present but degraded to a
+readonly-bit projection; the alternative (silent no-op) is a worse
+contract.
+
+## Encoding, CRLF and console mode — the three hard problems
+
+1. **stdout must be raw bytes.** Two fixes at startup, both mandatory:
+   ```powershell
+   [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+   $OutputEncoding = [System.Text.Encoding]::UTF8   # for pipeline → external
+   ```
+   For binary frames the helper bypasses PS entirely:
+   ```powershell
+   $stdout = [Console]::OpenStandardOutput()
+   $stdout.Write($bytes, 0, $n); $stdout.Flush()
+   ```
+2. **Line endings must be LF, not CRLF.**
+   ```powershell
+   [Console]::Out.NewLine = "`n"
+   ```
+   `Write-Host`/`Write-Output` respect it after this. `WriteLine` on
+   `[Console]::Out` does. `Write-Output "x"` piped elsewhere doesn't
+   necessarily — safer to use `[Console]::Out.WriteLine($s)` everywhere
+   in the helper.
+3. **stdin must deliver raw bytes for binary payloads.**
+   ```powershell
+   $stdin = [Console]::OpenStandardInput()
+   # ReadExact:
+   $buf = [byte[]]::new($n); $off = 0
+   while ($off -lt $n) {
+     $r = $stdin.Read($buf, $off, $n - $off)
+     if ($r -le 0) { throw 'eof' }; $off += $r
+   }
+   ```
+   For line-oriented reads, keep a `[BufferedStream]` in front of
+   `$stdin` and pull one line at a time (LF-terminated, strip trailing
+   CR if present — some SSH servers still cook).
+
+Also disable progress and prompts:
+```powershell
+$ProgressPreference   = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+$PSStyle.OutputRendering = 'PlainText'   # PS 7.2+
+```
+
+## Session bootstrap
+
+The client already ships `helper.sh` down the pipe as the first thing.
+For the Windows flavor:
+
+1. Client detects the peer is PowerShell (see `flavor detection`,
+   pending Explore report).
+2. Client ships `helper.ps1` with `__F4_TOKEN__` substituted, terminated
+   by a newline and possibly a sentinel line so the helper knows the
+   script ended and can start its `while` loop.
+3. Because PS parses the whole script before running, the shipping is
+   just "paste text, then press Enter". No `. { ... }` block wrapper
+   needed if the file ends with a call to the dispatch loop.
+
+## Go-side integration points (from a client-code map)
+
+- **Helper delivery** is `HandshakeWithOptions` in `session.go:246-304`.
+  Two strategies today, both POSIX-shell:
+  - `BootstrapScriptLines`: writes `BootstrapLine(token)`, waits for the
+    ready marker, then pipes `HelperScript(token) + "F4EOF\n"`. The
+    wrapper is `while IFS= read -r F4L; do [ "$F4L" = F4EOF ] && break;
+    F4S=$F4S$F4L$F4NL; done; eval "$F4S"` (`script.go:75-80`).
+  - `BootstrapBase64Line`: single ASCII line, whole helper base64-encoded,
+    decoded on the peer by one of `'base64 -d' 'base64 -D' 'base64 --decode'
+    'openssl base64 -A -d'`, then `eval` on the result (`script.go:96-117`).
+- **Prompt-drain / login-noise consumption:** `waitForReady` scans up to
+  `maxBootstrapLines = 1000` lines for the token-anchored `F4RDY<token>`
+  (`session.go:328-351`, `script.go:54`). No client-side stty/PS1 taming —
+  all hygiene is inside the helper.
+- **`Compact` strips CRs** from the embedded helper source
+  (`script.go:33-36`). The PS port has the mirror-image concern: keep
+  CRLF **out** of outbound bytes.
+- **Feature-token enumerations are validated by the client**:
+  `ListingModes` (`fs.go:56`), `ReadModes` (`read.go:31`), `WriteModes`
+  (`write.go:30`). Any new mode name has to be added to both the helper's
+  advertised feats AND those Go enums. **Big simplification: reusing
+  existing tokens skips the Go change** —
+  - `write:b64` already exists; the client sends payload as one trailing
+    base64 line, no byte-exact stdin needed on the peer. This is the
+    natural choice for PS (`[Console]::In.ReadLine`).
+  - `read:cat` exists as the whole-file-dump fallback; a byte-range read
+    needs one of `dd`/`ddbytes`/`tailc`, none of which map to a real PS
+    idiom, so adding a new token like `read:filestream` is honest — one
+    line into `ReadModes`.
+- **`readLine` strips both `\r` and `\n`** (`session.go:617`) — so
+  incoming CRLF from PowerShell is tolerated. That is one less thing to
+  fight; we still prefer LF, but a stray CR won't sync-break.
+- **Argument grammar refuses whitespace** (`session.go:431-434`). Any new
+  arg tokens must be single non-whitespace words.
+- **`mockPeer`** (`session_test.go:59-124`) is language-agnostic — it
+  parses wire tokens and returns caller-supplied replies. The PS port
+  needs no new mock; existing tests validate the wire, and helper.ps1 is
+  validated by running it under a real `pwsh`, the same pattern
+  `TestHelperAgainstLocalShell` (`session_test.go:805-…`) uses for
+  `/bin/sh`, currently skipped on `runtime.GOOS == "windows"`. The PS
+  variant is gated by presence of `pwsh` on PATH.
+
+## Flavor detection — pick strategy
+
+**A. Retry-on-fail (dumb, robust).** Send POSIX bootstrap first. On
+`waitForReady` timeout or peer syntax error, close the pipe, reopen, send
+PS bootstrap. Zero probe overhead on POSIX, one reconnect on PS.
+
+**B. Explicit probe before bootstrap.** One line that both shells accept
+but that answers differently:
+`echo __F4A__$([regex]::Match($PSVersionTable.PSVersion.ToString(),'^\d+').Value)__F4B__`
+– POSIX prints `__F4A____F4B__`, PS prints `__F4A__5__F4B__` or similar.
+One extra roundtrip on every connect, no reconnect on either path.
+
+**Recommendation: (A) for the first pass** — fits the existing
+`HandshakeWithOptions` shape, needs zero new probe code. Switch to (B) if
+the reconnect proves painful in practice.
+
+## Bootstrap for PowerShell
+
+Analog of `BootstrapBase64Line`, one line:
+
+```
+$s=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('<b64>'));iex $s
+```
+
+Prompt/PSReadLine noise is kept out by invoking pwsh with `-NoProfile
+-NonInteractive -Command -` if the SSH server can be told to; otherwise
+the helper's first act is `Remove-Module PSReadLine -Force -ErrorAction
+SilentlyContinue`.
+
+Go-side, new exports next to `BootstrapBase64Line`:
+
+```go
+func BootstrapBase64LinePwsh(token string) string { ... }
+```
+
+`Session` gains a `flavor` field, `HandshakeWithOptions` picks the right
+bootstrap+helper pair based on it, and `Features` gains a `Flavor()`
+accessor derived from a new banner tag `flavor:posix|pwsh` (added to both
+helpers for symmetry).
+
+## Test strategy
+
+The existing `*_test.go` uses in-process `mockPeer` fakes that speak
+the wire protocol. The port needs:
+
+1. A `mockPeer` variant that answers Windows-flavored replies (mode
+   line `M getchilditem`, feature string with the Windows set).
+2. A real integration lane, gated by an env var or build tag, that
+   pipes `helper.ps1` into a local `pwsh` and runs the full suite
+   against it. Analogous to the `helper.sh`/`/bin/sh` lane if one
+   exists (verify from Explore report).
+
+## Path convention on the wire
+
+`FishVFS` (`fish_vfs.go`) uses `path.Join`/`path.IsAbs`/`path.Clean`
+— strictly POSIX. Returning `C:\Users\foo` from `pwd` would break
+every join and every abs-check in the VFS. So:
+
+**helper.ps1 speaks POSIX-shaped paths on the wire.** Windows
+translation lives entirely inside helper.ps1.
+
+Convention (matches Cygwin / Git-Bash):
+
+```
+/c/Users/foo/bar        ↔  C:\Users\foo\bar
+/d/Backup               ↔  D:\Backup
+//server/share/dir      ↔  \\server\share\dir
+/                       ↔  (virtual root listing drive letters)
+```
+
+Enum of `/` returns one entry per fixed local drive:
+`{c d e ...}` as directory entries with size 0, mtime epoch.
+Enum of `/c` behaves like `C:\` — top-level listing.
+
+Filenames with `\` inside are impossible on Windows (invalid char).
+Filenames with `/` in them are also impossible on Windows. So a name
+returned in a listing never needs re-encoding.
+
+Path arguments the client sends arrive at helper.ps1 as POSIX-shaped
+already (client-side is path-agnostic and just relays what pwd/enum
+gave it). helper.ps1 does the translation, and every `f4_safe_target`
+analog is done post-translation on the Windows path.
+
+`f4_safe_target` port: reject anything that (a) is not `^/[a-z]/` or
+`^//[^/]+/` shaped, (b) contains a `/../` or ends in `/..`. Same
+spirit as POSIX: absolute, no dot-dot components.
+
+## Feats string, final draft
+
+```
+FISHPLUS 1 flavor:pwsh base64 grep sed awk wc head tail truncate touch \
+         date sha256sum findbin jobs cp dd readlink du chown \
+         mode:stat read:filestream write:b64 headc headsafe tailc \
+         ddnotrunc statl ddbytes awkflush
+```
+
+Every `feats.Has(...)` check on the client side is satisfied by
+announcing the fake feature — real work goes through .NET. Rationale
+per token:
+
+- `mode:stat` — required by `parseListing` (hard enum
+  `{find,stat,statbsd,ls}`); we emit stat's `%f %s %Y %X %Z %u %g %n`
+  with hex mode.
+- `read:filestream` — informational; `ReadMode()` just returns the
+  string.
+- `write:b64` — **mandatory**; `Client.Write` gates the base64 payload
+  path on `writeMode == "b64"`. Any other value makes the client send
+  raw bytes and PS's line-buffered stdin can't count them.
+- `chown` — announced yes (fake) so the client offers the menu; the
+  actual `chown` command returns `err "chown unsupported on windows"`.
+  Alternative would be to hide the menu; announcing lets the user
+  discover the limitation instead of finding it missing.
+- `findbin`, `awk`, `jobs`, `sha256sum` — gate `CanFind/CanIndexLines/
+  CanRunJobs/CanScan/hash` on the client side. All fake — .NET does
+  the actual work.
+- `sed`, `grep`, `wc`, `head`, `tail`, `cp`, `dd`, `du`, `readlink`,
+  `truncate`, `touch`, `date`, `base64` — checked by `feats.Has(...)`
+  various places; announce for compatibility.
+- `headc`, `headsafe`, `tailc`, `ddnotrunc`, `statl`, `ddbytes`,
+  `awkflush` — sub-feature flags helper.sh advertises; announced for
+  symmetry, meaning "capability implied by using .NET". Cost is zero
+  and it keeps the feature-parity story clean.
+
+## helper.ps1 layout (final)
+
+1. **Prologue** (~30 lines) — `$F4TOKEN`, `$F4PROTO`, constants,
+   pragma comments, license header.
+2. **Setup** (~50 lines) — force UTF-8, force LF, disable prompts /
+   progress / PSReadLine, capture raw stdin/stdout streams as
+   `[FileStream]` for byte-exact I/O.
+3. **Path translation** (~80 lines) — `PosixToWin`, `WinToPosix`,
+   `SafeTarget`, `DriveList`, `IsVirtualRoot`.
+4. **Wire I/O primitives** (~100 lines) — `Emit-Line`, `Emit-Frame`,
+   `Emit-End`, `Emit-EndErr`, `Read-CmdLine`, `Read-PathLine`,
+   `Read-Base64Line`, `Read-ExactBytes`, `Flat-Message`.
+5. **Entry synthesis** (~120 lines) — `Get-StatMode` (project
+   `FileAttributes` onto a hex st_mode with type bits), `Format-StatEntry`
+   (emit `%f %s %Y %X %Z %u %g %n` line), owner SID → uid/gid stub
+   (0/0 by default; TBD if we ever want real Windows SIDs).
+6. **Command implementations** (~700 lines) — one function per wire
+   command, `Cmd-Foo`. Grouped by domain in the file (listing,
+   mutation, I/O, search, jobs).
+7. **Job runtime** (~150 lines) — job dir under `%TEMP%\.f4jobs.<pid>.<token>`,
+   `Start-ThreadJob` (fallback: `Start-Job`) with output/err/rc/kill/n files,
+   scan/hash/exec job bodies.
+8. **Banner + dispatch loop** (~50 lines) — emit `printf '\n'` analog,
+   emit banner, then `while ($line = Read-CmdLine) { switch ($cmd) ... }`.
+9. **Trap cleanup** (~10 lines) — `try/finally` to `Remove-Item -Recurse
+   -Force $F4JDIR` on exit, kill any running jobs.
+
+Total estimate: ~1200 lines of PowerShell.
+
+## Go-side changes needed (Phase 2 of the port)
+
+Minimal set to make an auto-probing client find and drive helper.ps1:
+
+- `script.go`: add `//go:embed helper.ps1` + `HelperSourcePwsh()` +
+  `HelperScriptPwsh(token)` + `BootstrapBase64LinePwsh(token)`.
+  `Compact` for PowerShell: strip CRs, keep comments (PS syntax has
+  hash-based comments, but stripping requires care — safer to just
+  strip CRs and blank lines).
+- `session.go`: add `flavor` field to `Session`; add `Flavor()` accessor
+  on `Features` reading the `flavor:` tag from the banner; extend
+  `HandshakeOptions` with a `Flavor` field or a new `BootstrapMethod`
+  constant `BootstrapBase64LinePwsh`; in `HandshakeWithOptions` branch
+  on flavor and select the right helper source.
+- Auto-probe (choice B): before the bootstrap, send one line
+  `echo __F4A__$([regex]::Match($PSVersionTable.PSVersion.ToString(),'^\d+').Value)__F4B__\n`,
+  read up to N lines looking for one that matches `__F4A__(\d*)__F4B__`,
+  branch on whether digits were captured. New function
+  `ProbeFlavor(ctx) (Flavor, error)` on `Session`.
+- Testing: `TestHelperAgainstLocalPwsh` gated on `pwsh` on PATH, using
+  the same shape as `TestHelperAgainstLocalShell` (`session_test.go:805-…`).
+
+The wire tests in `*_test.go` need no change — `mockPeer` is
+language-agnostic.

--- a/plugins/netfox/fishplus/helper.ps1
+++ b/plugins/netfox/fishplus/helper.ps1
@@ -81,11 +81,21 @@ $F4NlBytes  = [byte[]]@($F4LF)
 # Path translation and safety guard.
 # ---------------------------------------------------------------------
 
+# The helper's target host is Windows; the wire uses Cygwin-shaped POSIX
+# paths that must be translated back to native Windows form. PowerShell
+# also runs on Linux and macOS, where paths are already POSIX and no
+# translation is meaningful — those platforms come up in the test suite
+# (CI runs the pwsh helper on Linux to catch wire-format regressions),
+# so translation is skipped there.
+$script:OnWindowsHost = ($env:OS -eq 'Windows_NT')
+
 # Decodes a wire path to a Windows path. The empty string, the virtual
 # root "/", and single-drive paths like "/c/" are handled explicitly so
-# the caller does not have to.
+# the caller does not have to. Under a non-Windows host the wire path
+# already matches the local filesystem, so it is returned verbatim.
 function Convert-PosixToWin([string]$p) {
     if ($null -eq $p) { return $null }
+    if (-not $script:OnWindowsHost) { return $p }
     if ($p -eq '' -or $p -eq '/') { return '' }
     # UNC: //server/share/rest -> \\server\share\rest
     if ($p.StartsWith('//')) {
@@ -121,6 +131,7 @@ function Convert-PosixToWin([string]$p) {
 # helper.sh's tools produce.
 function Convert-WinToPosix([string]$w) {
     if ($null -eq $w -or $w -eq '') { return '/' }
+    if (-not $script:OnWindowsHost) { return $w }
     if ($w.StartsWith('\\')) {
         # \\server\share\rest
         $tail = $w.Substring(2).Replace('\', '/')

--- a/plugins/netfox/fishplus/helper.ps1
+++ b/plugins/netfox/fishplus/helper.ps1
@@ -188,6 +188,9 @@ function Test-SafeTarget([string]$winPath) {
     # Absolute: either drive-letter (X:\) or UNC (\\srv\share).
     if ($winPath.Length -ge 3 -and $winPath[1] -eq ':' -and ($winPath[2] -eq '\' -or $winPath[2] -eq '/')) { return $true }
     if ($winPath.StartsWith('\\')) { return $true }
+    # On a non-Windows host, path translation is a no-op and the path
+    # arrives here in native POSIX shape: absolute means leading '/'.
+    if (-not $script:OnWindowsHost -and $winPath.StartsWith('/')) { return $true }
     return $false
 }
 

--- a/plugins/netfox/fishplus/helper.ps1
+++ b/plugins/netfox/fishplus/helper.ps1
@@ -1,0 +1,1945 @@
+# FISH+ remote helper, protocol version 1, PowerShell backend.
+#
+# Windows counterpart of helper.sh. Same wire protocol on the outside;
+# .NET on the inside. The client that talks to us is the same Go program
+# that speaks to /bin/sh; nothing on that side knows Windows.
+#
+# Paths on the wire are POSIX-shaped (Cygwin convention):
+#   /c/Users/foo   <->   C:\Users\foo
+#   //server/share <->   \\server\share
+#   /              <->   virtual root, lists local drives as directories
+# Every translation is done inside this file; the request stream stays
+# byte-for-byte compatible with what helper.sh produces.
+#
+# See WINDOWS_PORT.md in this directory for the full design notes and
+# the rationale behind every feature announced in the banner.
+
+$F4TOKEN = '__F4_TOKEN__'
+$F4PROTO = 1
+
+# ---------------------------------------------------------------------
+# Setup: force byte-safe, LF-only, prompt-free I/O.
+# The wire protocol requires exact byte counts on both directions and
+# LF line endings; anything else desynchronizes the session.
+# ---------------------------------------------------------------------
+$ErrorActionPreference = 'Stop'
+$ProgressPreference    = 'SilentlyContinue'
+$WarningPreference     = 'SilentlyContinue'
+$VerbosePreference     = 'SilentlyContinue'
+$DebugPreference       = 'SilentlyContinue'
+$InformationPreference = 'SilentlyContinue'
+$ConfirmPreference     = 'None'
+
+# PSReadLine hooks TAB, cursor keys and buffer paints; even a NonInteractive
+# session can pull it in through a profile. Nothing here reads from the
+# console line editor.
+if (Get-Module PSReadLine -ErrorAction SilentlyContinue) {
+    Remove-Module PSReadLine -Force -ErrorAction SilentlyContinue
+}
+
+# The encoding the console host decodes stdin with. It has to be read
+# before anything else touches the console, because it is the key that
+# turns a line the host handed us back into the bytes that arrived on the
+# wire: the host decodes stdin with its own code page (cp866, cp1252, ...)
+# and never asks us. Reversing that decoding is what keeps a UTF-8 path
+# byte-exact. [Console]::InputEncoding is deliberately NOT set: the host's
+# line reader captured its encoding at startup and ignores later changes,
+# so setting it would only desynchronize this key from reality.
+$F4HostEnc = [Console]::InputEncoding
+
+# UTF-8 without BOM on stdout; a BOM at the start of the banner would
+# ruin the terminator's "starts a line" property.
+$utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+try {
+    [Console]::OutputEncoding = $utf8NoBom
+    $OutputEncoding           = $utf8NoBom
+} catch { }
+
+# Silence the console host's own writer. Two things go through it that
+# would corrupt the wire: the prompt it paints between commands, and the
+# echo of every line it reads for us when stdin is a pipe. Nothing in this
+# helper prints through it — every byte we emit goes to the raw stdout
+# stream below — so muting it costs nothing and removes both hazards.
+try { [Console]::SetOut([System.IO.TextWriter]::Null) } catch { }
+
+# Raw byte streams. Everything binary — the "#<n>" frame during read,
+# the base64 payload line during write — goes through these to bypass
+# PS's text pipeline entirely. Wrap stdout in a buffered stream so the
+# terminator is emitted as a single Write, not a syscall per character.
+#
+# stdin is deliberately NOT opened here. Merely opening it costs bytes:
+# the stream buffers whatever has arrived, and those bytes then belong to
+# neither reader — the console host cannot see them and we never ask for
+# them once the host turns out to be the one doing the reading. It is
+# opened on first use instead, which only happens where stdin is ours.
+$F4RawOut   = [Console]::OpenStandardOutput()
+$F4Out      = New-Object System.IO.BufferedStream($F4RawOut, 65536)
+$F4LF       = [byte]0x0A
+$F4NlBytes  = [byte[]]@($F4LF)
+
+# ---------------------------------------------------------------------
+# Path translation and safety guard.
+# ---------------------------------------------------------------------
+
+# Decodes a wire path to a Windows path. The empty string, the virtual
+# root "/", and single-drive paths like "/c/" are handled explicitly so
+# the caller does not have to.
+function Convert-PosixToWin([string]$p) {
+    if ($null -eq $p) { return $null }
+    if ($p -eq '' -or $p -eq '/') { return '' }
+    # UNC: //server/share/rest -> \\server\share\rest
+    if ($p.StartsWith('//')) {
+        $rest = $p.Substring(2).Replace('/', '\')
+        return '\\' + $rest
+    }
+    if (-not $p.StartsWith('/')) {
+        # Relative paths never enter helper.sh either; every wire path
+        # comes from a pwd or an enum, both of which return absolutes.
+        return $p.Replace('/', '\')
+    }
+    # /c/foo/bar or /c
+    $tail = $p.Substring(1)
+    $slash = $tail.IndexOf('/')
+    if ($slash -lt 0) {
+        # /c -> C:\
+        if ($tail.Length -eq 1) { return $tail.ToUpper() + ':\' }
+        # /something-not-a-drive at top level; not addressable on Windows
+        return $tail.Replace('/', '\')
+    }
+    $drive = $tail.Substring(0, $slash)
+    $rest  = $tail.Substring($slash + 1)
+    if ($drive.Length -eq 1) {
+        $win = $drive.ToUpper() + ':\' + $rest.Replace('/', '\')
+        return $win
+    }
+    # Not a drive-shaped first segment: treat as-is with separator swap.
+    return $p.Substring(1).Replace('/', '\')
+}
+
+# Encodes a Windows path as a wire path. The result never ends in a
+# separator (except the virtual root itself), which matches what
+# helper.sh's tools produce.
+function Convert-WinToPosix([string]$w) {
+    if ($null -eq $w -or $w -eq '') { return '/' }
+    if ($w.StartsWith('\\')) {
+        # \\server\share\rest
+        $tail = $w.Substring(2).Replace('\', '/')
+        return '//' + $tail.TrimEnd('/')
+    }
+    if ($w.Length -ge 2 -and $w[1] -eq ':') {
+        $drive = [char]::ToLower($w[0])
+        $rest  = if ($w.Length -gt 2) { $w.Substring(2).TrimStart('\').Replace('\', '/') } else { '' }
+        if ($rest -eq '') { return '/' + $drive }
+        return '/' + $drive + '/' + $rest.TrimEnd('/')
+    }
+    # Path without a drive letter, no UNC — probably came from an odd
+    # cmdlet result. Fall back to naive translation.
+    return '/' + $w.Replace('\', '/').TrimStart('/').TrimEnd('/')
+}
+
+# The virtual root is not backed by a filesystem: only "/" is virtual;
+# every other path resolves to something real.
+function Test-VirtualRoot([string]$p) { return $p -eq '' -or $p -eq '/' }
+
+# Enumerates the fixed drives on this host. Removable/network drives are
+# included as well so a user who plugged a stick in can see it under /d;
+# the cost is one extra stat on the wire when the drive is absent.
+function Get-RootEntries {
+    $result = New-Object System.Collections.Generic.List[hashtable]
+    foreach ($d in [System.IO.DriveInfo]::GetDrives()) {
+        if (-not $d.IsReady) {
+            # An unready drive still shows up: the panel can display it,
+            # and enum-ing into it will fail cleanly with "not a directory".
+        }
+        $name = $d.Name.TrimEnd('\', ':').ToLower()
+        if ($name.Length -eq 0) { continue }
+        $result.Add(@{
+            Name  = $name
+            IsDir = $true
+            Size  = 0L
+            MTime = [DateTimeOffset]::FromUnixTimeSeconds(0)
+            ATime = [DateTimeOffset]::FromUnixTimeSeconds(0)
+            CTime = [DateTimeOffset]::FromUnixTimeSeconds(0)
+            Mode  = 0x41ED   # 040755 dir
+        })
+    }
+    return $result
+}
+
+# f4_safe_target port: absolute path, no dot-dot segments, and not the
+# virtual root (which is meaningful for enum but not for a destructive
+# op). Called AFTER the wire path has been translated to Windows.
+function Test-SafeTarget([string]$winPath) {
+    if ([string]::IsNullOrEmpty($winPath)) { return $false }
+    $lower = $winPath.ToLower()
+    if ($lower -like '*\..\*' -or $lower -like '*/../*') { return $false }
+    if ($lower.EndsWith('\..') -or $lower.EndsWith('/..')) { return $false }
+    # Absolute: either drive-letter (X:\) or UNC (\\srv\share).
+    if ($winPath.Length -ge 3 -and $winPath[1] -eq ':' -and ($winPath[2] -eq '\' -or $winPath[2] -eq '/')) { return $true }
+    if ($winPath.StartsWith('\\')) { return $true }
+    return $false
+}
+
+# ---------------------------------------------------------------------
+# Wire I/O primitives.
+# Every emit that touches stdout goes through these; nothing else prints.
+# ---------------------------------------------------------------------
+
+$script:F4ID = 0
+
+function Write-BytesRaw([byte[]]$b) {
+    if ($null -eq $b -or $b.Length -eq 0) { return }
+    $F4Out.Write($b, 0, $b.Length)
+}
+
+function Write-LineBytes([byte[]]$b) {
+    if ($null -ne $b -and $b.Length -gt 0) {
+        $F4Out.Write($b, 0, $b.Length)
+    }
+    $F4Out.Write($F4NlBytes, 0, 1)
+}
+
+function Write-Line([string]$s) {
+    if ($null -eq $s) { $s = '' }
+    $bytes = $utf8NoBom.GetBytes($s)
+    Write-LineBytes $bytes
+}
+
+function Write-Frame([byte[]]$data) {
+    $n = if ($null -eq $data) { 0 } else { $data.Length }
+    Write-Line ("#" + $n)
+    if ($n -gt 0) { Write-BytesRaw $data }
+}
+
+# Reduce every disturbing byte in an error message to a plain space so
+# the client always parses it as one line.
+function Format-Flat([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return '' }
+    $sb = New-Object System.Text.StringBuilder $s.Length
+    foreach ($c in $s.ToCharArray()) {
+        switch ($c) {
+            "`r" { [void]$sb.Append(' ') }
+            "`n" { [void]$sb.Append(' ') }
+            "`t" { [void]$sb.Append(' ') }
+            default { [void]$sb.Append($c) }
+        }
+    }
+    return $sb.ToString()
+}
+
+function Write-End([string]$status, [string]$msg) {
+    $line = ".$F4TOKEN $($script:F4ID) $status"
+    if (-not [string]::IsNullOrEmpty($msg)) {
+        $line = $line + ' ' + (Format-Flat $msg)
+    }
+    Write-Line $line
+    $F4Out.Flush()
+}
+
+function Write-Ok { Write-End 'ok' $null }
+function Write-Err([string]$msg) { Write-End 'err' $msg }
+
+# Reads one LF-terminated line from stdin as raw bytes, decoded UTF-8.
+# Returns $null on EOF. The buffered read matches what helper.sh sees
+# from "IFS= read -r".
+#
+# Which of the two paths below is usable is decided by the host, not by us.
+# A console host with a redirected stdin keeps a read pending on that handle
+# for its own line reader, and it wins every race: bytes that arrive after
+# the helper started are consumed by the host and a stream read here blocks
+# forever. So the host's reader is asked first, and the raw stream is used
+# only where the host refuses to read at all (-NonInteractive), which is the
+# standalone case where nothing competes for stdin anyway.
+$script:F4LineBuf = New-Object System.IO.MemoryStream
+$script:F4ReadMode = $null      # 'host' | 'stream'
+
+# One line through the host's reader, converted back to the bytes that
+# arrived. Returns $null on EOF; the host strips the line terminator
+# itself, CR included.
+function Read-HostLineBytes {
+    $line = $host.UI.ReadLine()
+    if ($null -eq $line) { return $null }
+    return $F4HostEnc.GetBytes($line)
+}
+
+# Opens stdin the first time a stream read needs it. See the note at the
+# top: opening it eagerly would swallow bytes the console host is meant
+# to hand us.
+$script:F4In = $null
+function Get-StdIn {
+    if ($null -eq $script:F4In) { $script:F4In = [Console]::OpenStandardInput() }
+    return $script:F4In
+}
+
+function Read-StreamLineBytes {
+    $in = Get-StdIn
+    $script:F4LineBuf.SetLength(0)
+    $one = New-Object 'byte[]' 1
+    while ($true) {
+        $n = $in.Read($one, 0, 1)
+        if ($n -le 0) {
+            if ($script:F4LineBuf.Length -eq 0) { return $null }
+            break
+        }
+        if ($one[0] -eq 0x0A) { break }
+        if ($one[0] -eq 0x0D) { continue }   # tolerate CRLF
+        $script:F4LineBuf.WriteByte($one[0])
+    }
+    return $script:F4LineBuf.ToArray()
+}
+
+function Read-LineBytes {
+    if ($null -eq $script:F4ReadMode) {
+        # The probe doubles as the first read: a host that answers has
+        # already consumed the line, so it must not be read twice.
+        try {
+            $b = Read-HostLineBytes
+            $script:F4ReadMode = 'host'
+            return $b
+        } catch {
+            $script:F4ReadMode = 'stream'
+        }
+    }
+    if ($script:F4ReadMode -eq 'host') { return Read-HostLineBytes }
+    return Read-StreamLineBytes
+}
+
+function Read-Line {
+    $b = Read-LineBytes
+    if ($null -eq $b) { return $null }
+    return $utf8NoBom.GetString($b)
+}
+
+# Reads a path line: base64-decode iff prefixed with '~'; otherwise
+# take the bytes verbatim. Returns the wire path (POSIX-shape); the
+# caller passes it to Convert-PosixToWin when it needs the OS form.
+function Read-PathLine {
+    $line = Read-Line
+    if ($null -eq $line) { throw 'eof' }
+    if ($line.StartsWith('~')) {
+        try {
+            $raw = [Convert]::FromBase64String($line.Substring(1))
+            return $utf8NoBom.GetString($raw)
+        } catch {
+            throw 'bad base64 path'
+        }
+    }
+    return $line
+}
+
+# Read the exact requested number of bytes from stdin.
+#
+# Only reachable while stdin belongs to us. Once the console host is doing
+# the reading there is no byte-exact path left — the host hands out whole
+# decoded lines and nothing smaller — so a raw payload is refused instead
+# of being half-read. The client never asks for one: the banner announces
+# write:b64, and wmode accepts nothing else.
+function Read-ExactBytes([int]$n) {
+    if ($script:F4ReadMode -eq 'host') {
+        throw 'raw payloads need byte-exact stdin, which this host does not give; use b64'
+    }
+    if ($n -le 0) { return [byte[]]@() }
+    $in = Get-StdIn
+    $buf = New-Object 'byte[]' $n
+    $off = 0
+    while ($off -lt $n) {
+        $r = $in.Read($buf, $off, $n - $off)
+        if ($r -le 0) { throw 'eof during payload' }
+        $off += $r
+    }
+    return $buf
+}
+
+# Numeric-argument helpers matching helper.sh's f4_num, plus a small
+# bounds check for the many "count" arguments in the wire grammar.
+function Test-IsUInt([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return $false }
+    foreach ($c in $s.ToCharArray()) {
+        if ($c -lt '0' -or $c -gt '9') { return $false }
+    }
+    return $true
+}
+function Parse-UInt([string]$s) {
+    if (-not (Test-IsUInt $s)) { throw "not a number: $s" }
+    return [int64]$s
+}
+
+# ---------------------------------------------------------------------
+# Entry synthesis: turn a Windows FileSystemInfo into a stat-shaped
+# line the client's parseStatEntry expects.
+# Format: "%f %s %Y %X %Z %u %g %n"   (mode in hex)
+# ---------------------------------------------------------------------
+
+# 040000 dir, 100000 reg, 120000 lnk in octal; here in hex.
+$F4MODE_DIR = 0x4000
+$F4MODE_REG = 0x8000
+$F4MODE_LNK = 0xA000
+$F4PERM_DEF = 0x1ED     # 0755
+$F4PERM_RO  = 0x1A4     # 0644
+
+function Get-EntryMode {
+    param([System.IO.FileSystemInfo]$fi)
+    $attr = $fi.Attributes
+    $type = if ($attr -band [System.IO.FileAttributes]::ReparsePoint) { $F4MODE_LNK }
+            elseif ($attr -band [System.IO.FileAttributes]::Directory)  { $F4MODE_DIR }
+            else { $F4MODE_REG }
+    $perm = if ($attr -band [System.IO.FileAttributes]::ReadOnly) { $F4PERM_RO } else { $F4PERM_DEF }
+    return $type -bor $perm
+}
+
+function Get-EpochSecs([datetime]$t) {
+    try {
+        return [int64]([DateTimeOffset]::new($t.ToUniversalTime(), [TimeSpan]::Zero)).ToUnixTimeSeconds()
+    } catch { return 0 }
+}
+
+# Emits one stat-format entry line. $nameOverride lets the caller
+# substitute the full path (used by tree search where the client needs
+# it) or force the name to "." for a self-stat.
+function Emit-StatEntry {
+    param(
+        [System.IO.FileSystemInfo]$fi,
+        [string]$nameOverride,
+        [int64]$sizeOverride = -1
+    )
+    $mode = Get-EntryMode $fi
+    $size = if ($sizeOverride -ge 0) {
+                $sizeOverride
+            } elseif ($fi -is [System.IO.FileInfo]) {
+                $fi.Length
+            } else { 0 }
+    $mtime = Get-EpochSecs $fi.LastWriteTimeUtc
+    $atime = Get-EpochSecs $fi.LastAccessTimeUtc
+    $ctime = Get-EpochSecs $fi.CreationTimeUtc
+    $name = if ([string]::IsNullOrEmpty($nameOverride)) { $fi.Name } else { $nameOverride }
+    Write-Line ("{0:x} {1} {2} {3} {4} 0 0 {5}" -f $mode, $size, $mtime, $atime, $ctime, $name)
+}
+
+# Emits the mode marker the client's parseListing keys off of.
+function Emit-ModeLine { Write-Line 'M stat' }
+
+# ---------------------------------------------------------------------
+# Cmd-* implementations. One function per wire command.
+# ---------------------------------------------------------------------
+
+function Cmd-Noop { Write-Ok }
+
+function Cmd-Pwd {
+    try {
+        $w = (Get-Location).Path
+        Write-Line (Convert-WinToPosix $w)
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Ping {
+    try {
+        $p = Read-PathLine
+        Write-Line $p
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Enum {
+    try {
+        $wire = Read-PathLine
+        if (Test-VirtualRoot $wire) {
+            Emit-ModeLine
+            foreach ($r in Get-RootEntries) {
+                # Root pseudo-entries look like dirs with mtime 0.
+                Write-Line ("{0:x} 0 0 0 0 0 0 {1}" -f $r.Mode, $r.Name)
+            }
+            Write-Ok
+            return
+        }
+        $win = Convert-PosixToWin $wire
+        if (-not (Test-Path -LiteralPath $win -PathType Container)) {
+            Write-Err 'not a directory'
+            return
+        }
+        Emit-ModeLine
+        # -Force includes hidden and system entries; -ErrorAction Stop
+        # would abort on the first inaccessible child, which is not
+        # what a panel wants.
+        $items = @()
+        try {
+            $items = Get-ChildItem -LiteralPath $win -Force -ErrorAction Stop
+        } catch {
+            Write-Err $_.Exception.Message
+            return
+        }
+        foreach ($it in $items) {
+            try { Emit-StatEntry -fi $it } catch { }
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-IsDirs {
+    param([string]$countArg)
+    try {
+        $n = Parse-UInt $countArg
+        $paths = New-Object 'string[]' $n
+        for ($i = 0; $i -lt $n; $i++) { $paths[$i] = Read-PathLine }
+        foreach ($p in $paths) {
+            if (Test-VirtualRoot $p) { Write-Line '1'; continue }
+            $w = Convert-PosixToWin $p
+            if ([System.IO.Directory]::Exists($w)) { Write-Line '1' } else { Write-Line '0' }
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Info {
+    param([bool]$follow)
+    try {
+        $wire = Read-PathLine
+        if (Test-VirtualRoot $wire) {
+            Emit-ModeLine
+            # The format operator binds tighter than -bor, so the mode has to
+            # be combined before it is formatted or the string gets ored.
+            Write-Line ("{0:x} 0 0 0 0 0 0 /" -f ($F4MODE_DIR -bor $F4PERM_DEF))
+            Write-Ok
+            return
+        }
+        $win = Convert-PosixToWin $wire
+        if (-not (Test-Path -LiteralPath $win)) {
+            Write-Err 'no such file'
+            return
+        }
+        $fi = Get-Item -LiteralPath $win -Force -ErrorAction Stop
+        if ($follow -and ($fi.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            try {
+                $resolved = [System.IO.Path]::GetFullPath($fi.Target)
+                if (Test-Path -LiteralPath $resolved) {
+                    $fi = Get-Item -LiteralPath $resolved -Force -ErrorAction Stop
+                }
+            } catch { }
+        }
+        Emit-ModeLine
+        # Name comes from the request on the client side, so what we
+        # emit is only for shape.
+        Emit-StatEntry -fi $fi -nameOverride $fi.Name
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-RdLink {
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        $fi   = Get-Item -LiteralPath $win -Force -ErrorAction Stop
+        if (-not ($fi.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            Write-Err 'not a symbolic link'
+            return
+        }
+        $t = $fi.Target
+        if ($null -eq $t -or $t -eq '') {
+            Write-Err 'no target'
+            return
+        }
+        # If the target is a Windows path we translate; otherwise emit
+        # as-is so a relative symlink's target survives unchanged.
+        if ($t -match '^[A-Za-z]:\\' -or $t.StartsWith('\\')) {
+            Write-Line (Convert-WinToPosix $t)
+        } else {
+            Write-Line ($t -replace '\\', '/')
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Mkdir {
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        [void](New-Item -ItemType Directory -Path $win -Force -ErrorAction Stop)
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Rm {
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        if (Test-Path -LiteralPath $win) {
+            Remove-Item -LiteralPath $win -Force -ErrorAction Stop
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Rmdir {
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        [System.IO.Directory]::Delete($win, $false)
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Rmtree {
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        if (Test-Path -LiteralPath $win) {
+            Remove-Item -LiteralPath $win -Recurse -Force -ErrorAction Stop
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Mv {
+    try {
+        $src = Convert-PosixToWin (Read-PathLine)
+        $dst = Convert-PosixToWin (Read-PathLine)
+        if (-not (Test-SafeTarget $src)) { Write-Err 'unsafe path'; return }
+        if (-not (Test-SafeTarget $dst)) { Write-Err 'unsafe path'; return }
+        Move-Item -LiteralPath $src -Destination $dst -Force -ErrorAction Stop
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Cp {
+    try {
+        $src = Convert-PosixToWin (Read-PathLine)
+        $dst = Convert-PosixToWin (Read-PathLine)
+        if (-not (Test-SafeTarget $src)) { Write-Err 'unsafe path'; return }
+        if (-not (Test-SafeTarget $dst)) { Write-Err 'unsafe path'; return }
+        Copy-Item -LiteralPath $src -Destination $dst -Recurse -Force -ErrorAction Stop
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# chmod on Windows is a projection: any write bit -> clear ReadOnly,
+# otherwise set ReadOnly. Nothing else NTFS ACLs express is touched.
+function Cmd-Chmod {
+    param([string]$modeArg)
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        if ($modeArg -match '[^0-7]' -or [string]::IsNullOrEmpty($modeArg)) {
+            Write-Err 'bad mode'
+            return
+        }
+        $m = [Convert]::ToInt32($modeArg, 8)
+        $ro = -not (($m -band 0x92) -ne 0)   # user/group/other write bits
+        $fi = Get-Item -LiteralPath $win -Force -ErrorAction Stop
+        if ($ro) {
+            $fi.Attributes = $fi.Attributes -bor [System.IO.FileAttributes]::ReadOnly
+        } else {
+            $fi.Attributes = $fi.Attributes -band (-bnot [System.IO.FileAttributes]::ReadOnly)
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# chown is meaningless without NTFS ACL manipulation, which we
+# deliberately don't do. Announced as a feature (so the client offers
+# the menu), refused with a clear message when invoked.
+function Cmd-Chown {
+    param([string]$uid, [string]$gid)
+    try {
+        $wire = Read-PathLine
+        Write-Err 'chown is not supported on this Windows host'
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Utime {
+    param([string]$mtimeArg, [string]$atimeArg)
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        if (($mtimeArg -ne '-' -and -not (Test-IsUInt $mtimeArg)) -or
+            ($atimeArg -ne '-' -and -not (Test-IsUInt $atimeArg))) {
+            Write-Err 'bad timestamp'
+            return
+        }
+        if ($mtimeArg -eq '-' -and $atimeArg -eq '-') {
+            Write-Err 'nothing to change'
+            return
+        }
+        if (-not (Test-Path -LiteralPath $win)) { Write-Err 'no such file'; return }
+        if ($mtimeArg -ne '-') {
+            $t = [DateTimeOffset]::FromUnixTimeSeconds([int64]$mtimeArg).UtcDateTime
+            [System.IO.File]::SetLastWriteTimeUtc($win, $t)
+        }
+        if ($atimeArg -ne '-') {
+            $t = [DateTimeOffset]::FromUnixTimeSeconds([int64]$atimeArg).UtcDateTime
+            [System.IO.File]::SetLastAccessTimeUtc($win, $t)
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-Trunc {
+    param([string]$sizeArg)
+    try {
+        $wire = Read-PathLine
+        $win  = Convert-PosixToWin $wire
+        if (-not (Test-SafeTarget $win)) { Write-Err 'unsafe path'; return }
+        if (-not (Test-IsUInt $sizeArg)) { Write-Err 'bad size'; return }
+        $size = [int64]$sizeArg
+        if ([System.IO.Directory]::Exists($win)) { Write-Err 'is a directory'; return }
+        if ($size -eq 0) {
+            # Same semantics as ": > file" — creates the file if absent.
+            [System.IO.File]::WriteAllBytes($win, [byte[]]@())
+            Write-Ok
+            return
+        }
+        $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::OpenOrCreate,
+                                     [System.IO.FileAccess]::Write,
+                                     [System.IO.FileShare]::Read)
+        try { $fs.SetLength($size) } finally { $fs.Dispose() }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# ---------------------------------------------------------------------
+# read: server -> client range transfer. Emits "S <size>" + one binary
+# frame with the bytes actually read. Length 0 means "to the end".
+# ---------------------------------------------------------------------
+function Cmd-Read {
+    param([string]$offArg, [string]$lenArg)
+    try {
+        $wire = Read-PathLine
+        if (-not (Test-IsUInt $offArg) -or -not (Test-IsUInt $lenArg)) {
+            Write-Err 'bad range'; return
+        }
+        $off = [int64]$offArg
+        $len = [int64]$lenArg
+        $win = Convert-PosixToWin $wire
+        if (-not (Test-Path -LiteralPath $win)) { Write-Err 'no such file'; return }
+        if ([System.IO.Directory]::Exists($win)) { Write-Err 'is a directory'; return }
+        $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::Open,
+                                     [System.IO.FileAccess]::Read,
+                                     [System.IO.FileShare]::ReadWrite)
+        try {
+            $size = $fs.Length
+            $avail = 0L
+            if ($off -lt $size) {
+                $avail = $size - $off
+                if ($len -gt 0 -and $len -lt $avail) { $avail = $len }
+            }
+            Write-Line ("S " + $size)
+            Write-Line ("#" + $avail)
+            if ($avail -gt 0) {
+                [void]$fs.Seek($off, [System.IO.SeekOrigin]::Begin)
+                # Stream in 64 KiB blocks straight to stdout; we already
+                # wrote the "#<n>" header, and Read-BytesFrom-Stream
+                # keeps its own byte count so a short read is fatal.
+                $remain = $avail
+                $buf = New-Object 'byte[]' 65536
+                while ($remain -gt 0) {
+                    $want = [int]([Math]::Min([int64]$buf.Length, $remain))
+                    $got  = $fs.Read($buf, 0, $want)
+                    if ($got -le 0) { throw 'short read' }
+                    $F4Out.Write($buf, 0, $got)
+                    $remain -= $got
+                }
+            }
+            Write-Ok
+        } finally { $fs.Dispose() }
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# ---------------------------------------------------------------------
+# write: client -> server. Only "b64" encoding is announced (write:b64),
+# so the payload is one base64 line read via Read-Line.
+# The reply protocol requires a "D" line before the terminator to say
+# the payload was drained; without it the client marks the session
+# broken.
+# ---------------------------------------------------------------------
+function Cmd-Write {
+    param([string]$offArg, [string]$lenArg, [string]$enc)
+    try {
+        $wire = Read-PathLine
+        $err = $null
+        if (-not (Test-IsUInt $offArg) -or -not (Test-IsUInt $lenArg)) {
+            $err = 'bad range'
+        }
+        $win = Convert-PosixToWin $wire
+        if (-not $err -and -not (Test-SafeTarget $win)) {
+            $err = 'unsafe path'
+        }
+        if (-not $err -and [System.IO.Directory]::Exists($win)) {
+            $err = 'is a directory'
+        }
+        switch ($enc) {
+            'b64' {
+                # Payload line arrives whether or not we can write; we
+                # MUST read it to keep the stream aligned.
+                $line = Read-Line
+                if ($null -eq $line) { throw 'eof' }
+                if ($err) {
+                    Write-Line 'D'
+                    Write-Err $err
+                    return
+                }
+                try {
+                    $bytes = [Convert]::FromBase64String($line)
+                } catch {
+                    Write-Line 'D'
+                    Write-Err 'bad base64 payload'
+                    return
+                }
+                # length arg must match the decoded byte count; the
+                # helper.sh port trusts the decoded count and writes it,
+                # so match that behaviour.
+                $off = [int64]$offArg
+                $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::OpenOrCreate,
+                                             [System.IO.FileAccess]::Write,
+                                             [System.IO.FileShare]::Read)
+                try {
+                    [void]$fs.Seek($off, [System.IO.SeekOrigin]::Begin)
+                    $fs.Write($bytes, 0, $bytes.Length)
+                } finally { $fs.Dispose() }
+                Write-Line 'D'
+                Write-Ok
+            }
+            'raw' {
+                # Raw payload: read exactly $lenArg bytes from stdin.
+                # We don't advertise write:raw as a preference, but the
+                # client can still ask for it explicitly via wmode.
+                $n = if (Test-IsUInt $lenArg) { [int64]$lenArg } else { 0 }
+                if ($err) {
+                    if ($n -gt 0) { [void](Read-ExactBytes $n) }
+                    Write-Line 'D'
+                    Write-Err $err
+                    return
+                }
+                $bytes = Read-ExactBytes $n
+                $off = [int64]$offArg
+                $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::OpenOrCreate,
+                                             [System.IO.FileAccess]::Write,
+                                             [System.IO.FileShare]::Read)
+                try {
+                    [void]$fs.Seek($off, [System.IO.SeekOrigin]::Begin)
+                    $fs.Write($bytes, 0, $bytes.Length)
+                } finally { $fs.Dispose() }
+                Write-Line 'D'
+                Write-Ok
+            }
+            default {
+                Write-Err 'bad payload encoding'
+            }
+        }
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# ---------------------------------------------------------------------
+# patch: rebuild <dst> out of segments of <src> (S <off> <len>) and
+# literal bytes (D <len> [+ payload]). See helper.sh's f4_cmd_patch.
+# ---------------------------------------------------------------------
+function Cmd-Patch {
+    param([string]$nsegsArg, [string]$enc)
+    try {
+        $srcWire = Read-PathLine
+        $dstWire = Read-PathLine
+        if ($enc -ne 'raw' -and $enc -ne 'b64') { Write-Err 'bad payload encoding'; return }
+        if (-not (Test-IsUInt $nsegsArg)) { Write-Err 'bad segment count'; return }
+        $nsegs = [int]$nsegsArg
+        $src = Convert-PosixToWin $srcWire
+        $dst = Convert-PosixToWin $dstWire
+        $perr = $null
+        $made = $false
+        if (-not (Test-SafeTarget $dst)) { $perr = 'unsafe path' }
+        elseif ([System.IO.Directory]::Exists($dst)) { $perr = 'is a directory' }
+        elseif (-not (Test-Path -LiteralPath $src -PathType Leaf)) { $perr = 'cannot read the original file' }
+        else {
+            try {
+                [System.IO.File]::WriteAllBytes($dst, [byte[]]@())
+                $made = $true
+            } catch {
+                $perr = $_.Exception.Message
+            }
+        }
+        $srcFs = $null
+        $dstFs = $null
+        try {
+            if (-not $perr) {
+                $srcFs = [System.IO.File]::Open($src, [System.IO.FileMode]::Open,
+                                                [System.IO.FileAccess]::Read,
+                                                [System.IO.FileShare]::ReadWrite)
+                $dstFs = [System.IO.File]::Open($dst, [System.IO.FileMode]::Append,
+                                                [System.IO.FileAccess]::Write,
+                                                [System.IO.FileShare]::Read)
+            }
+            for ($i = 0; $i -lt $nsegs; $i++) {
+                $head = Read-Line
+                if ($null -eq $head) { throw 'eof' }
+                $parts = $head.Split(' ', 3)
+                switch ($parts[0]) {
+                    'S' {
+                        if ($parts.Length -lt 3 -or -not (Test-IsUInt $parts[1]) -or -not (Test-IsUInt $parts[2])) {
+                            if (-not $perr) { $perr = 'bad segment' }
+                            continue
+                        }
+                        if ($perr) { continue }
+                        $so = [int64]$parts[1]
+                        $sl = [int64]$parts[2]
+                        [void]$srcFs.Seek($so, [System.IO.SeekOrigin]::Begin)
+                        $buf = New-Object 'byte[]' 65536
+                        $left = $sl
+                        while ($left -gt 0) {
+                            $want = [int]([Math]::Min([int64]$buf.Length, $left))
+                            $got  = $srcFs.Read($buf, 0, $want)
+                            if ($got -le 0) { $perr = 'copying from the original failed'; break }
+                            $dstFs.Write($buf, 0, $got)
+                            $left -= $got
+                        }
+                    }
+                    'D' {
+                        if ($parts.Length -lt 2 -or -not (Test-IsUInt $parts[1])) {
+                            if ($made) { Remove-Item -LiteralPath $dst -Force -ErrorAction SilentlyContinue }
+                            Write-Err 'bad segment length'
+                            return
+                        }
+                        $dl = [int64]$parts[1]
+                        if ($enc -eq 'b64') {
+                            $payload = Read-Line
+                            if ($null -eq $payload) { throw 'eof' }
+                            if (-not $perr) {
+                                try {
+                                    $bytes = [Convert]::FromBase64String($payload)
+                                    $dstFs.Write($bytes, 0, $bytes.Length)
+                                } catch {
+                                    $perr = 'bad base64 payload'
+                                }
+                            }
+                        } else {
+                            if ($perr) {
+                                if ($dl -gt 0) { [void](Read-ExactBytes $dl) }
+                            } else {
+                                $bytes = Read-ExactBytes $dl
+                                $dstFs.Write($bytes, 0, $bytes.Length)
+                            }
+                        }
+                    }
+                    default {
+                        if ($made) { Remove-Item -LiteralPath $dst -Force -ErrorAction SilentlyContinue }
+                        Write-Err 'bad segment'
+                        return
+                    }
+                }
+            }
+        } finally {
+            if ($null -ne $srcFs) { $srcFs.Dispose() }
+            if ($null -ne $dstFs) { $dstFs.Dispose() }
+        }
+        Write-Line 'D'
+        if ($perr) {
+            if ($made) { Remove-Item -LiteralPath $dst -Force -ErrorAction SilentlyContinue }
+            Write-Err $perr
+        } else {
+            Write-Ok
+        }
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# ---------------------------------------------------------------------
+# grep: byte offset per match, up to <limit> matches. Emits offsets in
+# the same order they appear in the file, one per line.
+# The client passes the byte-oriented offset semantics helper.sh has
+# (grep -abo), so we count bytes in the file, not codepoints.
+# ---------------------------------------------------------------------
+function Cmd-Grep {
+    param([string]$modeArg, [string]$limArg)
+    try {
+        $pat = Read-PathLine       # pattern (arrives as a path line for base64 handling)
+        $wire = Read-PathLine
+        if (-not (Test-IsUInt $limArg)) { Write-Err 'bad limit'; return }
+        $limit = [int]$limArg
+        $mode = if ($modeArg.StartsWith('f')) { 'fixed' }
+                elseif ($modeArg.StartsWith('e')) { 'regex' }
+                else { Write-Err 'bad grep mode'; return }
+        $ci = $modeArg.EndsWith('i')
+        $win = Convert-PosixToWin $wire
+        if (-not (Test-Path -LiteralPath $win -PathType Leaf)) { Write-Err 'not a regular file'; return }
+
+        $patBytes = $utf8NoBom.GetBytes($pat)
+        $rx = $null
+        if ($mode -eq 'regex') {
+            $opts = [System.Text.RegularExpressions.RegexOptions]::CultureInvariant
+            if ($ci) { $opts = $opts -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase }
+            $rx = New-Object System.Text.RegularExpressions.Regex($pat, $opts)
+        }
+
+        $cmp = if ($ci) { [System.StringComparison]::OrdinalIgnoreCase }
+               else     { [System.StringComparison]::Ordinal }
+
+        $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::Open,
+                                     [System.IO.FileAccess]::Read,
+                                     [System.IO.FileShare]::ReadWrite)
+        try {
+            # The file is walked as the byte stream it is rather than through
+            # a StreamReader: the reader hides how long a line's terminator
+            # was, and on a CRLF file — the common case here — every offset
+            # after the first line would be short by one byte per line.
+            # A CR before the LF stays part of the line, which is what grep
+            # sees too.
+            $buf  = New-Object 'byte[]' 65536
+            $acc  = New-Object System.IO.MemoryStream
+            $count = 0
+            $lineStart = 0L
+            $pos = 0L
+            $stop = $false
+            while (-not $stop) {
+                $got = $fs.Read($buf, 0, $buf.Length)
+                if ($got -le 0) { break }
+                for ($i = 0; $i -lt $got; $i++) {
+                    if ($buf[$i] -ne 0x0A) { $acc.WriteByte($buf[$i]); continue }
+                    $count = Emit-GrepHits $acc $lineStart $pat $rx $cmp $count $limit
+                    $acc.SetLength(0)
+                    $lineStart = $pos + $i + 1
+                    if ($count -ge $limit) { $stop = $true; break }
+                }
+                $pos += $got
+            }
+            # A last line without a trailing LF still counts, as it does for
+            # grep.
+            if (-not $stop -and $acc.Length -gt 0) {
+                [void](Emit-GrepHits $acc $lineStart $pat $rx $cmp $count $limit)
+            }
+        } finally { $fs.Dispose() }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# Emits one offset per match inside a single line, the way "grep -a -b -o"
+# does: the offset of the match itself, not of the line holding it, and one
+# line of output per match. Returns the running match count.
+function Emit-GrepHits {
+    param(
+        [System.IO.MemoryStream]$acc,
+        [int64]$lineStart,
+        [string]$pat,
+        $rx,
+        [System.StringComparison]$cmp,
+        [int]$count,
+        [int]$limit
+    )
+    if ($count -ge $limit) { return $count }
+    $text = $utf8NoBom.GetString($acc.ToArray())
+    if ($null -ne $rx) {
+        foreach ($m in $rx.Matches($text)) {
+            Write-Line ([string]($lineStart + $utf8NoBom.GetByteCount($text.Substring(0, $m.Index))))
+            $count++
+            if ($count -ge $limit) { return $count }
+        }
+        return $count
+    }
+    if ($pat.Length -eq 0) { return $count }
+    $from = 0
+    while ($from -le $text.Length - $pat.Length) {
+        $j = $text.IndexOf($pat, $from, $cmp)
+        if ($j -lt 0) { break }
+        Write-Line ([string]($lineStart + $utf8NoBom.GetByteCount($text.Substring(0, $j))))
+        $count++
+        if ($count -ge $limit) { return $count }
+        $from = $j + $pat.Length
+    }
+    return $count
+}
+
+# ---------------------------------------------------------------------
+# lidx <first> <count>: byte offsets of the given lines + "T <total>".
+# One pass over the file; byte offsets are counted at the LF boundary.
+# ---------------------------------------------------------------------
+function Cmd-LineIdx {
+    param([string]$firstArg, [string]$countArg)
+    try {
+        $wire = Read-PathLine
+        if (-not (Test-IsUInt $firstArg) -or -not (Test-IsUInt $countArg)) { Write-Err 'bad line range'; return }
+        $first = [int64]$firstArg
+        $count = [int64]$countArg
+        if ($first -lt 1) { Write-Err 'bad line range'; return }
+        $win = Convert-PosixToWin $wire
+        if (-not (Test-Path -LiteralPath $win -PathType Leaf)) { Write-Err 'not a regular file'; return }
+        $fs = [System.IO.File]::Open($win, [System.IO.FileMode]::Open,
+                                     [System.IO.FileAccess]::Read,
+                                     [System.IO.FileShare]::ReadWrite)
+        try {
+            # Byte-level walk for the same reason as grep: a StreamReader
+            # eats the terminator without saying how many bytes it was, so a
+            # CRLF file came out one byte short per line. awk on the POSIX
+            # side counts the CR as part of the line, and so does this.
+            $buf = New-Object 'byte[]' 65536
+            $lineNo = 0L
+            $lineStart = 0L
+            $pos = 0L
+            while ($true) {
+                $got = $fs.Read($buf, 0, $buf.Length)
+                if ($got -le 0) { break }
+                for ($i = 0; $i -lt $got; $i++) {
+                    if ($buf[$i] -ne 0x0A) { continue }
+                    $lineNo++
+                    if ($lineNo -ge $first -and $lineNo -lt ($first + $count)) {
+                        Write-Line ([string]$lineStart)
+                    }
+                    $lineStart = $pos + $i + 1
+                }
+                $pos += $got
+            }
+            # A trailing line with no LF of its own is still a line.
+            if ($lineStart -lt $pos) {
+                $lineNo++
+                if ($lineNo -ge $first -and $lineNo -lt ($first + $count)) {
+                    Write-Line ([string]$lineStart)
+                }
+            }
+            Write-Line ("T " + $lineNo)
+        } finally { $fs.Dispose() }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# Byte-level content search over a file. Reads it in fixed chunks and
+# does the match on each chunk after decoding through ISO-8859-1 — the
+# only byte-transparent single-byte .NET encoding, where every byte b
+# becomes the char U+00b. That lets .NET's native String.IndexOf and
+# Regex.IsMatch run over the raw bytes without ever loading the whole
+# file, which is what grep -a does with its 32 KB read buffer. A
+# previous size-cap approach here was working around symptoms; this is
+# the actual fix. Runs at wire speed even against multi-gigabyte
+# binaries and keeps the helper's RSS at the buffer size.
+#
+# The pattern gets the same UTF-8 -> ISO-8859-1 round-trip so that a
+# Cyrillic search string is matched as its UTF-8 byte sequence in a
+# UTF-8-encoded file, matching grep's default byte semantics. Regex
+# meta-characters are ASCII and survive the round-trip untouched.
+# Regex character classes referring to non-ASCII code points (rare in
+# file-manager searches) may fail to match after the transform; that
+# is a documented limitation shared with grep in POSIX locales.
+$F4ContentChunkSize = 1MB
+$F4ContentRxOverlap = 8192    # keeps a regex match up to this long across chunk boundary
+$F4Latin1 = [System.Text.Encoding]::GetEncoding(28591)  # ISO-8859-1, byte-preserving
+$F4Utf8Bare = [System.Text.UTF8Encoding]::new($false)
+
+function ConvertTo-BytePreservingPattern([string]$s) {
+    if ([string]::IsNullOrEmpty($s)) { return '' }
+    return $F4Latin1.GetString($F4Utf8Bare.GetBytes($s))
+}
+
+function Test-FileContainsPattern {
+    param(
+        [string]$path,
+        [string]$fixedPat,    # non-null when fixed-string search
+        $rx,                  # System.Text.RegularExpressions.Regex, or $null
+        [bool]$ci             # only meaningful when fixedPat is used
+    )
+    $fixed = -not [string]::IsNullOrEmpty($fixedPat)
+    if (-not $fixed -and $null -eq $rx) { return $false }
+    $overlap = if ($fixed) { [Math]::Max(0, $fixedPat.Length - 1) } else { $F4ContentRxOverlap }
+    $cmp = if ($ci) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+    $fs = $null
+    try {
+        $fs = [System.IO.File]::Open($path, [System.IO.FileMode]::Open,
+                                     [System.IO.FileAccess]::Read,
+                                     [System.IO.FileShare]::ReadWrite)
+        $buf = New-Object 'byte[]' ($F4ContentChunkSize + $overlap)
+        $carry = 0
+        while ($true) {
+            $got = $fs.Read($buf, $carry, $F4ContentChunkSize)
+            if ($got -le 0) { return $false }
+            $have = $carry + $got
+            $chunk = $F4Latin1.GetString($buf, 0, $have)
+            if ($fixed) {
+                if ($chunk.IndexOf($fixedPat, $cmp) -ge 0) { return $true }
+            } else {
+                if ($rx.IsMatch($chunk)) { return $true }
+            }
+            if ($overlap -gt 0 -and $have -gt $overlap) {
+                [Array]::Copy($buf, $have - $overlap, $buf, 0, $overlap)
+                $carry = $overlap
+            } else {
+                $carry = 0
+            }
+        }
+    } catch { return $false } finally {
+        if ($null -ne $fs) { $fs.Dispose() }
+    }
+    return $false
+}
+
+# ---------------------------------------------------------------------
+# ffind <limit> <nmasks> <grep mode>: walk a whole tree, emit
+# stat-shaped entries for hits, up to <limit>. If grep mode != '-',
+# also read a pattern line and filter files whose content matches.
+#
+# Reparse points are NOT followed for recursion — Windows profiles
+# contain self-referential junctions (AppData\Local\Application Data ->
+# AppData\Local is the classic offender), and every recursive .NET or
+# PowerShell walk follows them by default (Get-ChildItem -Recurse and
+# Directory.EnumerateFiles with SearchOption.AllDirectories both do).
+# Without this guard Alt+F7 anywhere inside a profile loops forever.
+# helper.sh has the same rule for its job body ("a link pointing at
+# its own parent cannot make the walk grow forever").
+# ---------------------------------------------------------------------
+function Cmd-FFind {
+    param([string]$limArg, [string]$nmArg, [string]$gmode)
+    try {
+        $dirWire = Read-PathLine
+        if (-not (Test-IsUInt $limArg) -or -not (Test-IsUInt $nmArg)) { Write-Err 'bad search request'; return }
+        $limit = [int]$limArg
+        $nm    = [int]$nmArg
+        if ($nm -lt 1) { Write-Err 'bad search request'; return }
+        $masks = New-Object 'string[]' $nm
+        for ($i = 0; $i -lt $nm; $i++) { $masks[$i] = Read-PathLine }
+        $pat = $null
+        $ci  = $false
+        $fixed = $false
+        if ($gmode -ne '-') {
+            if ($gmode -match '[^fie]') { Write-Err 'bad grep mode'; return }
+            $pat = Read-PathLine
+            if ([string]::IsNullOrEmpty($pat)) { Write-Err 'empty search pattern'; return }
+            $fixed = $gmode.Contains('f')
+            $ci    = $gmode.Contains('i')
+        }
+        $dir = Convert-PosixToWin $dirWire
+        if (-not (Test-Path -LiteralPath $dir -PathType Container)) { Write-Err 'not a directory'; return }
+        Emit-ModeLine
+        # Both fixed and regex searches operate on the file's bytes
+        # after decoding through ISO-8859-1 — a byte-preserving
+        # encoding — so the pattern travels through the same round-trip
+        # to make sure a Cyrillic search string is matched as the UTF-8
+        # bytes a UTF-8 file actually stores.
+        $bytePat = ConvertTo-BytePreservingPattern $pat
+        $rx = $null
+        if ($pat -ne $null -and -not $fixed) {
+            $opts = [System.Text.RegularExpressions.RegexOptions]::CultureInvariant
+            if ($ci) { $opts = $opts -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase }
+            $rx = New-Object System.Text.RegularExpressions.Regex($bytePat, $opts)
+        }
+        $count = 0
+        $stack = New-Object System.Collections.Generic.Stack[string]
+        $stack.Push($dir)
+        $reparse = [System.IO.FileAttributes]::ReparsePoint
+        :outer while ($stack.Count -gt 0 -and $count -lt $limit) {
+            $cur = $stack.Pop()
+            $files = $null
+            try { $files = [System.IO.Directory]::EnumerateFiles($cur) } catch { }
+            if ($null -ne $files) {
+                foreach ($fp in $files) {
+                    if ($count -ge $limit) { break outer }
+                    $fi = $null
+                    try { $fi = New-Object System.IO.FileInfo $fp } catch { continue }
+                    if ($fi.Attributes -band $reparse) { continue }
+                    $name = $fi.Name
+                    $ok = $false
+                    foreach ($m in $masks) {
+                        if ($name -like $m) { $ok = $true; break }
+                    }
+                    if (-not $ok) { continue }
+                    if ($pat -ne $null) {
+                        $fixedArg = if ($fixed) { $bytePat } else { $null }
+                        if (-not (Test-FileContainsPattern $fi.FullName $fixedArg $rx $ci)) { continue }
+                    }
+                    # For a tree search the client wants the FULL wire
+                    # path in the name field of the entry.
+                    $wirePath = Convert-WinToPosix $fi.FullName
+                    try { Emit-StatEntry -fi $fi -nameOverride $wirePath } catch { }
+                    $count++
+                }
+            }
+            $subs = $null
+            try { $subs = [System.IO.Directory]::EnumerateDirectories($cur) } catch { }
+            if ($null -ne $subs) {
+                foreach ($sd in $subs) {
+                    try {
+                        $di = New-Object System.IO.DirectoryInfo $sd
+                        if ($di.Attributes -band $reparse) { continue }
+                        $stack.Push($sd)
+                    } catch { }
+                }
+            }
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# ---------------------------------------------------------------------
+# Background job runtime.
+# Layout (mirrors helper.sh): job dir under %TEMP%\.f4jobs.<pid>.<token>
+# with one subdir per job holding pid/kind/out/err/rc/n/kill files.
+# We use Start-ThreadJob when available (PS 7+ or ThreadJob module),
+# fall back to Start-Job (a full PS runspace per job) elsewhere.
+# ---------------------------------------------------------------------
+$script:F4JDir = $null
+$script:F4JN   = 0
+$script:F4Jobs = @{}
+$script:F4HasThreadJob = $null
+
+function Test-ThreadJobAvailable {
+    if ($script:F4HasThreadJob -ne $null) { return $script:F4HasThreadJob }
+    $script:F4HasThreadJob = $null -ne (Get-Command Start-ThreadJob -ErrorAction SilentlyContinue)
+    return $script:F4HasThreadJob
+}
+
+function Ensure-JobDir {
+    if ($null -ne $script:F4JDir) { return }
+    $base = $env:TEMP
+    if ([string]::IsNullOrEmpty($base)) { $base = [System.IO.Path]::GetTempPath() }
+    $script:F4JDir = Join-Path $base (".f4jobs." + $PID + "." + $F4TOKEN)
+    [void](New-Item -ItemType Directory -Path $script:F4JDir -Force -ErrorAction Stop)
+}
+
+function New-JobSlot {
+    Ensure-JobDir
+    $script:F4JN++
+    $d = Join-Path $script:F4JDir $script:F4JN
+    [void](New-Item -ItemType Directory -Path $d -Force -ErrorAction Stop)
+    return @{ Id = $script:F4JN; Dir = $d }
+}
+
+# The scan job body: walks a tree, counts files/dirs and their bytes,
+# emits "P" progress lines every 2000 entries and one "T" total at end.
+function Cmd-JStart {
+    param([string]$kind, [string]$nPathsArg)
+    try {
+        if (-not (Test-IsUInt $nPathsArg)) { Write-Err 'bad path count'; return }
+        $n = [int]$nPathsArg
+        if ($n -gt 4) { Write-Err 'bad path count'; return }
+        $paths = New-Object 'string[]' $n
+        for ($i = 0; $i -lt $n; $i++) { $paths[$i] = Read-PathLine }
+        switch ($kind) {
+            'scan' { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
+            'hash' { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
+            'exec' { if ($n -ne 2) { Write-Err 'the exec job takes a directory and a command'; return } }
+            default { Write-Err 'unknown job kind'; return }
+        }
+        $slot = New-JobSlot
+        $jd = $slot.Dir
+        $outP = Join-Path $jd 'out'
+        $errP = Join-Path $jd 'err'
+        $rcP  = Join-Path $jd 'rc'
+        $nP   = Join-Path $jd 'n'
+        [System.IO.File]::WriteAllText((Join-Path $jd 'kind'), $kind + "`n", $utf8NoBom)
+        [System.IO.File]::WriteAllText($nP, '0', $utf8NoBom)
+        [System.IO.File]::WriteAllBytes($outP, [byte[]]@())
+
+        # exec bypasses Start-Job entirely. On PS 5.1 launched through
+        # the "cmd /c powershell.exe" flavor route, Start-Job has to
+        # spawn a fresh pwsh child, and doing that from inside a
+        # nested-cmd/nested-powershell chain can hang outright (observed:
+        # "clear" and "git -v" from an f4 panel terminal never return).
+        # A shell command is an external process anyway — no PS runspace
+        # wrapper is needed to run it in the background, we just start
+        # cmd.exe directly and let it write its own rc file when done.
+        if ($kind -eq 'exec') {
+            $dirWire = $paths[0]
+            $cmdText = $paths[1]
+            $cwd = $null
+            if (-not [string]::IsNullOrEmpty($dirWire)) {
+                $cwd = Convert-PosixToWin $dirWire
+                if (-not (Test-Path -LiteralPath $cwd -PathType Container)) {
+                    [System.IO.File]::AppendAllText($errP, "no such directory`n", $utf8NoBom)
+                    [System.IO.File]::WriteAllText($rcP, '1', $utf8NoBom)
+                    Write-Line ("J " + $slot.Id); Write-Ok; return
+                }
+            }
+            if ([string]::IsNullOrEmpty($cmdText)) {
+                [System.IO.File]::AppendAllText($errP, "empty command`n", $utf8NoBom)
+                [System.IO.File]::WriteAllText($rcP, '1', $utf8NoBom)
+                Write-Line ("J " + $slot.Id); Write-Ok; return
+            }
+            # The user command lives in exec.cmd; wrap.cmd runs it with
+            # cmd's own redirection (stdin from NUL, stdout+stderr into
+            # the job's out file), then writes the exit code to rc. That
+            # single cmd.exe is the entire job — Cmd-JPoll only has to
+            # look at the rc file to know it finished.
+            $exec = Join-Path $jd 'exec.cmd'
+            $wrap = Join-Path $jd 'wrap.cmd'
+            $execBody = "@echo off`r`n" + $cmdText + "`r`nexit /b %ERRORLEVEL%`r`n"
+            [System.IO.File]::WriteAllText($exec, $execBody, [System.Text.Encoding]::Default)
+            $wrapBody = "@echo off`r`n" +
+                        "call `"$exec`" < NUL > `"$outP`" 2>&1`r`n" +
+                        "set F4RC=%ERRORLEVEL%`r`n" +
+                        "> `"$rcP`" echo %F4RC%`r`n" +
+                        "exit /b %F4RC%`r`n"
+            [System.IO.File]::WriteAllText($wrap, $wrapBody, [System.Text.Encoding]::Default)
+            $comspec = $env:ComSpec
+            if ([string]::IsNullOrEmpty($comspec)) { $comspec = 'cmd.exe' }
+            $psi = New-Object System.Diagnostics.ProcessStartInfo
+            $psi.FileName = $comspec
+            # /d skips AutoRun; /c runs the wrap batch and exits. The
+            # outer quotes let cmd take the file path even when TEMP has
+            # spaces.
+            $psi.Arguments = "/d /c `"$wrap`""
+            $psi.UseShellExecute = $false
+            $psi.CreateNoWindow  = $true
+            if ($null -ne $cwd) { $psi.WorkingDirectory = $cwd }
+            $p = [System.Diagnostics.Process]::Start($psi)
+            $script:F4Jobs[$slot.Id] = $p
+            [System.IO.File]::WriteAllText((Join-Path $jd 'pid'), $p.Id.ToString(), $utf8NoBom)
+            Write-Line ("J " + $slot.Id)
+            Write-Ok
+            return
+        }
+
+        # scan and hash still go through Start-Job (or Start-ThreadJob
+        # if the module is installed). They are pure PS bodies that do
+        # not spawn subprocesses, so the nested-launch hang exec had
+        # does not apply — if it ever does, they get the same treatment.
+        #
+        # The body runs in its own runspace (Start-Job) or thread
+        # (Start-ThreadJob). Neither one inherits the parent's function
+        # table, so every helper the body needs is defined inside it.
+        # The parent's Invoke-JobScan/Hash/Exec below are kept only as
+        # references so a maintainer can read them independently; the
+        # runtime copies live in $body.
+        $body = {
+            param($kind, $paths, $jd, $outP, $errP, $rcP)
+            $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+            function Convert-PosixToWin([string]$p) {
+                if ($p -eq '' -or $p -eq '/') { return '' }
+                if ($p.StartsWith('//')) { return '\\' + $p.Substring(2).Replace('/', '\') }
+                if (-not $p.StartsWith('/')) { return $p.Replace('/', '\') }
+                $tail = $p.Substring(1); $s = $tail.IndexOf('/')
+                if ($s -lt 0) { if ($tail.Length -eq 1) { return $tail.ToUpper() + ':\' } else { return $tail.Replace('/', '\') } }
+                $d = $tail.Substring(0, $s); $r = $tail.Substring($s + 1)
+                if ($d.Length -eq 1) { return $d.ToUpper() + ':\' + $r.Replace('/', '\') }
+                return $p.Substring(1).Replace('/', '\')
+            }
+            function Convert-WinToPosix([string]$w) {
+                if ([string]::IsNullOrEmpty($w)) { return '/' }
+                if ($w.StartsWith('\\')) { return '//' + $w.Substring(2).Replace('\', '/').TrimEnd('/') }
+                if ($w.Length -ge 2 -and $w[1] -eq ':') {
+                    $dr = [char]::ToLower($w[0])
+                    $rs = if ($w.Length -gt 2) { $w.Substring(2).TrimStart('\').Replace('\', '/') } else { '' }
+                    if ($rs -eq '') { return '/' + $dr } else { return '/' + $dr + '/' + $rs.TrimEnd('/') }
+                }
+                return '/' + $w.Replace('\', '/').TrimStart('/').TrimEnd('/')
+            }
+            # Depth-first walk that skips reparse points during recursion,
+            # so a junction cycle (Windows profile: AppData\Local\Application
+            # Data -> AppData\Local, and friends) does not loop the scan
+            # forever. helper.sh has the same rule in f4_job_scan's comment.
+            # Yields two things: for each file it invokes $onFile with
+            # the FileInfo, and for each directory it invokes $onDir with
+            # its full path (a scan counts both, hash only files).
+            function Walk-Tree {
+                param([string]$root, [scriptblock]$onFile, [scriptblock]$onDir)
+                $reparse = [System.IO.FileAttributes]::ReparsePoint
+                $stack = New-Object System.Collections.Generic.Stack[string]
+                $stack.Push($root)
+                if ($null -ne $onDir) { & $onDir $root }
+                while ($stack.Count -gt 0) {
+                    $cur = $stack.Pop()
+                    $files = $null
+                    try { $files = [System.IO.Directory]::EnumerateFiles($cur) } catch { }
+                    if ($null -ne $files -and $null -ne $onFile) {
+                        foreach ($fp in $files) {
+                            $fi = $null
+                            try { $fi = New-Object System.IO.FileInfo $fp } catch { continue }
+                            if ($fi.Attributes -band $reparse) { continue }
+                            & $onFile $fi
+                        }
+                    }
+                    $subs = $null
+                    try { $subs = [System.IO.Directory]::EnumerateDirectories($cur) } catch { }
+                    if ($null -ne $subs) {
+                        foreach ($sd in $subs) {
+                            try {
+                                $di = New-Object System.IO.DirectoryInfo $sd
+                                if ($di.Attributes -band $reparse) { continue }
+                                if ($null -ne $onDir) { & $onDir $sd }
+                                $stack.Push($sd)
+                            } catch { }
+                        }
+                    }
+                }
+            }
+            function Run-JobScan {
+                param($rootWin, $outPath, $errPath, $rcPath, $enc)
+                $rc = 0
+                try {
+                    if (-not (Test-Path -LiteralPath $rootWin -PathType Container)) { throw 'not a directory' }
+                    $out = New-Object System.IO.StreamWriter($outPath, $false, $enc)
+                    try {
+                        $stateRef = [pscustomobject]@{
+                            Fbytes=0L; Dbytes=0L; Files=0L; Dirs=0L; K=0L
+                        }
+                        $onFile = {
+                            param($fi)
+                            $stateRef.Files++
+                            $stateRef.Fbytes += $fi.Length
+                            $stateRef.K++
+                            if (($stateRef.K % 2000) -eq 0) {
+                                $lp = Convert-WinToPosix $fi.FullName
+                                $out.WriteLine("P $($stateRef.Fbytes) $($stateRef.Dbytes) $($stateRef.Files) $($stateRef.Dirs) $lp")
+                                $out.Flush()
+                            }
+                        }
+                        $onDir = {
+                            param($p)
+                            $stateRef.Dirs++
+                            $stateRef.K++
+                            if (($stateRef.K % 2000) -eq 0) {
+                                $lp = Convert-WinToPosix $p
+                                $out.WriteLine("P $($stateRef.Fbytes) $($stateRef.Dbytes) $($stateRef.Files) $($stateRef.Dirs) $lp")
+                                $out.Flush()
+                            }
+                        }
+                        Walk-Tree $rootWin $onFile $onDir
+                        $out.WriteLine("T $($stateRef.Fbytes) $($stateRef.Dbytes) $($stateRef.Files) $($stateRef.Dirs)")
+                        $out.Flush()
+                    } finally { $out.Dispose() }
+                } catch {
+                    [System.IO.File]::AppendAllText($errPath, $_.Exception.Message + "`n", $enc)
+                    $rc = 1
+                }
+                [System.IO.File]::WriteAllText($rcPath, $rc.ToString(), $enc)
+            }
+            function Run-JobHash {
+                param($rootWin, $jobDir, $outPath, $errPath, $rcPath, $enc)
+                $rc = 0
+                try {
+                    if (-not (Test-Path -LiteralPath $rootWin -PathType Container)) { throw 'not a directory' }
+                    $sizesPath = Join-Path $jobDir 'sizes'
+                    $sw = New-Object System.IO.StreamWriter($sizesPath, $false, $enc)
+                    try {
+                        $writer = $sw
+                        $onFile = {
+                            param($fi)
+                            try { $writer.WriteLine("$($fi.Length) $($fi.FullName)") } catch { }
+                        }
+                        Walk-Tree $rootWin $onFile $null
+                    } finally { $sw.Dispose() }
+                    $counts = @{}
+                    foreach ($ln in [System.IO.File]::ReadLines($sizesPath, $enc)) {
+                        $sp = $ln.IndexOf(' '); if ($sp -lt 0) { continue }
+                        $k = $ln.Substring(0, $sp)
+                        if ($counts.ContainsKey($k)) { $counts[$k]++ } else { $counts[$k] = 1 }
+                    }
+                    $candPath = Join-Path $jobDir 'cand'
+                    $cw = New-Object System.IO.StreamWriter($candPath, $false, $enc)
+                    $total = 0L
+                    try {
+                        foreach ($ln in [System.IO.File]::ReadLines($sizesPath, $enc)) {
+                            $sp = $ln.IndexOf(' '); if ($sp -lt 0) { continue }
+                            if ($counts[$ln.Substring(0, $sp)] -gt 1) {
+                                $cw.WriteLine($ln.Substring($sp + 1)); $total++
+                            }
+                        }
+                    } finally { $cw.Dispose() }
+                    $out = New-Object System.IO.StreamWriter($outPath, $false, $enc)
+                    try {
+                        $sha = [System.Security.Cryptography.SHA256]::Create()
+                        $n = 0L
+                        foreach ($p in [System.IO.File]::ReadLines($candPath, $enc)) {
+                            $n++
+                            $hex = ''
+                            try {
+                                $fs = [System.IO.File]::Open($p, [System.IO.FileMode]::Open,
+                                                             [System.IO.FileAccess]::Read,
+                                                             [System.IO.FileShare]::ReadWrite)
+                                try {
+                                    $hex = [BitConverter]::ToString($sha.ComputeHash($fs)).Replace('-','').ToLower()
+                                } finally { $fs.Dispose() }
+                            } catch { }
+                            # Paths leave this helper in wire shape, always:
+                            # what the client gets back from a hash job is
+                            # fed straight into its own path handling, and a
+                            # "C:\dir\file" there is not a path it can use.
+                            $wp = Convert-WinToPosix $p
+                            if (-not [string]::IsNullOrEmpty($hex)) { $out.WriteLine("H $hex $wp") }
+                            $out.WriteLine("P $n $total $wp"); $out.Flush()
+                        }
+                        $out.WriteLine("T $n")
+                    } finally { $out.Dispose() }
+                } catch {
+                    [System.IO.File]::AppendAllText($errPath, $_.Exception.Message + "`n", $enc)
+                    $rc = 1
+                }
+                [System.IO.File]::WriteAllText($rcPath, $rc.ToString(), $enc)
+            }
+            function Run-JobExec {
+                param($dirWire, $cmdText, $outPath, $errPath, $rcPath, $enc)
+                try {
+                    $cwd = $null
+                    if (-not [string]::IsNullOrEmpty($dirWire)) {
+                        $cwd = Convert-PosixToWin $dirWire
+                        if (-not (Test-Path -LiteralPath $cwd -PathType Container)) {
+                            [System.IO.File]::AppendAllText($errPath, "no such directory`n", $enc)
+                            [System.IO.File]::WriteAllText($rcPath, '1', $enc); return
+                        }
+                    }
+                    if ([string]::IsNullOrEmpty($cmdText)) {
+                        [System.IO.File]::AppendAllText($errPath, "empty command`n", $enc)
+                        [System.IO.File]::WriteAllText($rcPath, '1', $enc); return
+                    }
+                    # The user's command goes through a tiny batch file
+                    # that cmd runs with its OWN redirection: stdin from
+                    # NUL, stdout AND stderr into the output file, all at
+                    # the cmd level. PowerShell never touches the child's
+                    # pipes, so a program that fills its stderr faster
+                    # than we could drain it cannot deadlock us, and no
+                    # child inherits the SSH channel as stdin. This is
+                    # the exact shape helper.sh gives its exec job with
+                    # </dev/null > out 2>&1 at the shell level.
+                    #
+                    # An earlier attempt used RedirectStandardOutput /
+                    # RedirectStandardError + ReadToEndAsync + WaitAll to
+                    # drive the same idea from the PS side. It hangs
+                    # under a real Start-Job runspace on PS 5.1 — even
+                    # "clear" or "git -v" from the panel terminal never
+                    # return — so the whole read-side is out of the way
+                    # now.
+                    $jobDir = [System.IO.Path]::GetDirectoryName($outPath)
+                    $batch  = Join-Path $jobDir 'exec.cmd'
+                    # cmd wants CRLF and the local OEM code page. echo
+                    # off silences the batch prologue; exit /b relays the
+                    # last command's ERRORLEVEL back through cmd so our
+                    # WaitForExit sees the right number.
+                    $batchBody = "@echo off`r`n" + $cmdText + "`r`nexit /b %ERRORLEVEL%`r`n"
+                    [System.IO.File]::WriteAllText($batch, $batchBody, [System.Text.Encoding]::Default)
+                    try {
+                        $comspec = $env:ComSpec
+                        if ([string]::IsNullOrEmpty($comspec)) { $comspec = 'cmd.exe' }
+                        $psi = New-Object System.Diagnostics.ProcessStartInfo
+                        $psi.FileName = $comspec
+                        # cmd's /c strips one leading and one trailing
+                        # quote off the string it is given; every path we
+                        # substitute in is separately double-quoted so a
+                        # space in TEMP or in the working directory
+                        # survives the parse.
+                        $psi.Arguments = "/d /c `"call `"$batch`" < NUL > `"$outPath`" 2>&1`""
+                        $psi.UseShellExecute = $false
+                        $psi.CreateNoWindow  = $true
+                        if ($null -ne $cwd) { $psi.WorkingDirectory = $cwd }
+                        $p = [System.Diagnostics.Process]::Start($psi)
+                        $p.WaitForExit()
+                        [System.IO.File]::WriteAllText($rcPath, $p.ExitCode.ToString(), $enc)
+                    } finally {
+                        Remove-Item -LiteralPath $batch -Force -ErrorAction SilentlyContinue
+                    }
+                } catch {
+                    [System.IO.File]::AppendAllText($errPath, $_.Exception.Message + "`n", $enc)
+                    [System.IO.File]::WriteAllText($rcPath, '1', $enc)
+                }
+            }
+            try {
+                switch ($kind) {
+                    'scan'  { Run-JobScan (Convert-PosixToWin $paths[0]) $outP $errP $rcP $utf8NoBom }
+                    'hash'  { Run-JobHash (Convert-PosixToWin $paths[0]) $jd $outP $errP $rcP $utf8NoBom }
+                    'exec'  { Run-JobExec $paths[0] $paths[1] $outP $errP $rcP $utf8NoBom }
+                }
+            } catch {
+                [System.IO.File]::AppendAllText($errP, $_.Exception.Message + "`n", $utf8NoBom)
+                [System.IO.File]::WriteAllText($rcP, '1', $utf8NoBom)
+            }
+        }
+        # In-process runspace via [PowerShell]::Create(). Start-Job under
+        # PS 5.1 spawns a fresh pwsh.exe process, which measured ~100x
+        # slower for the byte-scan content search than the same code in
+        # the main helper process — Windows appears to apply background
+        # I/O priority to job processes, and the cross-process pipes and
+        # remoting serialization add on top. A runspace lives in this
+        # very process, so file I/O runs at the same priority as the
+        # rest of the helper and there is no serialization for the job's
+        # implicit output streams. Startup is ~100 ms rather than
+        # several seconds. Start-ThreadJob would give the same wins but
+        # is a separate module and is not present on stock PS 5.1, which
+        # is what the cmd fallback route lands on.
+        $ps = [System.Management.Automation.PowerShell]::Create()
+        [void]$ps.AddScript($body)
+        [void]$ps.AddArgument($kind)
+        [void]$ps.AddArgument($paths)
+        [void]$ps.AddArgument($jd)
+        [void]$ps.AddArgument($outP)
+        [void]$ps.AddArgument($errP)
+        [void]$ps.AddArgument($rcP)
+        [void]$ps.BeginInvoke()
+        $script:F4Jobs[$slot.Id] = $ps
+        [System.IO.File]::WriteAllText((Join-Path $jd 'pid'), $PID.ToString(), $utf8NoBom)
+        Write-Line ("J " + $slot.Id)
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Get-JobDir([string]$idArg) {
+    if (-not (Test-IsUInt $idArg)) { return $null }
+    if ($null -eq $script:F4JDir) { return $null }
+    $d = Join-Path $script:F4JDir $idArg
+    if (-not (Test-Path -LiteralPath $d -PathType Container)) { return $null }
+    return $d
+}
+
+# Every read of a job's files goes through these two: the job is writing to
+# the same files at the same time, and a reader that does not allow a
+# concurrent writer fails outright with a sharing violation. [IO.File]'s
+# ReadLines and ReadAllText do exactly that, which made a poll of a running
+# job fail with "the process cannot access the file" instead of returning
+# what had been written so far.
+function Open-SharedReader([string]$path) {
+    $fs = [System.IO.File]::Open($path, [System.IO.FileMode]::Open,
+                                 [System.IO.FileAccess]::Read,
+                                 [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+    return New-Object System.IO.StreamReader($fs, $utf8NoBom)
+}
+
+function Read-SharedText([string]$path) {
+    $sr = Open-SharedReader $path
+    try { return $sr.ReadToEnd() } finally { $sr.Dispose() }
+}
+
+function Cmd-JPoll {
+    param([string]$idArg, [string]$limArg)
+    try {
+        $jd = Get-JobDir $idArg
+        if ($null -eq $jd) { Write-Err 'no such job'; return }
+        if (-not (Test-IsUInt $limArg) -or [int]$limArg -lt 1) { Write-Err 'bad limit'; return }
+        $limit = [int]$limArg
+        $rcP = Join-Path $jd 'rc'
+        $killP = Join-Path $jd 'kill'
+        $errP = Join-Path $jd 'err'
+        $outP = Join-Path $jd 'out'
+        $nP = Join-Path $jd 'n'
+        $state = 'run'; $rc = '-'; $msg = ''
+        if (Test-Path -LiteralPath $killP) {
+            $state = 'kill'
+        } elseif (Test-Path -LiteralPath $rcP) {
+            $state = 'done'
+            $rcText = (Read-SharedText $rcP).Trim()
+            if (Test-IsUInt $rcText) { $rc = $rcText } else { $rc = '-' }
+            if ($rc -ne '0' -and (Test-Path -LiteralPath $errP)) {
+                $sr = Open-SharedReader $errP
+                try { $msg = $sr.ReadLine() } finally { $sr.Dispose() }
+                if ($null -eq $msg) { $msg = '' }
+            }
+        }
+        $sLine = "S $state $rc"
+        if (-not [string]::IsNullOrEmpty($msg)) { $sLine = $sLine + ' ' + (Format-Flat $msg) }
+        Write-Line $sLine
+
+        # How many whole lines have been emitted so far, and how many we
+        # already gave the caller (persisted in $nP).
+        # Only whole lines count, so the count is the number of LFs, the same
+        # thing "wc -l" gives the POSIX helper. A job that is halfway through
+        # writing a line has not written its LF yet, and that half line stays
+        # invisible until it is complete.
+        $tot = 0L
+        if (Test-Path -LiteralPath $outP) {
+            $sr = Open-SharedReader $outP
+            try {
+                $cbuf = New-Object 'char[]' 8192
+                while (($cn = $sr.Read($cbuf, 0, $cbuf.Length)) -gt 0) {
+                    for ($i = 0; $i -lt $cn; $i++) {
+                        if ($cbuf[$i] -eq "`n") { $tot++ }
+                    }
+                }
+            } finally { $sr.Dispose() }
+        }
+        $done = 0L
+        if (Test-Path -LiteralPath $nP) {
+            $t = (Read-SharedText $nP).Trim()
+            if (Test-IsUInt $t) { $done = [int64]$t }
+        }
+        $avail = $tot - $done
+        if ($avail -gt 0) {
+            if ($avail -gt $limit) { $avail = $limit }
+            $skip = $done
+            $sent = 0
+            $sr = Open-SharedReader $outP
+            try {
+                while ($sent -lt $avail) {
+                    $ln = $sr.ReadLine()
+                    if ($null -eq $ln) { break }
+                    if ($skip -gt 0) { $skip--; continue }
+                    Write-Line $ln
+                    $sent++
+                }
+            } finally { $sr.Dispose() }
+            # What was actually sent, not what was hoped for: a short read
+            # here would otherwise skip lines on the next poll forever.
+            [System.IO.File]::WriteAllText($nP, ($done + $sent).ToString(), $utf8NoBom)
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# Stops whatever background executor a job entry holds. Three shapes are
+# possible: exec jobs are raw System.Diagnostics.Process objects (cmd.exe
+# running the user's command), scan/hash/ffind jobs are
+# System.Management.Automation.PowerShell instances (in-process runspace),
+# and older versions used PS Job objects (kept as a fallback in case an
+# entry from before an upgrade is still around).
+function Stop-JobEntry($entry) {
+    if ($null -eq $entry) { return }
+    if ($entry -is [System.Diagnostics.Process]) {
+        try { if (-not $entry.HasExited) { $entry.Kill() } } catch { }
+        return
+    }
+    if ($entry -is [System.Management.Automation.PowerShell]) {
+        try { $entry.Stop() } catch { }
+        return
+    }
+    try { Stop-Job -Job $entry -ErrorAction SilentlyContinue } catch { }
+}
+
+function Remove-JobEntry($entry) {
+    if ($null -eq $entry) { return }
+    if ($entry -is [System.Diagnostics.Process]) {
+        try { $entry.Dispose() } catch { }
+        return
+    }
+    if ($entry -is [System.Management.Automation.PowerShell]) {
+        try { $entry.Dispose() } catch { }
+        return
+    }
+    try { Remove-Job -Job $entry -Force -ErrorAction SilentlyContinue } catch { }
+}
+
+function Cmd-JKill {
+    param([string]$idArg)
+    try {
+        $jd = Get-JobDir $idArg
+        if ($null -eq $jd) { Write-Err 'no such job'; return }
+        Stop-JobEntry $script:F4Jobs[[int]$idArg]
+        [System.IO.File]::WriteAllText((Join-Path $jd 'kill'), '1', $utf8NoBom)
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-JDrop {
+    param([string]$idArg)
+    try {
+        $jd = Get-JobDir $idArg
+        if ($null -eq $jd) { Write-Ok; return }
+        $entry = $script:F4Jobs[[int]$idArg]
+        if ($null -ne $entry) {
+            Stop-JobEntry $entry
+            Remove-JobEntry $entry
+            $script:F4Jobs.Remove([int]$idArg)
+        }
+        try { Remove-Item -LiteralPath $jd -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+function Cmd-JList {
+    try {
+        if ($null -ne $script:F4JDir -and (Test-Path -LiteralPath $script:F4JDir)) {
+            foreach ($d in [System.IO.Directory]::EnumerateDirectories($script:F4JDir)) {
+                $id = [System.IO.Path]::GetFileName($d)
+                $state = 'run'
+                if (Test-Path -LiteralPath (Join-Path $d 'kill')) { $state = 'kill' }
+                elseif (Test-Path -LiteralPath (Join-Path $d 'rc')) { $state = 'done' }
+                $kind = ''
+                $kP = Join-Path $d 'kind'
+                if (Test-Path -LiteralPath $kP) {
+                    $kind = (Read-SharedText $kP).Trim()
+                }
+                Write-Line "$id $state $kind"
+            }
+        }
+        Write-Ok
+    } catch { Write-Err $_.Exception.Message }
+}
+
+# mode/rmode/wmode: only one backend per capability exists in this
+# helper, so accept its exact name and reject the rest.
+function Cmd-Mode {
+    param([string]$name)
+    if ($name -eq 'stat') { Write-Ok } else { Write-Err 'mode not available' }
+}
+function Cmd-RMode {
+    param([string]$name)
+    if ($name -eq 'filestream' -or $name -eq 'cat') { Write-Ok } else { Write-Err 'read mode not available' }
+}
+function Cmd-WMode {
+    param([string]$name)
+    if ($name -eq 'b64') { Write-Ok } else { Write-Err 'write mode not available' }
+}
+
+# ---------------------------------------------------------------------
+# Cleanup + banner + main loop.
+# ---------------------------------------------------------------------
+function Invoke-JCleanup {
+    if ($null -eq $script:F4JDir) { return }
+    foreach ($entry in $script:F4Jobs.Values) {
+        Stop-JobEntry $entry
+        Remove-JobEntry $entry
+    }
+    try { Remove-Item -LiteralPath $script:F4JDir -Recurse -Force -ErrorAction SilentlyContinue } catch { }
+    $script:F4JDir = $null
+    $script:F4Jobs = @{}
+}
+
+# The features string mirrors what helper.sh advertises, with fake
+# tokens for tools the client uses to gate features. Real work happens
+# in .NET. See WINDOWS_PORT.md for the rationale of each tag.
+# "hash:<tool>" is what gates the duplicate search on the client side
+# (Features.HashTool, checked by CanHash); announcing sha256sum alone is
+# not enough, exactly as in helper.sh where the two are separate tags.
+$F4FEATS = 'flavor:pwsh base64 grep sed awk wc head tail truncate touch date sha256sum findbin jobs cp dd readlink du chown mode:stat hash:sha256sum read:filestream write:b64 headc headsafe tailc ddnotrunc statl ddbytes awkflush'
+
+try {
+    # A leading LF ensures the terminator starts a line even if the
+    # remote shell's login noise did not end in one.
+    Write-Line ''
+    Write-End 'ok' ("FISHPLUS " + $F4PROTO + " " + $F4FEATS)
+
+    while ($true) {
+        $reqLine = Read-Line
+        if ($null -eq $reqLine) { break }
+        if ($reqLine -eq '') { continue }
+        $parts = $reqLine.Split(' ', 5)
+        if ($parts.Length -lt 2) { continue }
+        if (-not (Test-IsUInt $parts[0])) { continue }
+        $script:F4ID = [int64]$parts[0]
+        $cmd = $parts[1]
+        $a1 = if ($parts.Length -ge 3) { $parts[2] } else { '' }
+        $a2 = if ($parts.Length -ge 4) { $parts[3] } else { '' }
+        $a3 = if ($parts.Length -ge 5) { $parts[4] } else { '' }
+
+        switch ($cmd) {
+            'noop'   { Cmd-Noop }
+            'pwd'    { Cmd-Pwd }
+            'ping'   { Cmd-Ping }
+            'enum'   { Cmd-Enum }
+            'isdirs' { Cmd-IsDirs $a1 }
+            'info'   { Cmd-Info $true }
+            'linfo'  { Cmd-Info $false }
+            'rdlink' { Cmd-RdLink }
+            'mkdir'  { Cmd-Mkdir }
+            'rm'     { Cmd-Rm }
+            'rmdir'  { Cmd-Rmdir }
+            'rmtree' { Cmd-Rmtree }
+            'mv'     { Cmd-Mv }
+            'cp'     { Cmd-Cp }
+            'chmod'  { Cmd-Chmod $a1 }
+            'chown'  { Cmd-Chown $a1 $a2 }
+            'utime'  { Cmd-Utime $a1 $a2 }
+            'trunc'  { Cmd-Trunc $a1 }
+            'read'   { Cmd-Read $a1 $a2 }
+            'write'  { Cmd-Write $a1 $a2 $a3 }
+            'patch'  { Cmd-Patch $a1 $a2 }
+            'grep'   { Cmd-Grep $a1 $a2 }
+            'lidx'   { Cmd-LineIdx $a1 $a2 }
+            'ffind'  { Cmd-FFind $a1 $a2 $a3 }
+            'jstart' { Cmd-JStart $a1 $a2 }
+            'jpoll'  { Cmd-JPoll $a1 $a2 }
+            'jkill'  { Cmd-JKill $a1 }
+            'jdrop'  { Cmd-JDrop $a1 }
+            'jlist'  { Cmd-JList }
+            'mode'   { Cmd-Mode $a1 }
+            'rmode'  { Cmd-RMode $a1 }
+            'wmode'  { Cmd-WMode $a1 }
+            'feats'  { Write-Line ($F4PROTO.ToString() + ' ' + $F4FEATS); Write-Ok }
+            'exit'   { Invoke-JCleanup; Write-Ok; break }
+            default  { Write-Err 'unknown command' }
+        }
+        $F4Out.Flush()
+    }
+} finally {
+    Invoke-JCleanup
+    try { $F4Out.Flush() } catch { }
+}

--- a/plugins/netfox/fishplus/script.go
+++ b/plugins/netfox/fishplus/script.go
@@ -18,9 +18,17 @@ const tokenPlaceholder = "__F4_TOKEN__"
 //go:embed helper.sh
 var helperSource string
 
+//go:embed helper.ps1
+var helperSourcePwsh string
+
 // HelperSource returns the unmodified helper script. Useful for tests and
 // for dumping the script when debugging a remote host.
 func HelperSource() string { return helperSource }
+
+// HelperSourcePwsh returns the unmodified PowerShell helper. Windows peers
+// speak the same wire protocol as POSIX ones; the flavor detection picks
+// which script is delivered.
+func HelperSourcePwsh() string { return helperSourcePwsh }
 
 // Compact strips comments and blank lines from a shell script and removes
 // leading indentation. The helper is sent over the wire on every connect,
@@ -128,4 +136,40 @@ func splitReadyMarker(s, token string) string {
 // substituted, ready to be written into the remote shell's stdin.
 func HelperScript(token string) string {
 	return Compact(strings.ReplaceAll(helperSource, tokenPlaceholder, token))
+}
+
+// HelperScriptPwsh returns the compacted PowerShell helper script with the
+// session token substituted. Compaction rules match the POSIX helper: strip
+// CRs, comment lines and blank lines, keep everything else. The PowerShell
+// helper is written without here-strings or backtick continuations so this
+// simple stripping never breaks a statement.
+func HelperScriptPwsh(token string) string {
+	return Compact(strings.ReplaceAll(helperSourcePwsh, tokenPlaceholder, token))
+}
+
+// Base64BootstrapLinePwsh is the PowerShell analogue of Base64BootstrapLine.
+// It fits the compacted helper into one printable-ASCII line that the remote
+// PowerShell decodes with .NET and hands to Invoke-Expression. No temporary
+// file, no assumption about locale, no dependency on PSReadLine.
+//
+// The readiness marker is printed before Invoke-Expression so waitForReady
+// consumes the login banner and any prompt output first. Splitting the
+// marker into two adjacent literals keeps a terminal echo of this very
+// command from looking like the marker itself, mirroring the POSIX version.
+func Base64BootstrapLinePwsh(token string) string {
+	prefix := "# F4B64" + token
+	payload := prefix + "\n" + HelperScriptPwsh(token)
+	encoded := base64.StdEncoding.EncodeToString([]byte(payload))
+	// Same reason as the POSIX version: the encoded blob must not contain the
+	// marker as one contiguous run of bytes.
+	encoded = splitReadyMarker(encoded, token)
+	return "$F4B='" + encoded + "'; " +
+		"Write-Output ('F4R'+'DY'+'" + token + "'); " +
+		"try { " +
+		"$F4S=[System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($F4B)); " +
+		"Remove-Variable F4B -Force -ErrorAction SilentlyContinue; " +
+		"Invoke-Expression $F4S " +
+		"} catch { " +
+		"Write-Output ('.' + '" + token + "' + ' 0 err bootstrap ' + $_.Exception.Message.Replace([char]10,' ').Replace([char]13,' ')) " +
+		"}\n"
 }

--- a/plugins/netfox/fishplus/script_pwsh_test.go
+++ b/plugins/netfox/fishplus/script_pwsh_test.go
@@ -1,0 +1,90 @@
+package fishplus
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// The PowerShell bootstrap has to fit in a single line, use only
+// printable ASCII, and produce the compacted helper when decoded. These
+// three invariants are what makes the line survive being pasted into a
+// remote shell that mangles anything else.
+
+func TestBase64BootstrapLinePwshIsOneLine(t *testing.T) {
+	token := "abcdef0123456789"
+	line := Base64BootstrapLinePwsh(token)
+	if !strings.HasSuffix(line, "\n") {
+		t.Fatalf("pwsh bootstrap does not end in a newline: %q", line[max(0, len(line)-20):])
+	}
+	body := strings.TrimSuffix(line, "\n")
+	if strings.ContainsAny(body, "\r\n") {
+		t.Fatalf("pwsh bootstrap body contains an embedded newline")
+	}
+}
+
+func TestBase64BootstrapLinePwshIsPrintableAscii(t *testing.T) {
+	token := "0011223344556677"
+	line := Base64BootstrapLinePwsh(token)
+	body := strings.TrimSuffix(line, "\n")
+	for i, r := range body {
+		if r < 0x20 || r > 0x7e {
+			t.Fatalf("pwsh bootstrap has a non-printable byte %#x at offset %d", r, i)
+		}
+	}
+}
+
+func TestBase64BootstrapLinePwshCarriesHelperScript(t *testing.T) {
+	token := "deadbeefcafefeed"
+	line := Base64BootstrapLinePwsh(token)
+	// Find the '<b64>' literal between the two single quotes assigning
+	// $F4B: base64 alphabet is [A-Za-z0-9+/=], never contains a quote.
+	const prefix = "$F4B='"
+	start := strings.Index(line, prefix)
+	if start < 0 {
+		t.Fatalf("pwsh bootstrap does not assign $F4B: %q", line[:min(80, len(line))])
+	}
+	rest := line[start+len(prefix):]
+	end := strings.Index(rest, "'")
+	if end < 0 {
+		t.Fatalf("pwsh bootstrap $F4B assignment is not terminated")
+	}
+	encoded := rest[:end]
+	// The compact helper sometimes contains the raw ready marker; the
+	// bootstrap splits it into F''4RDY<token> so a terminal echo cannot
+	// look like the marker itself. Undo the split before decoding.
+	restored := strings.ReplaceAll(encoded, "F''4RDY"+token, "F4RDY"+token)
+	decoded, err := base64.StdEncoding.DecodeString(restored)
+	if err != nil {
+		t.Fatalf("pwsh bootstrap payload is not valid base64: %v", err)
+	}
+	got := string(decoded)
+	// The payload begins with the sentinel comment then the helper.
+	if !strings.HasPrefix(got, "# F4B64"+token+"\n") {
+		t.Fatalf("pwsh bootstrap payload has no sentinel prefix; got head %q", got[:min(80, len(got))])
+	}
+	// And the tail is exactly the compacted helper the same call produces.
+	want := "# F4B64" + token + "\n" + HelperScriptPwsh(token)
+	if got != want {
+		t.Fatalf("pwsh bootstrap payload does not match HelperScriptPwsh(token)")
+	}
+}
+
+func TestHelperScriptPwshSubstitutesToken(t *testing.T) {
+	token := "0123456789abcdef"
+	s := HelperScriptPwsh(token)
+	if strings.Contains(s, tokenPlaceholder) {
+		t.Fatalf("helper.ps1 still contains the token placeholder")
+	}
+	if !strings.Contains(s, token) {
+		t.Fatalf("helper.ps1 does not contain the substituted token")
+	}
+}
+
+func TestHelperSourcePwshIsNotEmpty(t *testing.T) {
+	if len(HelperSourcePwsh()) < 1000 {
+		t.Fatalf("helper.ps1 embed looks truncated: %d bytes", len(HelperSourcePwsh()))
+	}
+}
+
+// max/min are 1.21+ builtins; f4 targets that already.

--- a/plugins/netfox/fishplus/session.go
+++ b/plugins/netfox/fishplus/session.go
@@ -99,6 +99,12 @@ const (
 	// BootstrapBase64Line sends one printable-ASCII line containing the
 	// complete base64-encoded helper. It avoids per-line shell read overhead.
 	BootstrapBase64Line
+	// BootstrapBase64LinePwsh is the PowerShell counterpart of
+	// BootstrapBase64Line: it fits the compacted helper.ps1 into one
+	// printable-ASCII line and drives a PowerShell peer through the same
+	// wire protocol. Selected explicitly by callers today; flavor auto-probe
+	// will pick it based on the peer's response to a probe line.
+	BootstrapBase64LinePwsh
 )
 
 // HandshakeOptions controls helper upload. Callers that do not need a
@@ -277,6 +283,14 @@ func (s *Session) HandshakeWithOptions(ctx context.Context, opts HandshakeOption
 		if err := s.waitForReady(ctx); err != nil {
 			return err
 		}
+	case BootstrapBase64LinePwsh:
+		if _, err := io.WriteString(s.w, Base64BootstrapLinePwsh(s.token)); err != nil {
+			s.broken = true
+			return err
+		}
+		if err := s.waitForReady(ctx); err != nil {
+			return err
+		}
 	default:
 		return fmt.Errorf("fishplus: unsupported bootstrap method %d", opts.Bootstrap)
 	}
@@ -327,6 +341,18 @@ func parseBanner(msg string) (Features, error) {
 // for the shell to report itself ready. A motd is long; it is not endless.
 const maxBootstrapLines = 1000
 
+// ReadyTimeout bounds how long the bootstrap may stay silent before the peer
+// is declared unable to run it. A shell that does not understand the
+// bootstrap does not answer at all: a PowerShell peer given the POSIX line
+// prints its parse error on stderr, which the transport discards, and then
+// waits for input forever. Without a bound the handshake would block there
+// for good, and a caller with a fallback flavor would never get the failure
+// it needs to try the other one.
+//
+// It bounds silence rather than the whole wait, so a long motd arriving one
+// slow line at a time still gets through.
+var ReadyTimeout = 20 * time.Second
+
 // waitForReady consumes whatever the login printed until the bootstrap says
 // it is running. Sending the helper before that is what the whole two step
 // upload exists to avoid.
@@ -337,7 +363,7 @@ func (s *Session) waitForReady(ctx context.Context) error {
 			s.broken = true
 			return err
 		}
-		line, err := s.readLine()
+		line, err := s.readLineWithin(ctx, ReadyTimeout)
 		if err != nil {
 			s.broken = true
 			return err
@@ -348,6 +374,37 @@ func (s *Session) waitForReady(ctx context.Context) error {
 	}
 	s.broken = true
 	return fmt.Errorf("fishplus: the remote shell never reported being ready")
+}
+
+// readLineWithin reads one line, giving up once the peer has been silent for
+// d or the context is done. The read itself cannot be interrupted — it is a
+// blocking read on a network stream — so it is left to finish in a goroutine
+// on the line it owns; the session is on its way out either way, since every
+// caller of this treats a failure here as fatal to the session.
+//
+// The timeout message is the one isHandshakeFailure already recognizes, so a
+// peer that stays silent reads as "this flavor is wrong" rather than as a
+// broken network.
+func (s *Session) readLineWithin(ctx context.Context, d time.Duration) (string, error) {
+	type result struct {
+		line string
+		err  error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		line, err := s.readLine()
+		ch <- result{line, err}
+	}()
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case r := <-ch:
+		return r.line, r.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	case <-timer.C:
+		return "", fmt.Errorf("fishplus: the remote shell never reported being ready within %s", d)
+	}
 }
 
 // Exec runs a command that takes only short tokens as arguments. A token

--- a/plugins/netfox/fishplus/session_pwsh_test.go
+++ b/plugins/netfox/fishplus/session_pwsh_test.go
@@ -1,0 +1,277 @@
+package fishplus
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestHelperAgainstLocalPwsh runs the real PowerShell helper in a local
+// pwsh process. It is the counterpart of TestHelperAgainstLocalShell for
+// the Windows backend: the two together are what prove the two helper
+// implementations serve the same wire protocol.
+//
+// The test is skipped when pwsh is not on PATH, and on Windows itself —
+// Windows console pipes are ~4 KiB and the base64 bootstrap is ~50 KiB,
+// which deadlocks the write-then-read pattern Handshake uses. On Linux
+// and macOS pipe buffers are 64 KiB and the whole line fits. The manual
+// Windows lane exercises the deadlock case with a spooled writer in the
+// probe program.
+//
+// pwsh under Linux does not reproduce every ConsoleHost quirk of Windows
+// PowerShell — the stdin race that motivated helper.ps1 defect fix
+// d4b52ad, for instance, is Windows-only — but every request-formatting
+// bug, every wire-format regression and every path-translation error
+// this test does catch.
+func TestHelperAgainstLocalPwsh(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("small Windows console pipes deadlock the write-then-read handshake in test conditions; run the manual probe instead")
+	}
+	pwsh, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Skip("pwsh not on PATH")
+	}
+	// -NoProfile keeps a user profile from printing before the banner;
+	// -NoLogo keeps pwsh's own greeting away. -NonInteractive is NOT
+	// passed on purpose: it disables the host reader helper.ps1 relies
+	// on for its stdin, so a "non-interactive" test would run the wrong
+	// code path.
+	cmd := exec.Command(pwsh, "-NoProfile", "-NoLogo")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout: %v", err)
+	}
+	stderr := &syncBuffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", pwsh, err)
+	}
+	sess := NewSession(stdin, stdout, stdin)
+	t.Cleanup(func() {
+		sess.Close()
+		done := make(chan struct{})
+		go func() {
+			cmd.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			cmd.Process.Kill()
+		}
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := sess.HandshakeWithOptions(ctx, HandshakeOptions{Bootstrap: BootstrapBase64LinePwsh}); err != nil {
+		t.Fatalf("pwsh handshake: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+	feats := sess.Features()
+	if feats.Proto != ProtocolVersion {
+		t.Fatalf("Proto = %d, want %d", feats.Proto, ProtocolVersion)
+	}
+	// The three tags helper.ps1 must announce for the client's
+	// capability gates to open: mode:stat (parseListing accepts it),
+	// write:b64 (Client.Write encodes the payload as base64), and
+	// flavor:pwsh (a hint for whoever cares who they are talking to).
+	for _, want := range []string{"mode:stat", "write:b64", "flavor:pwsh"} {
+		if !feats.Has(want) {
+			t.Errorf("features do not include %q; raw = %q", want, feats.Raw)
+		}
+	}
+	// hash:sha256sum is what Client.CanHash gates on — the tag was
+	// added in commit b5f5b60 after the Windows lane found CanHash
+	// false. Regressing to a bare "sha256sum" would silently disable
+	// the duplicate search on every Windows peer.
+	if feats.HashTool() != "sha256sum" {
+		t.Errorf("HashTool = %q, want %q; raw = %q", feats.HashTool(), "sha256sum", feats.Raw)
+	}
+
+	if err := sess.Noop(ctx); err != nil {
+		t.Fatalf("noop: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+
+	// Ping payload covers the encoding path end to end: spaces, ASCII
+	// quotes, PowerShell variable syntax, and non-ASCII bytes so a
+	// hidden re-encoding through a code page other than UTF-8 shows up.
+	const payload = "spaces and юникод and 'quotes' and $VARS"
+	got, err := sess.Ping(ctx, payload)
+	if err != nil {
+		t.Fatalf("ping: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+	if got != payload {
+		t.Errorf("ping echoed %q, want %q", got, payload)
+	}
+
+	// The point of this call is *the pause*. Every regression of the
+	// stdin-race bug the Windows lane found — a helper that reads from
+	// stdin ahead of the request loop and loses whatever arrives after
+	// the handshake — hangs here on Windows. The test still runs the
+	// call on other systems so a change that always breaks it fails
+	// everywhere, not only on Windows.
+	time.Sleep(500 * time.Millisecond)
+	got, err = sess.Ping(ctx, "after-pause")
+	if err != nil {
+		t.Fatalf("ping after pause: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+	if got != "after-pause" {
+		t.Errorf("ping after pause echoed %q, want %q", got, "after-pause")
+	}
+
+	// pwd from a helper that speaks POSIX-shaped wire paths is either
+	// "/" (running from a drive root) or begins with a slash and a
+	// single lowercase letter (Cygwin convention).
+	resp, err := sess.Exec(ctx, "pwd")
+	if err != nil {
+		t.Fatalf("pwd: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+	if err := resp.Err("pwd"); err != nil {
+		t.Fatalf("pwd: %v", err)
+	}
+	if len(resp.Lines) != 1 {
+		t.Fatalf("pwd payload = %q, want one line", resp.Lines)
+	}
+	if !strings.HasPrefix(resp.Lines[0], "/") {
+		t.Errorf("pwd = %q, want a POSIX-shaped path", resp.Lines[0])
+	}
+
+	// An unknown command MUST not desynchronize the session — this is
+	// the defect that costs a whole panel connection when it regresses.
+	resp, err = sess.Exec(ctx, "frobnicate")
+	if err != nil {
+		t.Fatalf("unknown command must not break the session: %v", err)
+	}
+	if resp.OK() || !strings.Contains(resp.Msg, "unknown") {
+		t.Errorf("unknown command: status = %q, msg = %q", resp.Status, resp.Msg)
+	}
+	if err := sess.Noop(ctx); err != nil {
+		t.Errorf("noop after error: %v", err)
+	}
+}
+
+// TestHelperAgainstLocalPwshEnumAndRead builds on the plain handshake
+// test with the two calls a panel makes first: enum of a directory and
+// read of a file. It exists here rather than as a subtest so a run that
+// stops at the handshake still shows the second test as separately
+// skipped rather than being silently swallowed.
+func TestHelperAgainstLocalPwshEnumAndRead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("see TestHelperAgainstLocalPwsh")
+	}
+	pwsh, err := exec.LookPath("pwsh")
+	if err != nil {
+		t.Skip("pwsh not on PATH")
+	}
+	dir := t.TempDir()
+	// A file with known contents and a known length: the enum entry
+	// carries the length, the read brings back the bytes.
+	const body = "one two three\nfour five six\n"
+	fp := filepath.Join(dir, "sample.txt")
+	if err := os.WriteFile(fp, []byte(body), 0644); err != nil {
+		t.Fatalf("write sample: %v", err)
+	}
+
+	cmd := exec.Command(pwsh, "-NoProfile", "-NoLogo")
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout: %v", err)
+	}
+	stderr := &syncBuffer{}
+	cmd.Stderr = stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", pwsh, err)
+	}
+	sess := NewSession(stdin, stdout, stdin)
+	t.Cleanup(func() {
+		sess.Close()
+		done := make(chan struct{})
+		go func() { cmd.Wait(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			cmd.Process.Kill()
+		}
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	if err := sess.HandshakeWithOptions(ctx, HandshakeOptions{Bootstrap: BootstrapBase64LinePwsh}); err != nil {
+		t.Fatalf("handshake: %v (pwsh stderr: %s)", err, stderr.String())
+	}
+
+	client := NewClient(sess)
+
+	// Translate the tmpdir to the wire's POSIX shape. On Linux the
+	// path already starts with a slash, so nothing changes; on macOS
+	// the same holds; on Windows this test would not run at all.
+	wireDir := "/" + strings.TrimPrefix(strings.TrimPrefix(dir, "/"), "\\")
+	wireDir = strings.ReplaceAll(wireDir, "\\", "/")
+	// Non-Windows path already correct as long as it starts with '/'.
+	if !strings.HasPrefix(wireDir, "/") {
+		t.Fatalf("cannot translate %q to a wire path", dir)
+	}
+
+	entries, err := client.Enum(ctx, wireDir)
+	if err != nil {
+		t.Fatalf("enum %q: %v (pwsh stderr: %s)", wireDir, err, stderr.String())
+	}
+	var seenSample bool
+	for _, e := range entries {
+		if e.Name != "sample.txt" {
+			continue
+		}
+		seenSample = true
+		if !e.IsRegular() {
+			t.Errorf("sample.txt IsRegular = false, mode = %#o", e.Mode)
+		}
+		if e.Size != int64(len(body)) {
+			t.Errorf("sample.txt Size = %d, want %d", e.Size, len(body))
+		}
+	}
+	if !seenSample {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name)
+		}
+		t.Fatalf("sample.txt not found in %q; got %q", wireDir, names)
+	}
+
+	wireFile := wireDir + "/sample.txt"
+	data, size, err := client.Read(ctx, wireFile, 0, int64(len(body)))
+	if err != nil {
+		t.Fatalf("read %q: %v (pwsh stderr: %s)", wireFile, err, stderr.String())
+	}
+	if size != int64(len(body)) {
+		t.Errorf("read reported size %d, want %d", size, len(body))
+	}
+	if string(data) != body {
+		t.Errorf("read %q returned %q, want %q", wireFile, string(data), body)
+	}
+
+	// The reverse direction: write a new file, then read it back and
+	// compare. Covers the write:b64 payload path end to end.
+	newFile := wireDir + "/written.txt"
+	newBody := []byte("bytes via base64 write\n")
+	if err := client.WriteFile(ctx, newFile, newBody); err != nil {
+		t.Fatalf("write %q: %v (pwsh stderr: %s)", newFile, err, stderr.String())
+	}
+	back, err := client.ReadFile(ctx, newFile)
+	if err != nil {
+		t.Fatalf("read-back %q: %v", newFile, err)
+	}
+	if string(back) != string(newBody) {
+		t.Errorf("read-back %q returned %q, want %q", newFile, string(back), string(newBody))
+	}
+}


### PR DESCRIPTION
Windows counterpart of helper.sh: a plain PowerShell 5.1+ script that speaks the FISH+ wire protocol v1 against a Windows OpenSSH-Server peer. Same client, same VFS, same test lab pattern — POSIX peers keep using helper.sh, the client picks between them based on how the transport handshake answers.

Transport in netfox/fish_vfs.go tries POSIX first ('exec /bin/sh' through the login shell), and on any handshake failure — an EOF from a cmd DefaultShell that could not parse the request, a timeout from a peer that stayed silent, an 'unexpected banner' from a shell that answered but does not speak FISH+ — falls back to a PowerShell shell request. The fallback runs 'powershell.exe -NoLogo -NoProfile' via sess.Start, so a stock OpenSSH-Server-Windows with DefaultShell still at cmd.exe routes correctly through cmd /c powershell. On a Windows peer whose DefaultShell is already powershell the request nests, at the cost of a second launch but with the same wire result.

Notable choices reflected in helper.ps1 (details in WINDOWS_PORT.md):

- stdin comes through $host.UI.ReadLine() re-encoded with the console code page, not through [Console]::OpenStandardInput() — the console host holds a pending read on the raw handle and swallows bytes the script would otherwise see.

- Content search (grep, ffind) reads 1 MB chunks decoded through ISO-8859-1 (byte-transparent) and matches with String.IndexOf / Regex.IsMatch on that string. Behaves like 'grep -a': RSS stays at the buffer size regardless of file size or binariness, and a Cyrillic pattern still matches its own UTF-8 bytes.

- exec jobs bypass Start-Job and run cmd.exe directly through a small wrapper batch that redirects stdin from NUL and stdout+stderr into the job's output file. Start-Job under the cmd-launched PS 5.1 hangs the whole session in ways that are not worth debugging.

- scan and hash jobs use [PowerShell]::Create() + BeginInvoke() — in-process runspace, same priority as the main helper — instead of Start-Job's separate pwsh.exe process (which gets background I/O priority and slows content-shaped work by up to 100×).

- Reparse points are never followed during recursion: Windows profile trees have self-referential junctions ('AppData\\Local\\ Application Data' -> 'AppData\\Local') that make every recursive .NET or PowerShell walk loop forever otherwise.

Feature announcement extends the base FISHPLUS 1 banner with 'flavor:pwsh', 'mode:stat' (helper.ps1 emits stat-format entries so the client's existing parseListing path is used unchanged), 'hash:sha256sum' (gates the duplicate search), 'read:filestream' and 'write:b64' — with everything the client's CanX gates need to open the corresponding features.

Tests:

- session_pwsh_test.go integration-runs the whole helper against a local pwsh, gated on pwsh presence + non-Windows (Windows console pipes deadlock the write-then-read handshake in a subprocess).
- script_pwsh_test.go checks the Base64BootstrapLinePwsh producer is single-line, printable ASCII, and decodes back to the compact helper with the session token substituted.

ffind stays synchronous in this PR (the sync path helper.sh has). A following PR replaces it with a background job kind and adds a parallel worker pool, keeping the transport contract the same.