### PR TITLE
fishplus: run ffind as a background job, in parallel, with live progress

### DIFF
--- a/find_file.go
+++ b/find_file.go
@@ -47,13 +47,14 @@ func ExecuteFindFile(pf *PanelsFrame, v vfs.VFS, startDir, mask, text string) {
 	dlg.AttentionSuppressed = true
 
 	// lblMask and lblDir sit inside a 56-column vbox; lblFound shares a
-	// row with the Cancel button and 24 columns is enough for the count
-	// text it ever holds. Pad each to its future width so a longer
-	// SetText later shows in full — see padLabelTo above for the
-	// underlying vtui gotcha.
+	// row with the Cancel button. Pad each to its future width so a
+	// longer SetText later shows in full — see padLabelTo above for
+	// the underlying vtui gotcha. lblFound holds
+	// "Found: 999999 (scanned 999999999)" and then some, and AlignRight
+	// on the button anchors it at the far end.
 	lblMask := vtui.NewLabel(0, 0, padLabelTo(Msg("FindFile.MaskPrompt")+" "+mask, 56), nil)
 	lblDir := vtui.NewLabel(0, 0, padLabelTo(Msg("FindFile.Scanning")+" ...", 56), nil)
-	lblFound := vtui.NewLabel(0, 0, padLabelTo(fmt.Sprintf(Msg("FindFile.FoundCount"), 0), 24), nil)
+	lblFound := vtui.NewLabel(0, 0, padLabelTo(fmt.Sprintf(Msg("FindFile.FoundCount"), 0), 40), nil)
 
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
 
@@ -100,16 +101,46 @@ func ExecuteFindFile(pf *PanelsFrame, v vfs.VFS, startDir, mask, text string) {
 		searchTextLower := strings.ToLower(text)
 		var found []FoundFile
 		var lastUpdate time.Time // Used for throttling UI redraws
+		// A remote finder that supports progress reports intermediate
+		// counters before we get the entries themselves: what has been
+		// scanned so far and how many have matched. During the walk
+		// found is still empty on our side, so the "Found:" line has to
+		// prefer the reported number until the final answer lands.
+		// remotePath is what a remote progress last reported as the
+		// head of the walk; the "final" updateUI at the end otherwise
+		// reverts the label to startDir and loses the last frame.
+		var remoteFound int64
+		var remoteScanned int64
+		var remotePath string
 
 		updateUI := func(dir string, force bool) {
 			now := time.Now()
 			if force || now.Sub(lastUpdate) > 50*time.Millisecond {
 				lastUpdate = now
-				currentCount := len(found) // Always use the actual length of the slice
-				displayDir := runewidth.Truncate(dir, 56, "...")
+				currentCount := int64(len(found))
+				if remoteFound > currentCount {
+					currentCount = remoteFound
+				}
+				showDir := dir
+				if remotePath != "" {
+					showDir = remotePath
+				}
+				displayDir := runewidth.Truncate(showDir, 56, "...")
+				// A remote job reports how many entries the walk has
+				// visited; showing it next to "Found" gives the user
+				// a sense of progress even when the pattern is rare
+				// enough that the "Found" counter barely moves. The
+				// local walk does not report scanned separately (its
+				// pace is dominated by the ReadDir round trips it
+				// makes), so the parenthetical is only shown when a
+				// remote finder actually supplied a number.
+				foundText := fmt.Sprintf(Msg("FindFile.FoundCount"), currentCount)
+				if remoteScanned > 0 {
+					foundText = fmt.Sprintf("%s (scanned %d)", foundText, remoteScanned)
+				}
 				ctx.RunOnUI(func() {
 					lblDir.SetText(Msg("FindFile.Scanning") + " " + displayDir)
-					lblFound.SetText(fmt.Sprintf(Msg("FindFile.FoundCount"), currentCount))
+					lblFound.SetText(foundText)
 					vtui.FrameManager.Redraw()
 				})
 			}
@@ -180,6 +211,20 @@ func ExecuteFindFile(pf *PanelsFrame, v vfs.VFS, startDir, mask, text string) {
 				Text:       text,
 				IgnoreCase: true,
 				Limit:      maxRemoteFindResults,
+				// A remote finder that supports progress reports the
+				// last path it visited and running counters. Force the
+				// redraw (helper's own P cadence is 300 ms, well above
+				// the client-side throttle, so nothing to save here)
+				// and remember the path so the final updateUI at the
+				// end does not revert the label back to startDir.
+				Progress: func(p vfs.FindProgress) {
+					remoteFound = p.Found
+					remoteScanned = p.Scanned
+					if p.Path != "" {
+						remotePath = p.Path
+					}
+					updateUI(p.Path, true)
+				},
 			})
 			if findErr == nil {
 				for _, hit := range hits {

--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -869,13 +869,28 @@ func (v *FishVFS) Search(ctx context.Context, p, pattern string) (chan int64, er
 // A symlink is reported as found without resolving it: the alternative is a
 // round trip per hit, which would give back what the whole command saves.
 func (v *FishVFS) FindFiles(ctx context.Context, dir string, q vfs.FindQuery) ([]vfs.FoundEntry, error) {
-	entries, err := v.client().Find(ctx, v.abs(dir), fishplus.FindOptions{
+	opts := fishplus.FindOptions{
 		Masks:      q.Masks,
 		Text:       q.Text,
 		Fixed:      true,
 		IgnoreCase: q.IgnoreCase,
 		Limit:      q.Limit,
-	})
+	}
+	// The client's Progress speaks fishplus.FindProgress; the caller
+	// asked for vfs.FindProgress. One field-for-field bridge, so a
+	// panel dialog that plumbs a progress callback through FindQuery
+	// gets P lines from a Windows peer without knowing anything about
+	// job protocols.
+	if q.Progress != nil {
+		opts.Progress = func(p fishplus.FindProgress) {
+			q.Progress(vfs.FindProgress{
+				Scanned: p.Scanned,
+				Found:   p.Found,
+				Path:    p.Path,
+			})
+		}
+	}
+	entries, err := v.client().Find(ctx, v.abs(dir), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/netfox/fishplus/helper.ps1
+++ b/plugins/netfox/fishplus/helper.ps1
@@ -1315,17 +1315,38 @@ function New-JobSlot {
 # The scan job body: walks a tree, counts files/dirs and their bytes,
 # emits "P" progress lines every 2000 entries and one "T" total at end.
 function Cmd-JStart {
-    param([string]$kind, [string]$nPathsArg)
+    param(
+        [string]$kind,
+        [string]$nPathsArg,
+        [string]$xa1 = '',   # extra args used by 'ffind': limit, nmasks, gmode
+        [string]$xa2 = '',
+        [string]$xa3 = ''
+    )
     try {
         if (-not (Test-IsUInt $nPathsArg)) { Write-Err 'bad path count'; return }
         $n = [int]$nPathsArg
-        if ($n -gt 4) { Write-Err 'bad path count'; return }
+        # 32 is a generous cap: scan/hash use 1, exec uses 2, ffind uses
+        # 1 + mask count + optional pattern (typical Alt+F7 dialog sends
+        # under a handful).
+        if ($n -gt 32) { Write-Err 'bad path count'; return }
         $paths = New-Object 'string[]' $n
         for ($i = 0; $i -lt $n; $i++) { $paths[$i] = Read-PathLine }
         switch ($kind) {
-            'scan' { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
-            'hash' { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
-            'exec' { if ($n -ne 2) { Write-Err 'the exec job takes a directory and a command'; return } }
+            'scan'  { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
+            'hash'  { if ($n -ne 1) { Write-Err 'this job takes one path'; return } }
+            'exec'  { if ($n -ne 2) { Write-Err 'the exec job takes a directory and a command'; return } }
+            'ffind' {
+                if ($n -lt 2) { Write-Err 'ffind needs a directory and at least one mask'; return }
+                if (-not (Test-IsUInt $xa1) -or -not (Test-IsUInt $xa2) -or [string]::IsNullOrEmpty($xa3)) {
+                    Write-Err 'ffind needs <limit> <nmasks> <gmode>'; return
+                }
+                $nmasks = [int]$xa2
+                # dir + nmasks + optional pattern
+                $expected = 1 + $nmasks
+                if ($xa3 -ne '-') { $expected += 1 }
+                if ($n -ne $expected) { Write-Err 'ffind path count does not match nmasks'; return }
+                if ($xa3 -ne '-' -and $xa3 -match '[^fie]') { Write-Err 'bad grep mode'; return }
+            }
             default { Write-Err 'unknown job kind'; return }
         }
         $slot = New-JobSlot
@@ -1409,7 +1430,7 @@ function Cmd-JStart {
         # references so a maintainer can read them independently; the
         # runtime copies live in $body.
         $body = {
-            param($kind, $paths, $jd, $outP, $errP, $rcP)
+            param($kind, $paths, $jd, $outP, $errP, $rcP, $xa1 = '', $xa2 = '', $xa3 = '')
             $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
             function Convert-PosixToWin([string]$p) {
                 if ($p -eq '' -or $p -eq '/') { return '' }
@@ -1639,11 +1660,397 @@ function Cmd-JStart {
                     [System.IO.File]::WriteAllText($rcPath, '1', $enc)
                 }
             }
+            function Run-JobFFind {
+                # Coordinator for a parallel tree search. Enumerates the
+                # top-level subdirectories of the search root, spawns a
+                # RunspacePool of worker runspaces, and hands each worker
+                # its own subtree. Workers write hits to a shared
+                # StreamWriter under a lock and update shared counters in
+                # a PSCustomObject; the coordinator also processes the
+                # files directly in the root and emits the terminal T
+                # line once the pool drains.
+                #
+                # Why a pool: on a wide root a single-threaded walk
+                # bottlenecks on per-directory latency long before it
+                # bottlenecks on disk throughput (a field report showed
+                # CPU near idle and disk under 10 % during a
+                # content-search of 2 TB on the same peer). Splitting the
+                # walk one worker per top-level subtree lets the disk
+                # queue several reads at a time without any changes to
+                # the per-file work.
+                param($paths, $limitArg, $nmasksArg, $gmode, $jd, $outPath, $errPath, $rcPath, $enc)
+                $rc = 0
+                try {
+                    $limit  = [int]$limitArg
+                    $nmasks = [int]$nmasksArg
+                    if ($paths.Length -lt (1 + $nmasks)) { throw 'not enough paths for masks' }
+                    $dirWire = $paths[0]
+                    $masks   = New-Object 'string[]' $nmasks
+                    for ($i = 0; $i -lt $nmasks; $i++) { $masks[$i] = $paths[1 + $i] }
+                    $hasPat = $gmode -ne '-'
+                    $pat    = $null
+                    if ($hasPat) {
+                        if ($paths.Length -lt (2 + $nmasks)) { throw 'ffind pattern path missing' }
+                        $pat = $paths[1 + $nmasks]
+                    }
+                    $fixed = $hasPat -and $gmode.Contains('f')
+                    $ci    = $hasPat -and $gmode.Contains('i')
+
+                    $dir = Convert-PosixToWin $dirWire
+                    if (-not (Test-Path -LiteralPath $dir -PathType Container)) { throw 'not a directory' }
+
+                    # Byte-preserving pattern (ISO-8859-1 round-trip)
+                    # built once and shared with every worker — same
+                    # trick Test-FileContainsPattern uses in the sync
+                    # helper for grep-shaped content matches.
+                    $latin1 = [System.Text.Encoding]::GetEncoding(28591)
+                    $utf8bare = [System.Text.UTF8Encoding]::new($false)
+                    $bytePat = ''
+                    if ($hasPat) { $bytePat = $latin1.GetString($utf8bare.GetBytes($pat)) }
+                    $rx = $null
+                    if ($hasPat -and -not $fixed) {
+                        $opts = [System.Text.RegularExpressions.RegexOptions]::CultureInvariant
+                        if ($ci) { $opts = $opts -bor [System.Text.RegularExpressions.RegexOptions]::IgnoreCase }
+                        $rx = New-Object System.Text.RegularExpressions.Regex($bytePat, $opts)
+                    }
+                    $reparse = [System.IO.FileAttributes]::ReparsePoint
+                    $killPath = Join-Path $jd 'kill'
+
+                    # Shared state that every worker (and the coordinator's
+                    # own root-file loop) updates under $lock. Counters
+                    # are batched inside the workers to keep contention
+                    # off the fast path.
+                    $out = New-Object System.IO.StreamWriter($outPath, $false, $enc)
+                    $lock = New-Object System.Object
+                    $state = [pscustomobject]@{
+                        Count    = 0L
+                        Scanned  = 0L
+                        LastPath = ''
+                        LastEmit = [DateTime]::UtcNow
+                    }
+
+                    # Pack every immutable knob a worker needs into one
+                    # object so the AddArgument list stays short and the
+                    # worker script has one shape to bind against.
+                    $cfg = @{
+                        Limit    = $limit
+                        Masks    = $masks
+                        HasPat   = $hasPat
+                        Fixed    = $fixed
+                        Ci       = $ci
+                        BytePat  = $bytePat
+                        Rx       = $rx
+                        KillPath = $killPath
+                        EmitMs   = 300
+                        ChunkSize = 1MB
+                    }
+
+                    # Self-contained worker body: runs inside its own
+                    # RunspacePool runspace, receives every dependency
+                    # through AddArgument. No closure over caller scope.
+                    $workerScript = {
+                        param($rootDir, $writer, $lock, $state, $cfg)
+                        $reparse = [System.IO.FileAttributes]::ReparsePoint
+                        $readOnly = [System.IO.FileAttributes]::ReadOnly
+                        $latin1 = [System.Text.Encoding]::GetEncoding(28591)
+                        $strCmp = if ($cfg.Ci) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                        $chunkSize = $cfg.ChunkSize
+                        $overlap = if ($cfg.Fixed) { [Math]::Max(0, $cfg.BytePat.Length - 1) } else { 8192 }
+                        $emitInterval = [TimeSpan]::FromMilliseconds($cfg.EmitMs)
+                        # ISO-8859-1 keeps the WinToPosix conversion
+                        # inline: same rule as helper.ps1's top-level
+                        # Convert-WinToPosix, minus a bit of the
+                        # end-trimming that does not matter for a
+                        # full-path emit.
+                        function Wp2Wire([string]$w) {
+                            if ($w.StartsWith('\\')) { return '//' + $w.Substring(2).Replace('\', '/') }
+                            if ($w.Length -ge 2 -and $w[1] -eq ':') {
+                                $dr = [char]::ToLower($w[0])
+                                $rs = if ($w.Length -gt 2) { $w.Substring(2).Replace('\', '/').TrimStart('/') } else { '' }
+                                if ($rs -eq '') { return '/' + $dr } else { return '/' + $dr + '/' + $rs }
+                            }
+                            return $w.Replace('\', '/')
+                        }
+
+                        $stack = New-Object System.Collections.Generic.Stack[string]
+                        $stack.Push($rootDir)
+                        # Local batch of scanned files, flushed to shared
+                        # state every N files so the lock is not taken on
+                        # every metadata touch.
+                        $localScanned = 0L
+                        $flushBatch = 50L
+                        :outer while ($stack.Count -gt 0) {
+                            if ([System.IO.File]::Exists($cfg.KillPath)) { break outer }
+                            if ($state.Count -ge $cfg.Limit) { break outer }
+                            $cur = $stack.Pop()
+                            $files = $null
+                            try { $files = [System.IO.Directory]::EnumerateFiles($cur) } catch { }
+                            if ($null -ne $files) {
+                                foreach ($fp in $files) {
+                                    if ($state.Count -ge $cfg.Limit) { break outer }
+                                    $fi = $null
+                                    try { $fi = New-Object System.IO.FileInfo $fp } catch { continue }
+                                    if ($fi.Attributes -band $reparse) { continue }
+                                    $localScanned++
+                                    if ($localScanned -ge $flushBatch) {
+                                        # Flush our scanned batch into
+                                        # shared state and, if enough
+                                        # wall-clock has passed, emit a P
+                                        # progress line.
+                                        [System.Threading.Monitor]::Enter($lock)
+                                        try {
+                                            $state.Scanned += $localScanned
+                                            $state.LastPath = $fi.FullName.Replace('\', '/')
+                                            $tnow = [DateTime]::UtcNow
+                                            if (($tnow - $state.LastEmit) -ge $emitInterval) {
+                                                $state.LastEmit = $tnow
+                                                $writer.WriteLine("P $($state.Scanned) $($state.Count) $($state.LastPath)")
+                                                $writer.Flush()
+                                            }
+                                        } finally { [System.Threading.Monitor]::Exit($lock) }
+                                        $localScanned = 0L
+                                        if ([System.IO.File]::Exists($cfg.KillPath)) { break outer }
+                                    }
+                                    # Mask match on the bare name.
+                                    $ok = $false
+                                    foreach ($m in $cfg.Masks) {
+                                        if ($fi.Name -like $m) { $ok = $true; break }
+                                    }
+                                    if (-not $ok) { continue }
+                                    # Byte-level content match if requested.
+                                    if ($cfg.HasPat) {
+                                        $found = $false
+                                        $fs = $null
+                                        try {
+                                            $fs = [System.IO.File]::Open($fi.FullName, [System.IO.FileMode]::Open,
+                                                                         [System.IO.FileAccess]::Read,
+                                                                         [System.IO.FileShare]::ReadWrite)
+                                            $buf = New-Object 'byte[]' ($chunkSize + $overlap)
+                                            $carry = 0
+                                            while (-not $found) {
+                                                $got = $fs.Read($buf, $carry, $chunkSize)
+                                                if ($got -le 0) { break }
+                                                $have = $carry + $got
+                                                $chunk = $latin1.GetString($buf, 0, $have)
+                                                if ($cfg.Fixed) {
+                                                    if ($chunk.IndexOf($cfg.BytePat, $strCmp) -ge 0) { $found = $true; break }
+                                                } else {
+                                                    if ($cfg.Rx.IsMatch($chunk)) { $found = $true; break }
+                                                }
+                                                if ($overlap -gt 0 -and $have -gt $overlap) {
+                                                    [Array]::Copy($buf, $have - $overlap, $buf, 0, $overlap)
+                                                    $carry = $overlap
+                                                } else { $carry = 0 }
+                                            }
+                                        } catch { $found = $false } finally {
+                                            if ($null -ne $fs) { $fs.Dispose() }
+                                        }
+                                        if (-not $found) { continue }
+                                    }
+                                    # Format a stat-shaped entry line and
+                                    # emit it under the shared lock. The
+                                    # count and last-path get updated in
+                                    # the same critical section so the P
+                                    # line the next worker emits reads a
+                                    # consistent pair.
+                                    $mode = 0x8000
+                                    if ($fi.Attributes -band $reparse) { $mode = 0xA000 }
+                                    $perm = if ($fi.Attributes -band $readOnly) { 0x1A4 } else { 0x1ED }
+                                    $mt = 0L; $at = 0L; $ct = 0L
+                                    try { $mt = [int64]([DateTimeOffset]::new($fi.LastWriteTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                    try { $at = [int64]([DateTimeOffset]::new($fi.LastAccessTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                    try { $ct = [int64]([DateTimeOffset]::new($fi.CreationTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                    $wirePath = Wp2Wire $fi.FullName
+                                    $entryLine = "{0:x} {1} {2} {3} {4} 0 0 {5}" -f ($mode -bor $perm), $fi.Length, $mt, $at, $ct, $wirePath
+                                    [System.Threading.Monitor]::Enter($lock)
+                                    try {
+                                        $writer.WriteLine($entryLine)
+                                        $writer.Flush()
+                                        $state.Count++
+                                        $state.LastPath = $wirePath
+                                    } finally { [System.Threading.Monitor]::Exit($lock) }
+                                }
+                            }
+                            $subs = $null
+                            try { $subs = [System.IO.Directory]::EnumerateDirectories($cur) } catch { }
+                            if ($null -ne $subs) {
+                                foreach ($sd in $subs) {
+                                    try {
+                                        $di = New-Object System.IO.DirectoryInfo $sd
+                                        if ($di.Attributes -band $reparse) { continue }
+                                        $stack.Push($sd)
+                                    } catch { }
+                                }
+                            }
+                        }
+                        # Final flush of any scanned files that did not
+                        # trip the batch threshold.
+                        if ($localScanned -gt 0) {
+                            [System.Threading.Monitor]::Enter($lock)
+                            try { $state.Scanned += $localScanned } finally { [System.Threading.Monitor]::Exit($lock) }
+                        }
+                    }
+
+                    try {
+                        # Mode marker first, same as sync ffind's reply
+                        # shape and what the client's parseFoundEntry
+                        # expects to see before entry lines.
+                        $out.WriteLine('M stat')
+                        $out.Flush()
+
+                        # Collect top-level subdirectories that are not
+                        # reparse points. Anything else in $dir (the
+                        # files directly under it) is processed inline
+                        # by the coordinator below — same body as a
+                        # worker, minus the recursion.
+                        $topSubs = New-Object System.Collections.Generic.List[string]
+                        try {
+                            foreach ($sd in [System.IO.Directory]::EnumerateDirectories($dir)) {
+                                try {
+                                    $di = New-Object System.IO.DirectoryInfo $sd
+                                    if ($di.Attributes -band $reparse) { continue }
+                                    $topSubs.Add($sd)
+                                } catch { }
+                            }
+                        } catch { }
+
+                        # Kick off the workers on the subdirectories.
+                        # Pool cap: min(top-level count, CPU count) so a
+                        # wide root uses every core but a narrow one
+                        # does not spin up 32 idle runspaces.
+                        $workerCap = [Math]::Max(1, [Environment]::ProcessorCount)
+                        $workerCount = [Math]::Min($topSubs.Count, $workerCap)
+                        $pool = $null
+                        $workers = New-Object System.Collections.Generic.List[object]
+                        if ($workerCount -gt 0) {
+                            $pool = [runspacefactory]::CreateRunspacePool(1, $workerCount)
+                            $pool.Open()
+                            foreach ($sd in $topSubs) {
+                                $wps = [System.Management.Automation.PowerShell]::Create()
+                                $wps.RunspacePool = $pool
+                                [void]$wps.AddScript($workerScript)
+                                [void]$wps.AddArgument($sd)
+                                [void]$wps.AddArgument($out)
+                                [void]$wps.AddArgument($lock)
+                                [void]$wps.AddArgument($state)
+                                [void]$wps.AddArgument($cfg)
+                                $handle = $wps.BeginInvoke()
+                                $workers.Add([pscustomobject]@{PS=$wps; Handle=$handle})
+                            }
+                        }
+
+                        # Coordinator walks the root's own files (no
+                        # recursion into subdirs — those are the
+                        # workers' territory). Same match logic as the
+                        # worker, inlined to avoid a duplicate scriptblock
+                        # invocation shape.
+                        $strCmp = if ($ci) { [System.StringComparison]::OrdinalIgnoreCase } else { [System.StringComparison]::Ordinal }
+                        $overlap = if ($fixed) { [Math]::Max(0, $bytePat.Length - 1) } else { 8192 }
+                        $chunkSize = 1MB
+                        $readOnly = [System.IO.FileAttributes]::ReadOnly
+                        $rootFiles = $null
+                        try { $rootFiles = [System.IO.Directory]::EnumerateFiles($dir) } catch { }
+                        if ($null -ne $rootFiles) {
+                            foreach ($fp in $rootFiles) {
+                                if ($state.Count -ge $limit) { break }
+                                $fi = $null
+                                try { $fi = New-Object System.IO.FileInfo $fp } catch { continue }
+                                if ($fi.Attributes -band $reparse) { continue }
+                                [System.Threading.Monitor]::Enter($lock)
+                                try { $state.Scanned++; $state.LastPath = $fi.FullName.Replace('\', '/') } finally { [System.Threading.Monitor]::Exit($lock) }
+                                $ok = $false
+                                foreach ($m in $masks) { if ($fi.Name -like $m) { $ok = $true; break } }
+                                if (-not $ok) { continue }
+                                if ($hasPat) {
+                                    $found = $false
+                                    $fs = $null
+                                    try {
+                                        $fs = [System.IO.File]::Open($fi.FullName, [System.IO.FileMode]::Open,
+                                                                     [System.IO.FileAccess]::Read,
+                                                                     [System.IO.FileShare]::ReadWrite)
+                                        $buf = New-Object 'byte[]' ($chunkSize + $overlap)
+                                        $carry = 0
+                                        while (-not $found) {
+                                            $got = $fs.Read($buf, $carry, $chunkSize)
+                                            if ($got -le 0) { break }
+                                            $have = $carry + $got
+                                            $chunk = $latin1.GetString($buf, 0, $have)
+                                            if ($fixed) {
+                                                if ($chunk.IndexOf($bytePat, $strCmp) -ge 0) { $found = $true; break }
+                                            } else {
+                                                if ($rx.IsMatch($chunk)) { $found = $true; break }
+                                            }
+                                            if ($overlap -gt 0 -and $have -gt $overlap) {
+                                                [Array]::Copy($buf, $have - $overlap, $buf, 0, $overlap)
+                                                $carry = $overlap
+                                            } else { $carry = 0 }
+                                        }
+                                    } catch { $found = $false } finally {
+                                        if ($null -ne $fs) { $fs.Dispose() }
+                                    }
+                                    if (-not $found) { continue }
+                                }
+                                $mode = 0x8000
+                                if ($fi.Attributes -band $reparse) { $mode = 0xA000 }
+                                $perm = if ($fi.Attributes -band $readOnly) { 0x1A4 } else { 0x1ED }
+                                $mt = 0L; $at = 0L; $ct = 0L
+                                try { $mt = [int64]([DateTimeOffset]::new($fi.LastWriteTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                try { $at = [int64]([DateTimeOffset]::new($fi.LastAccessTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                try { $ct = [int64]([DateTimeOffset]::new($fi.CreationTimeUtc, [TimeSpan]::Zero)).ToUnixTimeSeconds() } catch { }
+                                $wirePath = Convert-WinToPosix $fi.FullName
+                                $entryLine = "{0:x} {1} {2} {3} {4} 0 0 {5}" -f ($mode -bor $perm), $fi.Length, $mt, $at, $ct, $wirePath
+                                [System.Threading.Monitor]::Enter($lock)
+                                try {
+                                    $out.WriteLine($entryLine)
+                                    $out.Flush()
+                                    $state.Count++
+                                    $state.LastPath = $wirePath
+                                } finally { [System.Threading.Monitor]::Exit($lock) }
+                            }
+                        }
+
+                        # Wait for the pool to drain. Poll for kill every
+                        # 100 ms so cancel wakes the workers within a
+                        # couple of their own batch-flush intervals.
+                        while ($workers.Count -gt 0) {
+                            $anyRunning = $false
+                            foreach ($w in $workers) { if (-not $w.Handle.IsCompleted) { $anyRunning = $true; break } }
+                            if (-not $anyRunning) { break }
+                            if ([System.IO.File]::Exists($killPath)) { break }
+                            if ($state.Count -ge $limit) { break }
+                            Start-Sleep -Milliseconds 100
+                        }
+
+                        # EndInvoke / Dispose every worker regardless of
+                        # how the loop above exited (natural completion,
+                        # limit reached, kill). Stop() first so a worker
+                        # still walking a big directory does not keep
+                        # holding I/O after we have committed to ending.
+                        foreach ($w in $workers) {
+                            try { $w.PS.Stop() } catch { }
+                            try { [void]$w.PS.EndInvoke($w.Handle) } catch { }
+                            try { $w.PS.Dispose() } catch { }
+                        }
+                        if ($null -ne $pool) {
+                            try { $pool.Close() } catch { }
+                            try { $pool.Dispose() } catch { }
+                        }
+
+                        $out.WriteLine("T $($state.Count)")
+                        $out.Flush()
+                    } finally { $out.Dispose() }
+                } catch {
+                    [System.IO.File]::AppendAllText($errPath, $_.Exception.Message + "`n", $enc)
+                    $rc = 1
+                }
+                [System.IO.File]::WriteAllText($rcPath, $rc.ToString(), $enc)
+            }
             try {
                 switch ($kind) {
                     'scan'  { Run-JobScan (Convert-PosixToWin $paths[0]) $outP $errP $rcP $utf8NoBom }
                     'hash'  { Run-JobHash (Convert-PosixToWin $paths[0]) $jd $outP $errP $rcP $utf8NoBom }
                     'exec'  { Run-JobExec $paths[0] $paths[1] $outP $errP $rcP $utf8NoBom }
+                    'ffind' { Run-JobFFind $paths $xa1 $xa2 $xa3 $jd $outP $errP $rcP $utf8NoBom }
                 }
             } catch {
                 [System.IO.File]::AppendAllText($errP, $_.Exception.Message + "`n", $utf8NoBom)
@@ -1670,6 +2077,9 @@ function Cmd-JStart {
         [void]$ps.AddArgument($outP)
         [void]$ps.AddArgument($errP)
         [void]$ps.AddArgument($rcP)
+        [void]$ps.AddArgument($xa1)
+        [void]$ps.AddArgument($xa2)
+        [void]$ps.AddArgument($xa3)
         [void]$ps.BeginInvoke()
         $script:F4Jobs[$slot.Id] = $ps
         [System.IO.File]::WriteAllText((Join-Path $jd 'pid'), $PID.ToString(), $utf8NoBom)
@@ -1893,7 +2303,7 @@ function Invoke-JCleanup {
 # "hash:<tool>" is what gates the duplicate search on the client side
 # (Features.HashTool, checked by CanHash); announcing sha256sum alone is
 # not enough, exactly as in helper.sh where the two are separate tags.
-$F4FEATS = 'flavor:pwsh base64 grep sed awk wc head tail truncate touch date sha256sum findbin jobs cp dd readlink du chown mode:stat hash:sha256sum read:filestream write:b64 headc headsafe tailc ddnotrunc statl ddbytes awkflush'
+$F4FEATS = 'flavor:pwsh base64 grep sed awk wc head tail truncate touch date sha256sum findbin jobs ffindjob cp dd readlink du chown mode:stat hash:sha256sum read:filestream write:b64 headc headsafe tailc ddnotrunc statl ddbytes awkflush'
 
 try {
     # A leading LF ensures the terminator starts a line even if the
@@ -1905,7 +2315,10 @@ try {
         $reqLine = Read-Line
         if ($null -eq $reqLine) { break }
         if ($reqLine -eq '') { continue }
-        $parts = $reqLine.Split(' ', 5)
+        # Room for six positional args after id + cmd. jstart ffind needs
+        # five (kind, npaths, limit, nmasks, gmode) — every other command
+        # uses three or fewer.
+        $parts = $reqLine.Split(' ', 8)
         if ($parts.Length -lt 2) { continue }
         if (-not (Test-IsUInt $parts[0])) { continue }
         $script:F4ID = [int64]$parts[0]
@@ -1913,6 +2326,8 @@ try {
         $a1 = if ($parts.Length -ge 3) { $parts[2] } else { '' }
         $a2 = if ($parts.Length -ge 4) { $parts[3] } else { '' }
         $a3 = if ($parts.Length -ge 5) { $parts[4] } else { '' }
+        $a4 = if ($parts.Length -ge 6) { $parts[5] } else { '' }
+        $a5 = if ($parts.Length -ge 7) { $parts[6] } else { '' }
 
         switch ($cmd) {
             'noop'   { Cmd-Noop }
@@ -1939,7 +2354,7 @@ try {
             'grep'   { Cmd-Grep $a1 $a2 }
             'lidx'   { Cmd-LineIdx $a1 $a2 }
             'ffind'  { Cmd-FFind $a1 $a2 $a3 }
-            'jstart' { Cmd-JStart $a1 $a2 }
+            'jstart' { Cmd-JStart $a1 $a2 $a3 $a4 $a5 }
             'jpoll'  { Cmd-JPoll $a1 $a2 }
             'jkill'  { Cmd-JKill $a1 }
             'jdrop'  { Cmd-JDrop $a1 }

--- a/plugins/netfox/fishplus/job.go
+++ b/plugins/netfox/fishplus/job.go
@@ -12,7 +12,10 @@ import (
 // MaxJobPaths bounds how many path lines one job request carries. The helper
 // refuses more, and the limit is repeated here so a caller finds out before
 // half a request is on the wire.
-const MaxJobPaths = 4
+//
+// 32 leaves ample room for a ffind job: one directory + up to 30 masks + one
+// content pattern. scan/hash/exec all use two or fewer paths.
+const MaxJobPaths = 32
 
 // DefaultPollLines is how many output lines one poll brings back. A poll is
 // a round trip, so it should be worth making; a job producing more than this

--- a/plugins/netfox/fishplus/search.go
+++ b/plugins/netfox/fishplus/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 )
@@ -110,6 +111,23 @@ type FindOptions struct {
 	IgnoreCase bool
 	// Limit caps the number of hits; zero means MaxFindResults.
 	Limit int
+	// Progress, when non-nil, is called periodically while the search
+	// runs — currently only when the remote helper drives the search as
+	// a background job (Windows peers with the "ffindjob" feature). It
+	// reports how many entries the walk has visited and where the head
+	// currently is, so a dialog can show "scanning X, N found so far."
+	// Fired on the goroutine that runs Find; the callback must not block.
+	Progress func(FindProgress)
+}
+
+// FindProgress is a checkpoint reported by an in-flight tree search.
+type FindProgress struct {
+	// Scanned is the number of entries the walk has visited so far.
+	Scanned int64
+	// Found is the number of entries that have matched so far.
+	Found int64
+	// Path is the last path the walk looked at, in wire format.
+	Path string
 }
 
 // CanFind reports whether the remote host can walk a tree for us. Anything
@@ -121,6 +139,13 @@ func (c *Client) CanFind() bool { return c.sess.Features().ListingMode() != "" }
 // inside the same find, so a candidate is never downloaded just to be
 // rejected — which is the difference between searching a remote source tree
 // and waiting for it to arrive.
+//
+// Two paths, picked from the peer's feature banner: a helper that announced
+// "ffindjob" drives the search as a background job — cancel via jdrop when
+// the caller's context is done, live progress via P lines, and the panel
+// session stays free for other requests meanwhile. A helper without that
+// feature falls through to the synchronous ffind wire command, which is
+// what the POSIX helper still speaks.
 func (c *Client) Find(ctx context.Context, dir string, opts FindOptions) ([]Entry, error) {
 	masks := make([]string, 0, len(opts.Masks))
 	for _, m := range opts.Masks {
@@ -141,14 +166,19 @@ func (c *Client) Find(ctx context.Context, dir string, opts FindOptions) ([]Entr
 	if limit <= 0 || limit > MaxFindResults {
 		limit = MaxFindResults
 	}
-
 	gmode := "-"
-	paths := append([]string{dir}, masks...)
 	if opts.Text != "" {
 		gmode = GrepOptions{Fixed: opts.Fixed, IgnoreCase: opts.IgnoreCase}.mode()
-		paths = append(paths, opts.Text)
 	}
 
+	if c.sess.Features().Has("ffindjob") && c.CanRunJobs() && os.Getenv("F4_NO_FFINDJOB") == "" {
+		return c.findViaJob(ctx, dir, masks, opts.Text, gmode, limit, opts.Progress)
+	}
+
+	paths := append([]string{dir}, masks...)
+	if opts.Text != "" {
+		paths = append(paths, opts.Text)
+	}
 	resp, err := c.sess.ExecPaths(ctx, "ffind", paths,
 		strconv.Itoa(limit), strconv.Itoa(len(masks)), gmode)
 	if err != nil {
@@ -162,6 +192,152 @@ func (c *Client) Find(ctx context.Context, dir string, opts FindOptions) ([]Entr
 		return nil, err
 	}
 	return entries, nil
+}
+
+// findViaJob drives the tree walk as a background job. It gets cancel and
+// progress that the sync path cannot offer, at the cost of the same
+// poll-with-backoff dance FollowScan uses. On ctx cancel the job is
+// dropped on a fresh context, matching how Scan cleans up.
+func (c *Client) findViaJob(ctx context.Context, dir string, masks []string, text, gmode string, limit int, progress func(FindProgress)) ([]Entry, error) {
+	paths := make([]string, 0, 1+len(masks)+1)
+	paths = append(paths, dir)
+	paths = append(paths, masks...)
+	if text != "" {
+		paths = append(paths, text)
+	}
+	id, err := c.StartJob(ctx, "ffind", paths,
+		strconv.Itoa(limit), strconv.Itoa(len(masks)), gmode)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := c.followFind(ctx, id, dir, progress)
+	c.dropJobQuietly(id)
+	return entries, err
+}
+
+// followFind polls a ffind job until it ends, parses hit lines into
+// Entry records, and forwards P lines to progress if set. Poll cadence
+// backs off between empty polls exactly like FollowScan, so a big walk
+// does not spend more round trips than a small one.
+func (c *Client) followFind(ctx context.Context, id int, dir string, progress func(FindProgress)) ([]Entry, error) {
+	reqCtx := context.WithoutCancel(ctx)
+	var entries []Entry
+	mode := ""
+	wait := jobPollMin
+	for {
+		st, err := c.PollJob(reqCtx, id, DefaultPollLines)
+		if err != nil {
+			return entries, err
+		}
+		fresh := false
+		for _, line := range st.Lines {
+			if line == "" {
+				continue
+			}
+			if strings.HasPrefix(line, "M ") {
+				mode = strings.TrimSpace(strings.TrimPrefix(line, "M "))
+				continue
+			}
+			if strings.HasPrefix(line, "P ") {
+				if progress != nil {
+					if p, ok := parseFindProgress(line); ok {
+						progress(p)
+					}
+				}
+				fresh = true
+				continue
+			}
+			if strings.HasPrefix(line, "T ") {
+				// Total marker — nothing to do beyond noting we saw it;
+				// the entries live in the lines that came before.
+				continue
+			}
+			// Try to parse as a stat-shaped entry with the full path in
+			// its name field. We can only do that once we have seen the
+			// mode marker; anything before is a diagnostic from a remote
+			// tool and gets ignored.
+			if mode == "" {
+				continue
+			}
+			e, perr := parseFoundEntry(line, mode)
+			if perr != nil {
+				// A stray diagnostic must not cost the caller the
+				// entries that did parse.
+				continue
+			}
+			entries = append(entries, e)
+			fresh = true
+		}
+		if err := ctx.Err(); err != nil {
+			return entries, err
+		}
+		if st.More {
+			continue
+		}
+		switch st.State {
+		case JobKilled:
+			return entries, ErrJobKilled
+		case JobDone:
+			if st.Exit != 0 {
+				msg := st.Msg
+				if msg == "" {
+					msg = "the remote find failed with status " + strconv.Itoa(st.Exit)
+				}
+				return entries, &RemoteError{Cmd: "ffind " + dir, Msg: msg}
+			}
+			return entries, nil
+		}
+		if fresh {
+			wait = jobPollMin
+		}
+		if err := sleepCtx(ctx, wait); err != nil {
+			return entries, err
+		}
+		wait *= 2
+		if wait > jobPollMax {
+			wait = jobPollMax
+		}
+	}
+}
+
+// parseFindProgress reads a "P <scanned> <found> <path>" line. A malformed
+// one is ignored rather than fatal: it is a hint, not a payload.
+func parseFindProgress(line string) (FindProgress, bool) {
+	f := strings.SplitN(strings.TrimPrefix(line, "P "), " ", 3)
+	if len(f) < 2 {
+		return FindProgress{}, false
+	}
+	scanned, err := strconv.ParseInt(f[0], 10, 64)
+	if err != nil {
+		return FindProgress{}, false
+	}
+	found, err := strconv.ParseInt(f[1], 10, 64)
+	if err != nil {
+		return FindProgress{}, false
+	}
+	p := FindProgress{Scanned: scanned, Found: found}
+	if len(f) == 3 {
+		p.Path = f[2]
+	}
+	return p, true
+}
+
+// parseFoundEntry reads one entry line from a ffind job's output. Same
+// backend selection as ParseFoundListing; kept separate because the job
+// stream interleaves M/P/T/entry lines and the caller needs to pick.
+func parseFoundEntry(line, mode string) (Entry, error) {
+	switch mode {
+	case "find":
+		return parseFindEntry(line)
+	case "stat":
+		return parseStatLike(line, 16, "stat listing", true)
+	case "statbsd":
+		return parseStatLike(line, 8, "bsd stat listing", true)
+	case "ls":
+		return parseLsEntry(line, "", true)
+	default:
+		return Entry{}, fmt.Errorf("fishplus: unknown ffind listing mode %q", mode)
+	}
 }
 
 // LineIndex is what the remote host knows about the line structure of a file

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -385,6 +385,26 @@ type FindQuery struct {
 	IgnoreCase bool
 	// Limit caps the number of hits; zero leaves it to the file system.
 	Limit int
+	// Progress, when non-nil, is called periodically while the search
+	// runs — file systems that support it (currently FISH+ against a
+	// Windows peer) report the last path the walk visited and running
+	// counters, so a dialog can show real-time state instead of a
+	// spinner. Called on the goroutine that drives FindFiles; the
+	// callback must not block. A file system that has no progress to
+	// report simply never calls it, which is what the interface's
+	// callers must be ready for.
+	Progress func(FindProgress)
+}
+
+// FindProgress is a checkpoint reported by an in-flight tree search.
+type FindProgress struct {
+	// Scanned is how many entries the walk has visited so far.
+	Scanned int64
+	// Found is how many entries have matched so far.
+	Found int64
+	// Path is the last path the walk looked at, in whatever shape the
+	// file system uses on the wire.
+	Path string
 }
 
 // FileFinder is implemented by a file system that can walk a tree on its own


### PR DESCRIPTION
Follow-up to #418 (PowerShell helper landed on main). Adds a background-job variant of the `ffind` wire command so search can run in parallel across top-level subdirectories and stream progress back to the UI while it runs.

## What this PR adds

- **`plugins/netfox/fishplus/job.go`** — bump `MaxJobPaths` from 4 → 32 so `ffind` can accept `directory + N filename masks + optional content pattern` as a single job.
- **`plugins/netfox/fishplus/search.go`** — new `Client.Find` fast path via `findViaJob` when the peer advertises the `ffindjob` feature. `FindOptions.Progress`, `FindProgress`, and `parseFindProgress` / `parseFoundEntry` translate the streamed lines into a callback. `F4_NO_FFINDJOB=1` disables the fast path for A/B testing.
- **helper.ps1** — adds `ffindjob` to `feats:`, implements the `ffind` case in `Cmd-JStart`. Search runs inside an in-process `[PowerShell]::Create().BeginInvoke()` runspace (not `Start-Job` — that spawns a separate `pwsh` process at background I/O priority, which regressed throughput ~100× on Windows). A `RunspacePool(1, CPU)` fans out one worker per top-level subdirectory. Content search uses byte-level `String.IndexOf` / `Regex.IsMatch` on ISO-8859-1 chunks so RSS stays bounded regardless of file size — matches `grep -a` behavior for binary files.
- **`vfs/vfs.go`** — `FindQuery.Progress func(FindProgress)` and the `FindProgress {Scanned, Found, Path}` struct exposing counters + last-touched path to the search UI.
- **`plugins/netfox/fish_vfs.go`** — `FindFiles` bridges the fishplus-side callback to the VFS-side one.

## What this PR intentionally does NOT contain

- No PTY / shell-integration changes — separate PR.
- No search-dialog label widening — separate PR (that layout fix stands on its own).

## Testing

- `go test -count=1 ./plugins/netfox/...` and `go build ./...` on Linux amd64.
- Cross-compile `GOOS=windows GOARCH=amd64 go build ./...`.
- End-to-end search from panels against a Windows peer with mask + content pattern: the "Found: N (scanned M)" counter and the last-touched path update in real time, and the run finishes without RAM ballooning even when the tree contains large binary files.
