### PR TITLE
gui: fix Ctrl+C interrupt on busy PTY via VK-based C0 synthesis

### DIFF
--- a/input_translation.go
+++ b/input_translation.go
@@ -179,6 +179,42 @@ func TranslateLegacySpecialKey(e *vtinput.InputEvent, appCursorKeys bool) string
 	return ""
 }
 
+// ctrlCharFromVK maps a virtual key code to the C0 control byte produced
+// by Ctrl+key, following xterm conventions. Returns -1 for keys without a
+// standard Ctrl mapping. Used only when the input backend could not supply
+// the character itself (Char == 0), e.g. in the gogpu GUI host.
+func ctrlCharFromVK(vk uint16) int {
+	switch {
+	case vk >= vtinput.VK_A && vk <= vtinput.VK_Z:
+		return int(vk-vtinput.VK_A) + 1
+	case vk == vtinput.VK_2:
+		return 0 // Ctrl+2 = NUL
+	case vk == vtinput.VK_3:
+		return 27 // Ctrl+3 = ESC
+	case vk == vtinput.VK_4:
+		return 28 // Ctrl+4 = FS
+	case vk == vtinput.VK_5:
+		return 29 // Ctrl+5 = GS
+	case vk == vtinput.VK_6:
+		return 30 // Ctrl+6 = RS
+	case vk == vtinput.VK_7:
+		return 31 // Ctrl+7 = US
+	case vk == vtinput.VK_8:
+		return 127 // Ctrl+8 = DEL
+	case vk == vtinput.VK_PAUSE:
+		return 3 // Ctrl+Pause/Ctrl+Break (maps to VK_CANCEL) = same as Ctrl+C = ETX
+	case vk == vtinput.VK_OEM_4:
+		return 27 // Ctrl+[ = ESC
+	case vk == vtinput.VK_OEM_5:
+		return 28 // Ctrl+\ = FS
+	case vk == vtinput.VK_OEM_6:
+		return 29 // Ctrl+] = GS
+	case vk == vtinput.VK_OEM_MINUS:
+		return 31 // Ctrl+_ = US
+	}
+	return -1
+}
+
 // TranslateInput converts f4 input events into ANSI sequences that interactive shell apps expect.
 func TranslateInput(e *vtinput.InputEvent, win32Mode bool, kittyFlags int, appCursorKeys bool) string {
 	if win32Mode && e.Type == vtinput.KeyEventType {
@@ -220,6 +256,25 @@ func TranslateInput(e *vtinput.InputEvent, win32Mode bool, kittyFlags int, appCu
 
 	ctrl := (e.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
+
+	// Some GUI hosts (gogpu window) deliver Ctrl+letter with Char == 0:
+	// their text-input path filters control characters (WM_CHAR < 0x20),
+	// so not even Ctrl+C arrives as a character, only as a modified key.
+	// In console mode Windows puts the C0 byte itself (0x03 = ETX for
+	// Ctrl+C) into the input record, so synthesizing from the virtual key
+	// code here is a no-op there. Real terminals (xterm, Windows Terminal)
+	// derive the control byte from the key too; without this a busy PTY
+	// child never receives Ctrl+C and e.g. `dir /s` cannot be interrupted.
+	if ctrl && e.Char == 0 {
+		if ch := ctrlCharFromVK(e.VirtualKeyCode); ch >= 0 {
+			out := ""
+			if alt {
+				out += "\x1b"
+			}
+			out += string(rune(ch))
+			return out
+		}
+	}
 
 	// Handle Character Input
 	if e.Char != 0 {

--- a/input_translation_test.go
+++ b/input_translation_test.go
@@ -20,6 +20,13 @@ func TestTranslateInput(t *testing.T) {
 		{"F1", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_F1, KeyDown: true}, 0, "\x1bOP"},
 		{"F5", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_F5, KeyDown: true}, 0, "\x1b[15~"},
 		{"Alt+a", &vtinput.InputEvent{Char: 'a', ControlKeyState: vtinput.LeftAltPressed, KeyDown: true}, 0, "\x1ba"},
+		{"Ctrl+C no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_C, ControlKeyState: vtinput.LeftCtrlPressed, KeyDown: true}, 0, string(rune(3))},
+		{"Ctrl+Z no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_Z, ControlKeyState: vtinput.RightCtrlPressed, KeyDown: true}, 0, string(rune(26))},
+		{"Ctrl+[ no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_4, ControlKeyState: vtinput.LeftCtrlPressed, KeyDown: true}, 0, "\x1b"},
+		{"Ctrl+Alt+C no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_C, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.LeftAltPressed, KeyDown: true}, 0, "\x1b\x03"},
+		{"Ctrl+2 no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_2, ControlKeyState: vtinput.LeftCtrlPressed, KeyDown: true}, 0, string(rune(0))},
+		{"Ctrl+Pause no char (gogpu)", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_PAUSE, ControlKeyState: vtinput.LeftCtrlPressed, KeyDown: true}, 0, string(rune(3))},
+		{"Pause no ctrl", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_PAUSE, KeyDown: true}, 0, ""},
 		{"Alt+Enter", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_RETURN, ControlKeyState: vtinput.LeftAltPressed, KeyDown: true}, 0, "\x1b\r"},
 		{"Standalone Modifier", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_SHIFT, KeyDown: true}, 0, ""},
 


### PR DESCRIPTION
gogpu window delivers Ctrl+letter with Char == 0 (its text-input path
filters control characters), so Ctrl+C never reached PTY children and
e.g. `dir /s` could not be interrupted. When Char is 0 but Ctrl is held,
synthesize the C0 byte from the virtual key code (xterm convention);
Ctrl+C -> ETX (0x03). In console mode this is a no-op: Windows already
puts the C0 byte into the input record.

Extends the same path to Ctrl+Pause/Ctrl+Break (VK_PAUSE -> ETX) and
adds TestTranslateInput cases for both.

close https://github.com/unxed/f4/issues/362
позже попытаемся ctrl-break обработку сделать (нужна правка в gogpu). Локально у меня получилось.

## Проблема

В GUI-версии (gogpu) Ctrl+C не прерывал зависшие команды в PTY. Причина:
gogpu-хост отдаёт Ctrl+буква с `Char == 0` (текстовый ввод фильтрует
управляющие символы < 0x20), и в PTY уходила пустая строка.

## Исправление

- `input_translation.go` — когда `Ctrl` зажат, а `Char == 0`, синтезируем
  C0-байт по виртуальному коду клавиши (по xterm-конвенции):
  `Ctrl+C` → `ETX (0x03)`; заодно `Ctrl+Pause/Ctrl+Break` → `ETX`.
- `input_translation_test.go` — кейсы `Ctrl+C`, `Ctrl+2`, `Ctrl+Pause`,
  `Pause` (без Ctrl).

В консольном режиме ветка — no-op: Windows сам кладёт C0-байт в
input record.

## Тестирование

- `go test . -run TestTranslateInput` — 17/17 ok
- сборка `f4-gui.exe` — ok
- запуск GUI и консоль — без регрессий, новых crash-логов нет

## Зависимости

Ctrl+Break полностью замыкается правками gogpu (VK_CANCEL → KeyPause)
и vtui (KeyPause → VK_PAUSE) — отдельными PR. 