### PR TITLE
Streamline the default panel layout

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -2219,7 +2219,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	// blank lines between them (see #298). Blank rows are kept only at
 	// transitions between widget kinds (checkbox↔combo↔radio↔button)
 	// so groups still read as groups.
-	const dialogHeight = 36
+	const dialogHeight = 37
 	dlg := vtui.NewCenteredDialog(60, dialogHeight, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
@@ -2244,6 +2244,10 @@ func actionPanelSettings(pf *PanelsFrame) {
 	chkSeparateExtensions := vtui.NewCheckbox(0, 0, Msg("PanelSettings.SeparateExtensions"), false)
 	if AppConfig.SeparateFileExtensions {
 		chkSeparateExtensions.State = 1
+	}
+	chkFileInfo := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowFileInfo"), false)
+	if AppConfig.ShowPanelFileInfo {
+		chkFileInfo.State = 1
 	}
 
 	scrollbarModes := []string{
@@ -2350,6 +2354,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(chkDirPrefix)
 	dlg.AddItem(chkHighlightMarks)
 	dlg.AddItem(chkSeparateExtensions)
+	dlg.AddItem(chkFileInfo)
 	dlg.AddItem(lblScrollbars)
 	dlg.AddItem(comboScrollbars)
 	dlg.AddItem(chkPaths)
@@ -2379,6 +2384,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	vbox.Add(chkDirPrefix, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkHighlightMarks, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkSeparateExtensions, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkFileInfo, vtui.Margins{}, vtui.AlignLeft)
 	// Blank row before the scrollbar combo — transition to a different
 	// widget kind, worth the visual separator.
 	rowScrollbars := vtui.NewHBoxLayout(0, 0, 56, 1)
@@ -2438,6 +2444,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.ShowDirPrefix = chkDirPrefix.State == 1
 		AppConfig.ShowHighlightMarks = chkHighlightMarks.State == 1
 		AppConfig.SeparateFileExtensions = chkSeparateExtensions.State == 1
+		AppConfig.ShowPanelFileInfo = chkFileInfo.State == 1
 		AppConfig.PanelScrollbarMode = PanelScrollbarMode(comboScrollbars.Menu.SelectPos)
 		AppConfig.SavePanelPaths = chkPaths.State == 1
 		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1

--- a/config.go
+++ b/config.go
@@ -118,6 +118,7 @@ type F4Config struct {
 	ShowHighlightMarks       bool
 	SeparateFileExtensions   bool
 	PanelScrollbarMode       PanelScrollbarMode
+	ShowPanelFileInfo        bool
 	SavePanelPaths           bool
 	InfoPanelBytes           bool // Ctrl+L info panel: true = raw bytes, false = human (GiB/MiB…)
 	InfoPanelCPUGPU          bool // Ctrl+L info panel: show CPU and GPU sections (off by default)
@@ -197,7 +198,7 @@ var AppConfig = F4Config{
 	FallbackLanguage:         "",
 	HelpLanguage:             "en",
 	AlwaysShowMenuBar:        false,
-	WorkspaceTabMode:         int(vtui.WorkspaceTabsOnCtrl),
+	WorkspaceTabMode:         int(vtui.WorkspaceTabsAlways),
 	CtrlTabShowsMenu:         false,
 	AltNumberSwitchesTabs:    true,
 	ShowHiddenFiles:          true,
@@ -205,6 +206,7 @@ var AppConfig = F4Config{
 	ShowHighlightMarks:       false,
 	SeparateFileExtensions:   false,
 	PanelScrollbarMode:       PanelScrollbarMinimal,
+	ShowPanelFileInfo:        false,
 	SavePanelPaths:           true,
 	InfoPanelBytes:           false,
 	InfoPanelCPUGPU:          false,
@@ -313,7 +315,7 @@ func LoadConfig() {
 	AppConfig.HelpLanguage = ini.GetString("Interface", "HelpLanguage", "en")
 	AppConfig.ConsoleTitleTemplate = ini.GetString("Interface", "ConsoleTitleTemplate", "f4 %Ver %Platform %Admin - %State")
 	AppConfig.AlwaysShowMenuBar = ini.GetString("Interface", "AlwaysShowMenuBar", "0") == "1"
-	switch strings.ToLower(ini.GetString("Interface", "WorkspaceTabMode", "ctrl")) {
+	switch strings.ToLower(ini.GetString("Interface", "WorkspaceTabMode", "always")) {
 	case "always":
 		AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsAlways)
 	case "ctrl":
@@ -343,6 +345,7 @@ func LoadConfig() {
 			AppConfig.PanelScrollbarMode = PanelScrollbarMinimal
 		}
 	}
+	AppConfig.ShowPanelFileInfo = ini.GetString("Panel", "ShowPanelFileInfo", "0") == "1"
 	AppConfig.SavePanelPaths = ini.GetString("Panel", "SavePanelPaths", "1") == "1"
 	AppConfig.InfoPanelBytes = ini.GetString("Panel", "InfoPanelBytes", "0") == "1"
 	AppConfig.InfoPanelCPUGPU = ini.GetString("Panel", "InfoPanelCPUGPU", "0") == "1"
@@ -489,6 +492,7 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("ShowHighlightMarks = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowHighlightMarks]))
 	sb.WriteString(fmt.Sprintf("SeparateFileExtensions = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SeparateFileExtensions]))
 	sb.WriteString(fmt.Sprintf("PanelScrollbarMode = %s\n", AppConfig.PanelScrollbarMode.String()))
+	sb.WriteString(fmt.Sprintf("ShowPanelFileInfo = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowPanelFileInfo]))
 	sb.WriteString(fmt.Sprintf("SavePanelPaths = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.SavePanelPaths]))
 	sb.WriteString(fmt.Sprintf("InfoPanelBytes = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelBytes]))
 	sb.WriteString(fmt.Sprintf("InfoPanelCPUGPU = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.InfoPanelCPUGPU]))

--- a/config_test.go
+++ b/config_test.go
@@ -38,6 +38,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.CommandLineAutoComplete = false
 	AppConfig.SeparateFileExtensions = true
 	AppConfig.PanelScrollbarMode = PanelScrollbarMinimal
+	AppConfig.ShowPanelFileInfo = true
 	AppConfig.MacroRecordFormat = 1
 	AppConfig.UseTrash = true
 	AppConfig.TerminalCtrlNWorkspace = false
@@ -57,6 +58,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.EditorColorerBackground = true
 	AppConfig.SeparateFileExtensions = false
 	AppConfig.PanelScrollbarMode = PanelScrollbarOff
+	AppConfig.ShowPanelFileInfo = false
 	AppConfig.MacroRecordFormat = 0
 	AppConfig.UseTrash = false
 	AppConfig.TerminalCtrlNWorkspace = true
@@ -104,6 +106,9 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if AppConfig.PanelScrollbarMode != PanelScrollbarMinimal {
 		t.Errorf("LoadConfig restored PanelScrollbarMode %v, want minimal", AppConfig.PanelScrollbarMode)
+	}
+	if !AppConfig.ShowPanelFileInfo {
+		t.Error("LoadConfig failed to restore ShowPanelFileInfo")
 	}
 	if AppConfig.MacroRecordFormat != 1 {
 		t.Error("LoadConfig failed to restore MacroRecordFormat")
@@ -194,7 +199,7 @@ func TestConfig_AltNumberSwitchesTabsDefaultsOnWhenKeyIsAbsent(t *testing.T) {
 	}
 }
 
-func TestConfig_WorkspaceTabModeDefaultsToOnCtrlWhenKeyIsAbsent(t *testing.T) {
+func TestConfig_WorkspaceTabModeDefaultsToAlwaysWhenKeyIsAbsent(t *testing.T) {
 	tmpDir := t.TempDir()
 	userIniPath := filepath.Join(tmpDir, "settings.ini")
 	if err := os.WriteFile(userIniPath, []byte("[Interface]\n"), 0600); err != nil {
@@ -214,9 +219,31 @@ func TestConfig_WorkspaceTabModeDefaultsToOnCtrlWhenKeyIsAbsent(t *testing.T) {
 
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsMultiple)
 	LoadConfig()
-	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsOnCtrl) {
-		t.Fatalf("WorkspaceTabMode without a saved key = %d, want Ctrl-only mode %d",
-			AppConfig.WorkspaceTabMode, vtui.WorkspaceTabsOnCtrl)
+	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsAlways) {
+		t.Fatalf("WorkspaceTabMode without a saved key = %d, want always-visible mode %d",
+			AppConfig.WorkspaceTabMode, vtui.WorkspaceTabsAlways)
+	}
+}
+
+func TestConfig_PanelFileInfoDefaultsHiddenWhenKeyIsAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+	userIniPath := filepath.Join(tmpDir, "settings.ini")
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origPathsFunc := getConfigIniPaths
+	oldCfg := AppConfig
+	defer func() {
+		getConfigIniPaths = origPathsFunc
+		AppConfig = oldCfg
+	}()
+	getConfigIniPaths = func() []string { return []string{userIniPath} }
+
+	AppConfig.ShowPanelFileInfo = true
+	LoadConfig()
+	if AppConfig.ShowPanelFileInfo {
+		t.Fatal("ShowPanelFileInfo must default to false when the setting is absent")
 	}
 }
 

--- a/file_panel.go
+++ b/file_panel.go
@@ -2152,7 +2152,7 @@ func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 	fp.drawCursorSeparators(scr)
 	fp.drawScrollBar(scr)
 
-	if fp.Y2-fp.Y1+1 > 6 {
+	if AppConfig.ShowPanelFileInfo && fp.Y2-fp.Y1+1 > 6 {
 		p := vtui.NewPainter(scr)
 		attrBox := vtui.Palette[ColPanelBox]
 		// far2l paints the per-file status line with COL_PANELTEXT;
@@ -2376,8 +2376,8 @@ func (fp *FileSystemPanel) drawFastFindMatches(scr *vtui.ScreenBuf) {
 func (fp *FileSystemPanel) SetPosition(x1, y1, x2, y2 int) {
 	fp.ScreenObject.SetPosition(x1, y1, x2, y2)
 	fp.frame.SetPosition(x1, y1, x2, y2)
-	// Table stays inside the frame, reserving space for status info if tall enough
-	if y2-y1+1 > 6 {
+	// Table stays inside the frame, reserving space for status info only when enabled.
+	if AppConfig.ShowPanelFileInfo && y2-y1+1 > 6 {
 		fp.table.SetPosition(x1+1, y1+1, x2-1, y2-3)
 	} else {
 		fp.table.SetPosition(x1+1, y1+1, x2-1, y2-1)

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -794,12 +794,13 @@ func TestMediumRow_GetCellText(t *testing.T) {
 		t.Errorf("Out of bounds should be empty")
 	}
 
-	fp.entries = make([]*fileEntry, 10)
-	for i := 0; i < 10; i++ {
+	columnHeight := fp.table.ViewHeight
+	fp.entries = make([]*fileEntry, columnHeight*2)
+	for i := range fp.entries {
 		fp.entries[i] = &fileEntry{VFSItem: vfs.VFSItem{Name: "f"}}
 	}
 	fp.entries[0].Name = "Left"
-	fp.entries[7].Name = "Right"
+	fp.entries[columnHeight].Name = "Right"
 	mRow = &mediumRow{fp: fp, r: 0}
 	if mRow.GetCellText(0) != "Left" {
 		t.Errorf("Expected 'Left', got %q", mRow.GetCellText(0))
@@ -944,9 +945,10 @@ func TestFileSystemPanel_CursorMapping(t *testing.T) {
 		t.Errorf("Medium mapping index 3: expected pos 3 col 0, got pos %d col %d", fp.table.SelectPos, fp.table.SelectCol)
 	}
 
-	fp.SetCursorIndex(10) // Index 10 with H=7 -> Col 1, Row 3
+	columnHeight := fp.table.ViewHeight
+	fp.SetCursorIndex(columnHeight + 3)
 	if fp.table.SelectPos != 3 || fp.table.SelectCol != 1 {
-		t.Errorf("Medium mapping index 10: expected pos 3 col 1, got pos %d col %d", fp.table.SelectPos, fp.table.SelectCol)
+		t.Errorf("Medium mapping index %d: expected pos 3 col 1, got pos %d col %d", columnHeight+3, fp.table.SelectPos, fp.table.SelectCol)
 	}
 
 	// 2. Detailed Mode

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -657,6 +657,10 @@ done2:
 	}
 }
 func TestFileSystemPanel_SelectedInfo(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelFileInfo = true
+
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()
 	scr := vtui.NewSilentScreenBuf()
@@ -708,6 +712,18 @@ func TestFileSystemPanel_SelectedInfo(t *testing.T) {
 		t.Errorf("Expected bottom bar to contain 'folders:1', got: %q", result)
 	}
 
+	// Hiding the separate file-information line must not hide the selection
+	// summary drawn directly on the panel's bottom border.
+	AppConfig.ShowPanelFileInfo = false
+	fp.SetPosition(0, 0, 79, 23)
+	fp.Show(scr)
+	if cell = scr.GetCell(40, 23); cell.Attributes != vtui.Palette[ColPanelSelectedInfo] {
+		t.Errorf("selected summary disappeared with file info hidden: got color %X", cell.Attributes)
+	}
+	if cell = scr.GetCell(0, 21); cell.Char == '├' {
+		t.Error("file-information separator remained visible when the option was disabled")
+	}
+
 	// Clear selection to check ColPanelTotalInfo
 	for _, e := range fp.entries {
 		e.Selected = false
@@ -723,6 +739,10 @@ func TestFileSystemPanel_SelectedInfo(t *testing.T) {
 }
 
 func TestFileSystemPanel_Initialization(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelFileInfo = false
+
 	if ViewModeMedium != 0 || ViewModeDetailed != 1 {
 		t.Fatalf("legacy view mode values changed: Medium=%d Detailed=%d", ViewModeMedium, ViewModeDetailed)
 	}
@@ -737,11 +757,15 @@ func TestFileSystemPanel_Initialization(t *testing.T) {
 	// Internal table must match panel interior (excluding borders)
 	tx1, ty1, tx2, ty2 := fp.table.GetPosition()
 	expectedTy2 := y + h - 2
-	if h > 6 {
-		expectedTy2 = y + h - 4
-	}
 	if tx1 != x+1 || ty1 != y+1 || tx2 != x+w-2 || ty2 != expectedTy2 {
 		t.Errorf("Internal table coordinates mismatch: got (%d,%d)-(%d,%d)", tx1, ty1, tx2, ty2)
+	}
+
+	AppConfig.ShowPanelFileInfo = true
+	fp.SetPosition(x, y, x+w-1, y+h-1)
+	_, _, _, ty2 = fp.table.GetPosition()
+	if expected := y + h - 4; ty2 != expected {
+		t.Errorf("table bottom with status info = %d, want %d", ty2, expected)
 	}
 
 	if fp.viewMode != ViewModeMedium {

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -536,6 +536,7 @@ PanelSettings.Title= Panel settings
 PanelSettings.ShowHidden=Show &hidden and system files
 PanelSettings.ShowDirPrefix=Show '/' prefix for &folders
 PanelSettings.SeparateExtensions=Align file &extensions to the right
+PanelSettings.ShowFileInfo=Show current file &information
 PanelSettings.Scrollbars=Panel scroll&bars:
 PanelSettings.ScrollbarsOff=Do not show
 PanelSettings.ScrollbarsMinimal=Minimal

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -536,6 +536,7 @@ PanelSettings.Title= Настройки панелей
 PanelSettings.ShowHidden=Показывать &скрытые и системные файлы
 PanelSettings.ShowDirPrefix=Показывать '/' перед &папками
 PanelSettings.SeparateExtensions=Выравнивать &расширения файлов по правому краю
+PanelSettings.ShowFileInfo=Показывать &информацию о текущем файле
 PanelSettings.Scrollbars=Полосы про&крутки панелей:
 PanelSettings.ScrollbarsOff=Не показывать
 PanelSettings.ScrollbarsMinimal=Минимальные

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -3325,7 +3325,7 @@ func (pf *PanelsFrame) GetWorkspaceTabTitle() string {
 		return path
 	}
 
-	return "📁 " + panelPath(pf.panels[0]) + " ↔ " + panelPath(pf.panels[1])
+	return "📁 " + panelPath(pf.panels[0]) + " ─ " + panelPath(pf.panels[1])
 }
 
 // GetWorkspaceMenuInfo supplies the Screens popup with full panel paths. The

--- a/panels_frame_test.go
+++ b/panels_frame_test.go
@@ -54,7 +54,7 @@ func TestPanelsFrame_WorkspaceTabTitleUsesFolderNames(t *testing.T) {
 	pf.panels[0] = &FileSystemPanel{vfs: vfs.NewOSVFS(leftPath)}
 	pf.panels[1] = &FileSystemPanel{vfs: vfs.NewOSVFS(rightPath)}
 	title := pf.GetWorkspaceTabTitle()
-	if !strings.Contains(title, "left-leaf ↔ right-leaf") {
+	if !strings.Contains(title, "left-leaf ─ right-leaf") {
 		t.Fatalf("workspace tab title = %q, want both leaf folder names", title)
 	}
 	if strings.Contains(title, root) {


### PR DESCRIPTION
## Summary
- add a panel setting for the separate current-file information row
- hide that row and its separator by default, reclaiming two rows for file entries
- keep selection and directory totals visible on the bottom panel border regardless of the setting
- make the workspace tab bar always visible by default while preserving saved user preferences
- add English and Russian labels plus persistence and rendering regression tests

## Tests
- targeted config, panel rendering, layout, and settings-dialog tests pass
- `go build -o f4.exe .` passes

## Known unrelated Windows test issues
The full main-package run currently encounters temporary-file locks in the existing Viewer/Editor tests and the existing `TestApplyCompletionDoesNotTouchClosedWorkspace` race.