### PR TITLE
Fix editor indexing fences and stabilize updater tests

### DIFF
--- a/editor_view.go
+++ b/editor_view.go
@@ -1168,11 +1168,7 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		} else {
 			ev.pasting = false
 			if len(ev.pasteBuffer) > 0 {
-				if ev.indexCancel != nil {
-					ev.indexCancel()
-					ev.indexCancel = nil
-				}
-				ev.edited = true
+				ev.noteBufferEdit()
 
 				ev.saveUndo(opOther)
 				if ev.selActive {
@@ -1240,7 +1236,11 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				match := ev.acMatches[ev.acCurrentIdx]
 				tail := match[len(ev.acPrefix):]
 				ev.acMatches = nil // Clear state
+				if tail == "" {
+					return true
+				}
 
+				ev.noteBufferEdit()
 				ev.saveUndo(opTyping)
 				ev.modified = true
 				offset := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
@@ -1658,11 +1658,11 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		if ev.selActive || ev.rectSelActive {
 			ev.DeleteSelection()
 		} else {
-			ev.noteBufferEdit()
-			ev.saveUndo(opOther)
-			ev.modified = true
 			offset := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
 			if offset > 0 {
+				ev.noteBufferEdit()
+				ev.saveUndo(opOther)
+				ev.modified = true
 				if ev.CursorPos == 0 {
 					// Merge with the previous line (remove line break)
 					prevLen := ev.getLineLength(ev.CursorLine - 1)
@@ -1709,11 +1709,11 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		if ev.selActive || ev.rectSelActive {
 			ev.DeleteSelection()
 		} else {
-			ev.noteBufferEdit()
-			ev.saveUndo(opOther)
-			ev.modified = true
 			offset := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
 			if offset < ev.pt.Size() {
+				ev.noteBufferEdit()
+				ev.saveUndo(opOther)
+				ev.modified = true
 				// Remove the UTF-8 character under the cursor
 				peekLen := 4
 				if ev.pt.Size()-offset < 4 {
@@ -3604,6 +3604,7 @@ func (ev *EditorView) insertTextAtCursor(data []byte) {
 	if len(data) == 0 {
 		return
 	}
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	if ev.selActive || ev.rectSelActive {
 		ev.inGroup = true
@@ -3654,6 +3655,7 @@ func (ev *EditorView) deleteSpacersForward() {
 	if count == 0 {
 		return
 	}
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	ev.modified = true
 	ev.pt.Delete(offset, count)
@@ -3739,15 +3741,31 @@ func (ev *EditorView) CopySelection() {
 }
 
 func (ev *EditorView) PasteRectangular(text string, targetCol int) {
+	if text == "" {
+		return
+	}
 	lines := strings.Split(text, "\n")
 	if len(lines) == 0 {
 		return
 	}
+	neededLines := ev.CursorLine + len(lines)
+	mutates := neededLines > ev.li.LineCount()
+	if !mutates {
+		for _, line := range lines {
+			if line != "" {
+				mutates = true
+				break
+			}
+		}
+	}
+	if !mutates {
+		return
+	}
 
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	ev.modified = true
 
-	neededLines := ev.CursorLine + len(lines)
 	for ev.li.LineCount() < neededLines {
 		offset := ev.pt.Size()
 		ev.pt.Insert(offset, []byte("\n"))
@@ -3809,20 +3827,16 @@ func (ev *EditorView) PasteRectangular(text string, targetCol int) {
 }
 
 func (ev *EditorView) PasteText(text string) {
-	if !ev.edited {
-		ev.edited = true
-		if ev.indexCancel != nil {
-			ev.indexCancel()
-		}
-	}
-	ev.editSession++
-
 	if GlobalLastClipboardWasRectangular {
 		targetCol := ev.getVisualColOf(ev.CursorLine, ev.CursorPos)
 		ev.PasteRectangular(text, targetCol)
 		return
 	}
+	if text == "" && !ev.selActive {
+		return
+	}
 
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	ev.inGroup = true
 	if ev.selActive {
@@ -3856,8 +3870,7 @@ func (ev *EditorView) DeleteSelection() {
 			minX, maxX = maxX, minX
 		}
 
-		ev.saveUndo(opOther)
-		ev.modified = true
+		mutated := false
 
 		for y := maxY; y >= minY; y-- {
 			lineStart := ev.li.GetLineOffset(y)
@@ -3902,6 +3915,14 @@ func (ev *EditorView) DeleteSelection() {
 					endByte = byteAcc
 				}
 				if endByte > startByte {
+					if !mutated {
+						if !ev.inGroup {
+							ev.noteBufferEdit()
+						}
+						ev.saveUndo(opOther)
+						ev.modified = true
+						mutated = true
+					}
 					delOff := lineStart + startByte
 					delLen := endByte - startByte
 					ev.pt.Delete(delOff, delLen)
@@ -3910,8 +3931,10 @@ func (ev *EditorView) DeleteSelection() {
 			}
 		}
 
-		ev.invalidateStates(minY)
-		ev.engine.InvalidateFrom(minY)
+		if mutated {
+			ev.invalidateStates(minY)
+			ev.engine.InvalidateFrom(minY)
+		}
 		ev.rectSelActive = false
 		ev.ensureCursorVisible()
 		return
@@ -3925,13 +3948,9 @@ func (ev *EditorView) DeleteSelection() {
 		max = ev.pt.Size()
 	}
 	if max > min {
-		if !ev.edited {
-			ev.edited = true
-			if ev.indexCancel != nil {
-				ev.indexCancel()
-			}
+		if !ev.inGroup {
+			ev.noteBufferEdit()
 		}
-		ev.editSession++
 
 		ev.saveUndo(opOther)
 
@@ -3949,6 +3968,7 @@ func (ev *EditorView) DeleteCurrentLine() {
 	if ev.pt.Size() == 0 {
 		return
 	}
+	ev.noteBufferEdit()
 	ev.saveUndo(opOther)
 	ev.modified = true
 

--- a/editor_view_test.go
+++ b/editor_view_test.go
@@ -1358,6 +1358,7 @@ func TestEditorView_Indexer_EditInterference(t *testing.T) {
 	defer ev.Close()
 	ev.asyncBuf = buf
 	ev.file = f
+	ev.CursorPos = 1
 
 	// 1. Start indexing
 	ev.StartIndexing()
@@ -1574,6 +1575,145 @@ func TestEditorView_Indexer_NonEditingKeysDoNotCancel(t *testing.T) {
 	}
 	if cancelled {
 		t.Error("F3 key erroneously cancelled the indexer")
+	}
+}
+
+func TestEditorView_IndexerNoOpDeletesDoNotCancel(t *testing.T) {
+	tests := []struct {
+		name string
+		key  uint16
+		pos  int
+	}{
+		{name: "backspace at beginning", key: vtinput.VK_BACK, pos: 0},
+		{name: "delete at end", key: vtinput.VK_DELETE, pos: len("test content")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := NewEditorView(piecetable.New([]byte("test content")), nil, "test.txt")
+			defer ev.Close()
+			ev.CursorPos = tt.pos
+			cancelled := false
+			ev.indexCancel = func() { cancelled = true }
+			initialSession := ev.editSession
+
+			ev.ProcessKey(&vtinput.InputEvent{
+				Type: vtinput.KeyEventType, KeyDown: true,
+				VirtualKeyCode: tt.key,
+			})
+
+			if ev.edited || cancelled || ev.editSession != initialSession {
+				t.Fatalf("no-op edit changed indexer state: edited=%t cancelled=%t session=%d, want %d", ev.edited, cancelled, ev.editSession, initialSession)
+			}
+		})
+	}
+
+	t.Run("zero-width rectangular selection", func(t *testing.T) {
+		ev := NewEditorView(piecetable.New([]byte("test content")), nil, "test.txt")
+		defer ev.Close()
+		ev.rectSelActive = true
+		ev.rectSelStartLine = 0
+		ev.rectSelStartCol = 0
+		ev.CursorLine = 0
+		ev.CursorPos = 0
+		cancelled := false
+		ev.indexCancel = func() { cancelled = true }
+		initialSession := ev.editSession
+
+		ev.DeleteSelection()
+
+		if ev.edited || cancelled || ev.editSession != initialSession {
+			t.Fatalf("empty rectangular selection changed indexer state: edited=%t cancelled=%t session=%d, want %d", ev.edited, cancelled, ev.editSession, initialSession)
+		}
+	})
+
+	t.Run("empty rectangular rows in existing lines", func(t *testing.T) {
+		ev := NewEditorView(piecetable.New([]byte("first\nsecond")), nil, "test.txt")
+		defer ev.Close()
+		cancelled := false
+		ev.indexCancel = func() { cancelled = true }
+		initialSession := ev.editSession
+
+		ev.PasteRectangular("\n", 0)
+
+		if ev.edited || cancelled || ev.editSession != initialSession {
+			t.Fatalf("empty rectangular paste changed indexer state: edited=%t cancelled=%t session=%d, want %d", ev.edited, cancelled, ev.editSession, initialSession)
+		}
+	})
+}
+
+func TestEditorView_BufferMutationsFenceIndexerOnce(t *testing.T) {
+	selectFirstByte := func(ev *EditorView) {
+		ev.selActive = true
+		ev.selAnchorOffset = 0
+		ev.CursorPos = 1
+	}
+
+	tests := []struct {
+		name    string
+		content string
+		prepare func(*EditorView)
+		mutate  func(*EditorView)
+	}{
+		{
+			name:    "bracketed paste",
+			content: "abc",
+			prepare: func(ev *EditorView) {
+				ev.pasting = true
+				ev.pasteBuffer = []rune("X")
+			},
+			mutate: func(ev *EditorView) {
+				ev.ProcessKey(&vtinput.InputEvent{Type: vtinput.PasteEventType})
+			},
+		},
+		{
+			name:    "autocomplete",
+			content: "foo",
+			prepare: func(ev *EditorView) {
+				ev.CursorPos = 3
+				ev.acEnabled = true
+				ev.acPrefix = "foo"
+				ev.acMatches = []string{"foobar"}
+			},
+			mutate: func(ev *EditorView) {
+				ev.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_TAB})
+			},
+		},
+		{name: "insert helper", content: "abc", mutate: func(ev *EditorView) { ev.insertTextAtCursor([]byte("X")) }},
+		{name: "delete spacers", content: "  abc", mutate: func(ev *EditorView) { ev.deleteSpacersForward() }},
+		{name: "rectangular paste", content: "abc", mutate: func(ev *EditorView) { ev.PasteRectangular("X", 0) }},
+		{
+			name:    "paste over selection",
+			content: "abc",
+			prepare: selectFirstByte,
+			mutate:  func(ev *EditorView) { ev.PasteText("X") },
+		},
+		{
+			name:    "delete selection",
+			content: "abc",
+			prepare: selectFirstByte,
+			mutate:  func(ev *EditorView) { ev.DeleteSelection() },
+		},
+		{name: "delete current line", content: "abc", mutate: func(ev *EditorView) { ev.DeleteCurrentLine() }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := NewEditorView(piecetable.New([]byte(tt.content)), nil, "test.txt")
+			defer ev.Close()
+			if tt.prepare != nil {
+				tt.prepare(ev)
+			}
+
+			cancelCount := 0
+			ev.indexCancel = func() { cancelCount++ }
+			initialSession := ev.editSession
+			tt.mutate(ev)
+
+			if !ev.edited || cancelCount != 1 || ev.editSession != initialSession+1 {
+				t.Fatalf("mutation fence: edited=%t, cancels=%d, session=%d; want true, 1, %d", ev.edited, cancelCount, ev.editSession, initialSession+1)
+			}
+		})
 	}
 }
 
@@ -4607,6 +4747,7 @@ func TestEditorView_Indexer_SessionFencing(t *testing.T) {
 	pt := piecetable.New([]byte("line1\nline2"))
 	ev := NewEditorView(pt, nil, "fencing.txt")
 	defer ev.Close()
+	ev.CursorPos = 1
 
 	// 1. Запоминаем текущую сессию
 	initialSession := ev.editSession

--- a/updater_test.go
+++ b/updater_test.go
@@ -6,6 +6,8 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +21,43 @@ import (
 	"github.com/unxed/sevenzip"
 	"github.com/unxed/vtui"
 )
+
+type memoryWriteSeeker struct {
+	data []byte
+	off  int64
+}
+
+func (w *memoryWriteSeeker) Write(p []byte) (int, error) {
+	end := w.off + int64(len(p))
+	if w.off < 0 || end < w.off {
+		return 0, errors.New("invalid memory write offset")
+	}
+	if end > int64(len(w.data)) {
+		w.data = append(w.data, make([]byte, end-int64(len(w.data)))...)
+	}
+	copy(w.data[w.off:end], p)
+	w.off = end
+	return len(p), nil
+}
+
+func (w *memoryWriteSeeker) Seek(offset int64, whence int) (int64, error) {
+	var base int64
+	switch whence {
+	case io.SeekStart:
+	case io.SeekCurrent:
+		base = w.off
+	case io.SeekEnd:
+		base = int64(len(w.data))
+	default:
+		return 0, errors.New("invalid seek origin")
+	}
+	next := base + offset
+	if next < 0 {
+		return 0, errors.New("negative seek offset")
+	}
+	w.off = next
+	return next, nil
+}
 
 func TestUpdater_ShouldCheck(t *testing.T) {
 	oldCfg := AppConfig
@@ -176,12 +215,8 @@ func TestUpdater_Extractors(t *testing.T) {
 		t.Errorf("TarGz extraction mismatch")
 	}
 
-	sevenPath := filepath.Join(t.TempDir(), "fixture.7z")
-	sevenFile, err := os.Create(sevenPath)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sw, err := sevenzip.NewWriter(sevenFile)
+	var sevenBuf memoryWriteSeeker
+	sw, err := sevenzip.NewWriter(&sevenBuf)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -206,12 +241,7 @@ func TestUpdater_Extractors(t *testing.T) {
 	if err := sw.Close(); err != nil {
 		t.Fatal(err)
 	}
-	defer sevenFile.Close()
-
-	sevenData, err := os.ReadFile(sevenPath)
-	if err != nil {
-		t.Fatal(err)
-	}
+	sevenData := append([]byte(nil), sevenBuf.data...)
 	dest7z := t.TempDir()
 	err = extract7zToDir(sevenData, dest7z)
 	if err != nil {
@@ -226,7 +256,6 @@ func TestUpdater_Extractors(t *testing.T) {
 		t.Error("7z Zip Slip vulnerability detected (absolute path extracted)!")
 	}
 	runtime.KeepAlive(sw)
-	runtime.KeepAlive(sevenFile)
 }
 
 func TestUpdater_GetCurrentVersion(t *testing.T) {


### PR DESCRIPTION
## Summary
- fence every real editor buffer mutation so stale background indexing results cannot overwrite edits
- keep no-op Backspace/Delete and empty rectangular operations from cancelling indexing or advancing the edit session
- make the updater 7z fixture fully in-memory to eliminate the intermittent closed-file race seen in CI

## Testing
- `go test . -run '^(TestEditorView_Indexer_(EditInterference|ModifierSafety|SessionFencing|NonEditingKeysDoNotCancel)|TestEditorView_IndexerNoOpDeletesDoNotCancel|TestEditorView_BufferMutationsFenceIndexerOnce|TestUpdater_Extractors)$' -count=100 -timeout=4m`
- `go test . -run '^TestEditorView_' -count=10 -timeout=4m`
- `go test . -run '^TestUpdater_' -count=10 -timeout=4m`
- `go test ./plugins/cloudfox ./plugins/archive -count=1 -timeout=4m`
- `git diff --check`

The earlier CloudFox PR is already merged. This follow-up is based on current `upstream/main` (`6b1a606`).