### PR TITLE
Use icons for viewer and editor workspace tabs

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -3510,6 +3510,19 @@ func (ev *EditorView) GetTitle() string {
 	}
 	return "Editor"
 }
+
+// GetWorkspaceTabTitle provides a compact, icon-led title for the workspace
+// tab bar while leaving GetTitle available for contexts that need the fuller
+// textual description.
+func (ev *EditorView) GetWorkspaceTabTitle() string {
+	if ev.DisplayTitle != "" {
+		return "✎ " + ev.DisplayTitle
+	}
+	if ev.filePath != "" {
+		return "✎ " + filepath.Base(ev.filePath)
+	}
+	return "✎ Editor"
+}
 func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, wholeWord, next bool) {
 	if pattern == "" {
 		return

--- a/editor_view_test.go
+++ b/editor_view_test.go
@@ -1030,12 +1030,18 @@ func TestEditorView_GetTitle(t *testing.T) {
 	if ev1.GetTitle() != "Edit: syslog" {
 		t.Errorf("GetTitle failed for valid path: %s", ev1.GetTitle())
 	}
+	if ev1.GetWorkspaceTabTitle() != "✎ syslog" {
+		t.Errorf("GetWorkspaceTabTitle failed for valid path: %s", ev1.GetWorkspaceTabTitle())
+	}
 
 	// Without path
 	ev2 := NewEditorView(pt, nil, "")
 	defer ev2.Close()
 	if ev2.GetTitle() != "Editor" {
 		t.Errorf("GetTitle failed for empty path: %s", ev2.GetTitle())
+	}
+	if ev2.GetWorkspaceTabTitle() != "✎ Editor" {
+		t.Errorf("GetWorkspaceTabTitle failed for empty path: %s", ev2.GetWorkspaceTabTitle())
 	}
 
 	// Internal editor workflows can hide a temporary filename.
@@ -1044,6 +1050,9 @@ func TestEditorView_GetTitle(t *testing.T) {
 	ev3.DisplayTitle = "Rename list of files"
 	if ev3.GetTitle() != "Rename list of files" {
 		t.Errorf("GetTitle ignored DisplayTitle: %s", ev3.GetTitle())
+	}
+	if ev3.GetWorkspaceTabTitle() != "✎ Rename list of files" {
+		t.Errorf("GetWorkspaceTabTitle ignored DisplayTitle: %s", ev3.GetWorkspaceTabTitle())
 	}
 }
 func TestViewerView_CodepageSwitch_Crash(t *testing.T) {

--- a/viewer_view.go
+++ b/viewer_view.go
@@ -988,3 +988,13 @@ func (vv *ViewerView) GetTitle() string {
 	}
 	return "Viewer"
 }
+
+// GetWorkspaceTabTitle provides a compact, icon-led title for the workspace
+// tab bar while leaving GetTitle available for contexts that need the fuller
+// textual description.
+func (vv *ViewerView) GetWorkspaceTabTitle() string {
+	if vv.path != "" {
+		return "👁  " + filepath.Base(vv.path)
+	}
+	return "👁  Viewer"
+}

--- a/viewer_view_test.go
+++ b/viewer_view_test.go
@@ -497,6 +497,9 @@ func TestViewerView_GetTitle(t *testing.T) {
 	if vv.GetTitle() != "View: doc.txt" {
 		t.Errorf("GetTitle failed: %s", vv.GetTitle())
 	}
+	if vv.GetWorkspaceTabTitle() != "👁  doc.txt" {
+		t.Errorf("GetWorkspaceTabTitle failed: %s", vv.GetWorkspaceTabTitle())
+	}
 
 }
 func TestLayout_ViewerSearchDialog_Validity(t *testing.T) {


### PR DESCRIPTION
## Summary
- replace the compact workspace-tab `View:` prefix with an eye icon
- replace the compact workspace-tab `Edit:` prefix with a pencil icon
- preserve the full textual titles outside the tab bar
- keep an explicit visual spacer after each icon, including the extra Windows glyph-width spacer for the eye
- cover file, empty editor, and custom editor titles with tests

## Tests
- `go test . -run 'Test(EditorView_GetTitle|ViewerView_GetTitle)$'` 
- `go build -o f4.exe .`