### PR TITLE
fix-regression: restore panel cursor after navigating restored paths

### DIFF
--- a/workspace_session.go
+++ b/workspace_session.go
@@ -286,9 +286,6 @@ func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, 
 			return
 		}
 	}
-	if restorePaths {
-		left.pendingSelection, right.pendingSelection = state.Left.Cursor, state.Right.Cursor
-	}
 	left.SetViewMode(validSessionViewMode(state.Left.ViewMode))
 	right.SetViewMode(validSessionViewMode(state.Right.ViewMode))
 	left.sortMode, right.sortMode = SortMode(state.Left.SortMode), SortMode(state.Right.SortMode)
@@ -306,6 +303,7 @@ func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, 
 	if restorePaths {
 		navigate(left, state.Left.Path)
 		navigate(right, state.Right.Path)
+		left.pendingSelection, right.pendingSelection = state.Left.Cursor, state.Right.Cursor
 	}
 
 	pf.activeIdx = state.ActivePanel


### PR DESCRIPTION
Поломка внесена коммитом 0258e69e — «feat: add persistent workspace tab bar».

Автор: Alexander Skakov <zoinen@gmail.com>
Дата: 10 августа 2026, 23:40:26 +0300

Причина: до этого коммита восстановление делалось в main.go напрямую — сначала NavigateToPath, и только после него 
lp.pendingSelection = LastLeftCursor. Новый applyWorkspaceSession ставит pendingSelection до NavigateToPath, а тот 
перезаписывает его на ".." (panels_frame.go:4092, 4118, 4220), поэтому курсор всегда попадает на верхний элемент. 

сейчас логика:
LoadSession() → loadWorkspaceSessions() (workspace_session.go:169) читает секции [Workspaces], [Workspace/N], 
[Workspace/N/Left], [Workspace/N/Right] в LastWorkspaceSessions. 

SetupUI() (main.go:430) → workspaceSessionsForRestore(...) выбирает: при RestoreWorkspaceTabs — все вкладки, иначе — 
только активную. 

applyWorkspaceSession(panels, states[0], ...) навигирует на Folder и после фикса восстанавливает CurFile в 
pendingSelection. 
Секции [Panel/Left] / [Panel/Right] (LastLeftPath/LastLeftCursor) — это legacy-путь: он используется только как 
fallback, если [Workspaces] в файле нет/пуст: 
