### PR TITLE
Fix workspace restoration and add tab persistence controls

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -3072,9 +3072,7 @@ func actionImportFar2lHistory(pf *PanelsFrame) {
 }
 
 func actionAppearanceSettings(pf *PanelsFrame) {
-	// One row shaved by dropping the blank between the two trailing
-	// checkboxes (see #298).
-	const width, height = 64, 26
+	const width, height = 64, 28
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
 	// Snapshot the whole palette (not just the style name) so a
@@ -3166,6 +3164,24 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	if AppConfig.AltNumberSwitchesTabs {
 		chkAltNumberTabs.State = 1
 	}
+	chkRestoreWorkspaceTabs := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.RestoreWorkspaceTabs"), AppConfig.RestoreWorkspaceTabs)
+	if AppConfig.RestoreWorkspaceTabs {
+		chkRestoreWorkspaceTabs.State = 1
+	}
+	workspaceNumberingModes := []string{
+		Msg("AppearanceSettings.WorkspaceNumbersAlways"),
+		Msg("AppearanceSettings.WorkspaceNumbersSession"),
+		Msg("AppearanceSettings.WorkspaceNumbersOrder"),
+	}
+	comboWorkspaceNumbering := vtui.NewComboBox(0, 0, 30, workspaceNumberingModes)
+	comboWorkspaceNumbering.DropdownOnly = true
+	workspaceNumberingSelection := int(AppConfig.WorkspaceTabNumbering)
+	if workspaceNumberingSelection < 0 || workspaceNumberingSelection >= len(workspaceNumberingModes) {
+		workspaceNumberingSelection = int(WorkspaceTabNumbersAlways)
+	}
+	comboWorkspaceNumbering.Menu.SetSelectPos(workspaceNumberingSelection)
+	comboWorkspaceNumbering.Edit.SetText(workspaceNumberingModes[workspaceNumberingSelection])
+	lblWorkspaceNumbering := vtui.NewLabel(0, 0, Msg("AppearanceSettings.WorkspaceNumbers"), comboWorkspaceNumbering)
 
 	chkCursor := vtui.NewCheckbox(0, 0, Msg("PanelSettings.KeepCursor"), false)
 	chkCursor.State = 0
@@ -3198,6 +3214,9 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	dlg.AddItem(lblCtrlTab)
 	dlg.AddItem(comboCtrlTab)
 	dlg.AddItem(chkAltNumberTabs)
+	dlg.AddItem(chkRestoreWorkspaceTabs)
+	dlg.AddItem(lblWorkspaceNumbering)
+	dlg.AddItem(comboWorkspaceNumbering)
 	dlg.AddItem(chkCursor)
 	dlg.AddItem(chkContrast)
 	dlg.AddItem(btnOk)
@@ -3232,6 +3251,11 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	rowCtrlTab.Add(comboCtrlTab, vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(rowCtrlTab, vtui.Margins{Top: 1}, vtui.AlignFill)
 	vbox.Add(chkAltNumberTabs, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkRestoreWorkspaceTabs, vtui.Margins{}, vtui.AlignLeft)
+	rowWorkspaceNumbering := vtui.NewHBoxLayout(0, 0, width-4, 1)
+	rowWorkspaceNumbering.Add(lblWorkspaceNumbering, vtui.Margins{Right: 1}, vtui.AlignLeft)
+	rowWorkspaceNumbering.Add(comboWorkspaceNumbering, vtui.Margins{}, vtui.AlignFill)
+	vbox.Add(rowWorkspaceNumbering, vtui.Margins{Top: 1}, vtui.AlignFill)
 
 	vbox.Add(chkCursor, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkContrast, vtui.Margins{}, vtui.AlignLeft)
@@ -3277,6 +3301,11 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		AppConfig.WorkspaceTabMode = comboWorkspaceTabs.Menu.SelectPos
 		AppConfig.CtrlTabShowsMenu = comboCtrlTab.Menu.SelectPos == 1
 		AppConfig.AltNumberSwitchesTabs = chkAltNumberTabs.State == 1
+		AppConfig.RestoreWorkspaceTabs = chkRestoreWorkspaceTabs.State == 1
+		AppConfig.WorkspaceTabNumbering = WorkspaceTabNumberingMode(comboWorkspaceNumbering.Menu.SelectPos)
+		if AppConfig.WorkspaceTabNumbering == WorkspaceTabNumbersOrder {
+			renumberWorkspaceScreens()
+		}
 		SaveConfig()
 
 		dlg.SetExitCode(1)

--- a/actions_test.go
+++ b/actions_test.go
@@ -1665,6 +1665,83 @@ func TestActionAppearanceSettingsSavesSystemMonospace(t *testing.T) {
 	}
 }
 
+func TestActionAppearanceSettingsSavesWorkspaceTabRestoration(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	getUserConfigIniPath = func() string { return filepath.Join(t.TempDir(), "settings.ini") }
+	defer func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	}()
+	AppConfig.RestoreWorkspaceTabs = true
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var restoreTabs *vtui.Checkbox
+	for _, child := range top.GetChildren() {
+		checkbox, ok := child.(*vtui.Checkbox)
+		if ok && checkbox.GetText() == Msg("AppearanceSettings.RestoreWorkspaceTabs") {
+			restoreTabs = checkbox
+			break
+		}
+	}
+	if restoreTabs == nil {
+		t.Fatal("workspace tab restoration checkbox not found in Appearance Settings")
+	}
+	if restoreTabs.State != 1 {
+		t.Fatal("workspace tab restoration must be enabled by default")
+	}
+	restoreTabs.Toggle()
+	clickDialogButton(t, top, "Ok")
+	if AppConfig.RestoreWorkspaceTabs {
+		t.Fatal("disabled workspace tab restoration setting was not saved")
+	}
+}
+
+func TestActionAppearanceSettingsSavesWorkspaceTabNumbering(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	getUserConfigIniPath = func() string { return filepath.Join(t.TempDir(), "settings.ini") }
+	defer func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	}()
+	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersAlways
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var numbering *vtui.ComboBox
+	for _, child := range top.GetChildren() {
+		combo, ok := child.(*vtui.ComboBox)
+		if ok && combo.Edit.GetText() == Msg("AppearanceSettings.WorkspaceNumbersAlways") {
+			numbering = combo
+			break
+		}
+	}
+	if numbering == nil {
+		t.Fatal("workspace tab numbering combobox not found in Appearance Settings")
+	}
+	numbering.Menu.SetSelectPos(int(WorkspaceTabNumbersOrder))
+	clickDialogButton(t, top, "Ok")
+	if AppConfig.WorkspaceTabNumbering != WorkspaceTabNumbersOrder {
+		t.Fatalf("workspace tab numbering = %v, want order", AppConfig.WorkspaceTabNumbering)
+	}
+}
+
 // TestActionAppearanceSettings_CancelPreservesPalette locks in the
 // fix: farcolors.ini overrides applied at startup were wiped when
 // the user opened Appearance settings and pressed Cancel, because

