### PR TITLE
editor: Find All and interactive search/replace overhaul

### DIFF
--- a/editor_find_all.go
+++ b/editor_find_all.go
@@ -258,7 +258,7 @@ func (ev *EditorView) FindAll(pattern string, caseSensitive, useRegex, wholeWord
 					return // buffer changed while scanning; offsets are stale
 				}
 				if len(spans) == 0 {
-					vtui.ShowMessage(" Search ", "Pattern not found.", []string{"&Ok"})
+					vtui.ShowMessage(Msg("Search.Title"), Msg("Search.NotFound"), []string{Msg("vtui.Ok")})
 					return
 				}
 				ev.showFindAllMenu(pattern, bytes, spans)

--- a/editor_replace_confirm.go
+++ b/editor_replace_confirm.go
@@ -1,0 +1,322 @@
+package main
+
+// Interactive Replace, ported from Far Manager (far/editor.cpp, the
+// IsReplaceMode branch of BaseSearchString): each occurrence is scrolled to
+// about a quarter of the screen from the top so the centered confirmation
+// dialog does not cover it, highlighted as the active selection, and
+// confirmed with a Replace / All / Skip / Cancel dialog (Far's
+// EditorConfirmReplaceId). [ All ] replaces the rest without further prompts
+// as one undo step, and a finished loop reports how many occurrences were
+// replaced.
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/coregx/coregex"
+	"github.com/unxed/vtui"
+)
+
+// Confirm dialog button order; ShowMessage reports the pressed button by
+// this index (Esc arrives as -1).
+const (
+	replaceBtnReplace = iota
+	replaceBtnAll
+	replaceBtnSkip
+	replaceBtnCancel
+)
+
+// replaceLoop carries one interactive Replace session across its
+// find → prompt → splice iterations. Fields are only touched on the UI
+// thread; every find re-reads the buffer, so no offsets survive a splice
+// except searchFrom, which the button handlers recompute from the occurrence
+// that was just confirmed.
+type replaceLoop struct {
+	ev            *EditorView
+	pattern       string
+	replacement   string
+	caseSensitive bool
+	reverse       bool
+	regexp        bool
+	wholeWord     bool
+	re            *coregex.Regex // non-nil iff regexp or wholeWord
+	searchFrom    int
+	replaced      int
+	found         bool // at least one occurrence was prompted
+	// session fences every background scan: it is captured while the loop's
+	// offsets are valid (loop start, and after each of the loop's own
+	// splices), so any foreign edit sneaking in between a dialog closing
+	// and its posted task running is detected before splicing.
+	session int
+}
+
+// renderReplacement renders the replacement for one matched span (or, with
+// the whole buffer as matched, for every span in it), following the same
+// rules everywhere replacement happens: $group expansion only when the user
+// typed a regex. A non-nil re with typedRegex=false is whole-word mode: the
+// pattern was typed as plain text, so the replacement is plain text too. A
+// nil re is a literal replacement of exactly one matched span.
+func renderReplacement(re *coregex.Regex, typedRegex bool, matched, replacement []byte) []byte {
+	switch {
+	case typedRegex:
+		return re.ReplaceAll(matched, replacement)
+	case re != nil:
+		return re.ReplaceAllLiteral(matched, replacement)
+	default:
+		return replacement
+	}
+}
+
+func (st *replaceLoop) renderReplacement(match []byte) []byte {
+	return renderReplacement(st.re, st.regexp, match, []byte(st.replacement))
+}
+
+// selectionIsMatch reports whether sel is exactly one occurrence of the
+// search pattern, using the same matching rules as findMatch.
+func selectionIsMatch(sel []byte, pattern string, caseSensitive bool, re *coregex.Regex) bool {
+	if re != nil {
+		loc := re.FindIndex(sel)
+		return loc != nil && loc[0] == 0 && loc[1] == len(sel)
+	}
+	if caseSensitive {
+		return string(sel) == pattern
+	}
+	return strings.EqualFold(string(sel), pattern)
+}
+
+// findNext locates the next occurrence from searchFrom and either prompts at
+// it or ends the loop. The find runs in the background under the cancelable
+// progress popup; all state transitions happen back on the UI thread.
+func (st *replaceLoop) findNext() {
+	ev := st.ev
+	vtui.FrameManager.PostTask(func() {
+		runSearchWithProgress(st.pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			data, errBytes := ev.pt.Bytes()
+			if errBytes != nil {
+				ctx.RunOnUI(func() {
+					dlg.Close()
+					vtui.ShowMessage(" Error ", "Failed to read file buffer.", []string{"&Ok"})
+				})
+				return
+			}
+
+			// A zero-length regex match (e.g. "a*" before non-"a" text) is
+			// not an occurrence, but text further on can still match: step
+			// one byte past it and keep looking — the same way
+			// findAllMatchSpans skips such matches — instead of ending the
+			// loop with a false "not found".
+			from := st.searchFrom
+			off, mLen := -1, 0
+			var err error
+			for ctx.Err() == nil {
+				o, l, e := findMatch(data, st.pattern, st.caseSensitive, st.reverse, st.regexp, st.wholeWord, false, from)
+				if e != nil || o == -1 {
+					err = e
+					break
+				}
+				if l > 0 {
+					off, mLen = o, l
+					break
+				}
+				if st.reverse {
+					from = min(o, from-1)
+				} else {
+					from = o + 1
+				}
+			}
+
+			ctx.RunOnUI(func() {
+				// Closing the dialog cancels the task via OnResult, so the
+				// cancellation state must be read first: a canceled replace
+				// must not touch the buffer.
+				canceled := ctx.Err() != nil
+				dlg.Close()
+				if canceled {
+					return
+				}
+				if err != nil {
+					vtui.ShowMessage(" Error ", fmt.Sprintf("Invalid regular expression:\n%v", err), []string{"&Ok"})
+					return
+				}
+				if ev.editSession != st.session {
+					return // buffer changed while scanning; offsets are stale
+				}
+				if off == -1 {
+					st.finish()
+					return
+				}
+				st.promptAt(data, off, mLen)
+			})
+		})
+	})
+}
+
+// promptAt shows the occurrence and the Replace / All / Skip / Cancel dialog
+// for it. Runs on the UI thread; the dialog is modal, so the buffer cannot
+// change between the prompt and the button handler.
+func (st *replaceLoop) promptAt(data []byte, off, mLen int) {
+	ev := st.ev
+	st.found = true
+	match := append([]byte(nil), data[off:off+mLen]...)
+	rendered := st.renderReplacement(match)
+
+	ev.selectFoundPattern(off, mLen)
+	ev.scrollFoundToQuarter(off)
+	vtui.FrameManager.Redraw()
+
+	buttons := []string{
+		Msg("Replace.BtnReplace"),
+		Msg("Replace.BtnAll"),
+		Msg("Replace.BtnSkip"),
+		Msg("vtui.Cancel"),
+	}
+	dlg := vtui.ShowMessageEx(Msg("Replace.ConfirmTitle"),
+		replacePromptBody(string(match), string(rendered)), buttons, vtui.MessageInfo)
+
+	// SetExitCode fires OnResult on every close, and a done dialog can be
+	// closed again during frame cleanup; only the first verdict counts.
+	handled := false
+	dlg.OnResult = func(code int) {
+		if handled {
+			return
+		}
+		handled = true
+		switch code {
+		case replaceBtnReplace:
+			ev.replaceRange(off, off+mLen, rendered)
+			st.session = ev.editSession
+			st.replaced++
+			if st.reverse {
+				// A splice changes nothing left of its start; continue
+				// strictly before the replaced occurrence.
+				st.searchFrom = off
+			} else {
+				// Continue from the end of the replacement (next=false
+				// semantics): an adjacent match starting exactly there must
+				// not be skipped, while the replacement's own output is
+				// never re-matched.
+				st.searchFrom = off + len(rendered)
+			}
+			st.findNext()
+		case replaceBtnAll:
+			st.replaceRemaining(off, mLen)
+		case replaceBtnSkip:
+			if st.reverse {
+				st.searchFrom = off
+			} else {
+				st.searchFrom = off + mLen
+			}
+			st.findNext()
+		default:
+			// Cancel or Esc: stop the loop; the occurrence stays selected
+			// with the cursor on it, and no summary is shown (Far does the
+			// same on cancel).
+		}
+	}
+}
+
+// replaceRemaining implements [ All ]: the confirmed occurrence and every
+// one the loop would still visit are collected in one linear pass over a
+// buffer snapshot — the same scan Find All uses — and applied as per-span
+// splices under a single undo step and one repaint.
+func (st *replaceLoop) replaceRemaining(off, mLen int) {
+	ev := st.ev
+	vtui.FrameManager.PostTask(func() {
+		runSearchWithProgress(st.pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			data, errBytes := ev.pt.Bytes()
+			if errBytes != nil {
+				ctx.RunOnUI(func() {
+					dlg.Close()
+					vtui.ShowMessage(" Error ", "Failed to read file buffer.", []string{"&Ok"})
+				})
+				return
+			}
+
+			// The confirmed occurrence plus — forward — everything after
+			// it, or — reverse — everything before it (the loop walks right
+			// to left). findAllMatchSpans returns ascending spans, which is
+			// what the splice wants, and skips zero-length matches, so an
+			// empty regex match cannot truncate the collection.
+			var spans []matchSpan
+			var err error
+			if st.reverse {
+				spans, err = findAllMatchSpans(ctx, data[:off], st.pattern, st.caseSensitive, st.regexp, st.wholeWord)
+				spans = append(spans, matchSpan{off, mLen})
+			} else {
+				tail, tailErr := findAllMatchSpans(ctx, data[off+mLen:], st.pattern, st.caseSensitive, st.regexp, st.wholeWord)
+				err = tailErr
+				spans = append(spans, matchSpan{off, mLen})
+				for _, s := range tail {
+					spans = append(spans, matchSpan{s.Off + off + mLen, s.Len})
+				}
+			}
+
+			renders := make([][]byte, len(spans))
+			replacement := []byte(st.replacement)
+			for i, s := range spans {
+				renders[i] = renderReplacement(st.re, st.regexp, data[s.Off:s.Off+s.Len], replacement)
+			}
+
+			ctx.RunOnUI(func() {
+				canceled := ctx.Err() != nil
+				dlg.Close()
+				if canceled {
+					return
+				}
+				if err != nil {
+					vtui.ShowMessage(" Error ", fmt.Sprintf("Invalid regular expression:\n%v", err), []string{"&Ok"})
+					return
+				}
+				if ev.editSession != st.session {
+					return // buffer changed while scanning; offsets are stale
+				}
+				ev.replaceSpans(spans, renders)
+				st.replaced += len(spans)
+				st.finish()
+			})
+		})
+	})
+}
+
+// finish ends the loop: a summary once any occurrence was prompted —
+// "0 occurrence(s) replaced" is the honest outcome of skipping every match —
+// and the not-found message only when the very first find came up empty.
+func (st *replaceLoop) finish() {
+	if st.found {
+		vtui.ShowMessage(Msg("Replace.ConfirmTitle"),
+			fmt.Sprintf(Msg("Replace.Replaced"), st.replaced), []string{Msg("vtui.Ok")})
+	} else {
+		vtui.ShowMessage(Msg("Replace.ConfirmTitle"), Msg("Search.NotFound"), []string{Msg("vtui.Ok")})
+	}
+}
+
+// replacePromptBody builds the four-line confirm dialog body: like Far, the
+// found text and the concrete rendered replacement are shown quoted, each on
+// its own line.
+func replacePromptBody(match, rendered string) string {
+	return Msg("Replace.AskReplace") + "\n" + promptQuote(match) + "\n" +
+		Msg("Replace.AskWith") + "\n" + promptQuote(rendered)
+}
+
+// promptQuote renders one side of the confirm dialog body: whitespace
+// control characters become plain spaces so the string stays on one line,
+// long text is truncated to keep the message box inside its width cap, and
+// the result is quoted like Far's quote_unconditional.
+func promptQuote(s string) string {
+	s = strings.NewReplacer("\r", " ", "\n", " ", "\t", " ").Replace(s)
+	return "\"" + vtui.TruncateString(s, 60, "…") + "\""
+}
+
+// scrollFoundToQuarter scrolls the view so the found line sits about a
+// quarter of the editor height from the top ("Отступим на четверть" in
+// far/editor.cpp): the centered confirm dialog then leaves it visible.
+func (ev *EditorView) scrollFoundToQuarter(off int) {
+	height := ev.Y2 - ev.Y1
+	if height <= 0 {
+		return
+	}
+	vRow, _ := ev.engine.LogicalToVisual(off)
+	top := max(vRow-height/4, 0)
+	maxTop := max(ev.engine.GetTotalVisualRows()-height, 0)
+	ev.ScrollTopRow = min(top, maxTop)
+}

