### PR TITLE
Fix Apply Command action dispatch isolation

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -155,7 +155,7 @@ func plainLabel(s string) string {
 func init() {
 	withPF := func(fn func(pf *PanelsFrame)) func() bool {
 		return func() bool {
-			if pf := findPanelsFrame(); pf != nil {
+			if pf := findPanelsFrameAnyScreen(); pf != nil {
 				fn(pf)
 				return true
 			}
@@ -272,7 +272,13 @@ func init() {
 		DefaultKeys: []string{"CtrlG"},
 		MenuPath:    "Files",
 		Visible:     panelCanApplyCommand,
-		Handler:     withPF(func(pf *PanelsFrame) { actionApplyCommand(pf) }),
+		Handler: func() bool {
+			if pf := findPanelsFrame(); pf != nil {
+				actionApplyCommand(pf)
+				return true
+			}
+			return false
+		},
 	})
 	RegisterAction(Action{
 		Name:        "File.Copy",


### PR DESCRIPTION
## Summary

- restore the existing any-screen lookup behavior for shared panel actions
- keep active-workspace lookup scoped specifically to `File.ApplyCommand`
- fix the Windows/amd64 `TestPanelsFrame_KeyHandling` Ctrl+Enter regression introduced by #431

## Verification

- `TestPanelsFrame_KeyHandling` and Apply action/workspace tests pass 20 consecutive runs
- Windows amd64 root tests compile
- Windows amd64 and Linux amd64 builds pass

This follow-up is intentionally limited to `action_registry.go`.