--- a/config.go
+++ b/config.go
@@ -93,6 +93,36 @@ func (m PanelScrollbarMode) String() string {
 	}
 }
 
+type WorkspaceTabNumberingMode int
+
+const (
+	WorkspaceTabNumbersAlways WorkspaceTabNumberingMode = iota
+	WorkspaceTabNumbersSession
+	WorkspaceTabNumbersOrder
+)
+
+func (m WorkspaceTabNumberingMode) String() string {
+	switch m {
+	case WorkspaceTabNumbersSession:
+		return "session"
+	case WorkspaceTabNumbersOrder:
+		return "order"
+	default:
+		return "always"
+	}
+}
+
+func ParseWorkspaceTabNumberingMode(value string) WorkspaceTabNumberingMode {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "session":
+		return WorkspaceTabNumbersSession
+	case "order":
+		return WorkspaceTabNumbersOrder
+	default:
+		return WorkspaceTabNumbersAlways
+	}
+}
+
 func ParsePanelScrollbarMode(value string) PanelScrollbarMode {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "minimal":
@@ -113,6 +143,8 @@ type F4Config struct {
 	WorkspaceTabMode         int
 	CtrlTabShowsMenu         bool
 	AltNumberSwitchesTabs    bool
+	RestoreWorkspaceTabs     bool
+	WorkspaceTabNumbering    WorkspaceTabNumberingMode
 	ShowHiddenFiles          bool
 	ShowDirPrefix            bool
 	ShowHighlightMarks       bool
@@ -220,6 +252,8 @@ var AppConfig = F4Config{
 	WorkspaceTabMode:         int(vtui.WorkspaceTabsAlways),
 	CtrlTabShowsMenu:         false,
 	AltNumberSwitchesTabs:    true,
+	RestoreWorkspaceTabs:     true,
+	WorkspaceTabNumbering:    WorkspaceTabNumbersAlways,
 	ShowHiddenFiles:          true,
 	ShowDirPrefix:            false,
 	ShowHighlightMarks:       false,
@@ -362,6 +396,8 @@ func LoadConfig() {
 	}
 	AppConfig.CtrlTabShowsMenu = strings.EqualFold(ini.GetString("Interface", "CtrlTabMode", "direct"), "menu")
 	AppConfig.AltNumberSwitchesTabs = ini.GetString("Interface", "AltNumberSwitchesTabs", "1") != "0"
+	AppConfig.RestoreWorkspaceTabs = ini.GetString("Interface", "RestoreWorkspaceTabs", "1") != "0"
+	AppConfig.WorkspaceTabNumbering = ParseWorkspaceTabNumberingMode(ini.GetString("Interface", "WorkspaceTabNumbering", "always"))
 	if AppConfig.ConsoleTitleTemplate == "f4 - %State" {
 		AppConfig.ConsoleTitleTemplate = "f4 %Ver %Platform %Admin - %State"
 	}
@@ -553,7 +589,9 @@ func SaveConfig() {
 	}
 	sb.WriteString(fmt.Sprintf("WorkspaceTabMode = %s\n", workspaceTabMode))
 	sb.WriteString(fmt.Sprintf("CtrlTabMode = %s\n", ctrlTabMode))
-	sb.WriteString(fmt.Sprintf("AltNumberSwitchesTabs = %d\n\n", map[bool]int{true: 1, false: 0}[AppConfig.AltNumberSwitchesTabs]))
+	sb.WriteString(fmt.Sprintf("AltNumberSwitchesTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.AltNumberSwitchesTabs]))
+	sb.WriteString(fmt.Sprintf("RestoreWorkspaceTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.RestoreWorkspaceTabs]))
+	sb.WriteString(fmt.Sprintf("WorkspaceTabNumbering = %s\n\n", AppConfig.WorkspaceTabNumbering.String()))
 	sb.WriteString("[Panel]\n")
 	sb.WriteString(fmt.Sprintf("ShowHiddenFiles = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowHiddenFiles]))
 	sb.WriteString(fmt.Sprintf("ShowDirPrefix = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.ShowDirPrefix]))

--- a/config_test.go
+++ b/config_test.go
@@ -45,6 +45,8 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsNever)
 	AppConfig.CtrlTabShowsMenu = true
 	AppConfig.AltNumberSwitchesTabs = false
+	AppConfig.RestoreWorkspaceTabs = false
+	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersOrder
 	AppConfig.ApplyCommandParallelism = 0
 
 	// 2. Save
@@ -65,6 +67,8 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsAlways)
 	AppConfig.CtrlTabShowsMenu = false
 	AppConfig.AltNumberSwitchesTabs = true
+	AppConfig.RestoreWorkspaceTabs = true
+	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersAlways
 	AppConfig.ApplyCommandParallelism = 1
 
 	// 4. Load
@@ -85,6 +89,12 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if AppConfig.AltNumberSwitchesTabs {
 		t.Error("LoadConfig failed to restore disabled Alt+number tab switching")
+	}
+	if AppConfig.RestoreWorkspaceTabs {
+		t.Error("LoadConfig failed to restore disabled workspace tab restoration")
+	}
+	if AppConfig.WorkspaceTabNumbering != WorkspaceTabNumbersOrder {
+		t.Errorf("LoadConfig restored workspace tab numbering %v, want order", AppConfig.WorkspaceTabNumbering)
 	}
 	if !AppConfig.ShowDirPrefix {
 		t.Error("LoadConfig failed to restore ShowDirPrefix")
@@ -222,6 +232,56 @@ func TestConfig_WorkspaceTabModeDefaultsToAlwaysWhenKeyIsAbsent(t *testing.T) {
 	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsAlways) {
 		t.Fatalf("WorkspaceTabMode without a saved key = %d, want always-visible mode %d",
 			AppConfig.WorkspaceTabMode, vtui.WorkspaceTabsAlways)
+	}
+}
+
+func TestConfig_RestoreWorkspaceTabsDefaultsOnWhenKeyIsAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+	userIniPath := filepath.Join(tmpDir, "settings.ini")
+	if err := os.WriteFile(userIniPath, []byte("[Interface]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origUserPathFunc := getUserConfigIniPath
+	origPathsFunc := getConfigIniPaths
+	oldCfg := AppConfig
+	defer func() {
+		getUserConfigIniPath = origUserPathFunc
+		getConfigIniPaths = origPathsFunc
+		AppConfig = oldCfg
+	}()
+	getUserConfigIniPath = func() string { return userIniPath }
+	getConfigIniPaths = func() []string { return []string{userIniPath} }
+
+	AppConfig.RestoreWorkspaceTabs = false
+	LoadConfig()
+	if !AppConfig.RestoreWorkspaceTabs {
+		t.Fatal("RestoreWorkspaceTabs must default to true when the setting is absent")
+	}
+}
+
+func TestConfig_WorkspaceTabNumberingDefaultsToAlwaysWhenKeyIsAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+	userIniPath := filepath.Join(tmpDir, "settings.ini")
+	if err := os.WriteFile(userIniPath, []byte("[Interface]\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origUserPathFunc := getUserConfigIniPath
+	origPathsFunc := getConfigIniPaths
+	oldCfg := AppConfig
+	defer func() {
+		getUserConfigIniPath = origUserPathFunc
+		getConfigIniPaths = origPathsFunc
+		AppConfig = oldCfg
+	}()
+	getUserConfigIniPath = func() string { return userIniPath }
+	getConfigIniPaths = func() []string { return []string{userIniPath} }
+
+	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersOrder
+	LoadConfig()
+	if AppConfig.WorkspaceTabNumbering != WorkspaceTabNumbersAlways {
+		t.Fatalf("WorkspaceTabNumbering must default to always, got %v", AppConfig.WorkspaceTabNumbering)
 	}
 }
 

--- a/file_panel.go
+++ b/file_panel.go
@@ -2117,6 +2117,21 @@ func (fp *FileSystemPanel) Refresh() {
 	}
 }
 
+func (fp *FileSystemPanel) cursorSizeOnBottomBorder() string {
+	if AppConfig.ShowPanelFileInfo || (fp.viewMode != ViewModeBrief && fp.viewMode != ViewModeMedium) {
+		return ""
+	}
+	idx := fp.GetCursorIndex()
+	if idx < 0 || idx >= len(fp.entries) {
+		return ""
+	}
+	entry := fp.entries[idx]
+	if entry == nil || entry.IsDir || entry.Name == ".." {
+		return ""
+	}
+	return " " + formatIntWithSpaces(entry.Size) + " B "
+}
+
 func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 	fp.frame.Show(scr)
 	titleAttr := vtui.Palette[ColPanelTitle]
@@ -2239,12 +2254,25 @@ func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 		attrTotal = vtui.Palette[ColPanelTotalInfo]
 	}
 
+	totalStart := fp.X2
 	if totalStr != "" {
 		totalW := runewidth.StringWidth(totalStr)
 		availBottom := fp.X2 - fp.X1 - 1
 		if totalW < availBottom {
+			totalStart = fp.X1 + 1 + (availBottom-totalW)/2
 			p := vtui.NewPainter(scr)
-			p.DrawString(fp.X1+1+(availBottom-totalW)/2, fp.Y2, totalStr, attrTotal)
+			p.DrawString(totalStart, fp.Y2, totalStr, attrTotal)
+		}
+	}
+
+	if cursorSize := fp.cursorSizeOnBottomBorder(); cursorSize != "" {
+		cursorSizeW := runewidth.StringWidth(cursorSize)
+		cursorSizeX := fp.X1 + 1
+		// Keep at least one frame cell between the cursor size and the centered
+		// selection/directory summary. On narrow panels the summary wins.
+		if cursorSizeX+cursorSizeW < totalStart {
+			p := vtui.NewPainter(scr)
+			p.DrawString(cursorSizeX, fp.Y2, cursorSize, vtui.Palette[ColPanelTotalInfo])
 		}
 	}
 

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -738,6 +738,80 @@ func TestFileSystemPanel_SelectedInfo(t *testing.T) {
 	}
 }
 
+func TestFileSystemPanel_HiddenInfoShowsCursorFileSizeOnMulticolumnBorder(t *testing.T) {
+	oldCfg := AppConfig
+	oldColor := vtui.Palette[ColPanelTotalInfo]
+	defer func() {
+		AppConfig = oldCfg
+		vtui.Palette[ColPanelTotalInfo] = oldColor
+	}()
+	AppConfig.ShowPanelFileInfo = false
+
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 12)
+	vtui.FrameManager.Init(scr)
+
+	fp := NewFileSystemPanel(0, 0, 80, 12, vfs.NewOSVFS(t.TempDir()))
+	if fp.cancelLoad != nil {
+		fp.cancelLoad()
+	}
+	fp.isLoading = false
+	if fp.loadingTimer != nil {
+		fp.loadingTimer.Stop()
+	}
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "file.bin", Size: 1234567}},
+		{VFSItem: vfs.VFSItem{Name: "other.bin", Size: 10}},
+	}
+	fp.SetViewMode(ViewModeMedium)
+	fp.SetCursorIndex(0)
+	rowText := func(x, y, width int) string {
+		runes := make([]rune, width)
+		for i := range runes {
+			cell := scr.GetCell(x+i, y)
+			runes[i] = rune(cell.Char)
+			if runes[i] == 0 {
+				runes[i] = ' '
+			}
+		}
+		return string(runes)
+	}
+
+	const themedAttr uint64 = 0x123456789ABCDEF0
+	vtui.Palette[ColPanelTotalInfo] = themedAttr
+	fp.Show(scr)
+
+	if got := rowText(1, fp.Y2, 13); got != " 1 234 567 B " {
+		t.Fatalf("medium bottom-left cursor size = %q, want %q", got, " 1 234 567 B ")
+	}
+	if got := scr.GetCell(2, fp.Y2).Attributes; got != themedAttr {
+		t.Fatalf("cursor size color = %#x, want current themed Panel.TotalInfo %#x", got, themedAttr)
+	}
+
+	// Brief is the other multicolumn mode and must expose the same compact
+	// status, while Detailed already has a visible Size column and must not.
+	fp.SetViewMode(ViewModeBrief)
+	fp.Show(scr)
+	if got := rowText(1, fp.Y2, 13); got != " 1 234 567 B " {
+		t.Fatalf("brief bottom-left cursor size = %q, want %q", got, " 1 234 567 B ")
+	}
+
+	fp.SetViewMode(ViewModeDetailed)
+	fp.Show(scr)
+	if got := rowText(1, fp.Y2, 13); strings.Contains(got, "1 234 567") {
+		t.Fatalf("detailed mode unexpectedly duplicated cursor size on bottom border: %q", got)
+	}
+
+	fp.SetViewMode(ViewModeMedium)
+	AppConfig.ShowPanelFileInfo = true
+	fp.Show(scr)
+	if got := rowText(1, fp.Y2, 13); strings.Contains(got, "1 234 567") {
+		t.Fatalf("visible file-info row unexpectedly duplicated cursor size on bottom border: %q", got)
+	}
+}
+
 func TestFileSystemPanel_Initialization(t *testing.T) {
 	oldCfg := AppConfig
 	defer func() { AppConfig = oldCfg }()

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -582,6 +582,11 @@ AppearanceSettings.CtrlTab=&Ctrl+Tab behavior:
 AppearanceSettings.CtrlTabDirect=Switch immediately
 AppearanceSettings.CtrlTabMenu=Show Screens menu
 AppearanceSettings.AltNumberTabs=Alt+&number switches workspace tab
+AppearanceSettings.RestoreWorkspaceTabs=&Restore open workspace tabs on startup
+AppearanceSettings.WorkspaceNumbers=Tab &numbering:
+AppearanceSettings.WorkspaceNumbersAlways=Always preserve numbers
+AppearanceSettings.WorkspaceNumbersSession=Preserve during current session
+AppearanceSettings.WorkspaceNumbersOrder=Follow current tab order
 AppearanceSettings.ExportBtn=E&xport Scheme
 AppearanceSettings.ColorCorrection=Enforce color &contrast correction
 

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -581,6 +581,11 @@ AppearanceSettings.CtrlTab=Поведение &Ctrl+Tab:
 AppearanceSettings.CtrlTabDirect=Переключать сразу
 AppearanceSettings.CtrlTabMenu=Показывать меню Screens
 AppearanceSettings.AltNumberTabs=Alt+&цифра переключает вкладку пространства
+AppearanceSettings.RestoreWorkspaceTabs=&Восстанавливать открытые вкладки при запуске
+AppearanceSettings.WorkspaceNumbers=&Нумерация вкладок:
+AppearanceSettings.WorkspaceNumbersAlways=Всегда сохранять номера
+AppearanceSettings.WorkspaceNumbersSession=Сохранять в текущей сессии
+AppearanceSettings.WorkspaceNumbersOrder=Следовать текущему порядку вкладок
 AppearanceSettings.ExportBtn=&Экспорт цветовой схемы
 AppearanceSettings.ColorCorrection=Корректировать &контрастность цветов
 

--- a/main.go
+++ b/main.go
@@ -411,7 +411,9 @@ func SetupUI() {
 
 	panels := NewPanelsFrame()
 	panels.ResizeConsole(width, height)
-	states := LastWorkspaceSessions
+	states, activeWorkspace := workspaceSessionsForRestore(
+		LastWorkspaceSessions, LastActiveWorkspace, AppConfig.RestoreWorkspaceTabs,
+	)
 	if len(states) == 0 && AppConfig.SavePanelPaths {
 		states = []workspaceSessionState{legacyWorkspaceSession()}
 	}
@@ -419,24 +421,28 @@ func SetupUI() {
 		applyWorkspaceSession(panels, states[0], width, height, AppConfig.SavePanelPaths)
 	}
 	vtui.FrameManager.Push(panels)
-	if len(LastWorkspaceSessions) > 1 {
+	if len(states) > 1 {
 		// AddScreenBackground inserts immediately after the active workspace;
 		// restore from right to left to preserve the saved tab order.
-		for i := len(LastWorkspaceSessions) - 1; i >= 1; i-- {
-			state := LastWorkspaceSessions[i]
+		for i := len(states) - 1; i >= 1; i-- {
+			state := states[i]
 			extra := NewPanelsFrame()
 			applyWorkspaceSession(extra, state, width, height, AppConfig.SavePanelPaths)
 			vtui.FrameManager.AddScreenBackground(extra)
 		}
 	}
-	if len(LastWorkspaceSessions) > 0 {
-		numbers := make([]int, len(LastWorkspaceSessions))
-		for i, state := range LastWorkspaceSessions {
-			numbers[i] = state.Number
+	if len(states) > 0 {
+		if AppConfig.WorkspaceTabNumbering == WorkspaceTabNumbersAlways {
+			numbers := make([]int, len(states))
+			for i, state := range states {
+				numbers[i] = state.Number
+			}
+			vtui.FrameManager.RestoreScreenNumbers(numbers)
+		} else {
+			renumberWorkspaceScreens()
 		}
-		vtui.FrameManager.RestoreScreenNumbers(numbers)
-		if LastActiveWorkspace > 0 && LastActiveWorkspace < len(vtui.FrameManager.Screens) {
-			vtui.FrameManager.SwitchScreen(LastActiveWorkspace)
+		if activeWorkspace > 0 && activeWorkspace < len(vtui.FrameManager.Screens) {
+			vtui.FrameManager.SwitchScreen(activeWorkspace)
 		}
 	}
 	previousEventFilter := vtui.FrameManager.EventFilter
@@ -453,6 +459,9 @@ func SetupUI() {
 	vtui.FrameManager.MenuBar = panels.menuBar
 	vtui.FrameManager.KeyBar = panels.keyBar
 	vtui.FrameManager.OnRender = func(scr *vtui.ScreenBuf) {
+		if AppConfig.WorkspaceTabNumbering == WorkspaceTabNumbersOrder {
+			renumberWorkspaceScreens()
+		}
 		UpdateWindowTitle(scr)
 		renderHelpSearch(scr)
 	}

--- a/workspace_session.go
+++ b/workspace_session.go
@@ -214,6 +214,27 @@ func loadWorkspaceSessions(ini *IniFile) ([]workspaceSessionState, int) {
 	return states, active
 }
 
+func workspaceSessionsForRestore(states []workspaceSessionState, active int, restoreTabs bool) ([]workspaceSessionState, int) {
+	if restoreTabs || len(states) == 0 {
+		return states, active
+	}
+	if active < 0 || active >= len(states) {
+		active = 0
+	}
+	return []workspaceSessionState{states[active]}, 0
+}
+
+func renumberWorkspaceScreens() {
+	if vtui.FrameManager == nil {
+		return
+	}
+	for i, screen := range vtui.FrameManager.Screens {
+		if screen != nil {
+			screen.Number = i + 1
+		}
+	}
+}
+
 func writePanelSession(sb *strings.Builder, section string, state panelSessionState) {
 	fmt.Fprintf(sb, "\n[%s]\n", section)
 	fmt.Fprintf(sb, "Folder = %s\n", state.Path)

--- a/workspace_session.go
+++ b/workspace_session.go
@@ -248,8 +248,23 @@ func validSessionViewMode(mode int) ViewMode {
 }
 
 func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, height int, restorePaths bool) {
-	left := pf.panels[0].(*FileSystemPanel)
-	right := pf.panels[1].(*FileSystemPanel)
+	if pf == nil {
+		return
+	}
+	left, leftOK := pf.panels[0].(*FileSystemPanel)
+	right, rightOK := pf.panels[1].(*FileSystemPanel)
+	if !leftOK || left == nil || !rightOK || right == nil {
+		// A freshly constructed background workspace has not been laid out yet,
+		// so ResizeConsole must create its file panels before session state can
+		// be applied. The first workspace is already resized by SetupUI, while
+		// restored background workspaces reach this function directly.
+		pf.ResizeConsole(width, height)
+		left, leftOK = pf.panels[0].(*FileSystemPanel)
+		right, rightOK = pf.panels[1].(*FileSystemPanel)
+		if !leftOK || left == nil || !rightOK || right == nil {
+			return
+		}
+	}
 	if restorePaths {
 		left.pendingSelection, right.pendingSelection = state.Left.Cursor, state.Right.Cursor
 	}

--- a/workspace_session_test.go
+++ b/workspace_session_test.go
@@ -69,3 +69,43 @@ func TestCaptureWorkspaceSessionsUsesTabOrderAndActiveIndex(t *testing.T) {
 		t.Fatal("captured panel paths do not belong to their ordered workspaces")
 	}
 }
+
+func TestApplyWorkspaceSessionInitializesFreshPanelsFrame(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+
+	pf := NewPanelsFrame()
+	t.Cleanup(func() { pf.Close() })
+	state := workspaceSessionState{
+		ActivePanel: 0,
+		WidePanel:   -1,
+		ShowPanels:  true,
+		ShowLeft:    true,
+		ShowRight:   true,
+		Left: panelSessionState{
+			ViewMode: int(ViewModeBrief), SortMode: int(SortExt), SortReverse: true,
+		},
+		Right: panelSessionState{
+			ViewMode: int(ViewModeDetailed), SortMode: int(SortTime),
+		},
+	}
+
+	// Background workspaces are restored immediately after construction,
+	// before SetupUI has explicitly resized them.
+	applyWorkspaceSession(pf, state, 80, 25, false)
+
+	left, leftOK := pf.panels[0].(*FileSystemPanel)
+	right, rightOK := pf.panels[1].(*FileSystemPanel)
+	if !leftOK || left == nil || !rightOK || right == nil {
+		t.Fatalf("fresh workspace panels were not initialized: left=%T right=%T", pf.panels[0], pf.panels[1])
+	}
+	if pf.activeIdx != 0 {
+		t.Fatalf("active panel = %d, want 0", pf.activeIdx)
+	}
+	if left.viewMode != ViewModeBrief || left.sortMode != SortExt || !left.sortReverse {
+		t.Fatalf("left panel state was not restored: view=%v sort=%v reverse=%v", left.viewMode, left.sortMode, left.sortReverse)
+	}
+	if right.viewMode != ViewModeDetailed || right.sortMode != SortTime || right.sortReverse {
+		t.Fatalf("right panel state was not restored: view=%v sort=%v reverse=%v", right.viewMode, right.sortMode, right.sortReverse)
+	}
+}

--- a/workspace_session_test.go
+++ b/workspace_session_test.go
@@ -109,3 +109,44 @@ func TestApplyWorkspaceSessionInitializesFreshPanelsFrame(t *testing.T) {
 		t.Fatalf("right panel state was not restored: view=%v sort=%v reverse=%v", right.viewMode, right.sortMode, right.sortReverse)
 	}
 }
+
+func TestWorkspaceSessionsForRestore(t *testing.T) {
+	states := []workspaceSessionState{{Number: 2}, {Number: 7}, {Number: 9}}
+
+	all, active := workspaceSessionsForRestore(states, 1, true)
+	if !reflect.DeepEqual(all, states) || active != 1 {
+		t.Fatalf("enabled restoration changed sessions: states=%#v active=%d", all, active)
+	}
+
+	one, active := workspaceSessionsForRestore(states, 1, false)
+	if len(one) != 1 || one[0].Number != 7 || active != 0 {
+		t.Fatalf("disabled restoration = %#v, active=%d; want active session 7 only", one, active)
+	}
+
+	one, active = workspaceSessionsForRestore(states, 99, false)
+	if len(one) != 1 || one[0].Number != 2 || active != 0 {
+		t.Fatalf("invalid active index fallback = %#v, active=%d; want first session", one, active)
+	}
+}
+
+func TestRenumberWorkspaceScreensFollowsCurrentOrder(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Screens = []*vtui.AppScreen{
+		{Number: 7},
+		{Number: 2},
+		{Number: 11},
+	}
+
+	renumberWorkspaceScreens()
+
+	got := []int{
+		vtui.FrameManager.Screens[0].Number,
+		vtui.FrameManager.Screens[1].Number,
+		vtui.FrameManager.Screens[2].Number,
+	}
+	want := []int{1, 2, 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("renumbered workspace screens = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

- initialize fresh background panel frames before applying restored workspace state, preventing startup crashes with multiple saved tabs
- add an enabled-by-default option to restore open workspace tabs on startup
- add three tab-numbering policies: preserve across restarts, preserve for the current session, or follow the current tab order
- show the cursor file's exact byte size on the lower panel border in Brief and Medium modes when the separate file-info row is hidden
- keep tab numbers synchronized with tab rendering, Screens, Alt+number navigation, and the semantic model

## Tests

- focused workspace session restoration and numbering tests
- configuration default and round-trip tests
- Appearance Settings interaction and layout tests
- themed panel render tests for the compact cursor file size