### PR TITLE
netfox + panels: PTY integration for Windows peers

### DIFF
--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1293,6 +1293,26 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	if e.VirtualKeyCode == vtinput.VK_C && alt && ctrl && e.KeyDown {
 		panic("Manual safe crash triggered by user (Ctrl+Alt+C) for testing!")
 	}
+
+	// Ctrl+C on a remote panel that carries a PTY-integration hint
+	// interrupts whatever is running on the far side, ahead of the
+	// Panel.SplitReset action bound to Ctrl+C globally. A user driving
+	// a remote command from the panel cmdline reaches for Ctrl+C to
+	// stop it; making them switch to the terminal view first (Ctrl+O)
+	// just to be heard would be worse than losing the split-reset
+	// binding on remote panels.
+	if e.KeyDown && ctrl && !alt && !shift && e.VirtualKeyCode == vtinput.VK_C {
+		if fsp := pf.getActivePanel(); fsp != nil {
+			if integ, ok := fsp.vfs.(vfs.PtyShellIntegration); ok {
+				if pty := pf.getActivePTY(); pty != nil {
+					if seq := integ.PtyInterrupt(); len(seq) > 0 {
+						pty.Write(seq)
+						return true
+					}
+				}
+			}
+		}
+	}
 	if e.Type == vtinput.FocusEventType {
 		pf.SetFocus(e.SetFocus)
 		// Reload macros from disk when regaining focus to share them across instances
@@ -1614,12 +1634,22 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 			if activePty != nil {
 				var path string
 				isWindowsShell := runtime.GOOS == "windows"
+				var integration vfs.PtyShellIntegration
 				if fsp, ok := pf.panels[pf.activeIdx].(*FileSystemPanel); ok {
 					if _, isOS := fsp.vfs.(*vfs.OSVFS); isOS {
 						path = fsp.vfs.GetPath()
 					} else if vfsHasRemotePTY(fsp.vfs) {
 						path = fsp.vfs.GetPath()
 						isWindowsShell = false
+					}
+					// A VFS that carries its own PTY-shell templates
+					// takes over the wire-command composition. FISH+
+					// against a Windows peer takes this branch so the
+					// PTY (cmd.exe by default) gets syntax cmd actually
+					// parses — the bash-shaped OSC-133-wrapped template
+					// below would come through as literal noise.
+					if integ, ok2 := fsp.vfs.(vfs.PtyShellIntegration); ok2 {
+						integration = integ
 					}
 				}
 
@@ -1633,7 +1663,13 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 					cmd = resolveWindowsCommand(cmd)
 				}
 
-				if isWindowsShell {
+				if integration != nil {
+					if seq := integration.PtyRunCommand(path, cmd); len(seq) > 0 {
+						fullWireCmd = string(seq)
+						pf.executing = true
+						pf.returnToPanels = pf.showPanels
+					}
+				} else if isWindowsShell {
 					// Use a combined command for reliable excision in AnsiParser: cd /d "path" & command
 					if path != "" {
 						fullWireCmd = fmt.Sprintf("cd /d \"%s\" & %s\r", path, cmd)
@@ -1664,11 +1700,18 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 					}
 				}
 
-				if !isWindowsShell {
+				// Print the clean command in the local terminal echo
+				// so the user sees what was sent. OSC-133 mute is only
+				// safe for the shells that emit the matching D marker
+				// — the bash templates above do, cmd.exe and the
+				// integration path do not.
+				if !isWindowsShell && integration == nil {
 					pf.termView.PrintCleanCommand(cmd)
 					if !isBackground {
 						pf.termView.SetMuted(true)
 					}
+				} else if integration != nil {
+					pf.termView.PrintCleanCommand(cmd)
 				}
 				activePty.Write([]byte(fullWireCmd))
 			}
@@ -2915,16 +2958,29 @@ func (pf *PanelsFrame) syncPTYDirectory(path string, v vfs.VFS) bool {
 	}
 
 	activePty := pf.getActivePTY()
-	if activePty != nil {
-		if isWindowsShell {
-			activePty.Write([]byte(fmt.Sprintf("cd /d \"%s\" & rem f4_sync\r", path)))
-		} else {
-			sqPath := strings.ReplaceAll(path, "'", "'\\''")
-			activePty.Write([]byte(fmt.Sprintf(" cd '%s' # f4_sync\r", sqPath)))
+	if activePty == nil {
+		return false
+	}
+
+	// A VFS that knows what its own PTY speaks composes the sync line
+	// itself. FISH+ against a Windows peer takes this branch so the
+	// PTY (cmd.exe by default) sees a "cd /d \"C:\\...\" & rem f4_sync"
+	// instead of the bash-shaped one, which cmd treats as a broken
+	// argument and complains about at every step.
+	if integ, ok := v.(vfs.PtyShellIntegration); ok {
+		if seq := integ.PtyChangeDirCommand(path); len(seq) > 0 {
+			activePty.Write(seq)
 		}
 		return true
 	}
-	return false
+
+	if isWindowsShell {
+		activePty.Write([]byte(fmt.Sprintf("cd /d \"%s\" & rem f4_sync\r", path)))
+	} else {
+		sqPath := strings.ReplaceAll(path, "'", "'\\''")
+		activePty.Write([]byte(fmt.Sprintf(" cd '%s' # f4_sync\r", sqPath)))
+	}
+	return true
 }
 
 func vfsHasRemotePTY(v vfs.VFS) bool {
@@ -2957,6 +3013,18 @@ func (pf *PanelsFrame) getActivePTYUnsafe() PtyBackend {
 			pty := res.(PtyBackend)
 			vtui.DebugLog("Created new remote PTY background session for VFS")
 			pf.remotePtys[activeVfs] = pty
+
+			// Give the VFS one chance to install shell settings before
+			// anyone else writes to the PTY. FISH+ against a Windows
+			// peer sends "prompt $E]133;D$E\$P$G" so cmd's own prompt
+			// embeds an OSC 133 D marker on every command completion —
+			// otherwise the panel frame never sees "command done" and
+			// stays in terminal mode instead of returning to panels.
+			if integ, ok := activeVfs.(vfs.PtyShellIntegration); ok {
+				if init := integ.PtyInitSequence(); len(init) > 0 {
+					pty.Write(init)
+				}
+			}
 
 			go func() {
 				buf := make([]byte, 32768) // Увеличен буфер

--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -902,6 +902,101 @@ func (v *FishVFS) FindFiles(ctx context.Context, dir string, q vfs.FindQuery) ([
 	return out, nil
 }
 
+// PtyChangeDirCommand implements vfs.PtyShellIntegration. The panel's
+// PTY channel runs the peer's DefaultShell — cmd.exe on a stock
+// OpenSSH-Server-Windows host, whatever the login shell is on a POSIX
+// host. Send syntax the actual PTY shell understands, converting the
+// path from the wire's Cygwin shape (/c/Users/foo) to what the shell
+// wants (C:\Users\foo for cmd, /c/Users/foo unchanged for POSIX).
+//
+// f4_sync is a stray marker helper.sh's own log filter can strip: cmd
+// keeps it as a rem comment, POSIX keeps it as a shell comment.
+func (v *FishVFS) PtyChangeDirCommand(dir string) []byte {
+	if v.peerIsWindows() {
+		winDir := fishplus.WirePathToWindows(dir)
+		if winDir == "" {
+			return nil
+		}
+		return []byte(fmt.Sprintf("cd /d \"%s\" & rem f4_sync\r", winDir))
+	}
+	sq := strings.ReplaceAll(dir, "'", "'\\''")
+	return []byte(fmt.Sprintf(" cd '%s' # f4_sync\r", sq))
+}
+
+// PtyRunCommand implements vfs.PtyShellIntegration. Same shell-flavor
+// split as PtyChangeDirCommand: cmd wants "cd /d \"path\" & command",
+// POSIX wants "cd 'path' && command". An empty dir skips the cd.
+func (v *FishVFS) PtyRunCommand(dir, command string) []byte {
+	if command == "" {
+		return nil
+	}
+	if v.peerIsWindows() {
+		if dir == "" {
+			return []byte(fmt.Sprintf("%s\r", command))
+		}
+		winDir := fishplus.WirePathToWindows(dir)
+		if winDir == "" {
+			return []byte(fmt.Sprintf("%s\r", command))
+		}
+		return []byte(fmt.Sprintf("cd /d \"%s\" & %s\r", winDir, command))
+	}
+	if dir == "" {
+		return []byte(fmt.Sprintf(" %s\r", command))
+	}
+	sq := strings.ReplaceAll(dir, "'", "'\\''")
+	return []byte(fmt.Sprintf(" cd '%s' && %s\r", sq, command))
+}
+
+// PtyInterrupt implements vfs.PtyShellIntegration. cmd.exe over ConPTY
+// and every POSIX shell treat a raw ETX (0x03) as SIGINT / Ctrl+C; no
+// flavor-specific wrapping is needed.
+func (v *FishVFS) PtyInterrupt() []byte {
+	return []byte{0x03}
+}
+
+// PtyInitSequence implements vfs.PtyShellIntegration. On a Windows peer
+// it sets cmd's PROMPT so that every prompt cmd draws — every time a
+// command finishes — embeds an OSC 133 D marker. The ANSI parser in
+// terminal_view.go then fires OnBusyChange(false), which is what makes
+// panels_frame return to panels after a cmdline command completes. This
+// is the same trick panels_frame.go uses for the local Windows PTY
+// (see the os.Setenv("PROMPT", ...) around initPTY).
+//
+// $E is cmd's PROMPT syntax for ESC; $E\ is the OSC ST terminator
+// (\x1b\); $P and $G are the standard current-path-and-'>' pieces. The
+// leading @ suppresses cmd's echo of the prompt-setup line in batch
+// contexts; interactive cmd on ConPTY still echoes it, so the second
+// half of the line is a cls that wipes the cmd banner + copyright +
+// the echoed setup line, leaving the panel-terminal view starting on
+// the first marker-embedded prompt with no visible init noise.
+func (v *FishVFS) PtyInitSequence() []byte {
+	if !v.peerIsWindows() {
+		return nil
+	}
+	return []byte("@prompt $E]133;D$E\\$P$G & cls\r")
+}
+
+// peerIsWindows reports whether the FISH+ helper on the peer announced
+// itself as PowerShell (flavor:pwsh feature). A Windows peer's PTY
+// channel is what needs cmd-shaped commands; a POSIX peer keeps the
+// original bash-style templates.
+func (v *FishVFS) peerIsWindows() bool {
+	c := v.client()
+	if c == nil {
+		return false
+	}
+	s := c.Session()
+	if s == nil {
+		return false
+	}
+	for _, n := range s.Features().Names() {
+		if n == "flavor:pwsh" {
+			return true
+		}
+	}
+	return false
+}
+
 // opStatsFromScan converts what the remote walk counted. PhysicalBytes stays
 // zero: the remote host reports apparent sizes, and a consumer that sees a
 // zero there hides the metric rather than showing a wrong one.

--- a/plugins/netfox/fishplus/paths.go
+++ b/plugins/netfox/fishplus/paths.go
@@ -1,0 +1,46 @@
+package fishplus
+
+import "strings"
+
+// WirePathToWindows converts a POSIX-shaped wire path back to the
+// Windows path it stands for. helper.ps1 speaks the Cygwin convention
+// on the wire (/c/Users/foo, //server/share/rest, / for the virtual
+// root), and callers that talk to a native Windows shell — cmd.exe on
+// a PTY channel, for instance — need the Windows form.
+//
+// Mirrors Convert-PosixToWin in helper.ps1. Kept in the fishplus
+// package rather than in netfox so a caller with only a client and no
+// FishVFS wrapper can still use it.
+func WirePathToWindows(p string) string {
+	if p == "" || p == "/" {
+		return ""
+	}
+	if strings.HasPrefix(p, "//") {
+		// UNC: //server/share/rest -> \\server\share\rest
+		return `\\` + strings.ReplaceAll(p[2:], "/", `\`)
+	}
+	if !strings.HasPrefix(p, "/") {
+		// Relative paths never enter our wire, but if one shows up
+		// hand it back with the separators flipped rather than
+		// producing something nonsensical.
+		return strings.ReplaceAll(p, "/", `\`)
+	}
+	tail := p[1:]
+	slash := strings.Index(tail, "/")
+	if slash < 0 {
+		// /c -> C:\, or /somethingLonger -> \somethingLonger
+		if len(tail) == 1 {
+			return strings.ToUpper(tail) + `:\`
+		}
+		return strings.ReplaceAll(tail, "/", `\`)
+	}
+	drive := tail[:slash]
+	rest := tail[slash+1:]
+	if len(drive) == 1 {
+		return strings.ToUpper(drive) + `:\` + strings.ReplaceAll(rest, "/", `\`)
+	}
+	// First segment is not a drive letter: separator swap and hope for
+	// the best. helper.sh paths never take this branch; Windows peers
+	// always produce single-letter drive prefixes.
+	return strings.ReplaceAll(p[1:], "/", `\`)
+}

--- a/plugins/netfox/fishplus/paths_test.go
+++ b/plugins/netfox/fishplus/paths_test.go
@@ -1,0 +1,26 @@
+package fishplus
+
+import "testing"
+
+func TestWirePathToWindows(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"", ""},
+		{"/", ""},
+		{"/c", `C:\`},
+		{"/c/", `C:\`},
+		{"/c/Users/sogonov", `C:\Users\sogonov`},
+		{"/c/Users/John Doe/AppData/Local", `C:\Users\John Doe\AppData\Local`},
+		{"/d/backups", `D:\backups`},
+		{"//server/share", `\\server\share`},
+		{"//server/share/rest/of/path", `\\server\share\rest\of\path`},
+		{"relative/path", `relative\path`},
+	}
+	for _, c := range cases {
+		got := WirePathToWindows(c.in)
+		if got != c.want {
+			t.Errorf("WirePathToWindows(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -395,6 +395,45 @@ type FileFinder interface {
 	FindFiles(ctx context.Context, dir string, q FindQuery) ([]FoundEntry, error)
 }
 
+// PtyShellIntegration is an optional interface for a VFS that owns a
+// remote PTY. It lets the VFS compose the exact bytes to send for the
+// integration tasks the panel does through the PTY — syncing its cwd
+// to the panel's, running a command line from the cmdline, sending an
+// interrupt — so a peer whose PTY runs a non-POSIX shell (cmd.exe on
+// Windows) can be driven correctly without the caller learning about
+// its shell. Fallback for a VFS that does not implement this is the
+// caller's built-in POSIX-style templates.
+type PtyShellIntegration interface {
+	// PtyChangeDirCommand returns the bytes to send to the PTY to
+	// change to dir. Path is in whatever shape the VFS uses on its
+	// wire; translation to what the PTY shell expects is the VFS's
+	// job. An empty return means "do not sync this path" (the VFS
+	// declines gracefully rather than sending broken syntax).
+	PtyChangeDirCommand(dir string) []byte
+
+	// PtyRunCommand returns the bytes to send to the PTY to run
+	// command in dir. If dir is empty, run wherever the PTY is now.
+	// An empty return declines the run.
+	PtyRunCommand(dir, command string) []byte
+
+	// PtyInterrupt returns the bytes to send to interrupt whatever
+	// command the PTY is currently running. Typically {0x03} — a
+	// literal Ctrl+C byte — since both cmd.exe over ConPTY and every
+	// POSIX shell treat that as SIGINT.
+	PtyInterrupt() []byte
+
+	// PtyInitSequence returns bytes to send to the PTY exactly once,
+	// right after it opens and before the caller sends anything else.
+	// A Windows peer uses this to install a PROMPT that embeds an OSC
+	// 133 D marker, matching what the local Windows PTY does — every
+	// time cmd shows the prompt (which is when the last command
+	// finished) the caller's OSC 133 handler is fired and the panel
+	// frame's OnBusyChange returns to panels. Returning nil means the
+	// shell needs no init, which is the honest answer for a POSIX
+	// peer whose command templates emit their own OSC 133.
+	PtyInitSequence() []byte
+}
+
 // LineIndexResult is what a LineIndexer answers with.
 type LineIndexResult struct {
 	// First is the one-based number of the line Offsets[0] belongs to.


### PR DESCRIPTION
Follow-up to #418 (PowerShell helper landed on main). Wires the interactive PTY layer (cmdline execution from panels, directory sync between panels and terminal, Ctrl+C interrupt, return-to-panels detection) to Windows peers whose shell is `cmd.exe`.

## What this PR adds

- **`vfs/vfs.go`** — new `PtyShellIntegration` interface with four methods (`PtyChangeDirCommand`, `PtyRunCommand`, `PtyInterrupt`, `PtyInitSequence`). Any VFS that reports being able to drive a peer's PTY implements this; the panel/frame code no longer hard-codes bash semantics.
- **`plugins/netfox/fish_vfs.go`** — implementation of the four methods. On Windows peers (detected via the `flavor:pwsh` feature): commands are chained as `cd /d "path" & command`, the OSC 133 D marker is embedded into every prompt via `PROMPT $E]133;D$E\$P$G` (with `& cls` to clear the setup echo), interrupt is a plain Ctrl+C key event. On POSIX peers, the existing bash-style chain and reset sequence are used.
- **`panels_frame.go`** — `syncPTYDirectory` and the panel cmdline handler go through `vfs.PtyShellIntegration` when available, so the same panel code drives both bash and cmd. `Ctrl+C` on a remote panel forwards `PtyInterrupt()` rather than sending SIGINT locally. `PtyInitSequence` is written to the PTY right after it opens so the prompt marker is armed from the first command.

## What this PR intentionally does NOT contain

- No `ffind` job / find progress changes — that ships as a separate PR.
- No search-dialog label widening — separate PR.

## Testing

- `go test -count=1 ./plugins/netfox/...` and `go build ./...` on Linux amd64.
- Cross-compile `GOOS=windows GOARCH=amd64 go build ./...`.
- End-to-end against a Windows peer whose default SSH shell is `cmd.exe`: panel-directory ↔ terminal-cwd stay in sync when navigating from either side; commands typed in the panel cmdline run in the peer's cmd shell with correct cwd; Ctrl+C interrupts the running command; return-to-panels detection fires on the OSC 133 D marker so the panels re-appear when the command exits.
