### PR TITLE
Use platform monospace defaults in GUI mode

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -2762,7 +2762,7 @@ func actionImportFar2lHistory(pf *PanelsFrame) {
 func actionAppearanceSettings(pf *PanelsFrame) {
 	// One row shaved by dropping the blank between the two trailing
 	// checkboxes (see #298).
-	const width, height = 64, 24
+	const width, height = 64, 26
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
 	// Snapshot the whole palette (not just the style name) so a
@@ -2801,6 +2801,17 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	}
 	editFont := vtui.NewEdit(0, 0, 30, AppConfig.GuiFont)
 	lblFont := vtui.NewLabel(0, 0, Msg("AppearanceSettings.Font"), editFont)
+	chkSystemMonospace := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.UseSystemMonospace"), false)
+	if AppConfig.GuiUseSystemMonospace {
+		chkSystemMonospace.State = 1
+	}
+	updateFontEditor := func() {
+		usePlatformFont := chkSystemMonospace.State == 1 && (runtime.GOOS == "windows" || runtime.GOOS == "darwin")
+		lblFont.SetDisabled(usePlatformFont)
+		editFont.SetDisabled(usePlatformFont)
+	}
+	chkSystemMonospace.OnChange = func(int) { updateFontEditor() }
+	updateFontEditor()
 
 	editSize := vtui.NewEdit(0, 0, 6, fmt.Sprintf("%d", AppConfig.GuiFontSize))
 	editSize.Validator = &vtui.IntRangeValidator{Min: 6, Max: 72}
@@ -2862,6 +2873,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 
 	dlg.AddItem(lblStyle)
 	dlg.AddItem(comboStyle)
+	dlg.AddItem(chkSystemMonospace)
 	dlg.AddItem(lblFont)
 	dlg.AddItem(editFont)
 	dlg.AddItem(lblSize)
@@ -2885,6 +2897,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	rowStyle.Add(comboStyle, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(rowStyle, vtui.Margins{}, vtui.AlignFill)
 
+	vbox.Add(chkSystemMonospace, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(lblFont, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(editFont, vtui.Margins{}, vtui.AlignFill)
 
@@ -2935,13 +2948,15 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		if len(names) > 0 {
 			AppConfig.ColorStyle = names[comboStyle.Menu.SelectPos]
 		}
-		fontChanged := AppConfig.GuiFont != editFont.GetText() || fmt.Sprintf("%d", AppConfig.GuiFontSize) != editSize.GetText()
+		useSystemMonospace := chkSystemMonospace.State == 1
+		fontChanged := AppConfig.GuiUseSystemMonospace != useSystemMonospace || AppConfig.GuiFont != editFont.GetText() || fmt.Sprintf("%d", AppConfig.GuiFontSize) != editSize.GetText()
 
 		AppConfig.ConsoleTitleTemplate = editTitle.GetText()
+		AppConfig.GuiUseSystemMonospace = useSystemMonospace
 		AppConfig.GuiFont = editFont.GetText()
 		fmt.Sscanf(editSize.GetText(), "%d", &AppConfig.GuiFontSize)
 		if AppConfig.GuiFontSize <= 0 {
-			AppConfig.GuiFontSize = 18
+			AppConfig.GuiFontSize = defaultGuiFontSize(runtime.GOOS)
 		}
 		AppConfig.KeepTerminalCursor = chkCursor.State == 1
 		vtui.ManageCursorStyle = !AppConfig.KeepTerminalCursor

--- a/actions_test.go
+++ b/actions_test.go
@@ -1625,6 +1625,46 @@ func TestActionAppearanceSettings_SaveCursor(t *testing.T) {
 	}
 }
 
+func TestActionAppearanceSettingsSavesSystemMonospace(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	getUserConfigIniPath = func() string { return filepath.Join(t.TempDir(), "settings.ini") }
+	defer func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	}()
+	AppConfig.GuiUseSystemMonospace = true
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var systemFont *vtui.Checkbox
+	for _, child := range top.GetChildren() {
+		checkbox, ok := child.(*vtui.Checkbox)
+		if ok && checkbox.GetText() == Msg("AppearanceSettings.UseSystemMonospace") {
+			systemFont = checkbox
+			break
+		}
+	}
+	if systemFont == nil {
+		t.Fatal("system monospace checkbox not found in Appearance Settings")
+	}
+	if systemFont.State != 1 {
+		t.Fatal("system monospace checkbox must be enabled by default")
+	}
+	systemFont.Toggle()
+	clickDialogButton(t, top, "Ok")
+	if AppConfig.GuiUseSystemMonospace {
+		t.Fatal("system monospace setting was not saved")
+	}
+}
+
 // TestActionAppearanceSettings_CancelPreservesPalette locks in the
 // fix: farcolors.ini overrides applied at startup were wiped when
 // the user opened Appearance settings and pressed Cancel, because

--- a/config.go
+++ b/config.go
@@ -164,6 +164,7 @@ type F4Config struct {
 	FileOpPathDisplay        int
 	MacroRecordFormat        int
 	GuiFont                  string
+	GuiUseSystemMonospace    bool
 	GuiFontSize              int
 	GuiCols                  int
 	GuiRows                  int
@@ -249,7 +250,8 @@ var AppConfig = F4Config{
 	DefaultFileOpMode:        0,
 	FileOpPathDisplay:        0,
 	GuiFont:                  "",
-	GuiFontSize:              18,
+	GuiUseSystemMonospace:    true,
+	GuiFontSize:              defaultGuiFontSize(runtime.GOOS),
 	GuiCols:                  100,
 	GuiRows:                  30,
 	ConsoleTitleTemplate:     "f4 %Ver %Platform %Admin - %State",
@@ -376,9 +378,11 @@ func LoadConfig() {
 	fmt.Sscanf(ini.GetString("System", "MacroRecordFormat", "0"), "%d", &AppConfig.MacroRecordFormat)
 	fmt.Sscanf(ini.GetString("Panel", "FileOpPathDisplay", "0"), "%d", &AppConfig.FileOpPathDisplay)
 	AppConfig.GuiFont = ini.GetString("Appearance", "GuiFont", "")
-	fmt.Sscanf(ini.GetString("Appearance", "GuiFontSize", "18"), "%d", &AppConfig.GuiFontSize)
+	AppConfig.GuiUseSystemMonospace = ini.GetString("Appearance", "GuiUseSystemMonospace", "1") == "1"
+	defaultFontSize := defaultGuiFontSize(runtime.GOOS)
+	fmt.Sscanf(ini.GetString("Appearance", "GuiFontSize", fmt.Sprintf("%d", defaultFontSize)), "%d", &AppConfig.GuiFontSize)
 	if AppConfig.GuiFontSize <= 0 {
-		AppConfig.GuiFontSize = 18
+		AppConfig.GuiFontSize = defaultFontSize
 	}
 	fmt.Sscanf(ini.GetString("Appearance", "GuiCols", "100"), "%d", &AppConfig.GuiCols)
 	if AppConfig.GuiCols <= 0 {
@@ -520,6 +524,7 @@ func SaveConfig() {
 
 	sb.WriteString("\n[Appearance]\n")
 	sb.WriteString(fmt.Sprintf("GuiFont = %s\n", AppConfig.GuiFont))
+	sb.WriteString(fmt.Sprintf("GuiUseSystemMonospace = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.GuiUseSystemMonospace]))
 	sb.WriteString(fmt.Sprintf("GuiFontSize = %d\n", AppConfig.GuiFontSize))
 	sb.WriteString(fmt.Sprintf("GuiCols = %d\n", AppConfig.GuiCols))
 	sb.WriteString(fmt.Sprintf("GuiRows = %d\n", AppConfig.GuiRows))

--- a/config_test.go
+++ b/config_test.go
@@ -423,11 +423,13 @@ func TestConfig_GuiFontPersistence(t *testing.T) {
 
 	// Задаем тестовые значения
 	AppConfig.GuiFont = "UbuntuMono-Regular"
+	AppConfig.GuiUseSystemMonospace = false
 	AppConfig.GuiFontSize = 22
 	SaveConfig()
 
 	// Сбрасываем текущую конфигурацию в памяти
 	AppConfig.GuiFont = ""
+	AppConfig.GuiUseSystemMonospace = true
 	AppConfig.GuiFontSize = 0
 
 	// Читаем заново из временного файла
@@ -438,6 +440,9 @@ func TestConfig_GuiFontPersistence(t *testing.T) {
 	}
 	if AppConfig.GuiFontSize != 22 {
 		t.Errorf("Expected GuiFontSize to be 22, got %d", AppConfig.GuiFontSize)
+	}
+	if AppConfig.GuiUseSystemMonospace {
+		t.Error("Expected GuiUseSystemMonospace to remain disabled")
 	}
 }
 

--- a/gui_font.go
+++ b/gui_font.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"runtime"
+	"strings"
+)
+
+// resolveGuiFont keeps Linux on its existing configured/backend default while
+// selecting the platform's established monospace family on Windows and macOS.
+// The explicit OS argument keeps the policy testable on every build host.
+func resolveGuiFont(goos string, useSystem bool, configured string) string {
+	configured = strings.TrimSpace(configured)
+	if !useSystem {
+		return configured
+	}
+	switch goos {
+	case "windows":
+		return "Consolas"
+	case "darwin":
+		return "Monaco"
+	default:
+		return configured
+	}
+}
+
+func effectiveGuiFont() string {
+	return resolveGuiFont(runtime.GOOS, AppConfig.GuiUseSystemMonospace, AppConfig.GuiFont)
+}
+
+func defaultGuiFontSize(goos string) int {
+	if goos == "darwin" {
+		return 17
+	}
+	return 16
+}

--- a/gui_font_test.go
+++ b/gui_font_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestResolveGuiFont(t *testing.T) {
+	tests := []struct {
+		name, goos, configured, want string
+		useSystem                    bool
+	}{
+		{name: "Windows system", goos: "windows", configured: "Custom Mono", useSystem: true, want: "Consolas"},
+		{name: "macOS system", goos: "darwin", configured: "Custom Mono", useSystem: true, want: "Monaco"},
+		{name: "Linux unchanged", goos: "linux", configured: "DejaVu Sans Mono", useSystem: true, want: "DejaVu Sans Mono"},
+		{name: "Linux backend default", goos: "linux", configured: "", useSystem: true, want: ""},
+		{name: "Custom override", goos: "windows", configured: "JetBrains Mono", useSystem: false, want: "JetBrains Mono"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := resolveGuiFont(test.goos, test.useSystem, test.configured); got != test.want {
+				t.Fatalf("resolveGuiFont(%q, %v, %q) = %q, want %q", test.goos, test.useSystem, test.configured, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDefaultGuiFontSize(t *testing.T) {
+	if got := defaultGuiFontSize("darwin"); got != 17 {
+		t.Fatalf("macOS default GUI font size = %d, want 17", got)
+	}
+	for _, goos := range []string{"windows", "linux", "freebsd"} {
+		if got := defaultGuiFontSize(goos); got != 16 {
+			t.Fatalf("%s default GUI font size = %d, want 16", goos, got)
+		}
+	}
+}

--- a/gui_unix.go
+++ b/gui_unix.go
@@ -12,7 +12,7 @@ func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
 	}
-	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, AppConfig.GuiFont, float64(AppConfig.GuiFontSize), func() {
+	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {
 		SetupUI()
 	})
 }

--- a/gui_windows.go
+++ b/gui_windows.go
@@ -14,7 +14,7 @@ func RunGui(backend string) error {
 	}
 	stopIconManager := startWindowsWindowIconManager()
 	defer stopIconManager()
-	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, AppConfig.GuiFont, float64(AppConfig.GuiFontSize), func() {
+	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {
 		SetupUI()
 	})
 }

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -556,6 +556,7 @@ PanelSettings.TerminalCtrlNWorkspace=Use Ctrl+N in terminal to &clone panels
 
 AppearanceSettings.Title= Appearance settings
 AppearanceSettings.Style=Application &style:
+AppearanceSettings.UseSystemMonospace=Use &system monospace font
 AppearanceSettings.Font=GUI F&ont (Path/Name):
 AppearanceSettings.FontSize=GUI Font Si&ze:
 AppearanceSettings.TitleTemplate=Window &Title Template:

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -556,6 +556,7 @@ PanelSettings.TerminalCtrlNWorkspace=Ctrl+N в терминале &клонир�
 
 AppearanceSettings.Title= Внешний вид
 AppearanceSettings.Style=Стиль &оформления:
+AppearanceSettings.UseSystemMonospace=Использовать системный &моноширинный шрифт
 AppearanceSettings.Font=Шрифт &GUI (Путь/Имя):
 AppearanceSettings.FontSize=Размер шрифта &GUI:
 AppearanceSettings.TitleTemplate=Шаблон &заголовка окна:


### PR DESCRIPTION
## Summary

- add a GUI option to use the platform monospace font, enabled by default
- use Monaco at 17 pt on macOS
- use Consolas on Windows
- preserve the existing configured/backend font behavior on Linux and other platforms
- allow users to disable the option and provide a custom font
- pass the resolved font through both Unix and Windows GoGPU launch paths

This PR is intentionally limited to font policy, configuration, Appearance settings, localization, and tests. It contains no QML, gallery, semantic UI, or Ctrl+G changes.

## Verification

- font policy, config persistence, Appearance dialog, and dialog-layout tests pass
- focused race tests pass
- Windows amd64, Linux amd64, and macOS arm64 builds pass