### PR TITLE
Fix command palette CI regressions

### DIFF
--- a/command_palette.go
+++ b/command_palette.go
@@ -250,10 +250,13 @@ func commandPaletteActionShortcuts(area, actionName string) []string {
 	for _, bindingArea := range areas {
 		for key, binding := range active[bindingArea] {
 			name, condition, _ := strings.Cut(binding, ":")
+			if !strings.EqualFold(name, actionName) {
+				continue
+			}
 			if condition != "" && !commandPaletteConditionTrue(condition) {
 				continue
 			}
-			if strings.EqualFold(name, actionName) && !seen[key] {
+			if !seen[key] {
 				seen[key] = true
 				keys = append(keys, FormatKeyForUI(key))
 			}

--- a/command_palette_test.go
+++ b/command_palette_test.go
@@ -100,6 +100,31 @@ func TestCommandPaletteActionShortcutsAreDeterministic(t *testing.T) {
 	}
 }
 
+func TestCommandPaletteActionShortcutsIgnoreUnrelatedConditions(t *testing.T) {
+	const unrelatedCondition = "commandpaletteunrelatedpanic"
+	conditionRegistry[unrelatedCondition] = func() bool {
+		panic("an unrelated shortcut condition was evaluated")
+	}
+	t.Cleanup(func() { delete(conditionRegistry, unrelatedCondition) })
+
+	previous := GlobalHotkeysMgr
+	GlobalHotkeysMgr = &HotkeyManager{
+		Defaults: map[string]map[string]string{},
+		Bindings: map[string]map[string]string{
+			"Shell": {
+				"CtrlP": "Test.PaletteAction",
+				"Esc":   "Other.Action:" + unrelatedCondition,
+			},
+		},
+	}
+	t.Cleanup(func() { GlobalHotkeysMgr = previous })
+
+	want := []string{"Ctrl+P"}
+	if got := commandPaletteActionShortcuts("Shell", "test.paletteaction"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("shortcuts = %v, want %v", got, want)
+	}
+}
+
 func TestCommandPaletteIncludesBothPluginLocationsAndReResolves(t *testing.T) {
 	api := &coreAPI{}
 	runs := 0

--- a/editor_view.go
+++ b/editor_view.go
@@ -2877,7 +2877,7 @@ func (ev *EditorView) showSearchDialog() {
 		chkRegexp.State = 1
 	}
 
-	chkHex := vtui.NewCheckbox(0, 0, "He&x pattern", false)
+	chkHex := vtui.NewCheckbox(0, 0, Msg("Search.HexPattern"), false)
 	if LastEditorSearchHex {
 		chkHex.State = 1
 	}
@@ -3182,7 +3182,7 @@ func (ev *EditorView) showReplaceDialog() {
 		chkRegexp.State = 1
 	}
 
-	chkHex := vtui.NewCheckbox(0, 0, "He&x pattern", false)
+	chkHex := vtui.NewCheckbox(0, 0, Msg("Search.HexPattern"), false)
 	if LastEditorSearchHex {
 		chkHex.State = 1
 	}

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -41,6 +41,9 @@ var conditionRegistry = map[string]func() bool{
 			if pf.showPanels {
 				return true
 			}
+			if pf.termView == nil {
+				return false
+			}
 			return !pf.termView.UseAltScreen && !pf.isPtyBusy()
 		}
 		return false
@@ -49,7 +52,7 @@ var conditionRegistry = map[string]func() bool{
 	// application (mc, htop) instead of triggering f4's own actions.
 	"noaltscreenapp": func() bool {
 		if pf := findPanelsFrameAnyScreen(); pf != nil {
-			return pf.showPanels || !pf.termView.UseAltScreen
+			return pf.showPanels || (pf.termView != nil && !pf.termView.UseAltScreen)
 		}
 		return false
 	},
@@ -61,7 +64,7 @@ var conditionRegistry = map[string]func() bool{
 	// way, which keeps the Shell binding of such a key unconditional.
 	"noterminalapp": func() bool {
 		if pf := findPanelsFrameAnyScreen(); pf != nil {
-			return pf.showPanels || (!pf.termView.UseAltScreen && !pf.isPtyBusy())
+			return pf.showPanels || (pf.termView != nil && !pf.termView.UseAltScreen && !pf.isPtyBusy())
 		}
 		return false
 	},
@@ -70,7 +73,7 @@ var conditionRegistry = map[string]func() bool{
 	// being forwarded to the running application.
 	"terminalquiet": func() bool {
 		if pf := findPanelsFrameAnyScreen(); pf != nil {
-			return !pf.termView.UseAltScreen && !pf.isPtyBusy()
+			return pf.termView != nil && !pf.termView.UseAltScreen && !pf.isPtyBusy()
 		}
 		return false
 	},

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -1044,6 +1044,7 @@ Permissions.BtnClose=&Close
 Search.Prompt=Search for:
 Search.WholeWords=Whole words
 Search.Regex=Regular expressions
+Search.HexPattern=He&x pattern
 Search.BtnFind=&Find
 Search.BtnAll=&All
 Search.Searching= Searching...

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -1040,6 +1040,7 @@ Permissions.BtnClose=&Закрыть
 Search.Prompt=Искать:
 Search.WholeWords=Только целые слова
 Search.Regex=Регулярные выражения
+Search.HexPattern=&Шестнадцатеричный шаблон
 Search.BtnFind=&Найти
 Search.BtnAll=&Все
 Search.Searching= Поиск...

--- a/static_direct_actions_test.go
+++ b/static_direct_actions_test.go
@@ -228,10 +228,13 @@ func TestFixedSideMenuKeepsActivePanelShortcutHints(t *testing.T) {
 func TestFixedSidePaletteEntriesUseLocalizedSideCategories(t *testing.T) {
 	oldScreens := vtui.FrameManager.Screens
 	oldActive := vtui.FrameManager.ActiveIdx
+	oldHotkeys := GlobalHotkeysMgr
 	defer func() {
 		vtui.FrameManager.Screens = oldScreens
 		vtui.FrameManager.ActiveIdx = oldActive
+		GlobalHotkeysMgr = oldHotkeys
 	}()
+	GlobalHotkeysMgr = NewHotkeyManager("")
 
 	pf := &PanelsFrame{cmdLine: NewCommandLine(""), panels: [2]Panel{&FileSystemPanel{}, &FileSystemPanel{}}}
 	vtui.FrameManager.Screens = []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}


### PR DESCRIPTION
Follow-up to #469, which was merged while its native test jobs were still finishing.

Fixes both failures reported by the Linux-native test suite:
- evaluate shortcut conditions only for the requested action and make terminal conditions safe for partially constructed panel frames;
- localize the two Hex Pattern checkbox captions instead of hard-coding them.

Adds deterministic regressions for the shortcut condition ordering and the full-catalog minimal-frame case.

Local verification:
- exact failing tests pass;
- language/hardcode tests pass;
- compile-only `go test ./... -run '^$'` passes.