--- a/editor_view.go
+++ b/editor_view.go
@@ -2137,12 +2137,8 @@ func (ev *EditorView) Replace(pattern, replacement string, caseSensitive, revers
 			text := string(bytes)
 			var newText string
 			switch {
-			case regexp:
-				newText = string(re.ReplaceAll(bytes, []byte(replacement)))
 			case re != nil:
-				// Whole-word mode. The pattern was typed as plain text, so
-				// the replacement is plain text too: no $group expansion.
-				newText = string(re.ReplaceAllLiteral(bytes, []byte(replacement)))
+				newText = string(renderReplacement(re, regexp, bytes, []byte(replacement)))
 			case caseSensitive:
 				newText = strings.ReplaceAll(text, pattern, replacement)
 			default:
@@ -2158,110 +2154,91 @@ func (ev *EditorView) Replace(pattern, replacement string, caseSensitive, revers
 				})
 			} else {
 				ctx.RunOnUI(func() {
-					vtui.ShowMessage(" Replace ", "Pattern not found.", []string{"&Ok"})
+					vtui.ShowMessage(Msg("Replace.ConfirmTitle"), Msg("Search.NotFound"), []string{Msg("vtui.Ok")})
 				})
 			}
 		})
 		return
 	}
 
-	// replacementFor renders the replacement for one matched span, following
-	// the same rules as replace-all: $group expansion only when the user
-	// typed a regex.
-	replacementFor := func(match []byte) []byte {
-		switch {
-		case regexp:
-			return re.ReplaceAll(match, []byte(replacement))
-		case re != nil:
-			return re.ReplaceAllLiteral(match, []byte(replacement))
-		default:
-			return []byte(replacement)
-		}
+	// Interactive path, ported from Far Manager: every occurrence is
+	// confirmed with a Replace / All / Skip / Cancel dialog; replacing
+	// without confirmation is only reachable through [ Replace all ].
+	st := &replaceLoop{
+		ev:            ev,
+		pattern:       pattern,
+		replacement:   replacement,
+		caseSensitive: caseSensitive,
+		reverse:       reverse,
+		regexp:        regexp,
+		wholeWord:     wholeWord,
+		re:            re,
+		session:       ev.editSession,
 	}
-
+	// A selection that is exactly one occurrence (made deliberately by the
+	// user, or left by a previous Cancel) is prompted as-is: re-searching
+	// from its start could pick a wider match (regex "a+" around a
+	// one-character selection) and silently replace more than was selected.
 	if ev.selActive {
-		min, max := ev.getSelectionRange()
-		data, _ := ev.pt.GetRange(min, max-min)
-		match := false
-		if regexp || wholeWord {
-			match = re.Match(data) && len(re.Find(data)) == len(data)
-		} else {
-			if caseSensitive {
-				match = string(data) == pattern
-			} else {
-				match = strings.EqualFold(string(data), pattern)
-			}
-		}
-		if match {
-			ev.replaceRange(min, max, replacementFor(data))
-			// next=false: the cursor sits at the end of the replacement,
-			// and a match can begin exactly there (e.g. "aa"->"x" in
-			// "aaaa"); next=true would skip it.
-			ev.Search(pattern, caseSensitive, reverse, regexp, wholeWord, false)
+		selMin, selMax := ev.getSelectionRange()
+		if data, err := ev.pt.Bytes(); err == nil && selMax > selMin &&
+			selectionIsMatch(data[selMin:selMax], pattern, caseSensitive, re) {
+			st.promptAt(data, selMin, selMax-selMin)
 			return
 		}
 	}
+	st.searchFrom = ev.searchSeedOffset(reverse, true)
+	st.findNext()
+}
 
-	// Nothing suitable selected: find the first occurrence from the cursor
-	// and replace it in the same click, then show the next one. The old
-	// find-only fallback needed a second dialog round-trip per occurrence,
-	// which read as the Replace button doing nothing.
-	vtui.FrameManager.PostTask(func() {
-		runSearchWithProgress(pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
-			startOff := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
-
-			data, errBytes := ev.pt.Bytes()
-			if errBytes != nil {
-				ctx.RunOnUI(func() {
-					dlg.Close()
-					vtui.ShowMessage(" Error ", "Failed to read file buffer.", []string{"&Ok"})
-				})
-				return
-			}
-
-			off, mLen, err := findMatch(data, pattern, caseSensitive, reverse, regexp, wholeWord, false, startOff)
-
-			ctx.RunOnUI(func() {
-				// Closing the dialog cancels the task via OnResult, so the
-				// cancellation state must be read first: a canceled replace
-				// must not touch the buffer.
-				canceled := ctx.Err() != nil
-				dlg.Close()
-				if canceled {
-					return
-				}
-				if err != nil {
-					vtui.ShowMessage(" Error ", fmt.Sprintf("Invalid regular expression:\n%v", err), []string{"&Ok"})
-					return
-				}
-				if off == -1 {
-					vtui.ShowMessage(" Replace ", "Pattern not found.", []string{"&Ok"})
-					return
-				}
-				ev.replaceRange(off, off+mLen, replacementFor(data[off:off+mLen]))
-				ev.Search(pattern, caseSensitive, reverse, regexp, wholeWord, false)
-			})
-		})
-	})
+// noteBufferEdit records that the buffer is about to change: the background
+// line indexer is canceled and every editSession fence held by an in-flight
+// task goes stale.
+func (ev *EditorView) noteBufferEdit() {
+	if !ev.edited {
+		ev.edited = true
+		if ev.indexCancel != nil {
+			ev.indexCancel()
+		}
+	}
+	ev.editSession++
 }
 
 // replaceRange replaces bytes [min, max) with repBytes as a single
 // undoable edit and leaves the cursor at the end of the replacement.
 func (ev *EditorView) replaceRange(min, max int, repBytes []byte) {
+	ev.replaceSpans([]matchSpan{{min, max - min}}, [][]byte{repBytes})
+}
+
+// replaceSpans replaces each span (ascending, non-overlapping) with its
+// rendered replacement as one undoable edit; the cursor lands at the end of
+// the last replacement. Splicing per span keeps memory at the size of the
+// replacements instead of the whole covered region.
+func (ev *EditorView) replaceSpans(spans []matchSpan, renders [][]byte) {
+	if len(spans) == 0 {
+		return
+	}
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	ev.modified = true
-	ev.pt.Delete(min, max-min)
-	ev.li.UpdateAfterDelete(min, max-min)
-	ev.pt.Insert(min, repBytes)
-	ev.li.UpdateAfterInsert(min, repBytes)
+
+	// Splice bottom-up so the still-pending spans keep their offsets.
+	for i := len(spans) - 1; i >= 0; i-- {
+		s := spans[i]
+		ev.pt.Delete(s.Off, s.Len)
+		ev.li.UpdateAfterDelete(s.Off, s.Len)
+		ev.pt.Insert(s.Off, renders[i])
+		ev.li.UpdateAfterInsert(s.Off, renders[i])
+	}
 
 	// Invalidate from the edit, not from the cursor: a reverse replace
 	// edits text above the current line.
-	startLine := ev.li.GetLineAtOffset(min)
+	startLine := ev.li.GetLineAtOffset(spans[0].Off)
 	ev.invalidateStates(startLine)
 	ev.engine.InvalidateFrom(startLine)
 
-	newCursorOff := min + len(repBytes)
+	last := len(spans) - 1
+	newCursorOff := spans[last].Off + len(renders[last])
 	ev.CursorLine = ev.li.GetLineAtOffset(newCursorOff)
 	ev.CursorPos = newCursorOff - ev.li.GetLineOffset(ev.CursorLine)
 
@@ -3744,6 +3721,23 @@ func findMatch(data []byte, pattern string, caseSensitive, reverse, regexp, whol
 	return foundOffset, matchLen, nil
 }
 
+// searchSeedOffset returns the offset a buffer scan starts from. An active
+// selection — typically the previously found or confirmed match — takes
+// precedence over the raw cursor: a replace scan (includeSelection) starts
+// at the selection's near edge so the highlighted occurrence is prompted
+// again, while a plain search starts at its end and continues past it,
+// exactly as if the cursor sat there.
+func (ev *EditorView) searchSeedOffset(reverse, includeSelection bool) int {
+	if ev.selActive {
+		selMin, selMax := ev.getSelectionRange()
+		if includeSelection && !reverse {
+			return selMin
+		}
+		return selMax
+	}
+	return ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
+}
+
 func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, wholeWord, next bool) {
 	if pattern == "" {
 		return
@@ -3761,9 +3755,10 @@ func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, who
 		pattern, caseSensitive, reverse, regexp, wholeWord, next)
 
 	vtui.FrameManager.PostTask(func() {
-		runSearchWithProgress(pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
-			startOff := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
+		// Read on the UI thread, before the background scan starts.
+		startOff := ev.searchSeedOffset(reverse, false)
 
+		runSearchWithProgress(pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
 			bytes, errBytes := ev.pt.Bytes()
 			if errBytes != nil {
 				ctx.RunOnUI(func() {
@@ -3794,7 +3789,7 @@ func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, who
 				if foundOffset != -1 {
 					ev.selectFoundPattern(foundOffset, matchLen)
 				} else {
-					vtui.ShowMessage(" Search ", "Pattern not found.", []string{"&Ok"})
+					vtui.ShowMessage(Msg("Search.Title"), Msg("Search.NotFound"), []string{Msg("vtui.Ok")})
 				}
 			})
 		})

--- a/editor_view_test.go
+++ b/editor_view_test.go
@@ -4399,59 +4399,216 @@ func TestEditorView_SearchPersistence(t *testing.T) {
 	}
 }
 
-func TestEditorView_Replace_FirstClickReplaces(t *testing.T) {
-	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-
-	pt := piecetable.New([]byte("match one, match two"))
-	ev := NewEditorView(pt, nil, "test.txt")
-	defer ev.Close()
-	ev.SetPosition(0, 0, 80, 24)
-
-	// No selection: a single Replace must consume the first occurrence,
-	// not merely select it (the old behavior needed a second dialog
-	// round-trip per occurrence).
-	ev.Replace("match", "X", false, false, false, false, false)
-
-	want := "X one, match two"
-	timeout := time.After(2 * time.Second)
-	for {
-		data, _ := ev.pt.Bytes()
-		if string(data) == want && ev.selActive {
-			break
-		}
-		select {
-		case task := <-vtui.FrameManager.TaskChan:
-			task()
-		case <-timeout:
-			data, _ := ev.pt.Bytes()
-			t.Fatalf("first Replace click did not replace, buffer: %q", string(data))
+// countDialogButtons tells a Replace confirmation prompt (4 buttons) apart
+// from the summary box (1 button) that shares its title.
+func countDialogButtons(w *vtui.Window) int {
+	n := 0
+	for _, c := range w.GetChildren() {
+		if _, ok := c.(*vtui.Button); ok {
+			n++
 		}
 	}
+	return n
+}
 
-	// The follow-up search must leave the next occurrence selected.
+// pumpReplacePrompt drains UI tasks until a Replace confirmation dialog
+// other than prev is on top, and returns it.
+func pumpReplacePrompt(t *testing.T, prev *vtui.Window) *vtui.Window {
+	t.Helper()
+	var dlg *vtui.Window
+	pumpFindAll(t, func() bool {
+		w, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+		if ok && w != prev && w.GetTitle() == Msg("Replace.ConfirmTitle") && countDialogButtons(w) == 4 {
+			dlg = w
+		}
+		return dlg != nil
+	})
+	return dlg
+}
+
+// pumpReplaceSummary drains UI tasks until the "N occurrence(s) replaced"
+// box shows up, proving the loop ended with a report instead of the bare
+// not-found message.
+func pumpReplaceSummary(t *testing.T) {
+	t.Helper()
+	pumpFindAll(t, func() bool {
+		w, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+		return ok && w.GetTitle() == Msg("Replace.ConfirmTitle") && countDialogButtons(w) == 1
+	})
+}
+
+func TestEditorView_Replace_InteractivePromptFlow(t *testing.T) {
+	content := "match one, match two, match three"
+	ev := newFindAllEditor(t, content)
+
+	// One click on [ Replace ] with no selection prompts at the first
+	// occurrence without touching the buffer.
+	ev.Replace("match", "X", false, false, false, false, false)
+	dlg := pumpReplacePrompt(t, nil)
+	if data, _ := ev.pt.Bytes(); string(data) != content {
+		t.Fatalf("the prompt must not replace by itself, buffer: %q", data)
+	}
+	if !ev.selActive || ev.selAnchorOffset != 0 {
+		t.Errorf("first occurrence should be selected at 0, got active=%v anchor=%d",
+			ev.selActive, ev.selAnchorOffset)
+	}
+
+	// Replace: exactly this occurrence, then a prompt at the next one.
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	want := "X one, match two, match three"
+	if data, _ := ev.pt.Bytes(); string(data) != want {
+		t.Fatalf("after Replace, buffer: %q, want %q", data, want)
+	}
 	if ev.selAnchorOffset != len("X one, ") {
-		t.Errorf("expected next occurrence selected at %d, got %d",
+		t.Errorf("second occurrence should be selected at %d, got %d",
 			len("X one, "), ev.selAnchorOffset)
 	}
 
-	// A second Replace consumes the selected occurrence; no more matches
-	// remain, so the buffer must settle at the final text.
-	ev.Replace("match", "X", false, false, false, false, false)
-	want = "X one, X two"
-	timeout = time.After(2 * time.Second)
-	for {
-		data, _ := ev.pt.Bytes()
-		if string(data) == want {
-			break
-		}
-		select {
-		case task := <-vtui.FrameManager.TaskChan:
-			task()
-		case <-timeout:
-			data, _ := ev.pt.Bytes()
-			t.Fatalf("second Replace click did not replace, buffer: %q", string(data))
-		}
+	// Skip: buffer untouched, prompt advances.
+	dlg2.SetExitCode(replaceBtnSkip)
+	dlg3 := pumpReplacePrompt(t, dlg2)
+	if data, _ := ev.pt.Bytes(); string(data) != want {
+		t.Fatalf("Skip must not edit, buffer: %q", data)
 	}
+	wantThird := len("X one, match two, ")
+	if ev.selAnchorOffset != wantThird {
+		t.Errorf("third occurrence should be selected at %d, got %d", wantThird, ev.selAnchorOffset)
+	}
+
+	// Cancel: the loop stops, nothing else changes, the occurrence stays
+	// selected with the cursor on it.
+	dlg3.SetExitCode(replaceBtnCancel)
+	pumpFindAllFor(t, 300*time.Millisecond, func() (string, bool) {
+		w, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+		if ok && w != dlg3 && w.GetTitle() == Msg("Replace.ConfirmTitle") {
+			return "Cancel must end the loop, but another Replace dialog appeared", true
+		}
+		return "", false
+	})
+	if data, _ := ev.pt.Bytes(); string(data) != want {
+		t.Errorf("Cancel must not edit, buffer: %q", data)
+	}
+	if !ev.selActive || ev.selAnchorOffset != wantThird {
+		t.Errorf("canceled occurrence should stay selected at %d, got active=%v anchor=%d",
+			wantThird, ev.selActive, ev.selAnchorOffset)
+	}
+}
+
+func TestEditorView_Replace_InteractiveAllSingleUndo(t *testing.T) {
+	content := "match one, match two, match three"
+	ev := newFindAllEditor(t, content)
+	ev.Replace("match", "X", false, false, false, false, false)
+
+	// All at the first prompt finishes the rest without further prompts
+	// and reports the total.
+	dlg := pumpReplacePrompt(t, nil)
+	dlg.SetExitCode(replaceBtnAll)
+	want := "X one, X two, X three"
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == want })
+	pumpReplaceSummary(t)
+
+	// Far wraps the All tail in a single undo block: one Undo restores
+	// everything the button replaced.
+	ev.Undo()
+	if data, _ := ev.pt.Bytes(); string(data) != content {
+		t.Errorf("All should be one undo step, after Undo: %q", data)
+	}
+}
+
+func TestEditorView_Replace_AdjacentOccurrenceNotSkipped(t *testing.T) {
+	ev := newFindAllEditor(t, "aaaa")
+	ev.Replace("aa", "x", false, false, false, false, false)
+
+	// Replace-Replace on "aaaa" with aa->x must produce "xx": the second
+	// occurrence starts exactly at the end of the first replacement.
+	dlg := pumpReplacePrompt(t, nil)
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	dlg2.SetExitCode(replaceBtnReplace)
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == "xx" })
+	pumpReplaceSummary(t)
+}
+
+func TestEditorView_Replace_ReplacementContainsPattern(t *testing.T) {
+	ev := newFindAllEditor(t, "aa")
+	ev.Replace("a", "aa", false, false, false, false, false)
+
+	// The replacement's own output must never be re-matched: exactly two
+	// prompts, then the summary.
+	dlg := pumpReplacePrompt(t, nil)
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	dlg2.SetExitCode(replaceBtnReplace)
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == "aaaa" })
+	pumpReplaceSummary(t)
+}
+
+func TestEditorView_Replace_RegexExpandsPerOccurrence(t *testing.T) {
+	ev := newFindAllEditor(t, "a1 b2")
+	ev.Replace(`([a-z])(\d)`, "$2$1", true, false, true, false, false)
+
+	dlg := pumpReplacePrompt(t, nil)
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	dlg2.SetExitCode(replaceBtnReplace)
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == "1a 2b" })
+	pumpReplaceSummary(t)
+}
+
+func TestReplacePrompt_RegexShowsExpandedReplacement(t *testing.T) {
+	// The prompt shows what will really be inserted for this occurrence,
+	// not the raw "$2$1" the user typed.
+	re, err := buildSearchRegex(`([a-z])(\d)`, true, true, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	st := &replaceLoop{replacement: "$2$1", regexp: true, re: re}
+	rendered := string(st.renderReplacement([]byte("a1")))
+	if rendered != "1a" {
+		t.Fatalf("rendered replacement = %q, want \"1a\"", rendered)
+	}
+	body := replacePromptBody("a1", rendered)
+	if !strings.Contains(body, "\"a1\"") || !strings.Contains(body, "\"1a\"") {
+		t.Errorf("prompt body should quote the match and the expanded replacement, got %q", body)
+	}
+}
+
+func TestEditorView_Replace_FoldedDifferentLength(t *testing.T) {
+	// K (U+212A, 3 bytes) case-folds to "k": the replacement must consume
+	// the folded character's real byte width, not len(pattern).
+	ev := newFindAllEditor(t, "K x k")
+	ev.Replace("k", "q", false, false, false, false, false)
+
+	dlg := pumpReplacePrompt(t, nil)
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	dlg2.SetExitCode(replaceBtnReplace)
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == "q x q" })
+	pumpReplaceSummary(t)
+}
+
+func TestEditorView_Replace_ReverseWalksRightToLeft(t *testing.T) {
+	content := "match one, match two"
+	ev := newFindAllEditor(t, content)
+	ev.CursorLine = 0
+	ev.CursorPos = len(content)
+	ev.Replace("match", "X", false, true, false, false, false)
+
+	dlg := pumpReplacePrompt(t, nil)
+	second := len("match one, ")
+	if ev.selAnchorOffset != second {
+		t.Fatalf("reverse should prompt the rightmost occurrence at %d, got %d",
+			second, ev.selAnchorOffset)
+	}
+	dlg.SetExitCode(replaceBtnReplace)
+	dlg2 := pumpReplacePrompt(t, dlg)
+	if ev.selAnchorOffset != 0 {
+		t.Errorf("second prompt should be at offset 0, got %d", ev.selAnchorOffset)
+	}
+	dlg2.SetExitCode(replaceBtnReplace)
+	pumpFindAll(t, func() bool { data, _ := ev.pt.Bytes(); return string(data) == "X one, X two" })
+	pumpReplaceSummary(t)
 }
 
 func TestEditorView_Autocomplete_Logic(t *testing.T) {

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -972,6 +972,14 @@ Replace.Title= Replace
 Replace.Prompt=Replace with:
 Replace.BtnReplace=&Replace
 Replace.BtnReplaceAll=Replace &All
+Replace.ConfirmTitle= Replace
+Replace.AskReplace=Replace this occurrence of
+Replace.AskWith=with
+Replace.BtnAll=&All
+Replace.BtnSkip=&Skip
+Replace.Replaced=%d occurrence(s) replaced
+Search.Title= Search
+Search.NotFound=Pattern not found.
 Codepage.Title= Code pages
 Codepage.ConvertTitle= Convert Codepage
 

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -969,6 +969,14 @@ Replace.Title= Замена
 Replace.Prompt=Заменить на:
 Replace.BtnReplace=&Заменить
 Replace.BtnReplaceAll=Заменить &все
+Replace.ConfirmTitle= Замена
+Replace.AskReplace=Заменить это вхождение
+Replace.AskWith=на
+Replace.BtnAll=&Все
+Replace.BtnSkip=&Пропустить
+Replace.Replaced=Заменено вхождений: %d
+Search.Title= Поиск
+Search.NotFound=Строка поиска не найдена.
 Codepage.Title= Кодировки
 Codepage.ConvertTitle= Конвертировать кодировку
 


### PR DESCRIPTION
## Summary

Two commits building out the editor's search/replace machinery:

**Find All + matching overhaul** (6bfec25)
- New Find All results menu (zoomable, resize-aware, per-line grouping) built on a shared `findAllMatchSpans` scan
- Search/replace matching unified on `buildSearchRegex`/`findMatch`: whole-word via `\b` wrapping, case folding via `strcase` (offset-safe for multi-byte folds like U+212A), reverse regex search without byte-offset corruption

**Interactive Replace confirm loop** (fd160cb)
- Far-style Replace / All / Skip / Cancel dialog per occurrence: the match is scrolled to the top quarter, highlighted, and shown with its concretely rendered replacement ($group expansion only for typed regexes)
- [All] collects the remaining occurrences in one linear `findAllMatchSpans` pass and applies them as per-span splices under a single undo step
- Replace splices register with the editSession/indexer fences (`noteBufferEdit`); background scans are fenced by a session captured while offsets are valid
- Zero-length regex matches are stepped over instead of terminating the loop; skipping every occurrence reports "0 occurrence(s) replaced" instead of "Pattern not found."
- A selection that is exactly one occurrence is prompted as-is instead of re-searched (a regex like `a+` can no longer silently widen the replaced range)
- Shared helpers for replacement rendering (`renderReplacement`) and search seeding (`searchSeedOffset`); new `Search.Title`/`Search.NotFound` lang keys (en/ru)

## Testing

- `go test -run 'TestEditor|TestReplace|TestFindAll|Search' -count=1 .` — all pass
- Interactive flow covered by new tests: prompt flow (Replace/Skip/Cancel), [All] single-undo, adjacent occurrences, replacement-contains-pattern, per-occurrence regex expansion, folded different-length matches, reverse right-to-left walk

🤖 Generated with [Claude Code](https://claude.com/claude-code)