### PR TITLE
Make inserted-path test portable

### DIFF
--- a/action_copyname_parent_test.go
+++ b/action_copyname_parent_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -115,7 +116,11 @@ func TestAction_PanelInsertPath_CursorOnFile(t *testing.T) {
 	if !RunAction("Panel.InsertPath") {
 		t.Fatal("Panel.InsertPath did not run")
 	}
-	want := `echo "` + filepath.Join(tmp, "a.txt") + `"`
+	path := filepath.Join(tmp, "a.txt")
+	want := "echo " + path
+	if runtime.GOOS == "windows" {
+		want = `echo "` + path + `"`
+	}
 	if got := pf.cmdLine.Edit.GetText(); got != want {
 		t.Errorf("command line = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- expect an unquoted inserted path on Unix when quoting is unnecessary
- retain the quoted Windows expectation for paths containing backslashes

## Tests
- go test . -run 'Test(Action_PanelInsertPath_CursorOnFile|PanelsFrame_CopyShortcuts)' -count=1

Follow-up to #449; fixes the remaining linux/amd64 failure.