### PR TITLE
Set the macOS Dock tile icon at runtime for bare-binary launches

### DIFF
--- a/gui_unix.go
+++ b/gui_unix.go
@@ -12,6 +12,7 @@ func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
 	}
+	applyDarwinDockIcon(backend)
 	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {
 		SetupUI()
 	})

--- a/window_icon_darwin.go
+++ b/window_icon_darwin.go
@@ -1,0 +1,68 @@
+//go:build darwin
+
+package main
+
+import (
+	_ "embed"
+	"unsafe"
+
+	"github.com/ebitengine/purego"
+	"github.com/ebitengine/purego/objc"
+	"github.com/unxed/vtui"
+)
+
+//go:embed assets/icon/generated/f4-512.png
+var darwinDockIconPNG []byte
+
+// applyDarwinDockIcon gives the Dock tile an image. gogpu switches the
+// process to NSApplicationActivationPolicyRegular, which is what makes the
+// tile appear at all, but the tile's image comes from the app bundle's
+// Info.plist — and a bare binary launched from a terminal has no bundle, so
+// the Dock shows the generic executable icon. [NSApp setApplicationIconImage:]
+// is the runtime override for exactly that case; when running from F4.app it
+// simply matches the bundled icns.
+//
+// AppKit calls must happen on the main OS thread: the main goroutine is
+// pinned to it by gogpu's darwin platform package init, and RunGui runs on
+// the main goroutine before handing it to the Cocoa event loop.
+func applyDarwinDockIcon(backend string) {
+	if backend != "gogpu" && backend != "ebiten" {
+		// x11/wayland windows (XQuartz) are not Cocoa apps; leave AppKit alone.
+		return
+	}
+	if len(darwinDockIconPNG) == 0 {
+		return
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			vtui.DebugLog("DOCK_ICON: skipped after panic: %v", r)
+		}
+	}()
+
+	// gogpu dlopens AppKit inside app.Run(); this runs earlier, so load it
+	// here. dlopen of an already-loaded framework just bumps a refcount.
+	if _, err := purego.Dlopen("/System/Library/Frameworks/AppKit.framework/AppKit", purego.RTLD_LAZY|purego.RTLD_GLOBAL); err != nil {
+		vtui.DebugLog("DOCK_ICON: AppKit dlopen failed: %v", err)
+		return
+	}
+
+	nsApp := objc.ID(objc.GetClass("NSApplication")).Send(objc.RegisterName("sharedApplication"))
+	if nsApp == 0 {
+		return
+	}
+	// alloc/init rather than the autoreleasing dataWithBytes:length: — this
+	// runs before gogpu sets up an NSAutoreleasePool, so an autoreleased
+	// object would never be drained.
+	data := objc.ID(objc.GetClass("NSData")).Send(objc.RegisterName("alloc")).Send(objc.RegisterName("initWithBytes:length:"),
+		unsafe.Pointer(&darwinDockIconPNG[0]), len(darwinDockIconPNG))
+	if data == 0 {
+		return
+	}
+	img := objc.ID(objc.GetClass("NSImage")).Send(objc.RegisterName("alloc")).Send(objc.RegisterName("initWithData:"), data)
+	data.Send(objc.RegisterName("release"))
+	if img == 0 {
+		return
+	}
+	nsApp.Send(objc.RegisterName("setApplicationIconImage:"), img)
+	img.Send(objc.RegisterName("release"))
+}

--- a/window_icon_unix.go
+++ b/window_icon_unix.go
@@ -1,0 +1,7 @@
+//go:build linux || openbsd || netbsd || dragonfly || freebsd || illumos || solaris
+
+package main
+
+// applyDarwinDockIcon is a no-op away from macOS; on X11/Wayland the window
+// icon comes from the .desktop file shipped in packaging/linux.
+func applyDarwinDockIcon(string) {}


### PR DESCRIPTION
## Summary
- gogpu switches the process to `NSApplicationActivationPolicyRegular`, which makes the Dock tile appear — but a bare binary launched from a terminal has no app bundle, so the tile shows the generic executable icon. This calls `[NSApp setApplicationIconImage:]` with the embedded 512px PNG before the main thread is handed to the Cocoa event loop. When running from F4.app it simply matches the bundled icns.
- Skipped for x11/wayland backends (XQuartz windows are not Cocoa apps); no-op stub on non-darwin Unix, where the window icon comes from the `.desktop` file.
- `NSData` is alloc/init''d rather than created via the autoreleasing `dataWithBytes:length:` factory, because this runs before gogpu sets up an `NSAutoreleasePool` — an autoreleased object would never be drained.

## Testing
- Cross-builds pass for darwin/arm64, darwin/amd64, and linux/amd64 against latest main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)