### PR TITLE
feat: Ctrl+Ins copies command line when it is not empty

### DIFF
--- a/action_copyname_parent_test.go
+++ b/action_copyname_parent_test.go
@@ -65,6 +65,25 @@ func TestAction_PanelCopyName_CursorOnFile(t *testing.T) {
 	}
 }
 
+func TestAction_PanelCopyName_CopiesCommandLineWhenNotEmpty(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pf := seedPanelForCopyName(t, tmp)
+	fsp := pf.getActivePanel()
+	fsp.SetCursorIndex(1) // "a.txt"
+	pf.cmdLine.Edit.SetText("echo hello world")
+	vtui.SetClipboard("")
+
+	if !RunAction("Panel.CopyName") {
+		t.Fatal("Panel.CopyName did not run")
+	}
+	if got := waitForCopyNameClipboard(t, "echo hello world"); got != "echo hello world" {
+		t.Errorf("clipboard = %q, want %q", got, "echo hello world")
+	}
+}
+
 func TestAction_PanelCopyPath_CursorOnFile(t *testing.T) {
 	tmp := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {

--- a/action_registry.go
+++ b/action_registry.go
@@ -803,9 +803,13 @@ func init() {
 		LabelKey:    "Action.Panel.CopyName",
 		Description: "Copy the current file name to clipboard",
 		DescKey:     "Action.Panel.CopyName.Desc",
-		DefaultKeys: []string{"CtrlIns:EmptyCommandLine"},
+		DefaultKeys: []string{"CtrlIns"},
 		MenuPath:    "Commands",
 		Handler: withPF(func(pf *PanelsFrame) {
+			if !pf.cmdLine.IsEmpty() {
+				vtui.SetClipboard(pf.cmdLine.Edit.GetText())
+				return
+			}
 			if fsp := pf.getActivePanel(); fsp != nil {
 				idx := fsp.GetCursorIndex()
 				if idx < 0 || idx >= len(fsp.entries) {


### PR DESCRIPTION
The new feature matches the behavior of FAR3!

Previously Ctrl+Ins was bound to Panel.CopyName only when the command
line was empty (CtrlIns:EmptyCommandLine), so with a non-empty command
the key did nothing. Now Ctrl+Ins copies the command line text to the
clipboard when present, and falls back to the current file name when
empty.

## Problem

`Ctrl+Ins` copied the current file name only while the command line was
empty (binding `CtrlIns:EmptyCommandLine`). With a non-empty command
line the key was effectively dead — nothing was copied.

## Change

Bind `Ctrl+Ins` unconditionally to `Panel.CopyName` and branch inside
the handler:

- command line not empty → copy the command line text to the clipboard;
- command line empty → copy the current file name (previous behavior).

The command-line branch returns before the panel lookup, so the file
under the cursor is never touched when a command is present.

## Verification

- `TestAction_PanelCopyName_CopiesCommandLineWhenNotEmpty` (new) passes
- `TestAction_PanelCopyName_CursorOnFile` / `_CursorOnParentUsesCurrentFolderName` pass
- `go build ./...` clean