### PR TITLE
Add built-in pure-Go MediaInfo plugin

### DIFF
--- a/command_palette_coverage_test.go
+++ b/command_palette_coverage_test.go
@@ -117,6 +117,12 @@ var commandPaletteProcessKeyAudit = map[string]commandPaletteSurfaceAudit{
 	"plugins/envman/manager_frame.go:(*managerWindow).ProcessKey": {
 		class: paletteAuditPluginLocal, rationale: "Environment Manager owns these keys inside its plugin window, reached through its rich command",
 	},
+	"plugins/mediainfo/dialog.go:(*reportWindow).ProcessKey": {
+		class: paletteAuditPluginLocal, rationale: "MediaInfo owns its F4 editor handoff while the modal report window is open",
+	},
+	"plugins/mediainfo/report_view.go:(*reportTextView).ProcessKey": {
+		class: paletteAuditPluginLocal, rationale: "the MediaInfo report view consumes scrolling and navigation keys as an embedded dialog control",
+	},
 	"plugins/netfox/dialog.go:(*protoUIContainer).ProcessKey": {
 		class: paletteAuditPluginLocal, rationale: "NetFox protocol controls consume keys inside the connection dialog",
 	},

--- a/plugins.go
+++ b/plugins.go
@@ -12,6 +12,7 @@ import (
 	"github.com/unxed/f4/plugins/envman"
 	"github.com/unxed/f4/plugins/id3editor"
 	iosfs "github.com/unxed/f4/plugins/ios"
+	"github.com/unxed/f4/plugins/mediainfo"
 	"github.com/unxed/f4/plugins/netfox"
 	"github.com/unxed/f4/plugins/visren"
 	"github.com/unxed/f4/vfs"
@@ -184,6 +185,7 @@ func (pm *PluginManager) loadInternal() {
 		&visren.Plugin{},
 		&id3editor.ID3EditorPlugin{},
 		envman.NewPlugin(GetF4ConfigDir()),
+		mediainfo.NewPlugin(GetF4ConfigDir()),
 	}
 
 	for _, p := range plugins {

--- a/plugins/mediainfo/README.md
+++ b/plugins/mediainfo/README.md
@@ -1,0 +1,65 @@
+# MediaInfo plugin
+
+This package implements f4's built-in, metadata-oriented MediaInfo plugin in
+pure Go. It reads through `vfs.VFS`, so local and remote-panel files follow the
+same path and no temporary OS copy or native MediaInfo library is required.
+
+## Entry points
+
+- **F11 → Media information** analyzes the item under the active-panel cursor
+  and opens a resizable report window.
+- **Ctrl+Q** invokes the registered fast Quick View provider for supported
+  audio/video containers. Images and text subtitles retain f4's native preview
+  precedence.
+- **`MediaInfo:path`** analyzes an absolute or active-VFS-relative path. The
+  prefix is configurable and an empty prefix disables it.
+- **F4** in a report opens a collision-safe, unsaved
+  `<name>.MediaInfo.txt` buffer in the editor. On a VFS that cannot guarantee
+  an atomic no-replace rename, the first save fails safely instead of risking
+  an overwrite; the report remains in the editor so its content can be copied.
+- **`Plugin.Call("f4.mediainfo", ...)`** exposes the Far-compatible macro
+  result `(ok, count, keys, values)`. The original plugin GUID
+  `919C1FC6-A571-4642-99DF-BDACE840ED18` is also accepted.
+
+Configuration is stored at `<f4-config>/plugins/mediainfo.json`. It controls
+menu visibility, Quick View, editor-first reports, command prefix, English or
+Russian report labels, and a custom Inform template.
+
+## Backend coverage
+
+The analyzer currently covers:
+
+- MP4/MOV/M4A/3GP/3G2 and fragmented ISO base media;
+- Matroska and WebM;
+- AVI, WAVE, RF64/BW64, and AIFF/AIFC;
+- MPEG audio/MP3, FLAC, and Ogg Vorbis/Opus/FLAC/Theora;
+- JPEG, PNG/APNG, GIF, BMP, TIFF and common TIFF-based RAW files, WebP,
+  HEIF/HEIC, and AVIF;
+- SRT, WebVTT, ASS/SSA, TTML, MicroDVD, and binary EBU STL subtitles.
+
+The parser is deliberately bounded by context, read, operation, element,
+stream, tag, chapter, value, cache-weight, and rendered-output limits. Fast
+mode has smaller limits for interactive Quick View; detailed mode trades more
+I/O for richer reports. Unsupported or partially decoded metadata is reported
+without turning the package into a media decoder.
+
+Transport streams and disc structures, FLV, ASF/WMV/WMA, RealMedia,
+MXF/GXF/LXF, DCP/IMF, VobSub, and PGS are outside the first implementation.
+BigTIFF, exact HEIF primary-item association, and multiplexed or chained Ogg
+are also not fully decoded.
+
+## Templates and macros
+
+The Inform subset supports `Section;template`, `%Field%`, optional `[ ... ]`
+groups, `\n`/`\r`/`\t`, and `Section_Begin`, `Section_Middle`, and
+`Section_End`. A Go `text/template` is selected when the source contains
+`{{`. Template source and generated output are bounded during execution.
+
+Macro arguments follow the original plugin conventions: booleans or integers
+select technical versus image fields, `{Key,Key}` is an exact key filter, and
+the last non-empty string is the requested path. Nested string slices are
+accepted as an additional exact-filter form. Keys are canonical English IDs;
+order and duplicate pairs are preserved.
+
+Run `go test ./plugins/mediainfo` and `go vet ./plugins/mediainfo` for the
+focused backend and integration checks.

--- a/plugins/mediainfo/analyzer.go
+++ b/plugins/mediainfo/analyzer.go
@@ -1,0 +1,109 @@
+package mediainfo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+type parserFunc func(*probe, []byte) error
+
+// Analyze probes src and returns a normalized report. A non-nil partial report
+// is returned only for non-fatal resource limits; cancellation always wins.
+func Analyze(ctx context.Context, src Source, opts Options) (report Report, err error) {
+	p, err := newProbe(ctx, src, opts)
+	if err != nil {
+		return Report{}, err
+	}
+	defer func() {
+		if v := recover(); v != nil {
+			report = Report{}
+			err = &ParseError{Format: p.report.General.Format, Offset: -1, Err: fmt.Errorf("parser panic: %v", v)}
+		}
+	}()
+
+	headLen := int64(64 << 10)
+	if src.Size < headLen {
+		headLen = src.Size
+	}
+	head, err := p.readAt(0, int(headLen))
+	if err != nil && !errors.Is(err, ErrLimit) {
+		return Report{}, err
+	}
+	parser := chooseParser(src.Name, head)
+	if parser == nil {
+		return Report{}, ErrUnsupported
+	}
+	if err := parser(p, head); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return Report{}, err
+		}
+		if errors.Is(err, ErrLimit) {
+			p.report.Truncated = true
+			p.warn("limit", "metadata scan stopped at the configured resource limit", -1)
+			return p.report, nil
+		}
+		return Report{}, err
+	}
+	// Some optional metadata walkers intentionally stop on a failed read and
+	// retain the already decoded primary stream. Cancellation must never be
+	// mistaken for that best-effort behavior.
+	if err := p.ctx.Err(); err != nil {
+		return Report{}, err
+	}
+	if p.report.General.Duration > 0 && p.report.General.FileSize > 0 && p.report.General.OverallBitRate == 0 {
+		p.report.General.OverallBitRate = int64(float64(p.report.General.FileSize*8) / p.report.General.Duration.Seconds())
+		p.report.General.OverallBitRateEstimated = true
+	}
+	return p.report, nil
+}
+
+func chooseParser(name string, h []byte) parserFunc {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".stl" {
+		return parseEBUSTL
+	}
+	if len(h) >= 12 {
+		if bytes.Equal(h[:4], []byte("RIFF")) && bytes.Equal(h[8:12], []byte("WEBP")) {
+			return parseImage
+		}
+		if bytes.Equal(h[:4], []byte("RIFF")) || bytes.Equal(h[:4], []byte("RIFX")) || bytes.Equal(h[:4], []byte("RF64")) || bytes.Equal(h[:4], []byte("BW64")) {
+			return parseRIFF
+		}
+		if bytes.Equal(h[:4], []byte("FORM")) && (bytes.Equal(h[8:12], []byte("AIFF")) || bytes.Equal(h[8:12], []byte("AIFC"))) {
+			return parseAIFF
+		}
+		if bytes.Equal(h[4:8], []byte("ftyp")) && isHEIFSource(name, h) {
+			return parseHEIF
+		}
+		if bytes.Equal(h[4:8], []byte("ftyp")) || bytes.Equal(h[4:8], []byte("styp")) || bytes.Equal(h[4:8], []byte("moov")) || bytes.Equal(h[4:8], []byte("moof")) {
+			return parseISOBaseMedia
+		}
+	}
+	if len(h) >= 4 {
+		switch {
+		case bytes.Equal(h[:4], []byte{0x1a, 0x45, 0xdf, 0xa3}):
+			return parseMatroska
+		case bytes.Equal(h[:4], []byte("fLaC")):
+			return parseFLAC
+		case bytes.Equal(h[:4], []byte("OggS")):
+			return parseOgg
+		}
+	}
+	if isTIFFMagic(h) {
+		return parseTIFFImage
+	}
+	if isImageMagic(h) {
+		return parseImage
+	}
+	if looksLikeMPEGAudio(h) || (len(h) >= 3 && bytes.Equal(h[:3], []byte("ID3"))) {
+		return parseMPEGAudio
+	}
+	if isSubtitleExtension(ext) && looksLikeText(h) {
+		return parseSubtitle
+	}
+	return nil
+}

--- a/plugins/mediainfo/backend_test.go
+++ b/plugins/mediainfo/backend_test.go
@@ -1,0 +1,346 @@
+package mediainfo
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"math"
+	"strings"
+	"testing"
+	"time"
+)
+
+type memorySource []byte
+
+func (m memorySource) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if off < 0 || off >= int64(len(m)) {
+		return 0, io.EOF
+	}
+	n := copy(p, m[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func analyzeBytes(t *testing.T, name string, b []byte, mode Mode) (Report, error) {
+	t.Helper()
+	return Analyze(context.Background(), Source{Name: name, Size: int64(len(b)), Reader: memorySource(b)}, DefaultOptions(mode))
+}
+
+func TestAnalyzeWave(t *testing.T) {
+	b := make([]byte, 12+8+16+8+8000)
+	copy(b[:4], "RIFF")
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	copy(b[8:12], "WAVE")
+	copy(b[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(b[16:20], 16)
+	binary.LittleEndian.PutUint16(b[20:22], 1)
+	binary.LittleEndian.PutUint16(b[22:24], 1)
+	binary.LittleEndian.PutUint32(b[24:28], 8000)
+	binary.LittleEndian.PutUint32(b[28:32], 8000)
+	binary.LittleEndian.PutUint16(b[32:34], 1)
+	binary.LittleEndian.PutUint16(b[34:36], 8)
+	copy(b[36:40], "data")
+	binary.LittleEndian.PutUint32(b[40:44], 8000)
+	r, e := analyzeBytes(t, "tone.wav", b, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if r.General.Format != "Wave" || len(r.Streams) != 1 {
+		t.Fatalf("unexpected report: %#v", r)
+	}
+	if got := r.Streams[0].Audio.SampleRate; got != 8000 {
+		t.Fatalf("sample rate=%d", got)
+	}
+	if r.General.Duration != time.Second {
+		t.Fatalf("duration=%v", r.General.Duration)
+	}
+}
+
+func TestAnalyzeFLACStreamInfo(t *testing.T) {
+	b := make([]byte, 4+4+34)
+	copy(b, "fLaC")
+	b[4] = 0x80
+	b[7] = 34
+	rate := uint64(48000)
+	channels := uint64(1)
+	bits := uint64(23)
+	samples := uint64(96000)
+	v := rate<<44 | channels<<41 | bits<<36 | samples
+	binary.BigEndian.PutUint64(b[18:26], v)
+	r, e := analyzeBytes(t, "tone.flac", b, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	s := r.Streams[0]
+	if s.Audio.SampleRate != 48000 || s.Audio.Channels != 2 || s.Audio.BitDepth != 24 {
+		t.Fatalf("bad stream: %#v", s)
+	}
+	if s.Duration != 2*time.Second {
+		t.Fatalf("duration=%v", s.Duration)
+	}
+}
+
+func TestAnalyzeMPEGAudio(t *testing.T) {
+	frame := make([]byte, 417)
+	copy(frame, []byte{0xff, 0xfb, 0x90, 0x00})
+	data := append(append([]byte(nil), frame...), frame...)
+	r, e := analyzeBytes(t, "tone.mp3", data, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	s := r.Streams[0]
+	if s.Audio.SampleRate != 44100 || s.Audio.Channels != 2 || s.BitRate != 128000 {
+		t.Fatalf("bad MP3 stream: %#v", s)
+	}
+}
+
+func oggPage(serial uint32, granule uint64, seq uint32, payload []byte) []byte {
+	segments := (len(payload) + 254) / 255
+	if len(payload) == 0 {
+		segments = 0
+	}
+	b := make([]byte, 27+segments+len(payload))
+	copy(b, "OggS")
+	b[4] = 0
+	binary.LittleEndian.PutUint64(b[6:14], granule)
+	binary.LittleEndian.PutUint32(b[14:18], serial)
+	binary.LittleEndian.PutUint32(b[18:22], seq)
+	b[26] = byte(segments)
+	left := len(payload)
+	for i := 0; i < segments; i++ {
+		n := left
+		if n > 255 {
+			n = 255
+		}
+		b[27+i] = byte(n)
+		left -= n
+	}
+	copy(b[27+segments:], payload)
+	return b
+}
+func TestAnalyzeOggOpus(t *testing.T) {
+	head := make([]byte, 19)
+	copy(head, "OpusHead")
+	head[8] = 1
+	head[9] = 2
+	binary.LittleEndian.PutUint16(head[10:12], 312)
+	comments := make([]byte, 8)
+	binary.LittleEndian.PutUint32(comments[:4], 0)
+	binary.LittleEndian.PutUint32(comments[4:8], 0)
+	tags := append([]byte("OpusTags"), comments...)
+	data := append(oggPage(7, 0, 0, head), oggPage(7, 0, 1, tags)...)
+	data = append(data, oggPage(7, 48000, 2, nil)...)
+	r, e := analyzeBytes(t, "tone.ogg", data, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	s := r.Streams[0]
+	if s.Format != "Opus" || s.Audio.SampleRate != 48000 || s.Duration != time.Second {
+		t.Fatalf("bad Ogg stream: %#v", s)
+	}
+}
+
+func TestAnalyzeSubRip(t *testing.T) {
+	b := []byte("1\r\n00:00:01,000 --> 00:00:02,500\r\nHello\r\n\r\n2\r\n00:00:03,000 --> 00:00:04,000\r\nWorld\r\n")
+	r, e := analyzeBytes(t, "captions.srt", b, ModeDetailed)
+	if e != nil {
+		t.Fatal(e)
+	}
+	text := r.Streams[0].Text
+	if text.CueCount != 2 || text.FirstCue != time.Second || text.LastCue != 4*time.Second {
+		t.Fatalf("bad text report: %#v", text)
+	}
+}
+
+func TestAnalyzePNG(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 3, 2))
+	img.Set(1, 1, color.NRGBA{R: 255, A: 255})
+	var b bytes.Buffer
+	if e := png.Encode(&b, img); e != nil {
+		t.Fatal(e)
+	}
+	r, e := analyzeBytes(t, "image.png", b.Bytes(), ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if r.Streams[0].Image.Width != 3 || r.Streams[0].Image.Height != 2 {
+		t.Fatalf("bad image: %#v", r.Streams[0].Image)
+	}
+}
+
+func TestAnalyzeMinimalMP4(t *testing.T) {
+	box := func(typ string, payload []byte) []byte {
+		x := make([]byte, 8+len(payload))
+		binary.BigEndian.PutUint32(x[:4], uint32(len(x)))
+		copy(x[4:8], typ)
+		copy(x[8:], payload)
+		return x
+	}
+	ftypPayload := append([]byte("isom\x00\x00\x00\x00"), []byte("isommp42")...)
+	ftyp := box("ftyp", ftypPayload)
+	mvhd := make([]byte, 20)
+	binary.BigEndian.PutUint32(mvhd[12:16], 1000)
+	binary.BigEndian.PutUint32(mvhd[16:20], 2500)
+	moov := box("moov", box("mvhd", mvhd))
+	data := append(ftyp, moov...)
+	r, e := analyzeBytes(t, "clip.mp4", data, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if r.General.Format != "MPEG-4" || r.General.Duration != 2500*time.Millisecond {
+		t.Fatalf("bad MP4 report: %#v", r.General)
+	}
+}
+
+func ebmlSize(n int) []byte {
+	if n < 127 {
+		return []byte{0x80 | byte(n)}
+	}
+	return []byte{0x40 | byte(n>>8), byte(n)}
+}
+func ebmlElement(id, payload []byte) []byte {
+	b := append(append([]byte(nil), id...), ebmlSize(len(payload))...)
+	return append(b, payload...)
+}
+func TestAnalyzeMatroska(t *testing.T) {
+	doc := ebmlElement([]byte{0x42, 0x82}, []byte("matroska"))
+	header := ebmlElement([]byte{0x1a, 0x45, 0xdf, 0xa3}, doc)
+	scale := ebmlElement([]byte{0x2a, 0xd7, 0xb1}, []byte{0x0f, 0x42, 0x40})
+	dur := make([]byte, 8)
+	binary.BigEndian.PutUint64(dur, math.Float64bits(2000))
+	info := ebmlElement([]byte{0x15, 0x49, 0xa9, 0x66}, append(scale, ebmlElement([]byte{0x44, 0x89}, dur)...))
+	typ := ebmlElement([]byte{0x83}, []byte{2})
+	codec := ebmlElement([]byte{0x86}, []byte("A_OPUS"))
+	rate := make([]byte, 8)
+	binary.BigEndian.PutUint64(rate, math.Float64bits(48000))
+	audio := ebmlElement([]byte{0xe1}, append(ebmlElement([]byte{0xb5}, rate), ebmlElement([]byte{0x9f}, []byte{2})...))
+	entry := ebmlElement([]byte{0xae}, append(append(typ, codec...), audio...))
+	tracks := ebmlElement([]byte{0x16, 0x54, 0xae, 0x6b}, entry)
+	segment := ebmlElement([]byte{0x18, 0x53, 0x80, 0x67}, append(info, tracks...))
+	data := append(header, segment...)
+	r, e := analyzeBytes(t, "clip.mkv", data, ModeFast)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if r.General.Duration != 2*time.Second || len(r.Streams) != 1 || r.Streams[0].Format != "Opus" {
+		t.Fatalf("bad Matroska report: %#v", r)
+	}
+}
+
+func TestAnalyzeMalformedRIFF(t *testing.T) {
+	b := []byte("RIFF\xff\xff\xff\x7fWAVEfmt \xff\xff\xff\x7f")
+	_, e := analyzeBytes(t, "bad.wav", b, ModeFast)
+	var pe *ParseError
+	if !errors.As(e, &pe) {
+		t.Fatalf("expected ParseError, got %v", e)
+	}
+}
+
+func TestAnalyzeHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, e := Analyze(ctx, Source{Name: "x.wav", Size: 12, Reader: memorySource(make([]byte, 12))}, DefaultOptions(ModeFast))
+	if !errors.Is(e, context.Canceled) {
+		t.Fatalf("error=%v", e)
+	}
+}
+
+func TestAnalyzeNilContextUsesBackground(t *testing.T) {
+	data := []byte("RIFF\x04\x00\x00\x00WAVE")
+	if _, err := Analyze(nil, Source{Name: "nil-context.wav", Size: int64(len(data)), Reader: memorySource(data)}, DefaultOptions(ModeFast)); err != nil {
+		t.Fatalf("Analyze(nil) = %v", err)
+	}
+}
+
+func TestAnalyzeReadLimitReturnsPartial(t *testing.T) {
+	b := make([]byte, 12+8+16)
+	copy(b[:4], "RIFF")
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	copy(b[8:12], "WAVE")
+	copy(b[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(b[16:20], 16)
+	opts := DefaultOptions(ModeFast)
+	opts.MaxReadBytes = 14
+	r, e := Analyze(context.Background(), Source{Name: "x.wav", Size: int64(len(b)), Reader: memorySource(b)}, opts)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if !r.Truncated {
+		t.Fatal("expected a partial report")
+	}
+}
+
+func TestRenderAndTemplate(t *testing.T) {
+	r := Report{General: General{FileName: "a.flac", FileSize: 1024, Format: "FLAC", Duration: time.Second}, Streams: []Stream{{ID: "1", Kind: StreamAudio, Format: "FLAC", Audio: &Audio{Channels: 2, SampleRate: 48000}}}, Tags: []Field{{Name: "Artist", Value: "First"}, {Name: "Artist", Value: "Second"}}}
+	text := RenderText(r, RenderOptions{})
+	if !strings.Contains(text, "General") || !strings.Contains(text, "Audio #1") {
+		t.Fatalf("rendered text:\n%s", text)
+	}
+	ru := RenderText(r, RenderOptions{Language: "ru"})
+	if !strings.Contains(ru, "Общее") || !strings.Contains(ru, "Имя файла") {
+		t.Fatalf("Russian render:\n%s", ru)
+	}
+	compact := RenderText(r, RenderOptions{Compact: true})
+	if strings.Contains(compact, "File name") || strings.Contains(compact, "Compression mode") {
+		t.Fatalf("compact render contains full-only fields:\n%s", compact)
+	}
+	got, e := ExecuteTemplate(r, "%CompleteName%: %Format%")
+	if e != nil || got != "a.flac: FLAC" {
+		t.Fatalf("template=%q err=%v", got, e)
+	}
+	inform := "General;%Format%[ by %Artist%]\\n\nAudio_Begin;audio:\\n\nAudio;%Format% %Channel_s_%ch\\n\nAudio_End;done\\n"
+	got, e = ExecuteTemplate(r, inform)
+	if e != nil || got != "FLAC by First\naudio:\nFLAC 2ch\ndone\n" {
+		t.Fatalf("Inform=%q err=%v", got, e)
+	}
+	got, e = ExecuteTemplate(r, `{{.General.Format}}/{{len .Streams}}`)
+	if e != nil || got != "FLAC/1" {
+		t.Fatalf("go template=%q err=%v", got, e)
+	}
+	sections := CanonicalSections(r)
+	artists := 0
+	for _, f := range sections[0].Fields {
+		if f.Name == "Artist" {
+			artists++
+		}
+	}
+	if artists != 2 {
+		t.Fatalf("duplicate tags lost: %#v", sections[0].Fields)
+	}
+}
+
+func TestTemplateOutputIsBoundedDuringExecution(t *testing.T) {
+	report := Report{Chapters: make([]Chapter, 3000)}
+	payload := strings.Repeat("x", 1024)
+
+	if _, err := ExecuteTemplate(report, "Menu;"+payload); !errors.Is(err, errTemplateOutputTooLarge) {
+		t.Fatalf("Inform template error = %v, want output limit", err)
+	}
+	if _, err := ExecuteTemplate(report, "{{range .Chapters}}"+payload+"{{end}}"); !errors.Is(err, errTemplateOutputTooLarge) {
+		t.Fatalf("Go template error = %v, want output limit", err)
+	}
+}
+
+func FuzzAnalyzeDoesNotPanic(f *testing.F) {
+	f.Add("sample.bin", []byte("not media"))
+	f.Add("sample.wav", []byte("RIFF\x04\x00\x00\x00WAVE"))
+	f.Fuzz(func(t *testing.T, name string, b []byte) {
+		if len(b) > 1<<20 {
+			t.Skip()
+		}
+		opts := DefaultOptions(ModeFast)
+		opts.MaxReadBytes = 2 << 20
+		opts.MaxReadOps = 10000
+		_, _ = Analyze(context.Background(), Source{Name: name, Size: int64(len(b)), Reader: memorySource(b)}, opts)
+	})
+}

--- a/plugins/mediainfo/cache.go
+++ b/plugins/mediainfo/cache.go
@@ -1,0 +1,295 @@
+package mediainfo
+
+import (
+	"container/list"
+	"fmt"
+	"reflect"
+	"sync"
+	"unsafe"
+
+	"github.com/unxed/f4/vfs"
+)
+
+const (
+	reportCacheCapacity      = 64
+	reportCacheByteCapacity  = 16 << 20
+	backendCacheVersion      = "purego-v1"
+	reportCacheEntryOverhead = 256
+)
+
+type cachedReport struct {
+	key    string
+	report Report
+	weight int64
+}
+
+type reportCache struct {
+	mu        sync.Mutex
+	capacity  int
+	maxBytes  int64
+	usedBytes int64
+	items     map[string]*list.Element
+	lru       *list.List
+}
+
+func newReportCache(capacity int) *reportCache {
+	return newReportCacheWithLimit(capacity, reportCacheByteCapacity)
+}
+
+func newReportCacheWithLimit(capacity int, maxBytes int64) *reportCache {
+	if capacity <= 0 {
+		capacity = reportCacheCapacity
+	}
+	if maxBytes <= 0 {
+		maxBytes = reportCacheByteCapacity
+	}
+	return &reportCache{capacity: capacity, maxBytes: maxBytes, items: make(map[string]*list.Element), lru: list.New()}
+}
+
+func (cache *reportCache) get(key string) (Report, bool) {
+	if cache == nil || key == "" {
+		return Report{}, false
+	}
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	element, ok := cache.items[key]
+	if !ok {
+		return Report{}, false
+	}
+	cache.lru.MoveToFront(element)
+	return element.Value.(cachedReport).report, true
+}
+
+func (cache *reportCache) put(key string, report Report) {
+	if cache == nil || key == "" {
+		return
+	}
+	weight := cachedReportWeight(key, report)
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	if weight > cache.maxBytes {
+		if element, ok := cache.items[key]; ok {
+			cache.removeElement(element)
+		}
+		return
+	}
+	if element, ok := cache.items[key]; ok {
+		old := element.Value.(cachedReport)
+		cache.usedBytes -= old.weight
+		element.Value = cachedReport{key: key, report: report, weight: weight}
+		cache.usedBytes += weight
+		cache.lru.MoveToFront(element)
+	} else {
+		element := cache.lru.PushFront(cachedReport{key: key, report: report, weight: weight})
+		cache.items[key] = element
+		cache.usedBytes += weight
+	}
+	for cache.lru.Len() > cache.capacity || cache.usedBytes > cache.maxBytes {
+		oldest := cache.lru.Back()
+		if oldest == nil {
+			break
+		}
+		cache.removeElement(oldest)
+	}
+}
+
+func (cache *reportCache) removeElement(element *list.Element) {
+	entry := element.Value.(cachedReport)
+	delete(cache.items, entry.key)
+	cache.usedBytes -= entry.weight
+	if cache.usedBytes < 0 {
+		cache.usedBytes = 0
+	}
+	cache.lru.Remove(element)
+}
+
+func (cache *reportCache) clear() {
+	if cache == nil {
+		return
+	}
+	cache.mu.Lock()
+	cache.items = make(map[string]*list.Element)
+	cache.lru.Init()
+	cache.usedBytes = 0
+	cache.mu.Unlock()
+}
+
+// cachedReportWeight deliberately overestimates retained heap payload. The
+// fixed struct headers are counted with unsafe.Sizeof, slice backing arrays are
+// counted by capacity, and all referenced string bytes are counted separately.
+// Saturating arithmetic prevents a hostile synthetic Report from wrapping the
+// admission calculation.
+func cachedReportWeight(key string, report Report) int64 {
+	w := cacheWeight{value: reportCacheEntryOverhead}
+	w.add(int64(unsafe.Sizeof(report)))
+	w.addStringTwice(key) // map key plus cachedReport key, conservatively.
+	addGeneralWeight(&w, report.General)
+	w.addSlice(cap(report.Streams), unsafe.Sizeof(Stream{}))
+	for _, stream := range report.Streams {
+		addStreamWeight(&w, stream)
+	}
+	w.addSlice(cap(report.Chapters), unsafe.Sizeof(Chapter{}))
+	for _, chapter := range report.Chapters {
+		w.addStrings(chapter.ID, chapter.Title, chapter.Language)
+	}
+	addFieldsWeight(&w, report.Tags)
+	w.addSlice(cap(report.Warnings), unsafe.Sizeof(Warning{}))
+	for _, warning := range report.Warnings {
+		w.addStrings(warning.Code, warning.Message)
+	}
+	return w.value
+}
+
+type cacheWeight struct{ value int64 }
+
+const maxCacheWeight = int64(^uint64(0) >> 1)
+
+func (w *cacheWeight) add(value int64) {
+	if value <= 0 || w.value == maxCacheWeight {
+		return
+	}
+	if value > maxCacheWeight-w.value {
+		w.value = maxCacheWeight
+		return
+	}
+	w.value += value
+}
+
+func (w *cacheWeight) addSlice(capacity int, elementSize uintptr) {
+	if capacity <= 0 {
+		return
+	}
+	if elementSize == 0 || uint64(capacity) > uint64(maxCacheWeight)/uint64(elementSize) {
+		w.value = maxCacheWeight
+		return
+	}
+	w.add(int64(uint64(capacity) * uint64(elementSize)))
+}
+
+func (w *cacheWeight) addStrings(values ...string) {
+	for _, value := range values {
+		w.add(int64(len(value)))
+	}
+}
+
+func (w *cacheWeight) addStringTwice(value string) {
+	w.add(int64(len(value)))
+	w.add(int64(len(value)))
+}
+
+func addGeneralWeight(w *cacheWeight, general General) {
+	w.addStrings(general.FileName, general.Format, general.FormatProfile, general.CodecID, general.MIME, general.MuxingApp, general.WritingApp)
+	w.addSlice(cap(general.CompatibleBrands), unsafe.Sizeof(""))
+	for _, brand := range general.CompatibleBrands {
+		w.addStrings(brand)
+	}
+	if general.EncodedDate != nil {
+		w.add(int64(unsafe.Sizeof(*general.EncodedDate)))
+	}
+	if general.TaggedDate != nil {
+		w.add(int64(unsafe.Sizeof(*general.TaggedDate)))
+	}
+	if general.Streamable != nil {
+		w.add(1)
+	}
+}
+
+func addStreamWeight(w *cacheWeight, stream Stream) {
+	w.addStrings(stream.ID, string(stream.Kind), stream.Format, stream.Profile, stream.Level, stream.CodecID, stream.CodecName, stream.Title, stream.Language, stream.BitRateMode)
+	if stream.Default != nil {
+		w.add(1)
+	}
+	if stream.Forced != nil {
+		w.add(1)
+	}
+	if stream.Encrypted != nil {
+		w.add(1)
+	}
+	if stream.Video != nil {
+		w.add(int64(unsafe.Sizeof(*stream.Video)))
+		w.addStrings(stream.Video.ColorSpace, stream.Video.ChromaSubsampling, stream.Video.ScanType, stream.Video.ScanOrder, stream.Video.ColorRange, stream.Video.ColorPrimaries, stream.Video.TransferCharacteristics, stream.Video.MatrixCoefficients, stream.Video.HDRFormat)
+	}
+	if stream.Audio != nil {
+		w.add(int64(unsafe.Sizeof(*stream.Audio)))
+		w.addStrings(stream.Audio.ChannelLayout, stream.Audio.CompressionMode)
+	}
+	if stream.Text != nil {
+		w.add(int64(unsafe.Sizeof(*stream.Text)))
+		w.addStrings(stream.Text.FormatVersion, stream.Text.Encoding)
+	}
+	if stream.Image != nil {
+		w.add(int64(unsafe.Sizeof(*stream.Image)))
+		w.addStrings(stream.Image.ColorModel, stream.Image.Compression, stream.Image.CameraMake, stream.Image.CameraModel, stream.Image.LensModel)
+		if stream.Image.TakenAt != nil {
+			w.add(int64(unsafe.Sizeof(*stream.Image.TakenAt)))
+		}
+		if stream.Image.Latitude != nil {
+			w.add(int64(unsafe.Sizeof(*stream.Image.Latitude)))
+		}
+		if stream.Image.Longitude != nil {
+			w.add(int64(unsafe.Sizeof(*stream.Image.Longitude)))
+		}
+		if stream.Image.GPSAltitude != nil {
+			w.add(int64(unsafe.Sizeof(*stream.Image.GPSAltitude)))
+		}
+		addFieldsWeight(w, stream.Image.EXIF)
+	}
+	addFieldsWeight(w, stream.Tags)
+}
+
+func addFieldsWeight(w *cacheWeight, fields []Field) {
+	w.addSlice(cap(fields), unsafe.Sizeof(Field{}))
+	for _, field := range fields {
+		w.addStrings(field.Target, field.Name, field.Value)
+	}
+}
+
+func reportCacheKey(fs vfs.VFS, path string, item vfs.VFSItem, mode Mode) string {
+	if item.Revision == "" && item.Size == 0 && !item.SizeKnown && item.MTime.IsZero() {
+		return ""
+	}
+	identity := vfsCacheIdentity(fs)
+	if identity == "" {
+		// A value-backed VFS without SessionIdentity has no safe, stable
+		// instance key. Bypass the cache instead of sharing metadata across
+		// unrelated accounts that happen to use the same implementation type.
+		return ""
+	}
+	return fmt.Sprintf("%s|%q|%q|%q|%d|%d|%d|%d",
+		backendCacheVersion, identity, path, item.Revision,
+		item.Size, item.MTime.UnixNano(), boolInt(item.SizeKnown), mode)
+}
+
+func vfsCacheIdentity(fs vfs.VFS) string {
+	if fs == nil {
+		return "<nil>"
+	}
+	if session, ok := fs.(vfs.SessionIdentity); ok {
+		if key := session.SessionKey(); key != nil {
+			value := reflect.ValueOf(key)
+			if !value.Type().Comparable() {
+				return ""
+			}
+			switch value.Kind() {
+			case reflect.Chan, reflect.Pointer, reflect.UnsafePointer:
+				if !value.IsNil() {
+					return fmt.Sprintf("session:%T:%x", key, value.Pointer())
+				}
+			default:
+				return fmt.Sprintf("session:%T:%v", key, key)
+			}
+		}
+	}
+	value := reflect.ValueOf(fs)
+	if value.Kind() == reflect.Pointer && !value.IsNil() {
+		return fmt.Sprintf("instance:%T:%x", fs, value.Pointer())
+	}
+	return ""
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
+}

--- a/plugins/mediainfo/cache_test.go
+++ b/plugins/mediainfo/cache_test.go
@@ -1,0 +1,138 @@
+package mediainfo
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/vfs"
+)
+
+type unkeyedMediaVFS struct {
+	vfs.VFS
+	values []int
+}
+
+func TestReportCacheLRUEviction(t *testing.T) {
+	cache := newReportCache(2)
+	cache.put("one", Report{General: General{Format: "one"}})
+	cache.put("two", Report{General: General{Format: "two"}})
+	if _, ok := cache.get("one"); !ok {
+		t.Fatal("first entry missing")
+	}
+	cache.put("three", Report{General: General{Format: "three"}})
+	if _, ok := cache.get("two"); ok {
+		t.Fatal("least recently used entry was retained")
+	}
+	if report, ok := cache.get("one"); !ok || report.General.Format != "one" {
+		t.Fatal("recently used entry was evicted")
+	}
+}
+
+func TestReportCacheWeightedEviction(t *testing.T) {
+	one := Report{Tags: []Field{{Name: "Title", Value: strings.Repeat("a", 256)}}}
+	two := Report{Tags: []Field{{Name: "Artist", Value: strings.Repeat("b", 256)}}}
+	oneWeight := cachedReportWeight("one", one)
+	twoWeight := cachedReportWeight("two", two)
+	cache := newReportCacheWithLimit(reportCacheCapacity, oneWeight+twoWeight-1)
+
+	cache.put("one", one)
+	cache.put("two", two)
+
+	if _, ok := cache.get("one"); ok {
+		t.Fatal("byte ceiling retained the least recently used entry")
+	}
+	if report, ok := cache.get("two"); !ok || report.Tags[0].Name != "Artist" {
+		t.Fatal("byte ceiling evicted the newest entry")
+	}
+	if cache.usedBytes != twoWeight || cache.usedBytes > cache.maxBytes {
+		t.Fatalf("used bytes = %d, want %d within %d", cache.usedBytes, twoWeight, cache.maxBytes)
+	}
+}
+
+func TestReportCacheRejectsOversizedReplacement(t *testing.T) {
+	small := Report{General: General{Format: "WAVE"}}
+	smallWeight := cachedReportWeight("same", small)
+	cache := newReportCacheWithLimit(reportCacheCapacity, smallWeight+64)
+	cache.put("same", small)
+	if _, ok := cache.get("same"); !ok {
+		t.Fatal("small entry was not admitted")
+	}
+
+	large := Report{General: General{Format: strings.Repeat("x", int(cache.maxBytes)+1)}}
+	cache.put("same", large)
+	if _, ok := cache.get("same"); ok {
+		t.Fatal("oversized replacement left a stale entry cached")
+	}
+	cache.put("other", large)
+	if _, ok := cache.get("other"); ok {
+		t.Fatal("oversized new entry was admitted")
+	}
+	if cache.usedBytes != 0 || cache.lru.Len() != 0 {
+		t.Fatalf("rejected entries retained accounting: bytes=%d entries=%d", cache.usedBytes, cache.lru.Len())
+	}
+}
+
+func TestReportCacheReplacementAndClearAccounting(t *testing.T) {
+	cache := newReportCacheWithLimit(reportCacheCapacity, 1<<20)
+	first := Report{General: General{Format: "FLAC"}}
+	cache.put("item", first)
+	if want := cachedReportWeight("item", first); cache.usedBytes != want {
+		t.Fatalf("initial weight = %d, want %d", cache.usedBytes, want)
+	}
+
+	fields := make([]Field, 1, 32)
+	fields[0] = Field{Name: "Comment", Value: strings.Repeat("v", 512)}
+	replacement := Report{General: General{Format: "FLAC"}, Tags: fields}
+	cache.put("item", replacement)
+	if want := cachedReportWeight("item", replacement); cache.usedBytes != want {
+		t.Fatalf("replacement weight = %d, want %d", cache.usedBytes, want)
+	}
+	if cache.lru.Len() != 1 {
+		t.Fatalf("replacement created %d entries", cache.lru.Len())
+	}
+
+	cache.clear()
+	if cache.usedBytes != 0 || cache.lru.Len() != 0 || len(cache.items) != 0 {
+		t.Fatalf("clear retained accounting: bytes=%d entries=%d items=%d", cache.usedBytes, cache.lru.Len(), len(cache.items))
+	}
+}
+
+func TestCachedReportWeightIncludesSliceCapacityAndStrings(t *testing.T) {
+	baseline := cachedReportWeight("key", Report{})
+	fields := make([]Field, 1, 64)
+	fields[0] = Field{Name: "Comment", Value: strings.Repeat("z", 1024)}
+	weighted := cachedReportWeight("key", Report{Tags: fields})
+	if weighted <= baseline+int64(len(fields[0].Name)+len(fields[0].Value)) {
+		t.Fatalf("weight %d does not include slice backing storage above baseline %d", weighted, baseline)
+	}
+}
+
+func TestReportCacheKeyTracksRevisionAndMode(t *testing.T) {
+	fs := vfs.NewOSVFS(t.TempDir())
+	item := vfs.VFSItem{Name: "movie.mp4", Size: 10, SizeKnown: true, MTime: time.Unix(1, 2), Revision: "a"}
+	fast := reportCacheKey(fs, "movie.mp4", item, ModeFast)
+	item.Revision = "b"
+	revised := reportCacheKey(fs, "movie.mp4", item, ModeFast)
+	detailed := reportCacheKey(fs, "movie.mp4", item, ModeDetailed)
+	if fast == revised {
+		t.Fatal("revision did not change the cache key")
+	}
+	if revised == detailed {
+		t.Fatal("analysis mode did not change the cache key")
+	}
+}
+
+func TestReportCacheBypassesUnkeyedValueVFS(t *testing.T) {
+	fs := unkeyedMediaVFS{values: []int{1}}
+	if key := reportCacheKey(fs, "movie.mp4", vfs.VFSItem{Name: "movie.mp4", SizeKnown: true}, ModeFast); key != "" {
+		t.Fatalf("unsafe cache key = %q", key)
+	}
+}
+
+func TestReportCacheBypassesFilesWithoutRevisionSizeOrTime(t *testing.T) {
+	fs := vfs.NewOSVFS(t.TempDir())
+	if key := reportCacheKey(fs, "unknown.mp4", vfs.VFSItem{Name: "unknown.mp4"}, ModeFast); key != "" {
+		t.Fatalf("unsafe unknown-file cache key = %q", key)
+	}
+}

--- a/plugins/mediainfo/config_dialog.go
+++ b/plugins/mediainfo/config_dialog.go
@@ -1,0 +1,143 @@
+package mediainfo
+
+import (
+	"fmt"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+func (plugin *Plugin) configure(app vfs.App) {
+	settings := plugin.settings()
+	width, height := 76, 17
+	if vtui.FrameManager != nil {
+		if maximum := vtui.FrameManager.GetScreenSize() - 2; maximum > 20 && width > maximum {
+			width = maximum
+		}
+		if maximum := vtui.FrameManager.GetScreenHeight() - 2; maximum > 10 && height > maximum {
+			height = maximum
+		}
+	}
+	dialog := vtui.NewCenteredDialog(width, height, " "+plugin.text("MediaInfo.SettingsTitle", "MediaInfo settings", "Настройки MediaInfo")+" ")
+	dialog.ShowClose = true
+
+	x := dialog.X1 + 2
+	y := dialog.Y1 + 2
+	showMenu := vtui.NewCheckbox(x, y, plugin.text("MediaInfo.ShowMenu", "Show in &Plugins menu", "Показывать в меню &Плагины"), false)
+	showMenu.State = boolInt(settings.ShowInPluginMenu)
+	y++
+	quickView := vtui.NewCheckbox(x, y, plugin.text("MediaInfo.EnableQuick", "Enable &Quick View provider", "Включить провайдер &быстрого просмотра"), false)
+	quickView.State = boolInt(settings.EnableQuickView)
+	y++
+	useEditor := vtui.NewCheckbox(x, y, plugin.text("MediaInfo.UseEditor", "Open detailed reports in the &editor", "Открывать подробные отчёты в &редакторе"), false)
+	useEditor.State = boolInt(settings.UseEditor)
+	y += 2
+
+	labelWidth := 18
+	dialog.AddItem(newMediaInfoDialogLabel(x, y, plugin.text("MediaInfo.Prefix", "Command prefix:", "Префикс команды:")))
+	prefix := vtui.NewEdit(x+labelWidth, y, width-labelWidth-4, settings.Prefix)
+	prefix.SetGrowMode(vtui.GrowHiX)
+	y += 2
+
+	dialog.AddItem(newMediaInfoDialogLabel(x, y, plugin.text("MediaInfo.Language", "Report language:", "Язык отчёта:")))
+	languages := []string{
+		plugin.text("MediaInfo.LanguageAuto", "Automatic", "Автоматически"),
+		plugin.text("MediaInfo.LanguageEnglish", "English", "Английский"),
+		plugin.text("MediaInfo.LanguageRussian", "Russian", "Русский"),
+	}
+	language := vtui.NewComboBox(x+labelWidth, y, width-labelWidth-4, languages)
+	language.DropdownOnly = true
+	selectedLanguage := 0
+	if settings.Language == "en" {
+		selectedLanguage = 1
+	} else if settings.Language == "ru" {
+		selectedLanguage = 2
+	}
+	language.Menu.SetSelectPos(selectedLanguage)
+	language.Edit.SetText(languages[selectedLanguage])
+	language.SetGrowMode(vtui.GrowHiX)
+	y += 2
+
+	dialog.AddItem(newMediaInfoDialogLabel(x, y, plugin.text("MediaInfo.Template", "Inform template:", "Шаблон Inform:")))
+	template := vtui.NewEdit(x+labelWidth, y, width-labelWidth-4, settings.Template)
+	template.SetGrowMode(vtui.GrowHiX)
+	dialog.AddItem(showMenu)
+	dialog.AddItem(quickView)
+	dialog.AddItem(useEditor)
+	dialog.AddItem(prefix)
+	dialog.AddItem(language)
+	dialog.AddItem(template)
+
+	saveButton := vtui.NewButton(0, 0, plugin.text("MediaInfo.Save", "&Save", "&Сохранить"))
+	cancelButton := vtui.NewButton(0, 0, plugin.text("MediaInfo.Cancel", "Cancel", "Отмена"))
+	saveButton.IsDefault = true
+	dialog.AddItem(saveButton)
+	dialog.AddItem(cancelButton)
+	buttons := vtui.NewHBoxLayout(dialog.X1+2, dialog.Y2-1, width-4, 1)
+	buttons.HorizontalAlign = vtui.AlignCenter
+	buttons.Spacing = 2
+	buttons.Add(saveButton, vtui.Margins{}, vtui.AlignTop)
+	buttons.Add(cancelButton, vtui.Margins{}, vtui.AlignTop)
+	buttons.Apply()
+	saveButton.SetGrowMode(vtui.GrowAll)
+	cancelButton.SetGrowMode(vtui.GrowAll)
+
+	showSaveError := func(err error) {
+		vtui.ShowMessageOn(dialog, " "+plugin.text("MediaInfo.SettingsError", "Settings error", "Ошибка настроек")+" ", err.Error(), []string{plugin.text("MediaInfo.OK", "&OK", "&ОК")})
+	}
+	saveButton.OnClick = func() {
+		languageIndex := language.Menu.SelectPos
+		if languageIndex < 0 || languageIndex > 2 {
+			languageIndex = 0
+		}
+		next := Settings{
+			ShowInPluginMenu: showMenu.State == 1,
+			EnableQuickView:  quickView.State == 1,
+			UseEditor:        useEditor.State == 1,
+			Prefix:           prefix.GetText(),
+			Template:         template.GetText(),
+			Language:         []string{"auto", "en", "ru"}[languageIndex],
+		}
+		next = normalizeSettings(next)
+		if err := next.validate(); err != nil {
+			showSaveError(err)
+			return
+		}
+
+		plugin.mu.Lock()
+		prefixRegistration := plugin.prefix
+		store := plugin.store
+		plugin.mu.Unlock()
+		if prefixRegistration == nil || store == nil {
+			showSaveError(fmt.Errorf("MediaInfo is not fully initialized"))
+			return
+		}
+		old := store.snapshot()
+		if err := prefixRegistration.SetPrefix(next.Prefix); err != nil {
+			showSaveError(err)
+			return
+		}
+		if err := store.save(next); err != nil {
+			if rollbackErr := prefixRegistration.SetPrefix(old.Prefix); rollbackErr != nil {
+				plugin.log("MediaInfo prefix rollback failed: %v", rollbackErr)
+			}
+			showSaveError(err)
+			return
+		}
+		dialog.Close()
+	}
+	cancelButton.OnClick = dialog.Close
+	if anchor, ok := app.(vtui.Frame); ok {
+		vtui.FrameManager.PushToFrameScreen(anchor, dialog)
+	} else {
+		vtui.FrameManager.Push(dialog)
+	}
+}
+
+// A zero explicit color tells vtui.Text to resolve ColDialogText and its
+// highlight from the current palette every time it draws. Passing the current
+// palette value here would freeze that snapshot if the user switches themes
+// while the dialog is open.
+func newMediaInfoDialogLabel(x, y int, text string) *vtui.Text {
+	return vtui.NewText(x, y, text, 0)
+}

--- a/plugins/mediainfo/dialog.go
+++ b/plugins/mediainfo/dialog.go
@@ -1,0 +1,104 @@
+package mediainfo
+
+import (
+	"fmt"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+type reportWindow struct {
+	*vtui.Window
+	onEditor func()
+}
+
+func (window *reportWindow) ProcessKey(event *vtinput.InputEvent) bool {
+	if event != nil && event.KeyDown && event.VirtualKeyCode == vtinput.VK_F4 {
+		if window.onEditor != nil {
+			window.onEditor()
+		}
+		return true
+	}
+	return window.Window.ProcessKey(event)
+}
+
+func (plugin *Plugin) showReportDialog(app vfs.App, fs vfs.VFS, sourcePath, editorPath string, report Report, text string, styleFieldNames bool) {
+	width, height := 88, 24
+	minWidth, minHeight := 54, 12
+	if vtui.FrameManager != nil {
+		if maximum := vtui.FrameManager.GetScreenSize() - 2; maximum > 20 && width > maximum {
+			width = maximum
+		}
+		if maximum := vtui.FrameManager.GetScreenHeight() - 2; maximum > 8 && height > maximum {
+			height = maximum
+		}
+	}
+	if minWidth > width {
+		minWidth = width
+	}
+	if minHeight > height {
+		minHeight = height
+	}
+	title := fmt.Sprintf(" %s: %s ", plugin.text("MediaInfo.Title", "MediaInfo", "MediaInfo"), fs.Base(sourcePath))
+	if report.General.Format != "" {
+		title = fmt.Sprintf(" %s: %s [%s] ", plugin.text("MediaInfo.Title", "MediaInfo", "MediaInfo"), fs.Base(sourcePath), report.General.Format)
+	}
+	window := &reportWindow{Window: vtui.NewCenteredDialog(width, height, vtui.TruncateMiddle(title, width-4))}
+	window.ShowClose = true
+	window.ShowZoom = true
+	window.MinW = minWidth
+	window.MinH = minHeight
+
+	lines, _ := splitRenderedTextLines(text, renderedTruncationNotice(plugin.reportLanguage()))
+	// The view reserves its last column for the conditional scrollbar. Put
+	// that column over the dialog's right border, like Far's native dialogs.
+	list := newReportTextView(window.X1+2, window.Y1+2, width-2, height-6, lines, styleFieldNames)
+	list.SetGrowMode(vtui.GrowHiX | vtui.GrowHiY)
+	window.AddItem(list)
+
+	toEditor := vtui.NewButton(0, 0, plugin.text("MediaInfo.ToEditor", "&To editor (F4)", "&В редактор (F4)"))
+	copyButton := vtui.NewButton(0, 0, plugin.text("MediaInfo.Copy", "&Copy", "&Копировать"))
+	aboutButton := vtui.NewButton(0, 0, plugin.text("MediaInfo.About", "&About", "&О программе"))
+	closeButton := vtui.NewButton(0, 0, plugin.text("MediaInfo.Close", "Close", "Закрыть"))
+	closeButton.IsDefault = true
+	window.AddItem(toEditor)
+	window.AddItem(copyButton)
+	window.AddItem(aboutButton)
+	window.AddItem(closeButton)
+	buttons := vtui.NewHBoxLayout(window.X1+2, window.Y2-1, width-4, 1)
+	buttons.HorizontalAlign = vtui.AlignCenter
+	buttons.Spacing = 1
+	buttons.Add(toEditor, vtui.Margins{}, vtui.AlignTop)
+	buttons.Add(copyButton, vtui.Margins{}, vtui.AlignTop)
+	buttons.Add(aboutButton, vtui.Margins{}, vtui.AlignTop)
+	buttons.Add(closeButton, vtui.Margins{}, vtui.AlignTop)
+	buttons.Apply()
+	for _, button := range []*vtui.Button{toEditor, copyButton, aboutButton, closeButton} {
+		button.SetGrowMode(vtui.GrowAll)
+	}
+
+	openEditor := func() {
+		if plugin.openReportEditor(app, fs, editorPath, text) {
+			window.Close()
+		}
+	}
+	window.onEditor = openEditor
+	toEditor.OnClick = openEditor
+	copyButton.OnClick = func() {
+		go vtui.SetClipboard(text)
+	}
+	aboutButton.OnClick = func() {
+		message := plugin.text("MediaInfo.AboutText",
+			"Pure-Go media metadata reader for f4.\n\nFast Quick View and bounded detailed analysis work directly through local and remote VFS sources. No native MediaInfo library or CGO is required.",
+			"Чистая Go-реализация чтения метаданных для f4.\n\nБыстрый просмотр и ограниченный подробный анализ работают напрямую с локальными и удалёнными VFS. Нативная библиотека MediaInfo и CGO не требуются.")
+		vtui.ShowMessageOn(window.Window, " "+plugin.text("MediaInfo.About", "About", "О программе")+" ", message, []string{plugin.text("MediaInfo.OK", "&OK", "&ОК")})
+	}
+	closeButton.OnClick = window.Close
+	window.SetFocusedItem(list)
+	if anchor, ok := app.(vtui.Frame); ok {
+		vtui.FrameManager.PushToFrameScreen(anchor, window)
+	} else {
+		vtui.FrameManager.Push(window)
+	}
+}

--- a/plugins/mediainfo/dialog_theme_test.go
+++ b/plugins/mediainfo/dialog_theme_test.go
@@ -1,0 +1,157 @@
+package mediainfo
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestReportViewUsesDialogThemeAndDimsFieldNames(t *testing.T) {
+	oldText := vtui.Palette[vtui.ColDialogText]
+	oldSelected := vtui.Palette[vtui.ColDialogSelectedButton]
+	oldBox := vtui.Palette[vtui.ColDialogBox]
+	t.Cleanup(func() {
+		vtui.Palette[vtui.ColDialogText] = oldText
+		vtui.Palette[vtui.ColDialogSelectedButton] = oldSelected
+		vtui.Palette[vtui.ColDialogBox] = oldBox
+	})
+	normal := vtui.SetRGBBoth(0, 0x102030, 0x405060)
+	selected := vtui.SetRGBBoth(0, 0x708090, 0xa0b0c0)
+	box := vtui.SetRGBBoth(0, 0x334455, 0x405060)
+	vtui.Palette[vtui.ColDialogText] = normal
+	vtui.Palette[vtui.ColDialogSelectedButton] = selected
+	vtui.Palette[vtui.ColDialogBox] = box
+
+	line := "Field     : Value"
+	view := newReportTextView(2, 2, 24, 4, []string{line, "Section", "Third", "Fourth", "Overflow"}, true)
+	if !view.ShowScrollBar || view.ScrollBar == nil || view.ScrollBar.ColorIdx != vtui.ColDialogBox {
+		t.Fatal("report view does not use an overflow-aware dialog scrollbar")
+	}
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(80, 25)
+	view.SetFocus(false)
+	view.Show(screen)
+	if got, want := screen.GetCell(2, 2).Attributes, subduedReportFieldAttr(normal); got != want {
+		t.Fatalf("field-name attr = %#x, want subdued dialog text %#x", got, want)
+	}
+	if got, oldDim, full := vtui.GetRGBFore(subduedReportFieldAttr(normal)), vtui.GetRGBFore(vtui.DimColor(normal)), vtui.GetRGBFore(normal); got <= oldDim || got >= full {
+		t.Fatalf("subdued foreground %#x must be brighter than old dim %#x and darker than normal %#x", got, oldDim, full)
+	}
+	valueX := 2 + strings.Index(line, " : ") + len(" : ")
+	if got := screen.GetCell(valueX, 2).Attributes; got != normal {
+		t.Fatalf("field-value attr = %#x, want dialog text %#x", got, normal)
+	}
+	if cell := screen.GetCell(view.X2, view.Y1); rune(cell.Char) != rune(vtui.ScrollUpArrow) || cell.Attributes != box {
+		t.Fatalf("overflow scrollbar cell = %#v, want arrow %q with dialog box attr %#x", cell, rune(vtui.ScrollUpArrow), box)
+	}
+
+	view.SetFocus(true)
+	view.Show(screen)
+	if got, want := screen.GetCell(2, 2).Attributes, subduedReportFieldAttr(selected); got != want {
+		t.Fatalf("focused field-name attr = %#x, want subdued selection %#x", got, want)
+	}
+	if got := screen.GetCell(valueX, 2).Attributes; got != selected {
+		t.Fatalf("focused field-value attr = %#x, want dialog selection %#x", got, selected)
+	}
+
+	updatedNormal := vtui.SetRGBBoth(0, 0x506070, 0x203040)
+	updatedSelected := vtui.SetRGBBoth(0, 0xc0d0e0, 0x304050)
+	updatedBox := vtui.SetRGBBoth(0, 0x8090a0, 0x203040)
+	vtui.Palette[vtui.ColDialogText] = updatedNormal
+	vtui.Palette[vtui.ColDialogSelectedButton] = updatedSelected
+	vtui.Palette[vtui.ColDialogBox] = updatedBox
+	view.SetFocus(false)
+	view.Show(screen)
+	if got, want := screen.GetCell(2, 2).Attributes, subduedReportFieldAttr(updatedNormal); got != want {
+		t.Fatalf("live-theme field-name attr = %#x, want %#x", got, want)
+	}
+	if got := screen.GetCell(valueX, 2).Attributes; got != updatedNormal {
+		t.Fatalf("live-theme field-value attr = %#x, want %#x", got, updatedNormal)
+	}
+	if got := screen.GetCell(view.X2, view.Y1).Attributes; got != updatedBox {
+		t.Fatalf("live-theme scrollbar attr = %#x, want %#x", got, updatedBox)
+	}
+}
+
+func TestReportViewHidesScrollbarWhenContentFits(t *testing.T) {
+	view := newReportTextView(2, 2, 24, 4, []string{"one", "two", "three", "four"}, true)
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(80, 25)
+	border := vtui.SetRGBBoth(0, 0x112233, 0x445566)
+	for y := view.Y1; y <= view.Y2; y++ {
+		screen.FillRect(view.X2, y, view.X2, y, '│', border)
+	}
+	view.Show(screen)
+	if cell := screen.GetCell(view.X2, view.Y1); rune(cell.Char) != '│' || cell.Attributes != border {
+		t.Fatalf("fitting report overwrote dialog border: %#v", cell)
+	}
+}
+
+func TestReportViewResizeClampsScrollPosition(t *testing.T) {
+	view := newReportTextView(2, 2, 24, 4, []string{"one", "two", "three", "four", "five", "six"}, true)
+	view.SetSelectPos(5)
+	if view.TopPos != 2 {
+		t.Fatalf("initial TopPos = %d, want 2", view.TopPos)
+	}
+
+	view.SetPosition(2, 2, 25, 7)
+	if view.ViewHeight != 6 || view.TopPos != 0 {
+		t.Fatalf("grown view = height %d, top %d; want height 6, top 0", view.ViewHeight, view.TopPos)
+	}
+
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(80, 25)
+	view.Show(screen)
+	if got := rune(screen.GetCell(view.X2, view.Y1).Char); got == rune(vtui.ScrollUpArrow) {
+		t.Fatal("grown report view retained a scrollbar although all rows fit")
+	}
+
+	view.SetPosition(2, 2, 25, 5)
+	if view.ViewHeight != 4 || view.TopPos != 2 {
+		t.Fatalf("shrunk view = height %d, top %d; want height 4, top 2", view.ViewHeight, view.TopPos)
+	}
+	view.Show(screen)
+	if got := rune(screen.GetCell(view.X2, view.Y1).Char); got != rune(vtui.ScrollUpArrow) {
+		t.Fatalf("shrunk report view scrollbar = %q, want %q", got, rune(vtui.ScrollUpArrow))
+	}
+}
+
+func TestReportViewLeavesCustomTemplateTextUnstyled(t *testing.T) {
+	oldText := vtui.Palette[vtui.ColDialogText]
+	t.Cleanup(func() { vtui.Palette[vtui.ColDialogText] = oldText })
+	normal := vtui.SetRGBBoth(0, 0x90a0b0, 0x102030)
+	vtui.Palette[vtui.ColDialogText] = normal
+
+	view := newReportTextView(2, 2, 30, 3, []string{"Literal : remains literal"}, false)
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(80, 25)
+	view.Show(screen)
+	for x := view.X1; x < view.X1+len("Literal : remains literal"); x++ {
+		if got := screen.GetCell(x, view.Y1).Attributes; got != normal {
+			t.Fatalf("custom template cell %d attr = %#x, want %#x", x-view.X1, got, normal)
+		}
+	}
+}
+
+func TestMediaInfoDialogLabelTracksLiveTheme(t *testing.T) {
+	oldText := vtui.Palette[vtui.ColDialogText]
+	t.Cleanup(func() { vtui.Palette[vtui.ColDialogText] = oldText })
+
+	first := vtui.SetRGBBoth(0, 0x112233, 0x445566)
+	second := vtui.SetRGBBoth(0, 0xaabbcc, 0x223344)
+	vtui.Palette[vtui.ColDialogText] = first
+	label := newMediaInfoDialogLabel(3, 3, "Label")
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(80, 25)
+	label.Show(screen)
+	if got := screen.GetCell(3, 3).Attributes; got != first {
+		t.Fatalf("initial label attr = %#x, want %#x", got, first)
+	}
+
+	vtui.Palette[vtui.ColDialogText] = second
+	label.Show(screen)
+	if got := screen.GetCell(3, 3).Attributes; got != second {
+		t.Fatalf("label retained stale theme attr = %#x, want %#x", got, second)
+	}
+}

--- a/plugins/mediainfo/exif_report_test.go
+++ b/plugins/mediainfo/exif_report_test.go
@@ -1,0 +1,96 @@
+package mediainfo
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestTIFFUsefulEXIFIsParsedAndRendered(t *testing.T) {
+	b := make([]byte, 560)
+	copy(b, "II*\x00")
+	binary.LittleEndian.PutUint32(b[4:8], 8)
+	putIFD := func(off int, entries [][4]uint32) {
+		binary.LittleEndian.PutUint16(b[off:off+2], uint16(len(entries)))
+		for i, entry := range entries {
+			pos := off + 2 + i*12
+			binary.LittleEndian.PutUint16(b[pos:pos+2], uint16(entry[0]))
+			binary.LittleEndian.PutUint16(b[pos+2:pos+4], uint16(entry[1]))
+			binary.LittleEndian.PutUint32(b[pos+4:pos+8], entry[2])
+			binary.LittleEndian.PutUint32(b[pos+8:pos+12], entry[3])
+		}
+	}
+	putIFD(8, [][4]uint32{
+		{0x010f, 2, 6, 320}, {0x0110, 2, 8, 340}, {0x0112, 3, 1, 6},
+		{0x8769, 4, 1, 100}, {0x8825, 4, 1, 200},
+	})
+	putIFD(100, [][4]uint32{
+		{0x829a, 5, 1, 420}, {0x829d, 5, 1, 428}, {0x8827, 3, 1, 400},
+		{0x9003, 2, 20, 360}, {0x920a, 5, 1, 436}, {0xa434, 2, 8, 390},
+	})
+	putIFD(200, [][4]uint32{
+		{0x0001, 2, 2, uint32('N')}, {0x0002, 5, 3, 444},
+		{0x0003, 2, 2, uint32('W')}, {0x0004, 5, 3, 468},
+		{0x0005, 1, 1, 0}, {0x0006, 5, 1, 492},
+	})
+	copy(b[320:], "Canon\x00")
+	copy(b[340:], "EOS R5\x00")
+	copy(b[360:], "2026:08:10 12:34:56\x00")
+	copy(b[390:], "RF50mm\x00")
+	// Inline SHORT value for ISO 400.
+	binary.LittleEndian.PutUint16(b[100+2+2*12+8:100+2+2*12+10], 400)
+	putRational := func(off int, numerator, denominator uint32) {
+		binary.LittleEndian.PutUint32(b[off:off+4], numerator)
+		binary.LittleEndian.PutUint32(b[off+4:off+8], denominator)
+	}
+	putRational(420, 1, 250)
+	putRational(428, 28, 10)
+	putRational(436, 50, 1)
+	for i, pair := range [][2]uint32{{55, 1}, {45, 1}, {30, 1}} {
+		putRational(444+i*8, pair[0], pair[1])
+	}
+	for i, pair := range [][2]uint32{{37, 1}, {36, 1}, {0, 1}} {
+		putRational(468+i*8, pair[0], pair[1])
+	}
+	putRational(492, 1234, 10)
+
+	opts := DefaultOptions(ModeDetailed)
+	p, err := newProbe(context.Background(), Source{Name: "photo.tiff", Size: int64(len(b)), Reader: memorySource(b)}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im := &Image{Width: 8192, Height: 5464, BitDepth: 14, ColorModel: "RGB", Compression: "JPEG"}
+	parseTIFFMeta(p, b, im)
+	if im.CameraMake != "Canon" || im.CameraModel != "EOS R5" || im.LensModel != "RF50mm" || im.Orientation != 6 {
+		t.Fatalf("basic EXIF = %#v", im)
+	}
+	if im.TakenAt == nil || im.Latitude == nil || im.Longitude == nil || im.GPSAltitude == nil {
+		t.Fatalf("date/GPS was not decoded: %#v", im)
+	}
+	if math.Abs(*im.Latitude-55.758333) > 0.00001 || math.Abs(*im.Longitude+37.6) > 0.00001 || math.Abs(*im.GPSAltitude-123.4) > 0.001 {
+		t.Fatalf("GPS = lat %v lon %v alt %v", *im.Latitude, *im.Longitude, *im.GPSAltitude)
+	}
+	values := map[string]string{}
+	for _, field := range im.EXIF {
+		values[field.Name] = field.Value
+	}
+	for name, want := range map[string]string{"Exposure time": "1/250 s", "F-number": "f/2.8", "ISO speed": "400", "Focal length": "50 mm"} {
+		if values[name] != want {
+			t.Errorf("%s = %q, want %q", name, values[name], want)
+		}
+	}
+
+	report := Report{General: General{FileName: "photo.tiff", Format: "TIFF"}, Streams: []Stream{{Kind: StreamImage, Format: "TIFF", Image: im}}}
+	detailed := RenderText(report, RenderOptions{})
+	for _, value := range []string{"Lens model", "Captured at", "Rotated 90° clockwise", "GPS latitude", "GPS altitude", "Exposure time", "F-number", "ISO speed", "Focal length"} {
+		if !strings.Contains(detailed, value) {
+			t.Errorf("detailed report does not contain %q:\n%s", value, detailed)
+		}
+	}
+	compact := RenderText(report, RenderOptions{Compact: true})
+	if strings.Contains(compact, "Exposure time") || strings.Contains(compact, "GPS latitude") {
+		t.Fatalf("compact report unexpectedly contains detailed EXIF:\n%s", compact)
+	}
+}

--- a/plugins/mediainfo/format_gaps_test.go
+++ b/plugins/mediainfo/format_gaps_test.go
@@ -1,0 +1,672 @@
+package mediainfo
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/binary"
+	"hash/crc32"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
+	"math"
+	"strings"
+	"testing"
+	"time"
+	"unsafe"
+)
+
+func isoTestBox(typ string, payload []byte) []byte {
+	b := make([]byte, 8+len(payload))
+	binary.BigEndian.PutUint32(b[:4], uint32(len(b)))
+	copy(b[4:8], typ)
+	copy(b[8:], payload)
+	return b
+}
+
+func TestAnalyzeHEIFItemSpatialProperties(t *testing.T) {
+	for _, tc := range []struct {
+		name, brand, format, codec string
+	}{
+		{"photo.heic", "heic", "HEIC", "HEVC"},
+		{"photo.avif", "avif", "AVIF", "AV1"},
+		{"photo.heif", "mif1", "HEIF", "HEIF"},
+	} {
+		t.Run(tc.format, func(t *testing.T) {
+			ftyp := isoTestBox("ftyp", append(append([]byte(tc.brand), 0, 0, 0, 0), []byte("mif1")...))
+			ispeData := make([]byte, 12)
+			binary.BigEndian.PutUint32(ispeData[4:8], 4032)
+			binary.BigEndian.PutUint32(ispeData[8:12], 3024)
+			pixiData := []byte{0, 0, 0, 0, 3, 10, 10, 10}
+			properties := isoTestBox("ipco", append(isoTestBox("ispe", ispeData), isoTestBox("pixi", pixiData)...))
+			meta := isoTestBox("meta", append(make([]byte, 4), isoTestBox("iprp", properties)...))
+			r, err := analyzeBytes(t, tc.name, append(ftyp, meta...), ModeFast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if r.General.Format != tc.format || len(r.Streams) != 1 {
+				t.Fatalf("report = %#v", r)
+			}
+			s := r.Streams[0]
+			if s.Format != tc.codec || s.Image.Width != 4032 || s.Image.Height != 3024 || s.Image.BitDepth != 10 {
+				t.Fatalf("image stream = %#v", s)
+			}
+		})
+	}
+}
+
+func rawTIFFFixture(cr2, dng bool) []byte {
+	ifd := 8
+	if cr2 {
+		ifd = 16
+	}
+	entries := 5
+	if dng {
+		entries++
+	}
+	b := make([]byte, 256)
+	copy(b, "II*\x00")
+	binary.LittleEndian.PutUint32(b[4:8], uint32(ifd))
+	if cr2 {
+		copy(b[8:12], "CR\x02\x00")
+		binary.LittleEndian.PutUint32(b[12:16], uint32(ifd))
+	}
+	binary.LittleEndian.PutUint16(b[ifd:ifd+2], uint16(entries))
+	pos := ifd + 2
+	put := func(tag, typ uint16, count, value uint32) {
+		binary.LittleEndian.PutUint16(b[pos:pos+2], tag)
+		binary.LittleEndian.PutUint16(b[pos+2:pos+4], typ)
+		binary.LittleEndian.PutUint32(b[pos+4:pos+8], count)
+		if typ == 3 && count == 1 {
+			binary.LittleEndian.PutUint16(b[pos+8:pos+10], uint16(value))
+		} else {
+			binary.LittleEndian.PutUint32(b[pos+8:pos+12], value)
+		}
+		pos += 12
+	}
+	put(0x0100, 4, 1, 6000)
+	put(0x0101, 4, 1, 4000)
+	put(0x0102, 3, 1, 14)
+	put(0x0103, 3, 1, 7)
+	makeOffset := uint32(180)
+	copy(b[makeOffset:], "Camera Co\x00")
+	put(0x010f, 2, uint32(len("Camera Co\x00")), makeOffset)
+	if dng {
+		put(0xc612, 1, 4, 0x00000401)
+	}
+	return b
+}
+
+func TestAnalyzeTIFFBasedCameraRAW(t *testing.T) {
+	for _, tc := range []struct {
+		name, format string
+		cr2, dng     bool
+	}{
+		{"photo.dng", "DNG", false, true},
+		{"photo.cr2", "Canon CR2", true, false},
+		{"photo.nef", "Nikon NEF", false, false},
+		{"photo.pef", "Pentax PEF", false, false},
+		{"photo.arw", "Sony ARW", false, false},
+		{"photo.tiff", "TIFF", false, false},
+	} {
+		t.Run(tc.format, func(t *testing.T) {
+			r, err := analyzeBytes(t, tc.name, rawTIFFFixture(tc.cr2, tc.dng), ModeFast)
+			if err != nil {
+				t.Fatal(err)
+			}
+			im := r.Streams[0].Image
+			if r.General.Format != tc.format || im.Width != 6000 || im.Height != 4000 || im.BitDepth != 14 || im.CameraMake != "Camera Co" {
+				t.Fatalf("report = %#v", r)
+			}
+		})
+	}
+}
+
+func pngTestChunk(typ string, data []byte) []byte {
+	b := make([]byte, 12+len(data))
+	binary.BigEndian.PutUint32(b[:4], uint32(len(data)))
+	copy(b[4:8], typ)
+	copy(b[8:], data)
+	binary.BigEndian.PutUint32(b[8+len(data):], crc32.ChecksumIEEE(b[4:8+len(data)]))
+	return b
+}
+
+func TestAnalyzeAPNGFrameCountAndDuration(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, image.NewNRGBA(image.Rect(0, 0, 4, 3))); err != nil {
+		t.Fatal(err)
+	}
+	b := encoded.Bytes()
+	ihdrEnd := 8 + 12 + int(binary.BigEndian.Uint32(b[8:12]))
+	actl := make([]byte, 8)
+	binary.BigEndian.PutUint32(actl[:4], 2)
+	fctl := func(sequence uint32, numerator, denominator uint16) []byte {
+		d := make([]byte, 26)
+		binary.BigEndian.PutUint32(d[:4], sequence)
+		binary.BigEndian.PutUint32(d[4:8], 4)
+		binary.BigEndian.PutUint32(d[8:12], 3)
+		binary.BigEndian.PutUint16(d[20:22], numerator)
+		binary.BigEndian.PutUint16(d[22:24], denominator)
+		return pngTestChunk("fcTL", d)
+	}
+	extra := append(pngTestChunk("acTL", actl), fctl(0, 1, 10)...)
+	extra = append(extra, fctl(1, 2, 10)...)
+	apng := append(append(append([]byte(nil), b[:ihdrEnd]...), extra...), b[ihdrEnd:]...)
+	r, err := analyzeBytes(t, "animated.png", apng, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im := r.Streams[0].Image
+	if !im.Animated || im.FrameCount != 2 || im.AnimationDuration != 300*time.Millisecond {
+		t.Fatalf("APNG metadata = %#v", im)
+	}
+}
+
+func TestAnalyzeGIFSkipsGlobalPalette(t *testing.T) {
+	palette := color.Palette{color.Black, color.White}
+	first := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+	second := image.NewPaletted(image.Rect(0, 0, 2, 2), palette)
+	second.SetColorIndex(0, 0, 1)
+	var b bytes.Buffer
+	if err := gif.EncodeAll(&b, &gif.GIF{Image: []*image.Paletted{first, second}, Delay: []int{10, 20}}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := analyzeBytes(t, "animated.gif", b.Bytes(), ModeDetailed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im := r.Streams[0].Image
+	if im.FrameCount != 2 || !im.Animated || im.AnimationDuration != 300*time.Millisecond {
+		t.Fatalf("GIF metadata = %#v", im)
+	}
+}
+
+func riffTestChunk(typ string, data []byte) []byte {
+	b := make([]byte, 8+len(data)+(len(data)&1))
+	copy(b, typ)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(data)))
+	copy(b[8:], data)
+	return b
+}
+
+func TestWebPAnimationCountAndDuration(t *testing.T) {
+	vp8x := make([]byte, 10)
+	vp8x[0] = 2
+	vp8x[4], vp8x[7] = 3, 2
+	frame := func(ms int) []byte {
+		d := make([]byte, 16)
+		d[12], d[13], d[14] = byte(ms), byte(ms>>8), byte(ms>>16)
+		return riffTestChunk("ANMF", d)
+	}
+	payload := append(riffTestChunk("VP8X", vp8x), frame(100)...)
+	payload = append(payload, frame(250)...)
+	file := make([]byte, 12)
+	copy(file, "RIFF")
+	copy(file[8:], "WEBP")
+	file = append(file, payload...)
+	binary.LittleEndian.PutUint32(file[4:8], uint32(len(file)-8))
+	p, err := newProbe(context.Background(), Source{Name: "x.webp", Size: int64(len(file)), Reader: memorySource(file)}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	im := &Image{FrameCount: 1}
+	parseWebPMeta(p, im)
+	if im.FrameCount != 2 || im.AnimationDuration != 350*time.Millisecond || im.Width != 4 || im.Height != 3 {
+		t.Fatalf("WebP metadata = %#v", im)
+	}
+}
+
+func TestAnalyzeWebPDispatchesBeforeGenericRIFF(t *testing.T) {
+	b, err := base64.StdEncoding.DecodeString("UklGRiIAAABXRUJQVlA4IBYAAAAwAQCdASoBAAEADsD+JaQAA3AAAAAA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	r, err := analyzeBytes(t, "pixel.webp", b, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.General.Format != "WEBP" || len(r.Streams) != 1 || r.Streams[0].Image.Width != 1 || r.Streams[0].Image.Height != 1 {
+		t.Fatalf("WebP report = %#v", r)
+	}
+}
+
+func TestCommonWebVTTTimestampWithoutHours(t *testing.T) {
+	r, err := analyzeBytes(t, "captions.vtt", []byte("WEBVTT\n\n00:01.000 --> 00:02.500\nHello\n"), ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x := r.Streams[0].Text
+	if x.CueCount != 1 || x.FirstCue != time.Second || x.LastCue != 2500*time.Millisecond {
+		t.Fatalf("WebVTT metadata = %#v", x)
+	}
+}
+
+func TestMicroDVDFPSDeclaration(t *testing.T) {
+	r, err := analyzeBytes(t, "captions.sub", []byte("{1}{1}24.0\n{24}{48}Hello\n"), ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x := r.Streams[0].Text
+	if x.CueCount != 1 || x.FirstCue != time.Second || x.LastCue != 2*time.Second {
+		t.Fatalf("MicroDVD metadata = %#v", x)
+	}
+}
+
+func TestAnalyzeEBUSTL(t *testing.T) {
+	b := bytes.Repeat([]byte{' '}, 1024+128)
+	copy(b[3:11], "STL25.01")
+	copy(b[12:14], "01")
+	copy(b[14:16], "09")
+	copy(b[16:48], "Programme")
+	copy(b[48:80], "Episode")
+	copy(b[238:243], "00001")
+	tti := b[1024:]
+	tti[0] = 1
+	binary.BigEndian.PutUint16(tti[1:3], 7)
+	tti[3] = 0xff
+	copy(tti[5:9], []byte{0, 0, 1, 12})
+	copy(tti[9:13], []byte{0, 0, 3, 0})
+	tti[15] = 0
+	r, err := analyzeBytes(t, "captions.stl", b, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	x := r.Streams[0].Text
+	if r.General.Format != "EBU STL" || x.Encoding != "ISO 8859-5 Cyrillic" || x.CueCount != 1 || x.FirstCue != 1480*time.Millisecond || x.LastCue != 3*time.Second {
+		t.Fatalf("EBU STL report = %#v", r)
+	}
+}
+
+func TestAnalyzeOggFLAC(t *testing.T) {
+	streamInfo := make([]byte, 34)
+	v := uint64(48000)<<44 | uint64(1)<<41 | uint64(23)<<36 | uint64(96000)
+	binary.BigEndian.PutUint64(streamInfo[10:18], v)
+	header := append([]byte{0x7f}, []byte("FLAC")...)
+	header = append(header, 1, 0, 0, 1)
+	header = append(header, []byte("fLaC")...)
+	header = append(header, 0, 0, 0, 34)
+	header = append(header, streamInfo...)
+	data := append(oggPage(11, 0, 0, header), oggPage(11, 96000, 1, nil)...)
+	r, err := analyzeBytes(t, "tone.oga", data, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := r.Streams[0]
+	if s.Format != "FLAC" || s.Audio.SampleRate != 48000 || s.Audio.Channels != 2 || s.Audio.BitDepth != 24 || s.Duration != 2*time.Second {
+		t.Fatalf("Ogg FLAC stream = %#v", s)
+	}
+}
+
+func TestAnalyzeOggTheoraIdentification(t *testing.T) {
+	header := make([]byte, 42)
+	header[0] = 0x80
+	copy(header[1:7], "theora")
+	header[7], header[8], header[9] = 3, 2, 1
+	header[14], header[15], header[16] = 0, 2, 128 // 640
+	header[17], header[18], header[19] = 0, 1, 224 // 480
+	binary.BigEndian.PutUint32(header[22:26], 30000)
+	binary.BigEndian.PutUint32(header[26:30], 1001)
+	r, err := analyzeBytes(t, "video.ogv", oggPage(9, 0, 0, header), ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := r.Streams[0]
+	if s.Format != "Theora" || s.Video.Width != 640 || s.Video.Height != 480 || math.Abs(s.FrameRate-29.970) > 0.001 || !strings.Contains(s.Profile, "3.2.1") {
+		t.Fatalf("Theora stream = %#v", s)
+	}
+}
+
+func TestAnalyzeRF64UsesDS64DataSize(t *testing.T) {
+	b := make([]byte, 12+8+28+8+16+8+8000)
+	copy(b[:4], "RF64")
+	binary.LittleEndian.PutUint32(b[4:8], ^uint32(0))
+	copy(b[8:12], "WAVE")
+	copy(b[12:16], "ds64")
+	binary.LittleEndian.PutUint32(b[16:20], 28)
+	binary.LittleEndian.PutUint64(b[20:28], uint64(len(b)-8))
+	binary.LittleEndian.PutUint64(b[28:36], 8000)
+	binary.LittleEndian.PutUint64(b[36:44], 8000)
+	copy(b[48:52], "fmt ")
+	binary.LittleEndian.PutUint32(b[52:56], 16)
+	binary.LittleEndian.PutUint16(b[56:58], 1)
+	binary.LittleEndian.PutUint16(b[58:60], 1)
+	binary.LittleEndian.PutUint32(b[60:64], 8000)
+	binary.LittleEndian.PutUint32(b[64:68], 8000)
+	binary.LittleEndian.PutUint16(b[68:70], 1)
+	binary.LittleEndian.PutUint16(b[70:72], 8)
+	copy(b[72:76], "data")
+	binary.LittleEndian.PutUint32(b[76:80], ^uint32(0))
+	r, err := analyzeBytes(t, "long.rf64", b, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.General.CodecID != "RF64" || r.General.Duration != time.Second {
+		t.Fatalf("RF64 report = %#v", r)
+	}
+}
+
+func TestAnalyzeOpenDMLFrameCount(t *testing.T) {
+	chunk := func(id string, payload []byte) []byte {
+		b := make([]byte, 8+len(payload)+(len(payload)&1))
+		copy(b, id)
+		binary.LittleEndian.PutUint32(b[4:8], uint32(len(payload)))
+		copy(b[8:], payload)
+		return b
+	}
+	avih := make([]byte, 40)
+	binary.LittleEndian.PutUint32(avih[:4], 40000)
+	// Legacy frame count is zero; OpenDML dmlh carries the real count.
+	odml := append([]byte("odml"), chunk("dmlh", []byte{100, 0, 0, 0})...)
+	payload := append(chunk("avih", avih), chunk("LIST", odml)...)
+	b := make([]byte, 12)
+	copy(b, "RIFF")
+	copy(b[8:], "AVI ")
+	b = append(b, payload...)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	r, err := analyzeBytes(t, "open-dml.avi", b, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.General.FrameCount != 100 || r.General.Duration != 4*time.Second {
+		t.Fatalf("OpenDML report = %#v", r)
+	}
+}
+
+func TestAnalyze3GPP2Brand(t *testing.T) {
+	ftyp := isoTestBox("ftyp", append([]byte("3g2a\x00\x00\x00\x00"), []byte("isom")...))
+	r, err := analyzeBytes(t, "phone.3g2", ftyp, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.General.Format != "3GPP2" || r.General.MIME != "video/3gpp2" {
+		t.Fatalf("3GPP2 general = %#v", r.General)
+	}
+}
+
+func TestAnalyzeITunesRawCopyrightAtom(t *testing.T) {
+	ftyp := isoTestBox("ftyp", []byte("M4A \x00\x00\x00\x00isom"))
+	dataPayload := append(make([]byte, 8), []byte("Track title")...)
+	rawTag := isoTestBox(string([]byte{0xa9, 'n', 'a', 'm'}), isoTestBox("data", dataPayload))
+	ilst := isoTestBox("ilst", rawTag)
+	meta := isoTestBox("meta", append(make([]byte, 4), ilst...))
+	moov := isoTestBox("moov", isoTestBox("udta", meta))
+	r, err := analyzeBytes(t, "song.m4a", append(ftyp, moov...), ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Tags) != 1 || r.Tags[0].Name != "Title" || r.Tags[0].Value != "Track title" {
+		t.Fatalf("iTunes tags = %#v", r.Tags)
+	}
+}
+
+func TestAnalyzeNativeMappedOggFLAC(t *testing.T) {
+	streamInfo := make([]byte, 34)
+	v := uint64(44100)<<44 | uint64(1)<<41 | uint64(15)<<36 | uint64(44100)
+	binary.BigEndian.PutUint64(streamInfo[10:18], v)
+	metadata := append([]byte{0, 0, 0, 34}, streamInfo...)
+	data := append(oggPage(12, 0, 0, []byte("fLaC")), oggPage(12, 44100, 1, metadata)...)
+	r, err := analyzeBytes(t, "native.oga", data, ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := r.Streams[0]
+	if s.Format != "FLAC" || s.Audio.SampleRate != 44100 || s.Audio.BitDepth != 16 || s.Duration != time.Second {
+		t.Fatalf("native Ogg FLAC stream = %#v", s)
+	}
+}
+
+type cancelOnReadSource struct {
+	data   []byte
+	cancel context.CancelFunc
+	reads  int
+}
+
+func (s *cancelOnReadSource) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	s.reads++
+	if off < 0 || off >= int64(len(s.data)) {
+		return 0, context.Canceled
+	}
+	n := copy(p, s.data[off:])
+	if s.reads == 2 {
+		s.cancel()
+	}
+	if n < len(p) {
+		return n, nil
+	}
+	return n, nil
+}
+
+func TestAnalyzeCancellationWinsAfterBestEffortMetadata(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := jpeg.Encode(&encoded, image.NewNRGBA(image.Rect(0, 0, 2, 2)), nil); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	src := &cancelOnReadSource{data: encoded.Bytes(), cancel: cancel}
+	_, err := Analyze(ctx, Source{Name: "photo.jpg", Size: int64(len(src.data)), Reader: src}, DefaultOptions(ModeFast))
+	if err != context.Canceled {
+		t.Fatalf("error = %v, reads = %d", err, src.reads)
+	}
+}
+
+func TestMP4TrackHeaderGeometrySurvivesHandler(t *testing.T) {
+	b := make([]byte, 140)
+	// Version-0 tkhd matrix and 16.16 display dimensions.
+	binary.BigEndian.PutUint32(b[40:44], 0)
+	binary.BigEndian.PutUint32(b[44:48], 0x10000)
+	binary.BigEndian.PutUint32(b[76:80], 640<<16)
+	binary.BigEndian.PutUint32(b[80:84], 480<<16)
+	copy(b[108:112], "vide")
+	p, err := newProbe(context.Background(), Source{Name: "x.mp4", Size: int64(len(b)), Reader: memorySource(b)}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Stream{}
+	parseTKHD(p, isoBox{data: 0, payload: 84}, s)
+	parseHDLR(p, isoBox{data: 100, payload: 32}, s)
+	if s.Kind != StreamVideo || s.Video == nil || s.Video.DisplayWidth != 640 || s.Video.DisplayHeight != 480 || s.Video.Rotation != 90 {
+		t.Fatalf("MP4 stream = %#v", s)
+	}
+}
+
+func TestMatroskaTagTargetReachesSiblingSimpleTag(t *testing.T) {
+	doc := ebmlElement([]byte{0x42, 0x82}, []byte("matroska"))
+	header := ebmlElement([]byte{0x1a, 0x45, 0xdf, 0xa3}, doc)
+	targets := ebmlElement([]byte{0x63, 0xc0}, ebmlElement([]byte{0x63, 0xc5}, []byte{42}))
+	simple := ebmlElement([]byte{0x67, 0xc8}, append(
+		ebmlElement([]byte{0x45, 0xa3}, []byte("TITLE")),
+		ebmlElement([]byte{0x44, 0x87}, []byte("Track title"))...,
+	))
+	tag := ebmlElement([]byte{0x73, 0x73}, append(targets, simple...))
+	tags := ebmlElement([]byte{0x12, 0x54, 0xc3, 0x67}, tag)
+	segment := ebmlElement([]byte{0x18, 0x53, 0x80, 0x67}, tags)
+	r, err := analyzeBytes(t, "tagged.mkv", append(header, segment...), ModeFast)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Tags) != 1 || r.Tags[0].Target != "42" || r.Tags[0].Name != "Title" || r.Tags[0].Value != "Track title" {
+		t.Fatalf("Matroska tags = %#v", r.Tags)
+	}
+}
+
+func TestAVIRejectedStreamDoesNotReusePreviousSTRF(t *testing.T) {
+	chunk := func(id string, payload []byte) []byte {
+		b := make([]byte, 8+len(payload)+(len(payload)&1))
+		copy(b, id)
+		binary.LittleEndian.PutUint32(b[4:8], uint32(len(payload)))
+		copy(b[8:], payload)
+		return b
+	}
+	strh := make([]byte, 48)
+	copy(strh[:4], "vids")
+	copy(strh[4:8], "H264")
+	strf := func(width int32) []byte {
+		b := make([]byte, 40)
+		binary.LittleEndian.PutUint32(b[:4], 40)
+		binary.LittleEndian.PutUint32(b[4:8], uint32(width))
+		binary.LittleEndian.PutUint32(b[8:12], 20)
+		binary.LittleEndian.PutUint16(b[14:16], 24)
+		copy(b[16:20], "H264")
+		return b
+	}
+	payload := append(chunk("strh", strh), chunk("strf", strf(10))...)
+	payload = append(payload, chunk("strh", strh)...)
+	payload = append(payload, chunk("strf", strf(999))...)
+	b := make([]byte, 12)
+	copy(b, "RIFF")
+	copy(b[8:], "AVI ")
+	b = append(b, payload...)
+	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	opts := DefaultOptions(ModeFast)
+	opts.MaxStreams = 1
+	r, err := Analyze(context.Background(), Source{Name: "limited.avi", Size: int64(len(b)), Reader: memorySource(b)}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Streams) != 1 || r.Streams[0].Video.Width != 10 || !r.Truncated {
+		t.Fatalf("AVI report = %#v", r)
+	}
+}
+
+func TestTIFFMetadataWalkIsElementAndTextBounded(t *testing.T) {
+	const entries = 4096
+	ifdBytes := 2 + entries*12 + 4
+	sharedOffset := 8 + ifdBytes
+	b := make([]byte, sharedOffset+(8<<20))
+	copy(b, "II*\x00")
+	binary.LittleEndian.PutUint32(b[4:8], 8)
+	binary.LittleEndian.PutUint16(b[8:10], entries)
+	for i := 0; i < entries; i++ {
+		pos := 10 + i*12
+		binary.LittleEndian.PutUint16(b[pos:pos+2], 0xeeee) // unsupported tag
+		binary.LittleEndian.PutUint16(b[pos+2:pos+4], 2)
+		binary.LittleEndian.PutUint32(b[pos+4:pos+8], 8<<20)
+		binary.LittleEndian.PutUint32(b[pos+8:pos+12], uint32(sharedOffset))
+	}
+	opts := DefaultOptions(ModeFast)
+	opts.MaxElements = 20
+	p, err := newProbe(context.Background(), Source{Name: "hostile.tiff", Size: 1, Reader: memorySource{0}}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parseTIFFMeta(p, b, &Image{})
+	if !p.report.Truncated || p.elements != 21 {
+		t.Fatalf("TIFF walk elements=%d truncated=%v", p.elements, p.report.Truncated)
+	}
+
+	textTIFF := make([]byte, 128)
+	copy(textTIFF, "II*\x00")
+	binary.LittleEndian.PutUint32(textTIFF[4:8], 8)
+	binary.LittleEndian.PutUint16(textTIFF[8:10], 1)
+	binary.LittleEndian.PutUint16(textTIFF[10:12], 0x010f)
+	binary.LittleEndian.PutUint16(textTIFF[12:14], 2)
+	binary.LittleEndian.PutUint32(textTIFF[14:18], 64)
+	binary.LittleEndian.PutUint32(textTIFF[18:22], 32)
+	copy(textTIFF[32:96], strings.Repeat("A", 64))
+	opts.MaxElements, opts.MaxValueBytes = 100, 8
+	p, err = newProbe(context.Background(), Source{Name: "text.tiff", Size: 1, Reader: memorySource{0}}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	im := &Image{}
+	parseTIFFMeta(p, textTIFF, im)
+	if im.CameraMake != "AAAAAAAA" || !p.report.Truncated {
+		t.Fatalf("camera make=%q truncated=%v", im.CameraMake, p.report.Truncated)
+	}
+}
+
+type countingMemorySource struct {
+	data  []byte
+	bytes int64
+}
+
+func (s *countingMemorySource) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if off < 0 || off >= int64(len(s.data)) {
+		return 0, context.Canceled
+	}
+	n := copy(p, s.data[off:])
+	s.bytes += int64(n)
+	return n, nil
+}
+
+func TestHEIFFTYPBrandListAndReadAreBounded(t *testing.T) {
+	ftypPayload := bytes.Repeat([]byte("junk"), (1<<20)/4)
+	copy(ftypPayload[:4], "avif")
+	clear(ftypPayload[4:8])
+	ftyp := isoTestBox("ftyp", ftypPayload)
+	ispe := make([]byte, 12)
+	binary.BigEndian.PutUint32(ispe[4:8], 16)
+	binary.BigEndian.PutUint32(ispe[8:12], 9)
+	properties := isoTestBox("ipco", isoTestBox("ispe", ispe))
+	meta := isoTestBox("meta", append(make([]byte, 4), isoTestBox("iprp", properties)...))
+	source := &countingMemorySource{data: append(ftyp, meta...)}
+	r, err := Analyze(context.Background(), Source{Name: "hostile.avif", Size: int64(len(source.data)), Reader: source}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.General.CompatibleBrands) > 64 || source.bytes > 128<<10 {
+		t.Fatalf("brands=%d bytes read=%d", len(r.General.CompatibleBrands), source.bytes)
+	}
+}
+
+func TestAddTagOwnsAcceptedValue(t *testing.T) {
+	large := strings.Repeat("0123456789", 1<<17)
+	target := large[12000:12004]
+	name := large[12300:12301]
+	value := large[12345:12353]
+	p, err := newProbe(context.Background(), Source{Name: "x", Size: 1, Reader: memorySource{0}}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.addTag(target, name, value)
+	got := p.report.Tags[0]
+	if got.Target != target || got.Name != name || got.Value != value ||
+		unsafe.StringData(got.Target) == unsafe.StringData(target) ||
+		unsafe.StringData(got.Name) == unsafe.StringData(name) ||
+		unsafe.StringData(got.Value) == unsafe.StringData(value) {
+		t.Fatalf("accepted field did not own its strings: %#v", got)
+	}
+	p.addTag("", strings.Repeat("N", 2048), "value")
+	if len(p.report.Tags[1].Name) != 1024 || !p.report.Truncated {
+		t.Fatalf("tag name length=%d truncated=%v", len(p.report.Tags[1].Name), p.report.Truncated)
+	}
+}
+
+func TestCleanTextCompactsLargePadding(t *testing.T) {
+	b := make([]byte, 8<<20)
+	b[0] = 'X'
+	for i := 1; i < len(b); i++ {
+		b[i] = ' '
+	}
+	if got := cleanText(b); got != "X" {
+		t.Fatalf("cleanText = %q", got)
+	}
+	utf16Bytes := []byte{' ', 0, 'X', 0, ' ', 0}
+	if got := decodeUTF16(utf16Bytes, true); got != "X" {
+		t.Fatalf("decodeUTF16 = %q", got)
+	}
+}
+
+func BenchmarkCleanTextLargePadding(b *testing.B) {
+	data := make([]byte, 8<<20)
+	data[0] = 'X'
+	for i := 1; i < len(data); i++ {
+		data[i] = ' '
+	}
+	b.ReportAllocs()
+	b.SetBytes(int64(len(data)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if got := cleanText(data); got != "X" {
+			b.Fatal(got)
+		}
+	}
+}

--- a/plugins/mediainfo/locale.go
+++ b/plugins/mediainfo/locale.go
@@ -1,0 +1,28 @@
+package mediainfo
+
+import "github.com/unxed/vtui"
+
+func (plugin *Plugin) text(key, english, russian string) string {
+	language := plugin.settings().Language
+	if language == "ru" {
+		return russian
+	}
+	if language == "en" {
+		return english
+	}
+	if translated := vtui.Msg(key); translated != "{"+key+"}" {
+		return translated
+	}
+	return english
+}
+
+func (plugin *Plugin) reportLanguage() string {
+	language := plugin.settings().Language
+	if language == "en" || language == "ru" {
+		return language
+	}
+	if vtui.Msg("MediaInfo.LanguageCode") == "ru" {
+		return "ru"
+	}
+	return "en"
+}

--- a/plugins/mediainfo/macro.go
+++ b/plugins/mediainfo/macro.go
@@ -1,0 +1,266 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/unxed/f4/vfs"
+)
+
+// macroPair is deliberately a pair rather than a map. MediaInfo's macro
+// result may contain the same English key once per stream and metadata tags
+// may themselves be repeated. Both order and duplicates are observable by
+// existing Far macros.
+type macroPair struct {
+	key   string
+	value string
+}
+
+type macroArguments struct {
+	path       string
+	technical  bool
+	filter     map[string]struct{}
+	filterUsed bool
+}
+
+func (plugin *Plugin) callMacro(ctx context.Context, callContext vfs.MacroCallContext, arguments []any) ([]any, error) {
+	parsed, err := parseMacroArguments(arguments)
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	fs, path, item, err := macroSource(ctx, callContext.Current, parsed.path)
+	if err != nil {
+		return macroResult(false, nil, parsed), nil
+	}
+	report, err := plugin.analyzePath(ctx, fs, path, item, ModeDetailed)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return macroResult(false, nil, parsed), nil
+	}
+
+	pairs := macroTechnicalPairs(report)
+	if !parsed.technical {
+		pairs = macroImagePairs(report)
+	}
+	return macroResult(true, pairs, parsed), nil
+}
+
+func parseMacroArguments(arguments []any) (macroArguments, error) {
+	parsed := macroArguments{technical: true, filter: make(map[string]struct{})}
+	for index, argument := range arguments {
+		switch value := argument.(type) {
+		case nil:
+			continue
+		case bool:
+			parsed.technical = value
+		case int:
+			parsed.technical = value != 0
+		case int8:
+			parsed.technical = value != 0
+		case int16:
+			parsed.technical = value != 0
+		case int32:
+			parsed.technical = value != 0
+		case int64:
+			parsed.technical = value != 0
+		case uint:
+			parsed.technical = value != 0
+		case uint8:
+			parsed.technical = value != 0
+		case uint16:
+			parsed.technical = value != 0
+		case uint32:
+			parsed.technical = value != 0
+		case uint64:
+			parsed.technical = value != 0
+		case string:
+			if value == "" {
+				continue
+			}
+			if isMacroFilter(value) {
+				parsed.filterUsed = true
+				for _, key := range strings.Split(value[1:len(value)-1], ",") {
+					parsed.filter[key] = struct{}{}
+				}
+				continue
+			}
+			// The original plugin accepts more than one filename and lets the
+			// last non-empty one win. Keep that order-independent convention.
+			parsed.path = value
+		case []any:
+			parsed.filterUsed = true
+			if err := addMacroArrayFilter(parsed.filter, value); err != nil {
+				return macroArguments{}, fmt.Errorf("MediaInfo macro argument %d: %w", index+1, err)
+			}
+		case []string:
+			parsed.filterUsed = true
+			for _, key := range value {
+				parsed.filter[key] = struct{}{}
+			}
+		default:
+			return macroArguments{}, fmt.Errorf("MediaInfo macro argument %d has unsupported type %T", index+1, argument)
+		}
+	}
+	return parsed, nil
+}
+
+func isMacroFilter(value string) bool {
+	return len(value) >= 2 && value[0] == '{' && value[len(value)-1] == '}'
+}
+
+func addMacroArrayFilter(filter map[string]struct{}, values []any) error {
+	for index, value := range values {
+		switch value := value.(type) {
+		case nil:
+			continue
+		case string:
+			filter[value] = struct{}{}
+		default:
+			return fmt.Errorf("filter item %d has unsupported type %T", index+1, value)
+		}
+	}
+	return nil
+}
+
+func macroSource(ctx context.Context, current vfs.FileRef, requested string) (vfs.VFS, string, vfs.VFSItem, error) {
+	fs := current.VFS
+	if fs == nil {
+		return nil, "", vfs.VFSItem{}, errors.New("MediaInfo macro has no active VFS")
+	}
+
+	path := requested
+	if path == "" {
+		path = current.Path
+		if path == "" && current.Name != "" && current.Name != ".." {
+			base := current.Dir
+			if base == "" {
+				base = fs.GetPath()
+			}
+			path = fs.Join(base, current.Name)
+		}
+	} else {
+		// Expansion changes only the requested path string; the file remains
+		// inside the active VFS and is still read through VFS.Open.
+		if _, ok := fs.(*vfs.OSVFS); ok {
+			path = expandOSPathEnvironment(path)
+		}
+		if !fs.IsAbs(path) {
+			base := current.Dir
+			if base == "" {
+				base = fs.GetPath()
+			}
+			path = fs.Join(base, path)
+		}
+	}
+	if path == "" {
+		return nil, "", vfs.VFSItem{}, errors.New("MediaInfo macro has no selected file")
+	}
+	absolute, err := fs.Abs(path)
+	if err != nil {
+		return nil, "", vfs.VFSItem{}, err
+	}
+	item, err := fs.Stat(ctx, absolute)
+	if err != nil {
+		return nil, "", vfs.VFSItem{}, err
+	}
+	if item.IsDir {
+		return nil, "", vfs.VFSItem{}, errMediaDirectory
+	}
+	return fs, absolute, item, nil
+}
+
+func macroResult(ok bool, pairs []macroPair, arguments macroArguments) []any {
+	keys := make([]string, 0, len(pairs))
+	values := make([]string, 0, len(pairs))
+	if ok {
+		for _, pair := range pairs {
+			if pair.key == "" || pair.value == "" {
+				continue
+			}
+			if arguments.filterUsed {
+				if _, present := arguments.filter[pair.key]; !present {
+					continue
+				}
+			}
+			keys = append(keys, pair.key)
+			values = append(values, pair.value)
+		}
+	}
+	return []any{ok, int64(len(keys)), keys, values}
+}
+
+func macroTechnicalPairs(report Report) []macroPair {
+	sections := CanonicalSections(report)
+	pairs := make([]macroPair, 0, 64+len(report.Tags))
+	for _, section := range sections {
+		for _, field := range section.Fields {
+			macroAdd(&pairs, field.Name, field.Value)
+		}
+	}
+	return pairs
+}
+
+func macroImagePairs(report Report) []macroPair {
+	pairs := make([]macroPair, 0, 24+len(report.Tags))
+	for _, stream := range report.Streams {
+		if stream.Image == nil {
+			continue
+		}
+		image := stream.Image
+		macroAdd(&pairs, "Width", plainInt(int64(image.Width)))
+		macroAdd(&pairs, "Height", plainInt(int64(image.Height)))
+		macroAdd(&pairs, "BitDepth", plainInt(int64(image.BitDepth)))
+		macroAdd(&pairs, "ColorSpace", image.ColorModel)
+		macroAdd(&pairs, "Compression_Mode", image.Compression)
+		macroAdd(&pairs, "FrameCount", plainInt(int64(image.FrameCount)))
+		if image.Animated {
+			macroAdd(&pairs, "Animation", "Yes")
+		}
+		macroAdd(&pairs, "Duration", formatDuration(image.AnimationDuration))
+		macroAdd(&pairs, "Orientation", plainInt(int64(image.Orientation)))
+		macroAdd(&pairs, "DPIX", plainFloat(image.DPIX))
+		macroAdd(&pairs, "DPIY", plainFloat(image.DPIY))
+		macroAdd(&pairs, "Make", image.CameraMake)
+		macroAdd(&pairs, "Model", image.CameraModel)
+		macroAdd(&pairs, "LensModel", image.LensModel)
+		if image.TakenAt != nil {
+			macroAdd(&pairs, "DateTimeOriginal", image.TakenAt.Format("2006-01-02 15:04:05 MST"))
+		}
+		if image.Latitude != nil {
+			macroAdd(&pairs, "GPSLatitude", plainFloat(*image.Latitude))
+		}
+		if image.Longitude != nil {
+			macroAdd(&pairs, "GPSLongitude", plainFloat(*image.Longitude))
+		}
+		if image.GPSAltitude != nil {
+			macroAdd(&pairs, "GPSAltitude", plainFloat(*image.GPSAltitude))
+		}
+		for _, field := range image.EXIF {
+			macroAdd(&pairs, field.Name, field.Value)
+		}
+		for _, field := range stream.Tags {
+			macroAdd(&pairs, field.Name, field.Value)
+		}
+	}
+	for _, field := range report.Tags {
+		macroAdd(&pairs, field.Name, field.Value)
+	}
+	return pairs
+}
+
+func macroAdd(pairs *[]macroPair, key, value string) {
+	if key != "" && value != "" {
+		*pairs = append(*pairs, macroPair{key: key, value: value})
+	}
+}

--- a/plugins/mediainfo/macro_test.go
+++ b/plugins/mediainfo/macro_test.go
@@ -1,0 +1,248 @@
+package mediainfo
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestParseMacroArgumentsKeepsLegacyLastValueSemantics(t *testing.T) {
+	arguments, err := parseMacroArguments([]any{
+		nil,
+		int64(0),
+		"first.wav",
+		[]any{"Width", nil},
+		"{Format,Duration}",
+		true,
+		"last.wav",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arguments.path != "last.wav" || !arguments.technical || !arguments.filterUsed {
+		t.Fatalf("parsed arguments = %#v", arguments)
+	}
+	for _, key := range []string{"Width", "Format", "Duration"} {
+		if _, ok := arguments.filter[key]; !ok {
+			t.Errorf("filter does not contain %q: %#v", key, arguments.filter)
+		}
+	}
+
+	arguments, err = parseMacroArguments(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !arguments.technical || arguments.filterUsed || arguments.path != "" {
+		t.Fatalf("default arguments = %#v", arguments)
+	}
+}
+
+func TestParseMacroArgumentsRejectsUnsupportedValues(t *testing.T) {
+	for _, arguments := range [][]any{
+		{float64(1)},
+		{[]any{"Format", int64(2)}},
+	} {
+		if _, err := parseMacroArguments(arguments); err == nil {
+			t.Fatalf("arguments %#v were accepted", arguments)
+		}
+	}
+}
+
+func TestMacroResultFiltersExactKeysAndPreservesDuplicates(t *testing.T) {
+	report := Report{
+		General: General{Format: "Matroska", Duration: 2 * time.Second},
+		Streams: []Stream{
+			{ID: "1", Kind: StreamVideo, Format: "AVC"},
+			{ID: "2", Kind: StreamAudio, Format: "AAC"},
+		},
+		Tags: []Field{
+			{Name: "Title", Value: "First title"},
+			{Name: "Title", Value: "Second title"},
+			{Name: "Empty", Value: ""},
+		},
+	}
+	pairs := macroTechnicalPairs(report)
+	arguments, err := parseMacroArguments([]any{"{Format}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := macroResult(true, pairs, arguments)
+	if !reflect.DeepEqual(result, []any{
+		true,
+		int64(3),
+		[]string{"Format", "Format", "Format"},
+		[]string{"Matroska", "AVC", "AAC"},
+	}) {
+		t.Fatalf("filtered result = %#v", result)
+	}
+
+	arguments, err = parseMacroArguments([]any{"{format}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result = macroResult(true, pairs, arguments)
+	if result[1] != int64(0) || len(result[2].([]string)) != 0 || len(result[3].([]string)) != 0 {
+		t.Fatalf("case-insensitive filter match = %#v", result)
+	}
+
+	arguments, err = parseMacroArguments([]any{"{Title}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result = macroResult(true, pairs, arguments)
+	if !reflect.DeepEqual(result[3], []string{"First title", "Second title"}) {
+		t.Fatalf("duplicate metadata values = %#v", result)
+	}
+}
+
+func TestMacroImageSelectorReturnsOnlyImageMetadata(t *testing.T) {
+	takenAt := time.Date(2024, 6, 7, 8, 9, 10, 0, time.UTC)
+	report := Report{
+		General: General{Format: "JPEG"},
+		Streams: []Stream{{
+			ID:     "1",
+			Kind:   StreamImage,
+			Format: "JPEG",
+			Image: &Image{
+				Width:       4032,
+				Height:      3024,
+				CameraMake:  "Example Camera Co.",
+				CameraModel: "Model One",
+				TakenAt:     &takenAt,
+			},
+		}},
+		Tags: []Field{
+			{Name: "Keyword", Value: "one"},
+			{Name: "Keyword", Value: "two"},
+		},
+	}
+	pairs := macroImagePairs(report)
+	if macroPairValues(pairs, "Format") != nil {
+		t.Fatalf("image backend exposed technical Format: %#v", pairs)
+	}
+	if got := macroPairValues(pairs, "Width"); !reflect.DeepEqual(got, []string{"4032"}) {
+		t.Fatalf("Width = %#v", got)
+	}
+	if got := macroPairValues(pairs, "Keyword"); !reflect.DeepEqual(got, []string{"one", "two"}) {
+		t.Fatalf("Keyword = %#v", got)
+	}
+}
+
+func TestCallMacroReadsCurrentVFSWithoutMaterializing(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "tone.wav")
+	if err := os.WriteFile(path, minimalWave(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	filesystem := &macroNoMaterializeVFS{VFS: vfs.NewOSVFS(directory)}
+	plugin := NewPlugin(t.TempDir())
+
+	result, err := plugin.callMacro(context.Background(), vfs.MacroCallContext{Current: vfs.FileRef{
+		VFS:  filesystem,
+		Dir:  directory,
+		Name: "tone.wav",
+		Path: path,
+	}}, []any{nil, int64(1), "{Format}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result[0] != true || result[1] != int64(2) {
+		t.Fatalf("result = %#v", result)
+	}
+	if !reflect.DeepEqual(result[2], []string{"Format", "Format"}) || !reflect.DeepEqual(result[3], []string{"Wave", "PCM"}) {
+		t.Fatalf("format pairs = %#v", result)
+	}
+	relativeResult, err := plugin.callMacro(context.Background(), vfs.MacroCallContext{Current: vfs.FileRef{
+		VFS: filesystem, Dir: directory,
+	}}, []any{"tone.wav", "{CodecID}"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(relativeResult[3], []string{"RIFF", "0x0001"}) {
+		t.Fatalf("relative-path codec pairs = %#v", relativeResult)
+	}
+
+	// reader::read in the original plugin ignores exif_read's false return:
+	// a readable non-image is still a successful image-mode call with no
+	// pairs. Some macros use that distinction from a missing/unreadable file.
+	imageResult, err := plugin.callMacro(context.Background(), vfs.MacroCallContext{Current: vfs.FileRef{
+		VFS: filesystem, Path: path,
+	}}, []any{false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(imageResult, []any{true, int64(0), []string{}, []string{}}) {
+		t.Fatalf("non-image image-mode result = %#v", imageResult)
+	}
+	if filesystem.opens != 1 || filesystem.creates != 0 {
+		t.Fatalf("VFS calls: opens=%d creates=%d", filesystem.opens, filesystem.creates)
+	}
+}
+
+func TestCallMacroFailureAndCancellation(t *testing.T) {
+	plugin := NewPlugin(t.TempDir())
+	result, err := plugin.callMacro(context.Background(), vfs.MacroCallContext{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(result, []any{false, int64(0), []string{}, []string{}}) {
+		t.Fatalf("missing source result = %#v", result)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := plugin.callMacro(ctx, vfs.MacroCallContext{}, nil); !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation error = %v", err)
+	}
+}
+
+func macroPairValues(pairs []macroPair, key string) []string {
+	var values []string
+	for _, pair := range pairs {
+		if pair.key == key {
+			values = append(values, pair.value)
+		}
+	}
+	return values
+}
+
+type macroNoMaterializeVFS struct {
+	vfs.VFS
+	opens   int
+	creates int
+}
+
+func (filesystem *macroNoMaterializeVFS) Open(ctx context.Context, path string) (vfs.ReadAtCloser, error) {
+	filesystem.opens++
+	return filesystem.VFS.Open(ctx, path)
+}
+
+func (filesystem *macroNoMaterializeVFS) Create(context.Context, string) (io.WriteCloser, error) {
+	filesystem.creates++
+	return nil, errors.New("Create must not be called by MediaInfo macros")
+}
+
+func minimalWave() []byte {
+	data := make([]byte, 44)
+	copy(data[0:4], "RIFF")
+	binary.LittleEndian.PutUint32(data[4:8], uint32(len(data)-8))
+	copy(data[8:12], "WAVE")
+	copy(data[12:16], "fmt ")
+	binary.LittleEndian.PutUint32(data[16:20], 16)
+	binary.LittleEndian.PutUint16(data[20:22], 1)
+	binary.LittleEndian.PutUint16(data[22:24], 1)
+	binary.LittleEndian.PutUint32(data[24:28], 8000)
+	binary.LittleEndian.PutUint32(data[28:32], 8000)
+	binary.LittleEndian.PutUint16(data[32:34], 1)
+	binary.LittleEndian.PutUint16(data[34:36], 8)
+	copy(data[36:40], "data")
+	return data
+}

--- a/plugins/mediainfo/matroska_bounds_test.go
+++ b/plugins/mediainfo/matroska_bounds_test.go
@@ -1,0 +1,226 @@
+package mediainfo
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+type rangeCountingSource struct {
+	data   []byte
+	size   int64
+	bytes  int64
+	maxEnd int64
+}
+
+func (s *rangeCountingSource) ReadAt(ctx context.Context, dst []byte, off int64) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	if off < 0 || off >= s.size {
+		return 0, io.EOF
+	}
+	n := len(dst)
+	if remaining := s.size - off; int64(n) > remaining {
+		n = int(remaining)
+	}
+	clear(dst[:n])
+	if off < int64(len(s.data)) {
+		copyEnd := int64(len(s.data))
+		if copyEnd > off+int64(n) {
+			copyEnd = off + int64(n)
+		}
+		copy(dst[:n], s.data[off:copyEnd])
+	}
+	s.bytes += int64(n)
+	if end := off + int64(n); end > s.maxEnd {
+		s.maxEnd = end
+	}
+	if n < len(dst) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func TestMatroskaDirectTextFieldsAreBoundedAndOwned(t *testing.T) {
+	const capBytes = 8
+	long := []byte("abcdefgh0123456789-should-not-be-retained")
+	doc := ebmlElement([]byte{0x42, 0x82}, []byte("matroska"))
+	header := ebmlElement([]byte{0x1a, 0x45, 0xdf, 0xa3}, doc)
+
+	infoPayload := ebmlElement([]byte{0x4d, 0x80}, long)
+	infoPayload = append(infoPayload, ebmlElement([]byte{0x57, 0x41}, long)...)
+	infoPayload = append(infoPayload, ebmlElement([]byte{0x7b, 0xa9}, long)...)
+	info := ebmlElement([]byte{0x15, 0x49, 0xa9, 0x66}, infoPayload)
+
+	trackPayload := ebmlElement([]byte{0x83}, []byte{2})
+	for _, field := range []struct {
+		id []byte
+	}{
+		{[]byte{0x53, 0x6e}},
+		{[]byte{0x22, 0xb5, 0x9d}},
+		{[]byte{0x86}},
+		{[]byte{0x25, 0x86, 0x88}},
+	} {
+		trackPayload = append(trackPayload, ebmlElement(field.id, long)...)
+	}
+	entry := ebmlElement([]byte{0xae}, trackPayload)
+	tracks := ebmlElement([]byte{0x16, 0x54, 0xae, 0x6b}, entry)
+
+	displayPayload := ebmlElement([]byte{0x85}, long)
+	displayPayload = append(displayPayload, ebmlElement([]byte{0x43, 0x7c}, long)...)
+	display := ebmlElement([]byte{0x80}, displayPayload)
+	chapter := ebmlElement([]byte{0xb6}, display)
+	edition := ebmlElement([]byte{0x45, 0xb9}, chapter)
+	chapters := ebmlElement([]byte{0x10, 0x43, 0xa7, 0x70}, edition)
+
+	simplePayload := ebmlElement([]byte{0x45, 0xa3}, long)
+	simplePayload = append(simplePayload, ebmlElement([]byte{0x44, 0x87}, long)...)
+	simple := ebmlElement([]byte{0x67, 0xc8}, simplePayload)
+	tag := ebmlElement([]byte{0x73, 0x73}, simple)
+	tags := ebmlElement([]byte{0x12, 0x54, 0xc3, 0x67}, tag)
+
+	segmentPayload := append(append(append(info, tracks...), chapters...), tags...)
+	segment := ebmlElement([]byte{0x18, 0x53, 0x80, 0x67}, segmentPayload)
+	data := append(header, segment...)
+	opts := DefaultOptions(ModeDetailed)
+	opts.MaxValueBytes = capBytes
+	report, err := Analyze(context.Background(), Source{Name: "bounded.mkv", Size: int64(len(data)), Reader: memorySource(data)}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !report.Truncated {
+		t.Fatal("expected oversized Matroska text to mark the report truncated")
+	}
+	assertBounded := func(name, value string) {
+		t.Helper()
+		if len(value) > capBytes {
+			t.Fatalf("%s retained %d bytes: %q", name, len(value), value)
+		}
+	}
+	assertBounded("muxing app", report.General.MuxingApp)
+	assertBounded("writing app", report.General.WritingApp)
+	if len(report.Streams) != 1 {
+		t.Fatalf("streams = %d", len(report.Streams))
+	}
+	stream := report.Streams[0]
+	assertBounded("track title", stream.Title)
+	assertBounded("track language", stream.Language)
+	assertBounded("track codec ID", stream.CodecID)
+	assertBounded("track codec name", stream.CodecName)
+	if len(report.Chapters) != 1 {
+		t.Fatalf("chapters = %d", len(report.Chapters))
+	}
+	assertBounded("chapter title", report.Chapters[0].Title)
+	assertBounded("chapter language", report.Chapters[0].Language)
+	for _, tag := range report.Tags {
+		assertBounded("tag value", tag.Value)
+	}
+
+	// All retained strings must own their compact allocation, not alias the
+	// source passed to Analyze.
+	before := report.General.MuxingApp
+	for i := range data {
+		data[i] = 'z'
+	}
+	if report.General.MuxingApp != before {
+		t.Fatalf("retained text aliases source storage: %q", report.General.MuxingApp)
+	}
+}
+
+func TestMatroskaHugeUnknownLeafDoesNotReadPayload(t *testing.T) {
+	doc := ebmlElement([]byte{0x42, 0x82}, []byte("matroska"))
+	header := ebmlElement([]byte{0x1a, 0x45, 0xdf, 0xa3}, doc)
+	const payloadSize = 1 << 20
+	// Void (0xec) with a four-byte EBML size. Its payload is represented by
+	// the sparse source and must never be requested by the parser.
+	unknownHeader := []byte{0xec, 0x10, 0x10, 0x00, 0x00}
+	prefix := append(append([]byte(nil), header...), unknownHeader...)
+	payloadStart := int64(len(prefix))
+	source := &rangeCountingSource{data: prefix, size: payloadStart + payloadSize}
+	p, err := newProbe(context.Background(), Source{Name: "unknown.mkv", Size: source.size, Reader: source}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := parseMatroska(p, nil); err != nil {
+		t.Fatal(err)
+	}
+	if source.maxEnd > payloadStart {
+		t.Fatalf("unknown leaf payload was read through offset %d (payload starts at %d)", source.maxEnd, payloadStart)
+	}
+	if source.bytes > 128 {
+		t.Fatalf("unknown leaf required %d bytes of I/O", source.bytes)
+	}
+}
+
+func TestMatroskaOversizedScalarLeavesDoNotReadPayload(t *testing.T) {
+	source := &rangeCountingSource{size: 1 << 20}
+	p, err := newProbe(context.Background(), Source{Name: "scalar.mkv", Size: source.size, Reader: source}, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	state := &ebmlState{}
+	ctx := &ebmlContext{}
+	if err := parseEBMLLeaf(p, state, 0x2ad7b1, 0, source.size, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := parseEBMLLeaf(p, state, 0x4489, 0, source.size, ctx); err != nil {
+		t.Fatal(err)
+	}
+	if source.bytes != 0 {
+		t.Fatalf("oversized scalar leaves read %d payload bytes", source.bytes)
+	}
+	if !p.report.Truncated {
+		t.Fatal("expected oversized scalar fields to mark the report truncated")
+	}
+}
+
+func TestVorbisVendorIsBoundedAndOwned(t *testing.T) {
+	const capBytes = 8
+	vendor := []byte("vendor-application-with-a-long-version")
+	b := make([]byte, 4+len(vendor)+4)
+	binary.LittleEndian.PutUint32(b[:4], uint32(len(vendor)))
+	copy(b[4:], vendor)
+	p, err := newProbe(context.Background(), Source{Name: "comments", Reader: memorySource(nil)}, Options{Mode: ModeFast, MaxValueBytes: capBytes})
+	if err != nil {
+		t.Fatal(err)
+	}
+	parseVorbisComments(p, b)
+	if got := p.report.General.WritingApp; got != string(vendor[:capBytes]) {
+		t.Fatalf("WritingApp = %q", got)
+	}
+	if !p.report.Truncated {
+		t.Fatal("expected oversized vendor to mark the report truncated")
+	}
+	got := p.report.General.WritingApp
+	for i := 4; i < 4+len(vendor); i++ {
+		b[i] = 'x'
+	}
+	if p.report.General.WritingApp != got {
+		t.Fatalf("WritingApp aliases the comment packet: %q", p.report.General.WritingApp)
+	}
+}
+
+func TestOggPacketAccumulatorIsBoundedAcrossPages(t *testing.T) {
+	first := oggPage(7, 0, 0, []byte(strings.Repeat("a", 255)))
+	second := oggPage(7, 0, 1, []byte(strings.Repeat("b", 255)))
+	data := append(first, second...)
+	secondPayloadStart := int64(len(first) + 28) // 27-byte header + one lacing byte.
+	source := &rangeCountingSource{data: data, size: int64(len(data))}
+	opts := DefaultOptions(ModeFast)
+	opts.MaxSingleMetadataBytes = 300
+	p, err := newProbe(context.Background(), Source{Name: "unterminated.ogg", Size: source.size, Reader: source}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _, err = readOggPackets(p, 3)
+	if !errors.Is(err, ErrLimit) {
+		t.Fatalf("readOggPackets error = %v, want ErrLimit", err)
+	}
+	if source.maxEnd > secondPayloadStart {
+		t.Fatalf("second page payload was read through offset %d (starts at %d)", source.maxEnd, secondPayloadStart)
+	}
+}

--- a/plugins/mediainfo/model.go
+++ b/plugins/mediainfo/model.go
@@ -1,0 +1,184 @@
+// Package mediainfo provides a bounded, pure-Go media metadata analyzer.
+//
+// It intentionally exposes a container-neutral report.  Parsers may leave
+// fields at their zero value when a format does not carry the information.
+package mediainfo
+
+import "time"
+
+// Mode selects how much of a file the analyzer may inspect.
+type Mode uint8
+
+const (
+	// ModeFast reads structural metadata only and is suitable for Quick View.
+	ModeFast Mode = iota
+	// ModeDetailed may scan bounded indexes, frame headers and subtitle text.
+	ModeDetailed
+)
+
+// StreamKind identifies the logical kind of a stream.
+type StreamKind string
+
+const (
+	StreamVideo StreamKind = "Video"
+	StreamAudio StreamKind = "Audio"
+	StreamText  StreamKind = "Text"
+	StreamImage StreamKind = "Image"
+	StreamMenu  StreamKind = "Menu"
+)
+
+// Field stores a repeatable metadata value. Target is empty for file-level
+// fields and contains a stream ID for stream-specific fields.
+type Field struct {
+	Target string
+	Name   string
+	Value  string
+}
+
+// Warning describes non-fatal damage, unsupported details, or a resource cap.
+type Warning struct {
+	Code    string
+	Message string
+	Offset  int64
+}
+
+// General describes the file/container as a whole.
+type General struct {
+	FileName                string
+	FileSize                int64
+	Format                  string
+	FormatProfile           string
+	CodecID                 string
+	MIME                    string
+	CompatibleBrands        []string
+	Duration                time.Duration
+	DurationEstimated       bool
+	OverallBitRate          int64
+	OverallBitRateEstimated bool
+	FrameCount              int64
+	FrameRate               float64
+	MuxingApp               string
+	WritingApp              string
+	EncodedDate             *time.Time
+	TaggedDate              *time.Time
+	Streamable              *bool
+}
+
+// Video contains video-specific stream properties.
+type Video struct {
+	Width                   int
+	Height                  int
+	DisplayWidth            int
+	DisplayHeight           int
+	PixelAspectRatio        float64
+	DisplayAspectRatio      float64
+	Rotation                float64
+	BitDepth                int
+	ColorSpace              string
+	ChromaSubsampling       string
+	ScanType                string
+	ScanOrder               string
+	ColorRange              string
+	ColorPrimaries          string
+	TransferCharacteristics string
+	MatrixCoefficients      string
+	HDRFormat               string
+	MaxCLL                  int
+	MaxFALL                 int
+}
+
+// Audio contains audio-specific stream properties.
+type Audio struct {
+	Channels        int
+	ChannelLayout   string
+	SampleRate      int
+	BitDepth        int
+	CompressionMode string
+	Delay           time.Duration
+	EncoderPadding  int64
+}
+
+// Text contains subtitle/text stream properties.
+type Text struct {
+	FormatVersion string
+	Encoding      string
+	CueCount      int64
+	FirstCue      time.Duration
+	LastCue       time.Duration
+	StyleCount    int
+}
+
+// Image contains still/animated image properties.
+type Image struct {
+	Width             int
+	Height            int
+	BitDepth          int
+	ColorModel        string
+	Compression       string
+	FrameCount        int
+	Animated          bool
+	AnimationDuration time.Duration
+	Orientation       int
+	DPIX              float64
+	DPIY              float64
+	CameraMake        string
+	CameraModel       string
+	LensModel         string
+	TakenAt           *time.Time
+	Latitude          *float64
+	Longitude         *float64
+	GPSAltitude       *float64
+	// EXIF contains useful camera fields which do not need dedicated typed
+	// accessors. Names are stable English keys and values are display-ready.
+	EXIF []Field
+}
+
+// Stream describes one elementary stream.
+type Stream struct {
+	Index              int
+	ID                 string
+	Kind               StreamKind
+	Format             string
+	Profile            string
+	Level              string
+	CodecID            string
+	CodecName          string
+	Title              string
+	Language           string
+	Duration           time.Duration
+	DurationEstimated  bool
+	BitRate            int64
+	BitRateEstimated   bool
+	BitRateMode        string
+	FrameCount         int64
+	FrameRate          float64
+	FrameRateEstimated bool
+	Default            *bool
+	Forced             *bool
+	Encrypted          *bool
+	Video              *Video
+	Audio              *Audio
+	Text               *Text
+	Image              *Image
+	Tags               []Field
+}
+
+// Chapter describes a chapter/menu entry.
+type Chapter struct {
+	ID       string
+	Start    time.Duration
+	End      time.Duration
+	Title    string
+	Language string
+}
+
+// Report is the normalized result returned by Analyze.
+type Report struct {
+	Mode      Mode
+	General   General
+	Streams   []Stream
+	Chapters  []Chapter
+	Tags      []Field
+	Warnings  []Warning
+	Truncated bool
+}

--- a/plugins/mediainfo/open.go
+++ b/plugins/mediainfo/open.go
@@ -1,0 +1,239 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+var errMediaDirectory = errors.New("selected item is a directory")
+
+func (plugin *Plugin) openCurrent(app vfs.App) {
+	if app == nil || app.GetActivePanelVFS() == nil {
+		plugin.showError(plugin.text("MediaInfo.NoPanel", "No active file panel is available.", "Нет активной файловой панели."))
+		return
+	}
+	name := app.GetSelectedName()
+	if name == "" || name == ".." {
+		plugin.showError(plugin.text("MediaInfo.NoSelection", "Select a media file first.", "Сначала выберите медиафайл."))
+		return
+	}
+	fs := app.GetActivePanelVFS()
+	plugin.openPath(app, fs, fs.Join(fs.GetPath(), name))
+}
+
+func (plugin *Plugin) handlePrefix(app vfs.App, rawArgument string) {
+	if strings.TrimSpace(rawArgument) == "" {
+		plugin.openCurrent(app)
+		return
+	}
+	if app == nil || app.GetActivePanelVFS() == nil {
+		plugin.showError(plugin.text("MediaInfo.NoPanel", "No active file panel is available.", "Нет активной файловой панели."))
+		return
+	}
+	fs := app.GetActivePanelVFS()
+	path, err := resolveMediaPath(fs, rawArgument)
+	if err != nil {
+		plugin.showError(err.Error())
+		return
+	}
+	plugin.openPath(app, fs, path)
+}
+
+func resolveMediaPath(fs vfs.VFS, raw string) (string, error) {
+	if fs == nil {
+		return "", errors.New("no active VFS")
+	}
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "", errors.New("media path is empty")
+	}
+	if value[0] == '"' || value[0] == '\'' {
+		quote := value[0]
+		if len(value) < 2 || value[len(value)-1] != quote {
+			return "", errors.New("invalid quoted media path")
+		}
+		value = value[1 : len(value)-1]
+		if quote == '\'' {
+			value = strings.ReplaceAll(value, "''", "'")
+		} else {
+			value = strings.ReplaceAll(value, `\"`, `"`)
+		}
+	}
+	if _, ok := fs.(*vfs.OSVFS); ok {
+		value = expandOSPathEnvironment(value)
+	}
+	if strings.TrimSpace(value) == "" {
+		return "", errors.New("media path is empty")
+	}
+	if !fs.IsAbs(value) {
+		value = fs.Join(fs.GetPath(), value)
+	}
+	absolute, err := fs.Abs(value)
+	if err != nil {
+		return "", fmt.Errorf("resolve media path: %w", err)
+	}
+	return absolute, nil
+}
+
+func expandOSPathEnvironment(value string) string {
+	value = os.ExpandEnv(value)
+	// FAR and cmd.exe users commonly write %NAME%, while Go's ExpandEnv
+	// intentionally recognizes only $NAME. Accept both on local panels.
+	var expanded strings.Builder
+	for offset := 0; offset < len(value); {
+		startRelative := strings.IndexByte(value[offset:], '%')
+		if startRelative < 0 {
+			expanded.WriteString(value[offset:])
+			break
+		}
+		start := offset + startRelative
+		expanded.WriteString(value[offset:start])
+		endRelative := strings.IndexByte(value[start+1:], '%')
+		if endRelative < 0 {
+			expanded.WriteString(value[start:])
+			break
+		}
+		end := start + 1 + endRelative
+		name := value[start+1 : end]
+		if name == "" {
+			expanded.WriteByte('%')
+			offset = end + 1
+			continue
+		}
+		replacement, exists := os.LookupEnv(name)
+		if !exists {
+			// Match os.ExpandEnv: an unknown variable expands to empty.
+			replacement = ""
+		}
+		expanded.WriteString(replacement)
+		offset = end + 1
+	}
+	return expanded.String()
+}
+
+func (plugin *Plugin) openPath(app vfs.App, fs vfs.VFS, path string) {
+	var (
+		report     Report
+		item       vfs.VFSItem
+		editorPath string
+	)
+	pluginSettings := plugin.settings()
+	title := " " + plugin.text("MediaInfo.Title", "MediaInfo", "MediaInfo") + " "
+	app.RunProgressTask(title,
+		plugin.text("MediaInfo.Opening", "Opening media file...", "Открытие медиафайла..."), false,
+		func(ctx context.Context, update func(string, int)) error {
+			var err error
+			item, err = fs.Stat(ctx, path)
+			if err != nil {
+				return err
+			}
+			if item.IsDir {
+				return errMediaDirectory
+			}
+			update(plugin.text("MediaInfo.Analyzing", "Reading media metadata...", "Чтение метаданных..."), -1)
+			report, err = plugin.analyzePath(ctx, fs, path, item, ModeDetailed)
+			if err != nil {
+				return err
+			}
+			editorPath, err = availableReportPath(ctx, fs, path)
+			if pluginSettings.UseEditor {
+				return err
+			}
+			// A read-only VFS can still show and copy the report. Defer a
+			// destination error until the user explicitly requests F4.
+			return nil
+		},
+		func(err error) {
+			if err != nil {
+				plugin.presentAnalysisError(path, err)
+				return
+			}
+			text, defaultLayout := plugin.renderReport(report, true)
+			if pluginSettings.UseEditor {
+				plugin.openReportEditor(app, fs, editorPath, text)
+				return
+			}
+			plugin.showReportDialog(app, fs, path, editorPath, report, text, defaultLayout)
+		})
+}
+
+func availableReportPath(ctx context.Context, fs vfs.VFS, sourcePath string) (string, error) {
+	name := fs.Base(sourcePath)
+	extension := filepath.Ext(name)
+	base := strings.TrimSuffix(name, extension)
+	if base == "" {
+		base = name
+	}
+	directory := fs.Dir(sourcePath)
+	for index := 1; index <= 999; index++ {
+		suffix := ""
+		if index > 1 {
+			suffix = fmt.Sprintf(" (%d)", index)
+		}
+		candidate := fs.Join(directory, base+".MediaInfo"+suffix+".txt")
+		_, err := fs.Stat(ctx, candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			return candidate, nil
+		}
+		if err != nil {
+			return "", fmt.Errorf("check report destination: %w", err)
+		}
+	}
+	return "", errors.New("could not find a free MediaInfo report name")
+}
+
+func (plugin *Plugin) openReportEditor(app vfs.App, fs vfs.VFS, outputPath, text string) bool {
+	if outputPath == "" {
+		plugin.showError(plugin.text("MediaInfo.ReportNameFailed", "Could not choose a collision-free report name on this VFS.", "Не удалось выбрать свободное имя отчёта в этой VFS."))
+		return false
+	}
+	host, ok := app.(vfs.TextEditorHost)
+	if !ok {
+		plugin.showError(plugin.text("MediaInfo.EditorUnsupported", "This host cannot open an in-memory report in the editor.", "Хост не может открыть отчёт в редакторе."))
+		return false
+	}
+	request := vfs.TextEditorRequest{
+		VFS:               fs,
+		Path:              outputPath,
+		DisplayTitle:      fs.Base(outputPath),
+		Content:           []byte(text),
+		Modified:          true,
+		Temporary:         false,
+		TargetKnownAbsent: true,
+	}
+	if err := host.OpenTextEditor(request); err != nil {
+		plugin.showError(fmt.Sprintf("%s\n\n%v", plugin.text("MediaInfo.EditorFailed", "Could not open the report in the editor.", "Не удалось открыть отчёт в редакторе."), err))
+		return false
+	}
+	return true
+}
+
+func (plugin *Plugin) presentAnalysisError(path string, err error) {
+	if errors.Is(err, context.Canceled) {
+		return
+	}
+	var parseError *ParseError
+	message := ""
+	switch {
+	case errors.Is(err, errMediaDirectory):
+		message = plugin.text("MediaInfo.Directory", "The selected item is a directory.", "Выбранный элемент является каталогом.")
+	case errors.Is(err, ErrUnsupported):
+		message = plugin.text("MediaInfo.Unsupported", "The selected file format is not supported.", "Формат выбранного файла не поддерживается.")
+	case errors.As(err, &parseError):
+		message = plugin.text("MediaInfo.Corrupt", "The media container is damaged or malformed.", "Медиаконтейнер повреждён или имеет неверную структуру.")
+	default:
+		message = plugin.text("MediaInfo.ReadFailed", "Could not read the selected file.", "Не удалось прочитать выбранный файл.")
+	}
+	plugin.showError(fmt.Sprintf("%s\n\n%s\n%v", message, path, err))
+}
+
+func (plugin *Plugin) showError(message string) {
+	vtui.ShowMessage(" "+plugin.text("MediaInfo.ErrorTitle", "MediaInfo error", "Ошибка MediaInfo")+" ", message, []string{plugin.text("MediaInfo.OK", "&OK", "&ОК")})
+}

--- a/plugins/mediainfo/open_test.go
+++ b/plugins/mediainfo/open_test.go
@@ -1,0 +1,63 @@
+package mediainfo
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestResolveMediaPathPreservesQuotedWindowsSeparators(t *testing.T) {
+	directory := t.TempDir()
+	fs := vfs.NewOSVFS(directory)
+	path, err := resolveMediaPath(fs, `"folder\movie file.mp4"`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(directory, `folder\movie file.mp4`)
+	if path != want {
+		t.Fatalf("resolved path = %q, want %q", path, want)
+	}
+}
+
+func TestResolveMediaPathExpandsLocalEnvironment(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("F4_MEDIA_TEST_DIR", directory)
+	fs := vfs.NewOSVFS(t.TempDir())
+	for _, raw := range []string{`${F4_MEDIA_TEST_DIR}/movie.mp4`, `%F4_MEDIA_TEST_DIR%/movie.mp4`} {
+		path, err := resolveMediaPath(fs, raw)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := filepath.Join(directory, "movie.mp4")
+		if path != want {
+			t.Fatalf("resolveMediaPath(%q) = %q, want %q", raw, path, want)
+		}
+	}
+}
+
+func TestAvailableReportPathAvoidsExistingFile(t *testing.T) {
+	directory := t.TempDir()
+	fs := vfs.NewOSVFS(directory)
+	source := filepath.Join(directory, "movie.mp4")
+	if err := os.WriteFile(filepath.Join(directory, "movie.MediaInfo.txt"), []byte("existing"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path, err := availableReportPath(context.Background(), fs, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(directory, "movie.MediaInfo (2).txt")
+	if path != want {
+		t.Fatalf("report path = %q, want %q", path, want)
+	}
+}
+
+func TestExpandOSPathEnvironmentDoesNotLoopOnSelfReference(t *testing.T) {
+	t.Setenv("F4_MEDIA_LOOP", "%F4_MEDIA_LOOP%")
+	if got := expandOSPathEnvironment("%F4_MEDIA_LOOP%"); got != "%F4_MEDIA_LOOP%" {
+		t.Fatalf("self reference = %q", got)
+	}
+}

--- a/plugins/mediainfo/parse_audio.go
+++ b/plugins/mediainfo/parse_audio.go
@@ -1,0 +1,688 @@
+package mediainfo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+)
+
+type mpegHeader struct {
+	version, layer                                    string
+	bitRate, sampleRate, channels, frameSize, samples int
+	channelMode                                       string
+}
+
+func looksLikeMPEGAudio(b []byte) bool {
+	for i := 0; i+4 <= len(b) && i < 4096; i++ {
+		if _, ok := decodeMPEGHeader(b[i : i+4]); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeMPEGHeader(b []byte) (mpegHeader, bool) {
+	if len(b) < 4 || b[0] != 0xff || b[1]&0xe0 != 0xe0 {
+		return mpegHeader{}, false
+	}
+	vbits, lbits := (b[1]>>3)&3, (b[1]>>1)&3
+	if vbits == 1 || lbits == 0 {
+		return mpegHeader{}, false
+	}
+	version := map[byte]string{0: "2.5", 2: "2", 3: "1"}[vbits]
+	layerNum := map[byte]int{1: 3, 2: 2, 3: 1}[lbits]
+	brIndex, srIndex := (b[2]>>4)&15, (b[2]>>2)&3
+	if brIndex == 0 || brIndex == 15 || srIndex == 3 {
+		return mpegHeader{}, false
+	}
+	var brs []int
+	if version == "1" {
+		switch layerNum {
+		case 1:
+			brs = []int{0, 32, 64, 96, 128, 160, 192, 224, 256, 288, 320, 352, 384, 416, 448}
+		case 2:
+			brs = []int{0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384}
+		default:
+			brs = []int{0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320}
+		}
+	} else {
+		if layerNum == 1 {
+			brs = []int{0, 32, 48, 56, 64, 80, 96, 112, 128, 144, 160, 176, 192, 224, 256}
+		} else {
+			brs = []int{0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160}
+		}
+	}
+	base := []int{44100, 48000, 32000}[srIndex]
+	if version == "2" {
+		base /= 2
+	} else if version == "2.5" {
+		base /= 4
+	}
+	bitRate := brs[brIndex] * 1000
+	padding := int((b[2] >> 1) & 1)
+	samples := 1152
+	var size int
+	if layerNum == 1 {
+		samples = 384
+		size = (12*bitRate/base + padding) * 4
+	} else if layerNum == 3 && version != "1" {
+		samples = 576
+		size = 72*bitRate/base + padding
+	} else {
+		size = 144*bitRate/base + padding
+	}
+	mode := (b[3] >> 6) & 3
+	modeName := []string{"Stereo", "Joint stereo", "Dual channel", "Mono"}[mode]
+	return mpegHeader{version: version, layer: fmt.Sprint(layerNum), bitRate: bitRate, sampleRate: base, channels: map[bool]int{true: 1, false: 2}[mode == 3], frameSize: size, samples: samples, channelMode: modeName}, size >= 4
+}
+
+func parseMPEGAudio(p *probe, head []byte) error {
+	p.report.General.Format = "MPEG Audio"
+	p.report.General.MIME = "audio/mpeg"
+	start := int64(0)
+	if len(head) >= 10 && string(head[:3]) == "ID3" {
+		sz := int64(syncSafe(head[6:10]))
+		start = 10 + sz
+		if head[5]&0x10 != 0 {
+			start += 10
+		}
+		if sz <= p.opts.MaxSingleMetadataBytes {
+			if err := parseID3v2(p, 0, int(10+sz)); err != nil {
+				p.warn("id3", err.Error(), 0)
+			}
+		} else {
+			p.warn("tag_limit", "ID3 tag is too large and was skipped", 0)
+		}
+	}
+	search := int64(256 << 10)
+	if p.src.Size-start < search {
+		search = p.src.Size - start
+	}
+	if search <= 0 {
+		return &ParseError{Format: "MPEG Audio", Offset: start, Err: errors.New("audio frame not found")}
+	}
+	b, err := p.readAt(start, int(search))
+	if err != nil && !errors.Is(err, ErrLimit) {
+		return err
+	}
+	frameOff := -1
+	var mh mpegHeader
+	for i := 0; i+4 <= len(b); i++ {
+		h, ok := decodeMPEGHeader(b[i : i+4])
+		if ok {
+			if i+h.frameSize+4 <= len(b) {
+				if h2, ok2 := decodeMPEGHeader(b[i+h.frameSize : i+h.frameSize+4]); !ok2 || h2.sampleRate != h.sampleRate {
+					continue
+				}
+			}
+			frameOff = i
+			mh = h
+			break
+		}
+	}
+	if frameOff < 0 {
+		return &ParseError{Format: "MPEG Audio", Offset: start, Err: errors.New("audio frame not found")}
+	}
+	start += int64(frameOff)
+	p.report.General.FormatProfile = "Layer " + mh.layer
+	stream := Stream{Index: 0, ID: "1", Kind: StreamAudio, Format: "MPEG Audio", Profile: "Version " + mh.version + " Layer " + mh.layer, CodecID: "MP" + mh.layer, BitRate: int64(mh.bitRate), BitRateMode: "CBR", Audio: &Audio{Channels: mh.channels, ChannelLayout: mh.channelMode, SampleRate: mh.sampleRate, CompressionMode: "Lossy"}}
+	firstLen := mh.frameSize
+	if firstLen > int(p.opts.MaxSingleMetadataBytes) {
+		firstLen = int(p.opts.MaxSingleMetadataBytes)
+	}
+	first, _ := p.readAt(start, firstLen)
+	frames, audioBytes := parseXingVBRI(first, mh)
+	if frames > 0 {
+		stream.FrameCount = int64(frames)
+		stream.Duration = durationFromUnits(uint64(frames*mh.samples), uint64(mh.sampleRate))
+		stream.BitRateMode = "VBR"
+		if audioBytes > 0 && stream.Duration > 0 {
+			stream.BitRate = int64(float64(audioBytes*8) / stream.Duration.Seconds())
+		}
+	}
+	if stream.Duration == 0 {
+		payload := p.src.Size - start
+		if payload > 128 {
+			tail, _ := p.readAt(p.src.Size-128, 128)
+			if len(tail) >= 3 && string(tail[:3]) == "TAG" {
+				payload -= 128
+				parseID3v1(p, tail)
+			}
+		}
+		stream.Duration = time.Duration(float64(payload*8) / float64(mh.bitRate) * float64(time.Second))
+		stream.DurationEstimated = true
+	}
+	p.report.General.Duration = stream.Duration
+	p.report.Streams = append(p.report.Streams, stream)
+	return nil
+}
+
+func parseXingVBRI(frame []byte, h mpegHeader) (frames int, bytesCount int64) {
+	for _, sig := range []string{"Xing", "Info"} {
+		if i := bytes.Index(frame, []byte(sig)); i >= 0 && i+12 <= len(frame) {
+			flags := binary.BigEndian.Uint32(frame[i+4 : i+8])
+			pos := i + 8
+			if flags&1 != 0 && pos+4 <= len(frame) {
+				frames = int(binary.BigEndian.Uint32(frame[pos : pos+4]))
+				pos += 4
+			}
+			if flags&2 != 0 && pos+4 <= len(frame) {
+				bytesCount = int64(binary.BigEndian.Uint32(frame[pos : pos+4]))
+			}
+			return
+		}
+	}
+	if i := bytes.Index(frame, []byte("VBRI")); i >= 0 && i+18 <= len(frame) {
+		bytesCount = int64(binary.BigEndian.Uint32(frame[i+10 : i+14]))
+		frames = int(binary.BigEndian.Uint32(frame[i+14 : i+18]))
+	}
+	return
+}
+
+func syncSafe(b []byte) int {
+	if len(b) < 4 {
+		return 0
+	}
+	return int(b[0]&0x7f)<<21 | int(b[1]&0x7f)<<14 | int(b[2]&0x7f)<<7 | int(b[3]&0x7f)
+}
+
+func parseID3v2(p *probe, off int64, total int) error {
+	b, err := p.readAt(off, total)
+	if err != nil {
+		return err
+	}
+	if len(b) < 10 {
+		return io.ErrUnexpectedEOF
+	}
+	ver := b[3]
+	data := b[10:]
+	if b[5]&0x80 != 0 {
+		data = deunsync(data)
+	}
+	for len(data) >= 6 && data[0] != 0 {
+		var id string
+		var size, header int
+		if ver == 2 {
+			id = string(data[:3])
+			size = int(data[3])<<16 | int(data[4])<<8 | int(data[5])
+			header = 6
+		} else {
+			if len(data) < 10 {
+				break
+			}
+			id = string(data[:4])
+			if ver == 4 {
+				size = syncSafe(data[4:8])
+			} else {
+				size = int(binary.BigEndian.Uint32(data[4:8]))
+			}
+			header = 10
+		}
+		if size < 0 || header+size > len(data) {
+			break
+		}
+		payload := data[header : header+size]
+		name := canonicalTag(id)
+		if isID3Text(id) && len(payload) > 1 {
+			p.addTag("", name, decodeID3Text(payload))
+		} else if id == "COMM" && len(payload) > 4 {
+			p.addTag("", "Comment", decodeID3Text(append([]byte{payload[0]}, payload[4:]...)))
+		}
+		data = data[header+size:]
+	}
+	return nil
+}
+
+func isID3Text(id string) bool {
+	return strings.HasPrefix(id, "T") && id != "TXXX" || id == "TT2" || id == "TP1" || id == "TAL" || id == "TRK" || id == "TYE"
+}
+func decodeID3Text(b []byte) string {
+	if len(b) < 2 {
+		return ""
+	}
+	enc := b[0]
+	d := b[1:]
+	switch enc {
+	case 0, 3:
+		return cleanText(d)
+	case 1:
+		if len(d) >= 2 && d[0] == 0xff && d[1] == 0xfe {
+			return decodeUTF16(d[2:], true)
+		}
+		if len(d) >= 2 && d[0] == 0xfe && d[1] == 0xff {
+			return decodeUTF16(d[2:], false)
+		}
+		return decodeUTF16(d, true)
+	case 2:
+		return decodeUTF16(d, false)
+	}
+	return ""
+}
+func deunsync(b []byte) []byte {
+	out := make([]byte, 0, len(b))
+	for i := 0; i < len(b); i++ {
+		out = append(out, b[i])
+		if b[i] == 0xff && i+1 < len(b) && b[i+1] == 0 {
+			i++
+		}
+	}
+	return out
+}
+func parseID3v1(p *probe, b []byte) {
+	if len(b) < 128 {
+		return
+	}
+	p.addTag("", "Title", cleanText(b[3:33]))
+	p.addTag("", "Artist", cleanText(b[33:63]))
+	p.addTag("", "Album", cleanText(b[63:93]))
+	p.addTag("", "Date", cleanText(b[93:97]))
+}
+
+func parseFLAC(p *probe, _ []byte) error {
+	p.report.General.Format = "FLAC"
+	p.report.General.MIME = "audio/flac"
+	stream := Stream{Index: 0, ID: "1", Kind: StreamAudio, Format: "FLAC", Audio: &Audio{CompressionMode: "Lossless"}}
+	pos := int64(4)
+	last := false
+	for !last {
+		if err := p.step(); err != nil {
+			return err
+		}
+		h, err := p.readAt(pos, 4)
+		if err != nil {
+			return &ParseError{Format: "FLAC", Offset: pos, Err: err}
+		}
+		last = h[0]&0x80 != 0
+		typ := h[0] & 0x7f
+		sz := int64(h[1])<<16 | int64(h[2])<<8 | int64(h[3])
+		data := pos + 4
+		if sz < 0 || data+sz > p.src.Size {
+			return &ParseError{Format: "FLAC", Offset: pos, Err: errors.New("metadata block exceeds file")}
+		}
+		switch typ {
+		case 0:
+			if sz >= 34 {
+				b, e := p.readAt(data, 34)
+				if e != nil {
+					return e
+				}
+				v := binary.BigEndian.Uint64(b[10:18])
+				rate := int(v >> 44)
+				channels := int((v>>41)&7) + 1
+				bits := int((v>>36)&31) + 1
+				samples := v & 0xfffffffff
+				stream.Audio.SampleRate = rate
+				stream.Audio.Channels = channels
+				stream.Audio.BitDepth = bits
+				stream.Duration = durationFromUnits(samples, uint64(rate))
+			}
+		case 4:
+			if sz <= p.opts.MaxSingleMetadataBytes {
+				b, e := p.readAt(data, int(sz))
+				if e == nil {
+					parseVorbisComments(p, b)
+				}
+			}
+		case 6:
+			if sz >= 32 && sz <= p.opts.MaxSingleMetadataBytes {
+				b, e := p.readAt(data, int(sz))
+				if e == nil {
+					parseFLACPictureInfo(p, b)
+				}
+			}
+		}
+		pos = data + sz
+	}
+	p.report.General.Duration = stream.Duration
+	p.report.Streams = append(p.report.Streams, stream)
+	return nil
+}
+
+func parseVorbisComments(p *probe, b []byte) {
+	if len(b) < 8 {
+		return
+	}
+	vendorSize := uint64(binary.LittleEndian.Uint32(b[:4]))
+	if vendorSize > uint64(len(b)-8) {
+		return
+	}
+	vendorLen := int(vendorSize)
+	vendor := b[4 : 4+vendorLen]
+	if len(vendor) > p.opts.MaxValueBytes {
+		vendor = vendor[:p.opts.MaxValueBytes]
+		p.report.Truncated = true
+	}
+	p.report.General.WritingApp = strings.Clone(cleanText(vendor))
+	pos := 4 + vendorLen
+	count := int(binary.LittleEndian.Uint32(b[pos : pos+4]))
+	pos += 4
+	for i := 0; i < count && pos+4 <= len(b); i++ {
+		n := int(binary.LittleEndian.Uint32(b[pos : pos+4]))
+		pos += 4
+		if n < 0 || pos+n > len(b) {
+			break
+		}
+		s := string(b[pos : pos+n])
+		pos += n
+		if eq := strings.IndexByte(s, '='); eq > 0 {
+			p.addTag("", canonicalTag(s[:eq]), s[eq+1:])
+		}
+	}
+}
+func parseFLACPictureInfo(p *probe, b []byte) {
+	if len(b) < 32 {
+		return
+	}
+	pos := 4
+	mimeLen := int(binary.BigEndian.Uint32(b[pos : pos+4]))
+	pos += 4 + mimeLen
+	if pos+4 > len(b) {
+		return
+	}
+	descLen := int(binary.BigEndian.Uint32(b[pos : pos+4]))
+	pos += 4 + descLen
+	if pos+16 > len(b) {
+		return
+	}
+	p.addTag("", "Cover dimensions", fmt.Sprintf("%dx%d", binary.BigEndian.Uint32(b[pos:pos+4]), binary.BigEndian.Uint32(b[pos+4:pos+8])))
+}
+
+func parseOgg(p *probe, _ []byte) error {
+	p.report.General.Format = "Ogg"
+	p.report.General.MIME = "application/ogg"
+	packets, serial, err := readOggPackets(p, 3)
+	if err != nil {
+		return err
+	}
+	if len(packets) == 0 {
+		return &ParseError{Format: "Ogg", Offset: 0, Err: errors.New("no packets")}
+	}
+	s := Stream{Index: 0, ID: fmt.Sprint(serial), Kind: StreamAudio, Audio: &Audio{}}
+	first := packets[0]
+	switch {
+	case len(first) >= 30 && first[0] == 1 && string(first[1:7]) == "vorbis":
+		s.Format = "Vorbis"
+		s.Audio.Channels = int(first[11])
+		s.Audio.SampleRate = int(binary.LittleEndian.Uint32(first[12:16]))
+		s.Audio.CompressionMode = "Lossy"
+		if len(packets) > 1 && len(packets[1]) > 7 && packets[1][0] == 3 {
+			parseVorbisComments(p, packets[1][7:])
+		}
+	case len(first) >= 19 && string(first[:8]) == "OpusHead":
+		s.Format = "Opus"
+		s.Audio.Channels = int(first[9])
+		s.Audio.SampleRate = 48000
+		s.Audio.Delay = durationFromUnits(uint64(binary.LittleEndian.Uint16(first[10:12])), 48000)
+		s.Audio.CompressionMode = "Lossy"
+		if len(packets) > 1 && len(packets[1]) > 8 && string(packets[1][:8]) == "OpusTags" {
+			parseVorbisComments(p, packets[1][8:])
+		}
+	case len(first) >= 80 && string(first[:8]) == "Speex   ":
+		s.Format = "Speex"
+		s.Audio.SampleRate = int(binary.LittleEndian.Uint32(first[36:40]))
+		s.Audio.Channels = int(binary.LittleEndian.Uint32(first[48:52]))
+		s.Audio.CompressionMode = "Lossy"
+	case len(first) >= 7 && first[0] == 0x80 && string(first[1:7]) == "theora":
+		s.Kind = StreamVideo
+		s.Format = "Theora"
+		s.Audio = nil
+		s.Video = &Video{}
+		parseTheoraIdentification(first, &s)
+	case isOggFLACHeader(first):
+		s.Format = "FLAC"
+		s.CodecID = "FLAC"
+		s.Audio.CompressionMode = "Lossless"
+		if !parseOggFLACStreamInfo(first, &s) && len(packets) > 1 {
+			parseOggFLACStreamInfo(packets[1], &s)
+		}
+	default:
+		s.Format = "Unknown"
+		s.CodecID = fmt.Sprintf("%x", first[:minInt(len(first), 8)])
+	}
+	granule := findLastOggGranule(p, serial)
+	if granule > 0 && s.Audio != nil && s.Audio.SampleRate > 0 {
+		s.Duration = durationFromUnits(uint64(granule), uint64(s.Audio.SampleRate))
+		p.report.General.Duration = s.Duration
+	}
+	p.report.Streams = append(p.report.Streams, s)
+	return nil
+}
+
+func isOggFLACHeader(b []byte) bool {
+	return len(b) >= 4 && string(b[:4]) == "fLaC" || len(b) >= 5 && b[0] == 0x7f && string(b[1:5]) == "FLAC"
+}
+
+func parseOggFLACStreamInfo(packet []byte, stream *Stream) bool {
+	marker := bytes.Index(packet, []byte("fLaC"))
+	start := 0
+	if marker >= 0 {
+		start = marker + 4
+	}
+	if start+4+34 > len(packet) {
+		return false
+	}
+	h := packet[start : start+4]
+	if h[0]&0x7f != 0 || int(h[1])<<16|int(h[2])<<8|int(h[3]) < 34 {
+		return false
+	}
+	b := packet[start+4 : start+4+34]
+	v := binary.BigEndian.Uint64(b[10:18])
+	rate := int(v >> 44)
+	stream.Audio.SampleRate = rate
+	stream.Audio.Channels = int((v>>41)&7) + 1
+	stream.Audio.BitDepth = int((v>>36)&31) + 1
+	stream.Duration = durationFromUnits(v&0xfffffffff, uint64(rate))
+	return rate > 0
+}
+
+func parseTheoraIdentification(packet []byte, stream *Stream) {
+	if len(packet) < 42 || stream.Video == nil {
+		return
+	}
+	width := int(packet[14])<<16 | int(packet[15])<<8 | int(packet[16])
+	height := int(packet[17])<<16 | int(packet[18])<<8 | int(packet[19])
+	if width == 0 {
+		width = int(binary.BigEndian.Uint16(packet[10:12])) * 16
+	}
+	if height == 0 {
+		height = int(binary.BigEndian.Uint16(packet[12:14])) * 16
+	}
+	stream.Video.Width, stream.Video.Height = width, height
+	numerator := binary.BigEndian.Uint32(packet[22:26])
+	denominator := binary.BigEndian.Uint32(packet[26:30])
+	if numerator > 0 && denominator > 0 {
+		stream.FrameRate = float64(numerator) / float64(denominator)
+	}
+	stream.Profile = fmt.Sprintf("Theora %d.%d.%d", packet[7], packet[8], packet[9])
+}
+
+func readOggPackets(p *probe, maxPackets int) ([][]byte, uint32, error) {
+	var packets [][]byte
+	var cur []byte
+	pos := int64(0)
+	var serial uint32
+	for pos+27 <= p.src.Size && len(packets) < maxPackets {
+		if err := p.step(); err != nil {
+			return packets, serial, err
+		}
+		h, e := p.readAt(pos, 27)
+		if e != nil {
+			return packets, serial, e
+		}
+		if string(h[:4]) != "OggS" {
+			return packets, serial, &ParseError{Format: "Ogg", Offset: pos, Err: errors.New("bad page capture")}
+		}
+		nseg := int(h[26])
+		lace, e := p.readAt(pos+27, nseg)
+		if e != nil {
+			return packets, serial, e
+		}
+		payloadLen := 0
+		for _, v := range lace {
+			payloadLen += int(v)
+		}
+		if int64(payloadLen) > p.opts.MaxSingleMetadataBytes {
+			return packets, serial, ErrLimit
+		}
+		// A packet may span arbitrarily many pages even though each individual
+		// page payload is small. Validate the accumulated packet size before
+		// reading this page's payload or growing cur.
+		packetLen := int64(len(cur))
+		packetCount := len(packets)
+		for _, v := range lace {
+			segmentLen := int64(v)
+			if packetLen > p.opts.MaxSingleMetadataBytes-segmentLen {
+				return packets, serial, ErrLimit
+			}
+			packetLen += segmentLen
+			if v < 255 {
+				packetCount++
+				packetLen = 0
+				if packetCount >= maxPackets {
+					break
+				}
+			}
+		}
+		payload, e := p.readAt(pos+27+int64(nseg), payloadLen)
+		if e != nil {
+			return packets, serial, e
+		}
+		if serial == 0 {
+			serial = binary.LittleEndian.Uint32(h[14:18])
+		}
+		at := 0
+		for _, v := range lace {
+			cur = append(cur, payload[at:at+int(v)]...)
+			at += int(v)
+			if v < 255 {
+				packets = append(packets, cur)
+				cur = nil
+				if len(packets) >= maxPackets {
+					break
+				}
+			}
+		}
+		pos += 27 + int64(nseg+payloadLen)
+	}
+	return packets, serial, nil
+}
+func findLastOggGranule(p *probe, serial uint32) int64 {
+	n := int64(256 << 10)
+	if p.src.Size < n {
+		n = p.src.Size
+	}
+	b, e := p.readAt(p.src.Size-n, int(n))
+	if e != nil {
+		return 0
+	}
+	for i := len(b) - 27; i >= 0; i-- {
+		if string(b[i:i+4]) == "OggS" && binary.LittleEndian.Uint32(b[i+14:i+18]) == serial {
+			return int64(binary.LittleEndian.Uint64(b[i+6 : i+14]))
+		}
+	}
+	return 0
+}
+
+func parseAIFF(p *probe, _ []byte) error {
+	h, e := p.readAt(0, 12)
+	if e != nil {
+		return e
+	}
+	form := string(h[8:12])
+	p.report.General.Format = form
+	p.report.General.MIME = "audio/aiff"
+	s := Stream{Index: 0, ID: "1", Kind: StreamAudio, Format: "PCM", Audio: &Audio{CompressionMode: "Lossless"}}
+	for pos := int64(12); pos+8 <= p.src.Size; {
+		if e := p.step(); e != nil {
+			return e
+		}
+		ch, e := p.readAt(pos, 8)
+		if e != nil {
+			return e
+		}
+		id := string(ch[:4])
+		sz := int64(binary.BigEndian.Uint32(ch[4:8]))
+		data := pos + 8
+		if data+sz > p.src.Size {
+			return &ParseError{Format: form, Offset: pos, Err: io.ErrUnexpectedEOF}
+		}
+		switch id {
+		case "COMM":
+			n := sz
+			if n > 64 {
+				n = 64
+			}
+			b, _ := p.readAt(data, int(n))
+			if len(b) >= 18 {
+				s.Audio.Channels = int(binary.BigEndian.Uint16(b[:2]))
+				frames := binary.BigEndian.Uint32(b[2:6])
+				s.Audio.BitDepth = int(binary.BigEndian.Uint16(b[6:8]))
+				s.Audio.SampleRate = int(extended80(b[8:18]))
+				s.Duration = durationFromUnits(uint64(frames), uint64(s.Audio.SampleRate))
+				if form == "AIFC" && len(b) >= 22 {
+					s.CodecID = fourCC(b[18:22])
+					s.Format = aiffCodec(s.CodecID)
+				}
+			}
+		case "NAME":
+			if sz <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(sz))
+				p.addTag("", "Title", cleanText(b))
+			}
+		case "AUTH":
+			if sz <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(sz))
+				p.addTag("", "Artist", cleanText(b))
+			}
+		case "ANNO":
+			if sz <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(sz))
+				p.addTag("", "Comment", cleanText(b))
+			}
+		}
+		pos = data + sz
+		if pos&1 != 0 {
+			pos++
+		}
+	}
+	p.report.General.Duration = s.Duration
+	p.report.Streams = append(p.report.Streams, s)
+	return nil
+}
+func extended80(b []byte) float64 {
+	if len(b) < 10 {
+		return 0
+	}
+	exp := int(binary.BigEndian.Uint16(b[:2])&0x7fff) - 16383
+	mant := binary.BigEndian.Uint64(b[2:])
+	if mant == 0 {
+		return 0
+	}
+	return math.Ldexp(float64(mant), exp-63)
+}
+func aiffCodec(id string) string {
+	switch strings.TrimSpace(id) {
+	case "NONE", "twos", "sowt":
+		return "PCM"
+	case "fl32", "FL32", "fl64", "FL64":
+		return "IEEE Float"
+	case "ulaw":
+		return "Mu-law"
+	case "alaw":
+		return "A-law"
+	case "ima4":
+		return "IMA ADPCM"
+	}
+	return id
+}
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/plugins/mediainfo/parse_ebu_stl.go
+++ b/plugins/mediainfo/parse_ebu_stl.go
@@ -1,0 +1,116 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// parseEBUSTL reads the fixed-size GSI/TTI records defined by EBU Tech 3264.
+// It deliberately does not decode the subtitle payload: timing and catalogue
+// metadata are sufficient for an information view and keep the probe bounded.
+func parseEBUSTL(p *probe, _ []byte) error {
+	if p.src.Size < 1024 {
+		return ErrUnsupported
+	}
+	gsi, err := p.readAt(0, 1024)
+	if err != nil {
+		return err
+	}
+	dfc := cleanSTLField(gsi[3:11])
+	if !strings.HasPrefix(dfc, "STL") {
+		return ErrUnsupported
+	}
+	fps := 25
+	if strings.Contains(dfc, "30") {
+		fps = 30
+	} else if strings.Contains(dfc, "24") {
+		fps = 24
+	}
+	encoding := stlCharacterTable(cleanSTLField(gsi[12:14]))
+	text := &Text{FormatVersion: dfc, Encoding: encoding}
+	stream := Stream{Index: 0, ID: "1", Kind: StreamText, Format: "EBU STL", Text: text}
+	p.report.General.Format = "EBU STL"
+	p.report.General.FormatProfile = dfc
+	p.report.General.MIME = "application/x-ebu-stl"
+	p.addTag("", "Original programme title", cleanSTLField(gsi[16:48]))
+	p.addTag("", "Original episode title", cleanSTLField(gsi[48:80]))
+	p.addTag("", "Language", cleanSTLField(gsi[14:16]))
+	p.addTag("", "Publisher", cleanSTLField(gsi[277:309]))
+
+	blocks := int((p.src.Size - 1024) / 128)
+	if declared := parseSTLDecimal(gsi[238:243]); declared > 0 && declared < blocks {
+		blocks = declared
+	}
+	seen := make(map[uint32]struct{})
+	for i := 0; i < blocks; i++ {
+		if err := p.step(); err != nil {
+			p.report.Streams = append(p.report.Streams, stream)
+			return err
+		}
+		off := int64(1024 + i*128)
+		tti, err := p.readAt(off, 128)
+		if err != nil {
+			return &ParseError{Format: "EBU STL", Offset: off, Err: err}
+		}
+		if tti[15] != 0 { // CF: comment rather than subtitle data.
+			continue
+		}
+		key := uint32(tti[0])<<16 | uint32(binary.BigEndian.Uint16(tti[1:3]))
+		if _, ok := seen[key]; !ok {
+			seen[key] = struct{}{}
+			text.CueCount++
+		}
+		start, okStart := stlTimecode(tti[5:9], fps)
+		end, okEnd := stlTimecode(tti[9:13], fps)
+		if okStart && (text.CueCount == 1 || start < text.FirstCue) {
+			text.FirstCue = start
+		}
+		if okEnd && end > text.LastCue {
+			text.LastCue = end
+		}
+	}
+	if text.CueCount == 0 {
+		return &ParseError{Format: "EBU STL", Offset: 1024, Err: errors.New("no subtitle records")}
+	}
+	stream.Duration = text.LastCue
+	p.report.General.Duration = text.LastCue
+	p.report.Streams = append(p.report.Streams, stream)
+	return nil
+}
+
+func cleanSTLField(b []byte) string {
+	return strings.TrimSpace(strings.TrimRight(string(b), "\x00\x8f"))
+}
+
+func parseSTLDecimal(b []byte) int {
+	v, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return v
+}
+
+func stlCharacterTable(code string) string {
+	switch code {
+	case "00":
+		return "ISO 6937-2 Latin"
+	case "01":
+		return "ISO 8859-5 Cyrillic"
+	case "02":
+		return "ISO 8859-6 Arabic"
+	case "03":
+		return "ISO 8859-7 Greek"
+	case "04":
+		return "ISO 8859-8 Hebrew"
+	default:
+		return code
+	}
+}
+
+func stlTimecode(b []byte, fps int) (time.Duration, bool) {
+	if len(b) < 4 || fps <= 0 || int(b[1]) >= 60 || int(b[2]) >= 60 || int(b[3]) >= fps {
+		return 0, false
+	}
+	return time.Duration(b[0])*time.Hour + time.Duration(b[1])*time.Minute +
+		time.Duration(b[2])*time.Second + time.Duration(b[3])*time.Second/time.Duration(fps), true
+}

--- a/plugins/mediainfo/parse_heif.go
+++ b/plugins/mediainfo/parse_heif.go
@@ -1,0 +1,191 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+)
+
+var heifBrands = map[string]bool{
+	"mif1": true, "msf1": true, "heic": true, "heix": true,
+	"hevc": true, "hevx": true, "heim": true, "heis": true,
+	"avic": true, "avif": true, "avis": true,
+}
+
+func isHEIFSource(name string, head []byte) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext == ".heif" || ext == ".heic" || ext == ".avif" {
+		return true
+	}
+	if len(head) < 16 || string(head[4:8]) != "ftyp" {
+		return false
+	}
+	end := len(head)
+	if size := int(binary.BigEndian.Uint32(head[:4])); size >= 16 && size < end {
+		end = size
+	}
+	for pos := 8; pos+4 <= end; pos += 4 {
+		if heifBrands[string(head[pos:pos+4])] {
+			return true
+		}
+	}
+	return false
+}
+
+type heifState struct {
+	format string
+	brands []string
+	width  int
+	height int
+	depth  int
+	codec  string
+}
+
+func parseHEIF(p *probe, _ []byte) error {
+	st := &heifState{format: "HEIF"}
+	if err := walkHEIFBoxes(p, st, 0, p.src.Size, 0, false); err != nil {
+		return err
+	}
+	if st.width <= 0 || st.height <= 0 {
+		return &ParseError{Format: st.format, Offset: 0, Err: errors.New("image spatial property not found")}
+	}
+	p.report.General.Format = st.format
+	p.report.General.CompatibleBrands = append([]string(nil), st.brands...)
+	switch st.format {
+	case "AVIF":
+		p.report.General.MIME = "image/avif"
+	case "HEIC":
+		p.report.General.MIME = "image/heic"
+	default:
+		p.report.General.MIME = "image/heif"
+	}
+	streamFormat := st.codec
+	if streamFormat == "" {
+		streamFormat = st.format
+	}
+	p.report.Streams = append(p.report.Streams, Stream{
+		Index: 0, ID: "1", Kind: StreamImage, Format: streamFormat,
+		Image: &Image{Width: st.width, Height: st.height, BitDepth: st.depth, FrameCount: 1},
+	})
+	return nil
+}
+
+func walkHEIFBoxes(p *probe, st *heifState, start, end int64, depth int, metaChildren bool) error {
+	if depth > 16 {
+		return &ParseError{Format: "HEIF", Offset: start, Err: errors.New("box nesting too deep")}
+	}
+	if metaChildren {
+		start += 4 // FullBox version and flags.
+	}
+	for pos := start; pos+8 <= end; {
+		if err := p.step(); err != nil {
+			return err
+		}
+		h, err := p.readAt(pos, 8)
+		if err != nil {
+			return err
+		}
+		size := int64(binary.BigEndian.Uint32(h[:4]))
+		header := int64(8)
+		if size == 1 {
+			x, err := p.readAt(pos+8, 8)
+			if err != nil {
+				return err
+			}
+			size, header = int64(binary.BigEndian.Uint64(x)), 16
+		} else if size == 0 {
+			size = end - pos
+		}
+		if size < header || pos > end-size {
+			return &ParseError{Format: "HEIF", Offset: pos, Err: fmt.Errorf("invalid %q box size", string(h[4:8]))}
+		}
+		typ, data, boxEnd := string(h[4:8]), pos+header, pos+size
+		switch typ {
+		case "ftyp":
+			if err := parseHEIFFTYP(p, st, data, boxEnd); err != nil {
+				return err
+			}
+		case "meta":
+			if err := walkHEIFBoxes(p, st, data, boxEnd, depth+1, true); err != nil {
+				return err
+			}
+		case "iprp", "ipco":
+			if err := walkHEIFBoxes(p, st, data, boxEnd, depth+1, false); err != nil {
+				return err
+			}
+		case "ispe":
+			if boxEnd-data >= 12 {
+				b, err := p.readAt(data, 12)
+				if err != nil {
+					return err
+				}
+				w, h := int(binary.BigEndian.Uint32(b[4:8])), int(binary.BigEndian.Uint32(b[8:12]))
+				if w > 0 && h > 0 && int64(w)*int64(h) > int64(st.width)*int64(st.height) {
+					st.width, st.height = w, h
+				}
+			}
+		case "pixi":
+			if boxEnd-data >= 6 {
+				b, err := p.readAt(data, int(min64(boxEnd-data, 32)))
+				if err != nil {
+					return err
+				}
+				channels := int(b[4])
+				for i := 0; i < channels && 5+i < len(b); i++ {
+					if int(b[5+i]) > st.depth {
+						st.depth = int(b[5+i])
+					}
+				}
+			}
+		case "hvcC":
+			st.codec = "HEVC"
+		case "av1C":
+			st.codec = "AV1"
+		}
+		pos = boxEnd
+	}
+	return nil
+}
+
+func parseHEIFFTYP(p *probe, st *heifState, start, end int64) error {
+	if end-start < 8 {
+		return io.ErrUnexpectedEOF
+	}
+	n := end - start
+	if n > 256 {
+		n = 256
+	}
+	b, err := p.readAt(start, int(n))
+	if err != nil {
+		return err
+	}
+	for pos := 0; pos+4 <= len(b); pos += 4 {
+		if len(st.brands) >= 64 {
+			break
+		}
+		if err := p.step(); err != nil {
+			return err
+		}
+		brand := string(b[pos : pos+4])
+		if pos == 4 { // minor version, not a brand
+			continue
+		}
+		if brand != "" && brand != "\x00\x00\x00\x00" {
+			st.brands = append(st.brands, brand)
+		}
+		switch brand {
+		case "avif", "avis", "avic":
+			st.format = "AVIF"
+			st.codec = "AV1"
+		case "heic", "heix", "hevc", "hevx", "heim", "heis":
+			if st.format != "AVIF" {
+				st.format = "HEIC"
+				st.codec = "HEVC"
+			}
+		}
+	}
+	return nil
+}

--- a/plugins/mediainfo/parse_image.go
+++ b/plugins/mediainfo/parse_image.go
@@ -1,0 +1,679 @@
+package mediainfo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"strings"
+	"time"
+
+	_ "golang.org/x/image/bmp"
+	_ "golang.org/x/image/tiff"
+	_ "golang.org/x/image/webp"
+)
+
+func isImageMagic(b []byte) bool {
+	return len(b) >= 2 && b[0] == 0xff && b[1] == 0xd8 || len(b) >= 8 && bytes.Equal(b[:8], []byte("\x89PNG\r\n\x1a\n")) || len(b) >= 6 && (string(b[:6]) == "GIF87a" || string(b[:6]) == "GIF89a") || len(b) >= 2 && string(b[:2]) == "BM" || isTIFFMagic(b) || len(b) >= 12 && string(b[:4]) == "RIFF" && string(b[8:12]) == "WEBP"
+}
+
+func parseImage(p *probe, _ []byte) error {
+	sr, e := p.section(0, p.src.Size)
+	if e != nil {
+		return e
+	}
+	cfg, format, e := image.DecodeConfig(sr)
+	if e != nil {
+		return &ParseError{Format: "Image", Offset: 0, Err: e}
+	}
+	p.report.General.Format = strings.ToUpper(format)
+	p.report.General.MIME = "image/" + strings.ToLower(format)
+	im := &Image{Width: cfg.Width, Height: cfg.Height, FrameCount: 1, ColorModel: fmt.Sprint(cfg.ColorModel)}
+	s := Stream{Index: 0, ID: "1", Kind: StreamImage, Format: p.report.General.Format, Image: im}
+	switch format {
+	case "jpeg":
+		parseJPEGMeta(p, im)
+	case "png":
+		parsePNGMeta(p, im)
+	case "gif":
+		parseGIFMeta(p, im)
+	case "webp":
+		parseWebPMeta(p, im)
+	case "tiff":
+		if n := min64(p.src.Size, p.opts.MaxSingleMetadataBytes); n > 0 {
+			b, _ := p.readAt(0, int(n))
+			parseTIFFMeta(p, b, im)
+		}
+	}
+	p.report.Streams = append(p.report.Streams, s)
+	return nil
+}
+
+func parseJPEGMeta(p *probe, im *Image) {
+	for pos := int64(2); pos+4 <= p.src.Size; {
+		h, e := p.readAt(pos, 4)
+		if e != nil || h[0] != 0xff {
+			return
+		}
+		marker := h[1]
+		if marker == 0xd9 || marker == 0xda {
+			return
+		}
+		sz := int64(binary.BigEndian.Uint16(h[2:4]))
+		if sz < 2 || pos+2+sz > p.src.Size {
+			return
+		}
+		if marker == 0xe1 && sz-2 <= p.opts.MaxSingleMetadataBytes {
+			b, e := p.readAt(pos+4, int(sz-2))
+			if e == nil && len(b) >= 6 && string(b[:6]) == "Exif\x00\x00" {
+				parseTIFFMeta(p, b[6:], im)
+			} else if e == nil && bytes.Contains(b, []byte("http://ns.adobe.com/xap/1.0/")) {
+				p.addTag("", "XMP", "Present")
+			}
+		} else if marker == 0xed {
+			p.addTag("", "IPTC", "Present")
+		}
+		pos += 2 + sz
+	}
+}
+
+func parsePNGMeta(p *probe, im *Image) {
+	for pos := int64(8); pos+12 <= p.src.Size; {
+		if err := p.step(); err != nil {
+			p.report.Truncated = true
+			return
+		}
+		h, e := p.readAt(pos, 8)
+		if e != nil {
+			return
+		}
+		n := int64(binary.BigEndian.Uint32(h[:4]))
+		typ := string(h[4:8])
+		data := pos + 8
+		if n < 0 || data+n+4 > p.src.Size {
+			return
+		}
+		switch typ {
+		case "IHDR":
+			if n >= 13 {
+				b, _ := p.readAt(data, 13)
+				if len(b) >= 13 {
+					im.BitDepth = int(b[8])
+				}
+			}
+		case "acTL":
+			if n >= 8 {
+				b, _ := p.readAt(data, 8)
+				if len(b) >= 8 {
+					im.FrameCount = int(binary.BigEndian.Uint32(b[:4]))
+					im.Animated = im.FrameCount > 1
+				}
+			}
+		case "fcTL":
+			if n >= 26 {
+				b, _ := p.readAt(data, 26)
+				if len(b) >= 26 {
+					numerator := binary.BigEndian.Uint16(b[20:22])
+					denominator := binary.BigEndian.Uint16(b[22:24])
+					if denominator == 0 {
+						denominator = 100
+					}
+					im.AnimationDuration += time.Duration(numerator) * time.Second / time.Duration(denominator)
+				}
+			}
+		case "pHYs":
+			if n >= 9 {
+				b, _ := p.readAt(data, 9)
+				if len(b) >= 9 && b[8] == 1 {
+					im.DPIX = float64(binary.BigEndian.Uint32(b[:4])) * 0.0254
+					im.DPIY = float64(binary.BigEndian.Uint32(b[4:8])) * 0.0254
+				}
+			}
+		case "eXIf":
+			if n <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(n))
+				parseTIFFMeta(p, b, im)
+			}
+		case "tEXt":
+			if n <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(n))
+				if i := bytes.IndexByte(b, 0); i > 0 {
+					p.addTag("", string(b[:i]), string(b[i+1:]))
+				}
+			}
+		case "IEND":
+			return
+		}
+		pos = data + n + 4
+	}
+}
+
+func parseGIFMeta(p *probe, im *Image) {
+	if p.opts.Mode == ModeFast {
+		return
+	}
+	limit := p.src.Size
+	if limit > p.opts.MaxTextBytes {
+		limit = p.opts.MaxTextBytes
+		p.report.Truncated = true
+	}
+	pos := int64(13)
+	if descriptor, e := p.readAt(10, 1); e == nil && descriptor[0]&0x80 != 0 {
+		pos += int64(3 * (1 << ((descriptor[0] & 7) + 1)))
+	}
+	frames := 0
+	var duration time.Duration
+	for pos < limit {
+		b, e := p.readAt(pos, 1)
+		if e != nil {
+			return
+		}
+		switch b[0] {
+		case 0x2c:
+			if pos+10 > limit {
+				return
+			}
+			d, _ := p.readAt(pos+1, 9)
+			packed := d[8]
+			pos += 10
+			if packed&0x80 != 0 {
+				pos += int64(3 * (1 << ((packed & 7) + 1)))
+			}
+			pos++
+			pos = skipGIFBlocks(p, pos, limit)
+			frames++
+		case 0x21:
+			lab, _ := p.readAt(pos+1, 1)
+			if lab[0] == 0xf9 && pos+8 <= limit {
+				d, _ := p.readAt(pos+2, 6)
+				if len(d) >= 6 {
+					duration += time.Duration(binary.LittleEndian.Uint16(d[2:4])) * 10 * time.Millisecond
+				}
+				pos += 8
+			} else {
+				pos = skipGIFBlocks(p, pos+2, limit)
+			}
+		case 0x3b:
+			pos = limit
+		default:
+			return
+		}
+	}
+	if frames > 0 {
+		im.FrameCount = frames
+		im.Animated = frames > 1
+		im.AnimationDuration = duration
+	}
+}
+func skipGIFBlocks(p *probe, pos, limit int64) int64 {
+	for pos < limit {
+		b, e := p.readAt(pos, 1)
+		if e != nil {
+			return limit
+		}
+		pos++
+		if b[0] == 0 {
+			return pos
+		}
+		pos += int64(b[0])
+	}
+	return limit
+}
+
+func parseWebPMeta(p *probe, im *Image) {
+	frames := 0
+	var duration time.Duration
+	for pos := int64(12); pos+8 <= p.src.Size; {
+		if err := p.step(); err != nil {
+			p.report.Truncated = true
+			return
+		}
+		h, e := p.readAt(pos, 8)
+		if e != nil {
+			return
+		}
+		typ := string(h[:4])
+		n := int64(binary.LittleEndian.Uint32(h[4:8]))
+		data := pos + 8
+		if data+n > p.src.Size {
+			return
+		}
+		switch typ {
+		case "VP8X":
+			if n >= 10 {
+				b, _ := p.readAt(data, 10)
+				if len(b) >= 10 {
+					im.Animated = b[0]&2 != 0
+					im.Width = 1 + (int(b[4]) | int(b[5])<<8 | int(b[6])<<16)
+					im.Height = 1 + (int(b[7]) | int(b[8])<<8 | int(b[9])<<16)
+				}
+			}
+		case "ANMF":
+			frames++
+			im.Animated = true
+			if n >= 16 {
+				b, _ := p.readAt(data, 16)
+				if len(b) >= 16 {
+					milliseconds := int(b[12]) | int(b[13])<<8 | int(b[14])<<16
+					duration += time.Duration(milliseconds) * time.Millisecond
+				}
+			}
+		case "EXIF":
+			if n <= p.opts.MaxSingleMetadataBytes {
+				b, _ := p.readAt(data, int(n))
+				if bytes.HasPrefix(b, []byte("Exif\x00\x00")) {
+					b = b[6:]
+				}
+				parseTIFFMeta(p, b, im)
+			}
+		case "XMP ":
+			p.addTag("", "XMP", "Present")
+		}
+		pos = data + n
+		if pos&1 != 0 {
+			pos++
+		}
+	}
+	if frames > 0 {
+		im.FrameCount = frames
+		im.AnimationDuration = duration
+	} else if im.FrameCount == 0 {
+		im.FrameCount = 1
+	}
+}
+
+func parseTIFFMeta(p *probe, b []byte, im *Image) {
+	if len(b) < 8 {
+		return
+	}
+	var order binary.ByteOrder
+	switch string(b[:2]) {
+	case "II":
+		order = binary.LittleEndian
+	case "MM":
+		order = binary.BigEndian
+	default:
+		return
+	}
+	if order.Uint16(b[2:4]) != 42 {
+		return
+	}
+	type ifdKind uint8
+	const (
+		ifdMain ifdKind = iota
+		ifdEXIF
+		ifdGPS
+	)
+	type gpsState struct {
+		latRef, lonRef string
+		lat, lon       []float64
+		altRef         int
+		alt            *float64
+	}
+	gps := gpsState{}
+	var xResolution, yResolution float64
+	resolutionUnit := uint64(2) // TIFF defaults to inches when the tag is absent.
+	seen := map[uint32]bool{}
+	var walk func(uint32, int, ifdKind)
+	walk = func(off uint32, depth int, kind ifdKind) {
+		if depth > 4 || seen[off] || int(off)+2 > len(b) {
+			return
+		}
+		seen[off] = true
+		count := int(order.Uint16(b[off : off+2]))
+		if count > 4096 {
+			return
+		}
+		for i := 0; i < count; i++ {
+			if err := p.step(); err != nil {
+				p.report.Truncated = true
+				return
+			}
+			pos := int(off) + 2 + i*12
+			if pos+12 > len(b) {
+				break
+			}
+			tag := order.Uint16(b[pos : pos+2])
+			typ := order.Uint16(b[pos+2 : pos+4])
+			units := order.Uint32(b[pos+4 : pos+8])
+			if !usefulTIFFTag(kind, tag) {
+				continue
+			}
+			unitSize := map[uint16]int{1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1, 9: 4, 10: 8}[typ]
+			if unitSize == 0 || uint64(units)*uint64(unitSize) > uint64(len(b)) {
+				continue
+			}
+			n := int(units) * unitSize
+			var raw []byte
+			if n <= 4 {
+				raw = b[pos+8 : pos+8+n]
+			} else {
+				o := int(order.Uint32(b[pos+8 : pos+12]))
+				if o < 0 || o+n > len(b) {
+					continue
+				}
+				raw = b[o : o+n]
+			}
+			if kind == ifdGPS {
+				switch tag {
+				case 0x0001:
+					gps.latRef = boundedTIFFText(p, raw)
+				case 0x0002:
+					gps.lat = tiffRationals(order, raw, false, 3)
+				case 0x0003:
+					gps.lonRef = boundedTIFFText(p, raw)
+				case 0x0004:
+					gps.lon = tiffRationals(order, raw, false, 3)
+				case 0x0005:
+					if len(raw) > 0 {
+						gps.altRef = int(raw[0])
+					}
+				case 0x0006:
+					if values := tiffRationals(order, raw, false, 1); len(values) == 1 {
+						gps.alt = &values[0]
+					}
+				}
+				continue
+			}
+			switch tag {
+			case 0x010f:
+				im.CameraMake = boundedTIFFText(p, raw)
+			case 0x0110:
+				im.CameraModel = boundedTIFFText(p, raw)
+			case 0xa434:
+				im.LensModel = boundedTIFFText(p, raw)
+			case 0x0131:
+				addImageEXIF(p, im, "Software", boundedTIFFText(p, raw))
+			case 0x013b:
+				addImageEXIF(p, im, "Artist", boundedTIFFText(p, raw))
+			case 0x8298:
+				addImageEXIF(p, im, "Copyright", boundedTIFFText(p, raw))
+			case 0xa431:
+				addImageEXIF(p, im, "Camera serial number", boundedTIFFText(p, raw))
+			case 0xa433:
+				addImageEXIF(p, im, "Lens make", boundedTIFFText(p, raw))
+			case 0xa435:
+				addImageEXIF(p, im, "Lens serial number", boundedTIFFText(p, raw))
+			case 0x0112:
+				if len(raw) >= 2 {
+					im.Orientation = int(order.Uint16(raw[:2]))
+				}
+			case 0x011a:
+				if values := tiffRationals(order, raw, false, 1); len(values) == 1 {
+					xResolution = values[0]
+				}
+			case 0x011b:
+				if values := tiffRationals(order, raw, false, 1); len(values) == 1 {
+					yResolution = values[0]
+				}
+			case 0x0128:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					resolutionUnit = value
+				}
+			case 0x9003, 0x9004, 0x0132:
+				if im.TakenAt == nil {
+					text := boundedTIFFText(p, raw)
+					if t, e := time.Parse("2006:01:02 15:04:05", text); e == nil {
+						im.TakenAt = &t
+					}
+				}
+			case 0x8769:
+				if len(raw) >= 4 {
+					walk(order.Uint32(raw[:4]), depth+1, ifdEXIF)
+				}
+			case 0x8825:
+				if len(raw) >= 4 {
+					walk(order.Uint32(raw[:4]), depth+1, ifdGPS)
+				}
+			case 0x829a:
+				addImageEXIF(p, im, "Exposure time", formatEXIFExposure(tiffRationals(order, raw, false, 1)))
+			case 0x829d:
+				addImageEXIF(p, im, "F-number", formatEXIFAperture(tiffRationals(order, raw, false, 1)))
+			case 0x8827:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "ISO speed", fmt.Sprint(value))
+				}
+			case 0x8822:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Exposure program", exifExposureProgram(value))
+				}
+			case 0x9000:
+				addImageEXIF(p, im, "EXIF version", formatEXIFVersion(raw))
+			case 0x9204:
+				if values := tiffRationals(order, raw, true, 1); len(values) == 1 {
+					addImageEXIF(p, im, "Exposure bias", fmt.Sprintf("%+.3g EV", values[0]))
+				}
+			case 0x9203:
+				if values := tiffRationals(order, raw, true, 1); len(values) == 1 {
+					addImageEXIF(p, im, "Brightness", fmt.Sprintf("%.3g EV", values[0]))
+				}
+			case 0x9206:
+				if values := tiffRationals(order, raw, false, 1); len(values) == 1 {
+					addImageEXIF(p, im, "Subject distance", fmt.Sprintf("%.4g m", values[0]))
+				}
+			case 0x9207:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Metering mode", exifMeteringMode(value))
+				}
+			case 0x9209:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Flash", exifFlash(value))
+				}
+			case 0x9208:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Light source", exifLightSource(value))
+				}
+			case 0x920a:
+				if values := tiffRationals(order, raw, false, 1); len(values) == 1 {
+					addImageEXIF(p, im, "Focal length", fmt.Sprintf("%.4g mm", values[0]))
+				}
+			case 0x9286:
+				addImageEXIF(p, im, "User comment", boundedEXIFComment(p, raw))
+			case 0xa403:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					if value == 0 {
+						addImageEXIF(p, im, "White balance", "Auto")
+					} else if value == 1 {
+						addImageEXIF(p, im, "White balance", "Manual")
+					}
+				}
+			case 0xa402:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Exposure mode", map[uint64]string{0: "Auto", 1: "Manual", 2: "Auto bracket"}[value])
+				}
+			case 0xa404:
+				if values := tiffRationals(order, raw, false, 1); len(values) == 1 && values[0] > 0 {
+					addImageEXIF(p, im, "Digital zoom", fmt.Sprintf("%.3g×", values[0]))
+				}
+			case 0xa405:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Focal length in 35mm", fmt.Sprintf("%d mm", value))
+				}
+			case 0xa406:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					addImageEXIF(p, im, "Scene capture type", map[uint64]string{0: "Standard", 1: "Landscape", 2: "Portrait", 3: "Night scene"}[value])
+				}
+			case 0xa408, 0xa409, 0xa40a:
+				if value, ok := tiffFirstInteger(order, raw, typ); ok {
+					name := map[uint16]string{0xa408: "Contrast", 0xa409: "Saturation", 0xa40a: "Sharpness"}[tag]
+					labels := map[uint64]string{0: "Normal", 1: "Soft", 2: "Hard"}
+					if tag == 0xa409 {
+						labels = map[uint64]string{0: "Normal", 1: "Low", 2: "High"}
+					}
+					addImageEXIF(p, im, name, labels[value])
+				}
+			case 0xa420:
+				addImageEXIF(p, im, "Image unique ID", boundedTIFFText(p, raw))
+			}
+		}
+	}
+	walk(order.Uint32(b[4:8]), 0, ifdMain)
+	if len(gps.lat) == 3 {
+		value := gps.lat[0] + gps.lat[1]/60 + gps.lat[2]/3600
+		if strings.EqualFold(gps.latRef, "S") {
+			value = -value
+		}
+		im.Latitude = &value
+	}
+	if len(gps.lon) == 3 {
+		value := gps.lon[0] + gps.lon[1]/60 + gps.lon[2]/3600
+		if strings.EqualFold(gps.lonRef, "W") {
+			value = -value
+		}
+		im.Longitude = &value
+	}
+	if gps.alt != nil {
+		value := *gps.alt
+		if gps.altRef == 1 {
+			value = -value
+		}
+		im.GPSAltitude = &value
+	}
+	if resolutionUnit == 3 {
+		xResolution *= 2.54
+		yResolution *= 2.54
+	}
+	if xResolution > 0 {
+		im.DPIX = xResolution
+	}
+	if yResolution > 0 {
+		im.DPIY = yResolution
+	}
+}
+
+func usefulTIFFTag[T ~uint8](kind T, tag uint16) bool {
+	if uint8(kind) == 2 { // GPS IFD
+		return tag >= 0x0001 && tag <= 0x0006
+	}
+	switch tag {
+	case 0x010f, 0x0110, 0x0112, 0x011a, 0x011b, 0x0128, 0x0131, 0x0132, 0x013b, 0x8298,
+		0x829a, 0x829d, 0x8769, 0x8822, 0x8825, 0x8827, 0x9000, 0x9003, 0x9004,
+		0x9203, 0x9204, 0x9206, 0x9207, 0x9208, 0x9209, 0x920a, 0x9286,
+		0xa402, 0xa403, 0xa404, 0xa405, 0xa406, 0xa408, 0xa409, 0xa40a,
+		0xa420, 0xa431, 0xa433, 0xa434, 0xa435:
+		return true
+	}
+	return false
+}
+
+func addImageEXIF(p *probe, im *Image, name, value string) {
+	if name == "" || value == "" {
+		return
+	}
+	if len(im.EXIF) >= p.opts.MaxTags {
+		p.report.Truncated = true
+		return
+	}
+	if len(value) > p.opts.MaxValueBytes {
+		value = value[:p.opts.MaxValueBytes]
+		p.report.Truncated = true
+	}
+	im.EXIF = append(im.EXIF, Field{Name: strings.Clone(name), Value: strings.Clone(value)})
+}
+
+func tiffRationals(order binary.ByteOrder, raw []byte, signed bool, limit int) []float64 {
+	count := len(raw) / 8
+	if count > limit {
+		count = limit
+	}
+	values := make([]float64, 0, count)
+	for index := 0; index < count; index++ {
+		part := raw[index*8 : index*8+8]
+		var numerator, denominator float64
+		if signed {
+			numerator = float64(int32(order.Uint32(part[:4])))
+			denominator = float64(int32(order.Uint32(part[4:])))
+		} else {
+			numerator = float64(order.Uint32(part[:4]))
+			denominator = float64(order.Uint32(part[4:]))
+		}
+		if denominator == 0 {
+			return nil
+		}
+		values = append(values, numerator/denominator)
+	}
+	return values
+}
+
+func tiffFirstInteger(order binary.ByteOrder, raw []byte, typ uint16) (uint64, bool) {
+	switch typ {
+	case 1, 7:
+		if len(raw) >= 1 {
+			return uint64(raw[0]), true
+		}
+	case 3:
+		if len(raw) >= 2 {
+			return uint64(order.Uint16(raw[:2])), true
+		}
+	case 4:
+		if len(raw) >= 4 {
+			return uint64(order.Uint32(raw[:4])), true
+		}
+	}
+	return 0, false
+}
+
+func formatEXIFExposure(values []float64) string {
+	if len(values) != 1 || values[0] <= 0 {
+		return ""
+	}
+	if values[0] < 1 {
+		return fmt.Sprintf("1/%.0f s", 1/values[0])
+	}
+	return fmt.Sprintf("%.4g s", values[0])
+}
+
+func formatEXIFAperture(values []float64) string {
+	if len(values) != 1 || values[0] <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("f/%.3g", values[0])
+}
+
+func formatEXIFVersion(raw []byte) string {
+	value := strings.TrimSpace(string(raw))
+	if len(value) == 4 && value[0] >= '0' && value[0] <= '9' {
+		return value[:2] + "." + value[2:]
+	}
+	return cleanText(raw)
+}
+
+func boundedEXIFComment(p *probe, raw []byte) string {
+	if len(raw) >= 8 {
+		prefix := string(raw[:8])
+		if strings.HasPrefix(prefix, "ASCII") || strings.HasPrefix(prefix, "UNICODE") || strings.HasPrefix(prefix, "JIS") {
+			raw = raw[8:]
+		}
+	}
+	return boundedTIFFText(p, raw)
+}
+
+func exifMeteringMode(value uint64) string {
+	return map[uint64]string{0: "Unknown", 1: "Average", 2: "Center-weighted average", 3: "Spot", 4: "Multi-spot", 5: "Pattern", 6: "Partial", 255: "Other"}[value]
+}
+
+func exifExposureProgram(value uint64) string {
+	return map[uint64]string{0: "Undefined", 1: "Manual", 2: "Normal program", 3: "Aperture priority", 4: "Shutter priority", 5: "Creative", 6: "Action", 7: "Portrait", 8: "Landscape", 9: "Bulb"}[value]
+}
+
+func exifLightSource(value uint64) string {
+	return map[uint64]string{0: "Unknown", 1: "Daylight", 2: "Fluorescent", 3: "Tungsten", 4: "Flash", 9: "Fine weather", 10: "Cloudy", 11: "Shade", 12: "Daylight fluorescent", 13: "Day white fluorescent", 14: "Cool white fluorescent", 15: "White fluorescent", 17: "Standard light A", 18: "Standard light B", 19: "Standard light C", 20: "D55", 21: "D65", 22: "D75", 23: "D50", 24: "ISO studio tungsten", 255: "Other"}[value]
+}
+
+func exifFlash(value uint64) string {
+	if value&1 != 0 {
+		return "Fired"
+	}
+	return "Did not fire"
+}
+
+func boundedTIFFText(p *probe, raw []byte) string {
+	if len(raw) > p.opts.MaxValueBytes {
+		raw = raw[:p.opts.MaxValueBytes]
+		p.report.Truncated = true
+	}
+	return cleanText(raw)
+}

--- a/plugins/mediainfo/parse_iso.go
+++ b/plugins/mediainfo/parse_iso.go
@@ -1,0 +1,577 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
+
+type isoBox struct {
+	typ                        string
+	start, data, size, payload int64
+}
+type isoState struct {
+	seenMdat    bool
+	sampleBytes map[int]int64
+}
+
+func parseISOBaseMedia(p *probe, _ []byte) error {
+	p.report.General.Format = "MPEG-4"
+	p.report.General.MIME = "video/mp4"
+	st := &isoState{sampleBytes: make(map[int]int64)}
+	if err := walkISO(p, st, 0, p.src.Size, 0, nil, ""); err != nil {
+		return err
+	}
+	if p.report.General.CodecID == "qt  " {
+		p.report.General.Format = "QuickTime"
+		p.report.General.MIME = "video/quicktime"
+	}
+	if len(p.report.Streams) == 0 && p.report.General.Format == "MPEG-4" {
+		p.warn("no_tracks", "no movie tracks were found", -1)
+	}
+	for i := range p.report.Streams {
+		s := &p.report.Streams[i]
+		if s.Duration > 0 && s.BitRate == 0 && st.sampleBytes[i] > 0 {
+			s.BitRate = int64(float64(st.sampleBytes[i]*8) / s.Duration.Seconds())
+		}
+	}
+	return nil
+}
+
+func readISOBox(p *probe, pos, end int64) (isoBox, error) {
+	if pos+8 > end {
+		return isoBox{}, io.EOF
+	}
+	h, e := p.readAt(pos, 8)
+	if e != nil {
+		return isoBox{}, e
+	}
+	sz := int64(binary.BigEndian.Uint32(h[:4]))
+	header := int64(8)
+	typ := string(h[4:8])
+	if sz == 1 {
+		b, e := p.readAt(pos+8, 8)
+		if e != nil {
+			return isoBox{}, e
+		}
+		u := binary.BigEndian.Uint64(b)
+		if u > math.MaxInt64 {
+			return isoBox{}, errors.New("box is too large")
+		}
+		sz = int64(u)
+		header = 16
+	} else if sz == 0 {
+		sz = end - pos
+	}
+	if sz < header || sz > end-pos {
+		return isoBox{}, &ParseError{Format: "ISO BMFF", Offset: pos, Err: fmt.Errorf("invalid %q box size %d", typ, sz)}
+	}
+	return isoBox{typ: typ, start: pos, data: pos + header, size: sz, payload: sz - header}, nil
+}
+
+func walkISO(p *probe, st *isoState, start, end int64, depth int, track *Stream, parent string) error {
+	if depth > 16 {
+		return &ParseError{Format: "ISO BMFF", Offset: start, Err: errors.New("box nesting too deep")}
+	}
+	for pos := start; pos+8 <= end; {
+		if e := p.step(); e != nil {
+			return e
+		}
+		box, e := readISOBox(p, pos, end)
+		if e != nil {
+			return e
+		}
+		var childTrack = track
+		switch box.typ {
+		case "ftyp", "styp":
+			parseFTYP(p, box)
+		case "mdat":
+			st.seenMdat = true
+		case "moov":
+			v := !st.seenMdat
+			p.report.General.Streamable = &v
+		case "trak":
+			if len(p.report.Streams) < p.opts.MaxStreams {
+				p.report.Streams = append(p.report.Streams, Stream{Index: len(p.report.Streams), ID: fmt.Sprint(len(p.report.Streams) + 1)})
+				childTrack = &p.report.Streams[len(p.report.Streams)-1]
+			} else {
+				p.report.Truncated = true
+			}
+		case "mvhd":
+			parseMVHD(p, box)
+		case "tkhd":
+			if track != nil {
+				parseTKHD(p, box, track)
+			}
+		case "mdhd":
+			if track != nil {
+				parseMDHD(p, box, track)
+			}
+		case "hdlr":
+			if track != nil {
+				parseHDLR(p, box, track)
+			}
+		case "stsd":
+			if track != nil {
+				if e := parseSTSD(p, st, box, track); e != nil {
+					return e
+				}
+			}
+		case "stts":
+			if track != nil && p.opts.Mode == ModeDetailed {
+				parseSTTS(p, box, track)
+			}
+		case "stsz":
+			if track != nil && p.opts.Mode == ModeDetailed {
+				st.sampleBytes[track.Index] = parseSTSZ(p, box, track)
+			}
+		case "btrt":
+			if track != nil {
+				parseBTRT(p, box, track)
+			}
+		case "pasp":
+			if track != nil && track.Video != nil {
+				if b, e := p.readAt(box.data, 8); e == nil {
+					h, v := binary.BigEndian.Uint32(b[:4]), binary.BigEndian.Uint32(b[4:])
+					if v > 0 {
+						track.Video.PixelAspectRatio = float64(h) / float64(v)
+					}
+				}
+			}
+		case "colr":
+			if track != nil && track.Video != nil {
+				parseCOLR(p, box, track.Video)
+			}
+		case "data":
+			if strings.HasPrefix(parent, "tag:") {
+				parseISODataTag(p, box, strings.TrimPrefix(parent, "tag:"))
+			}
+		case "sidx":
+			if p.opts.Mode == ModeDetailed {
+				parseSIDX(p, box)
+			}
+		}
+
+		childStart := box.data
+		container := isoContainer(box.typ)
+		childParent := box.typ
+		if box.typ == "meta" && box.payload >= 4 {
+			childStart += 4
+		}
+		if isISOTagBox(box.typ) && parent == "ilst" {
+			container = true
+			childParent = "tag:" + box.typ
+		}
+		if container && childStart < box.start+box.size && box.typ != "stsd" {
+			if e := walkISO(p, st, childStart, box.start+box.size, depth+1, childTrack, childParent); e != nil {
+				return e
+			}
+		}
+		pos = box.start + box.size
+	}
+	return nil
+}
+
+func isoContainer(t string) bool {
+	switch t {
+	case "moov", "trak", "mdia", "minf", "stbl", "edts", "dinf", "udta", "ilst", "meta", "mvex", "moof", "traf", "mfra", "tref", "wave":
+		return true
+	}
+	return false
+}
+func isISOTagBox(t string) bool {
+	if len(t) != 4 {
+		return false
+	}
+	switch t {
+	case "covr":
+		return false
+	case "\xa9nam", "\xa9ART", "\xa9alb", "\xa9day", "\xa9gen", "\xa9cmt", "\xa9wrt", "\xa9too", "aART", "trkn", "disk", "gnre", "cprt", "desc", "tmpo":
+		return true
+	}
+	return t == "----"
+}
+
+func parseFTYP(p *probe, b isoBox) {
+	if b.payload < 8 {
+		return
+	}
+	n := b.payload
+	if n > 256 {
+		n = 256
+	}
+	d, e := p.readAt(b.data, int(n))
+	if e != nil || len(d) < 8 {
+		return
+	}
+	major := string(d[:4])
+	p.report.General.CodecID = major
+	p.report.General.CompatibleBrands = nil
+	for i := 8; i+4 <= len(d); i += 4 {
+		p.report.General.CompatibleBrands = append(p.report.General.CompatibleBrands, string(d[i:i+4]))
+	}
+	switch strings.TrimSpace(major) {
+	case "M4A", "M4B":
+		p.report.General.MIME = "audio/mp4"
+	case "3gp4", "3gp5", "3gp6", "3gp7", "3gp8", "3gp9":
+		p.report.General.Format = "3GPP"
+		p.report.General.MIME = "video/3gpp"
+	case "3g2a", "3g2b", "3g2c":
+		p.report.General.Format = "3GPP2"
+		p.report.General.MIME = "video/3gpp2"
+	}
+}
+
+func parseMVHD(p *probe, b isoBox) {
+	n := b.payload
+	if n > 40 {
+		n = 40
+	}
+	d, e := p.readAt(b.data, int(n))
+	if e != nil || len(d) < 20 {
+		return
+	}
+	ver := d[0]
+	var scale uint32
+	var dur uint64
+	if ver == 1 && len(d) >= 32 {
+		scale = binary.BigEndian.Uint32(d[20:24])
+		dur = binary.BigEndian.Uint64(d[24:32])
+	} else {
+		scale = binary.BigEndian.Uint32(d[12:16])
+		dur = uint64(binary.BigEndian.Uint32(d[16:20]))
+	}
+	p.report.General.Duration = durationFromUnits(dur, uint64(scale))
+}
+
+func parseTKHD(p *probe, b isoBox, s *Stream) {
+	n := b.payload
+	if n > 96 {
+		n = 96
+	}
+	d, e := p.readAt(b.data, int(n))
+	if e != nil || len(d) < 40 {
+		return
+	}
+	ver := d[0]
+	var id uint32
+	var matrixOff, widthOff int
+	if ver == 1 {
+		id = binary.BigEndian.Uint32(d[20:24])
+		matrixOff = 52
+		widthOff = 88
+	} else {
+		id = binary.BigEndian.Uint32(d[12:16])
+		matrixOff = 40
+		widthOff = 76
+	}
+	if id > 0 {
+		s.ID = fmt.Sprint(id)
+	}
+	if len(d) >= widthOff+8 {
+		w := binary.BigEndian.Uint32(d[widthOff : widthOff+4])
+		h := binary.BigEndian.Uint32(d[widthOff+4 : widthOff+8])
+		if w != 0 || h != 0 {
+			video := ensureVideo(s)
+			video.DisplayWidth = int(w >> 16)
+			video.DisplayHeight = int(h >> 16)
+		}
+	}
+	if len(d) >= matrixOff+20 {
+		a := int32(binary.BigEndian.Uint32(d[matrixOff : matrixOff+4]))
+		bb := int32(binary.BigEndian.Uint32(d[matrixOff+4 : matrixOff+8]))
+		rotation := 0.0
+		switch {
+		case a == 0 && bb == 0x10000:
+			rotation = 90
+		case a == -0x10000 && bb == 0:
+			rotation = 180
+		case a == 0 && bb == -0x10000:
+			rotation = 270
+		}
+		if rotation != 0 {
+			ensureVideo(s).Rotation = rotation
+		}
+	}
+}
+
+func parseMDHD(p *probe, b isoBox, s *Stream) {
+	n := b.payload
+	if n > 40 {
+		n = 40
+	}
+	d, e := p.readAt(b.data, int(n))
+	if e != nil || len(d) < 20 {
+		return
+	}
+	ver := d[0]
+	var scale uint32
+	var dur uint64
+	var langOff int
+	if ver == 1 && len(d) >= 34 {
+		scale = binary.BigEndian.Uint32(d[20:24])
+		dur = binary.BigEndian.Uint64(d[24:32])
+		langOff = 32
+	} else {
+		scale = binary.BigEndian.Uint32(d[12:16])
+		dur = uint64(binary.BigEndian.Uint32(d[16:20]))
+		langOff = 20
+	}
+	s.Duration = durationFromUnits(dur, uint64(scale))
+	if len(d) >= langOff+2 {
+		s.Language = parseISO639(binary.BigEndian.Uint16(d[langOff : langOff+2]))
+	}
+}
+
+func parseHDLR(p *probe, b isoBox, s *Stream) {
+	n := b.payload
+	if n > 256 {
+		n = 256
+	}
+	d, e := p.readAt(b.data, int(n))
+	if e != nil || len(d) < 12 {
+		return
+	}
+	typ := string(d[8:12])
+	switch typ {
+	case "vide":
+		s.Kind = StreamVideo
+		ensureVideo(s)
+		s.Format = "Video"
+	case "soun":
+		s.Kind = StreamAudio
+		s.Audio = &Audio{}
+		s.Format = "Audio"
+	case "text", "sbtl", "subt", "clcp":
+		s.Kind = StreamText
+		s.Text = &Text{}
+		s.Format = "Text"
+	case "pict":
+		s.Kind = StreamImage
+		s.Image = &Image{}
+		s.Format = "Image"
+	case "meta":
+		s.Kind = StreamMenu
+		s.Format = "Metadata"
+	}
+	if len(d) > 24 {
+		s.Title = cleanText(d[24:])
+	}
+}
+
+func parseSTSD(p *probe, st *isoState, b isoBox, s *Stream) error {
+	if b.payload < 8 {
+		return nil
+	}
+	h, e := p.readAt(b.data, 8)
+	if e != nil {
+		return e
+	}
+	count := int(binary.BigEndian.Uint32(h[4:8]))
+	pos := b.data + 8
+	end := b.start + b.size
+	for i := 0; i < count && pos+8 <= end; i++ {
+		if e := p.step(); e != nil {
+			return e
+		}
+		entry, e := readISOBox(p, pos, end)
+		if e != nil {
+			return e
+		}
+		s.CodecID = entry.typ
+		s.Format = isoCodec(entry.typ, s.Kind)
+		base := entry.data
+		if s.Kind == StreamVideo && entry.payload >= 78 {
+			d, e := p.readAt(base, 78)
+			if e == nil {
+				s.Video.Width = int(binary.BigEndian.Uint16(d[24:26]))
+				s.Video.Height = int(binary.BigEndian.Uint16(d[26:28]))
+				s.Video.BitDepth = int(binary.BigEndian.Uint16(d[74:76]))
+				if s.Video.DisplayWidth == 0 {
+					s.Video.DisplayWidth = s.Video.Width
+					s.Video.DisplayHeight = s.Video.Height
+				}
+			}
+			if entry.payload > 78 {
+				_ = walkISO(p, st, base+78, entry.start+entry.size, 6, s, "sample")
+			}
+		} else if s.Kind == StreamAudio && entry.payload >= 28 {
+			d, e := p.readAt(base, 28)
+			if e == nil {
+				s.Audio.Channels = int(binary.BigEndian.Uint16(d[16:18]))
+				s.Audio.BitDepth = int(binary.BigEndian.Uint16(d[18:20]))
+				s.Audio.SampleRate = int(binary.BigEndian.Uint32(d[24:28]) >> 16)
+			}
+			if entry.payload > 28 {
+				_ = walkISO(p, st, base+28, entry.start+entry.size, 6, s, "sample")
+			}
+		}
+		pos = entry.start + entry.size
+	}
+	return nil
+}
+
+func isoCodec(id string, k StreamKind) string {
+	switch id {
+	case "avc1", "avc3":
+		return "AVC"
+	case "hvc1", "hev1":
+		return "HEVC"
+	case "av01":
+		return "AV1"
+	case "vp08":
+		return "VP8"
+	case "vp09":
+		return "VP9"
+	case "mp4v":
+		return "MPEG-4 Visual"
+	case "jpeg", "mjpg", "mjpa", "mjpb":
+		return "Motion JPEG"
+	case "mp4a":
+		return "AAC"
+	case "alac":
+		return "ALAC"
+	case "ac-3":
+		return "AC-3"
+	case "ec-3":
+		return "E-AC-3"
+	case "Opus":
+		return "Opus"
+	case "fLaC":
+		return "FLAC"
+	case "lpcm", "sowt", "twos", "ipcm", "fpcm":
+		return "PCM"
+	case "tx3g":
+		return "Timed Text"
+	case "wvtt":
+		return "WebVTT"
+	case "stpp":
+		return "TTML"
+	}
+	if k == StreamVideo {
+		return videoCodec(id)
+	}
+	return id
+}
+
+func parseSTTS(p *probe, b isoBox, s *Stream) {
+	if b.payload < 8 || b.payload > p.opts.MaxSingleMetadataBytes {
+		return
+	}
+	d, e := p.readAt(b.data, int(b.payload))
+	if e != nil {
+		return
+	}
+	count := int(binary.BigEndian.Uint32(d[4:8]))
+	pos := 8
+	var samples uint64
+	var ticks uint64
+	for i := 0; i < count && pos+8 <= len(d); i++ {
+		n := uint64(binary.BigEndian.Uint32(d[pos : pos+4]))
+		delta := uint64(binary.BigEndian.Uint32(d[pos+4 : pos+8]))
+		samples += n
+		ticks += n * delta
+		pos += 8
+	}
+	s.FrameCount = int64(samples)
+	if s.Duration > 0 {
+		s.FrameRate = float64(samples) / s.Duration.Seconds()
+	}
+	_ = ticks
+}
+func parseSTSZ(p *probe, b isoBox, s *Stream) int64 {
+	if b.payload < 12 || b.payload > p.opts.MaxSingleMetadataBytes {
+		return 0
+	}
+	d, e := p.readAt(b.data, int(b.payload))
+	if e != nil {
+		return 0
+	}
+	size := binary.BigEndian.Uint32(d[4:8])
+	count := binary.BigEndian.Uint32(d[8:12])
+	if s.FrameCount == 0 {
+		s.FrameCount = int64(count)
+	}
+	if size > 0 {
+		return int64(size) * int64(count)
+	}
+	var sum int64
+	for pos := 12; pos+4 <= len(d); pos += 4 {
+		sum += int64(binary.BigEndian.Uint32(d[pos : pos+4]))
+	}
+	return sum
+}
+func parseBTRT(p *probe, b isoBox, s *Stream) {
+	if b.payload < 12 {
+		return
+	}
+	d, e := p.readAt(b.data, 12)
+	if e == nil {
+		s.BitRate = int64(binary.BigEndian.Uint32(d[8:12]))
+	}
+}
+func parseCOLR(p *probe, b isoBox, v *Video) {
+	if b.payload < 10 {
+		return
+	}
+	d, e := p.readAt(b.data, int(min64(b.payload, 32)))
+	if e != nil {
+		return
+	}
+	if string(d[:4]) == "nclx" || string(d[:4]) == "nclc" {
+		v.ColorPrimaries = fmt.Sprint(binary.BigEndian.Uint16(d[4:6]))
+		v.TransferCharacteristics = fmt.Sprint(binary.BigEndian.Uint16(d[6:8]))
+		v.MatrixCoefficients = fmt.Sprint(binary.BigEndian.Uint16(d[8:10]))
+		if len(d) > 10 && d[10]&0x80 != 0 {
+			v.ColorRange = "Full"
+		} else {
+			v.ColorRange = "Limited"
+		}
+	}
+}
+func parseISODataTag(p *probe, b isoBox, key string) {
+	if key == "covr" || b.payload <= 8 || b.payload-8 > p.opts.MaxSingleMetadataBytes {
+		return
+	}
+	d, e := p.readAt(b.data+8, int(b.payload-8))
+	if e != nil {
+		return
+	}
+	value := cleanText(d)
+	if key == "trkn" && len(d) >= 6 {
+		value = fmt.Sprint(binary.BigEndian.Uint16(d[2:4]))
+	}
+	if key == "disk" && len(d) >= 6 {
+		value = fmt.Sprint(binary.BigEndian.Uint16(d[2:4]))
+	}
+	p.addTag("", canonicalTag(key), value)
+}
+func parseSIDX(p *probe, b isoBox) {
+	if b.payload < 20 || p.report.General.Duration > 0 {
+		return
+	}
+	d, e := p.readAt(b.data, int(min64(b.payload, 40)))
+	if e != nil {
+		return
+	}
+	ver := d[0]
+	scale := binary.BigEndian.Uint32(d[8:12])
+	pos := 12
+	if ver == 0 {
+		pos += 8
+	} else {
+		pos += 16
+	}
+	if scale == 0 || len(d) < pos+4 {
+		return
+	}
+}
+func min64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/plugins/mediainfo/parse_matroska.go
+++ b/plugins/mediainfo/parse_matroska.go
@@ -1,0 +1,543 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+	"time"
+)
+
+type ebmlState struct {
+	docType       string
+	timecodeScale uint64
+	duration      float64
+}
+type ebmlContext struct {
+	track     *Stream
+	chapter   *Chapter
+	tagName   string
+	tagTarget *string
+}
+
+func parseMatroska(p *probe, _ []byte) error {
+	p.report.General.Format = "Matroska"
+	p.report.General.MIME = "video/x-matroska"
+	st := &ebmlState{timecodeScale: 1000000}
+	if err := walkEBML(p, st, 0, p.src.Size, 0, ebmlContext{}); err != nil {
+		return err
+	}
+	if st.docType != "matroska" && st.docType != "webm" {
+		return ErrUnsupported
+	}
+	if st.docType == "webm" {
+		p.report.General.Format = "WebM"
+		p.report.General.MIME = "video/webm"
+	}
+	if st.duration > 0 {
+		p.report.General.Duration = time.Duration(st.duration * float64(st.timecodeScale))
+	}
+	for i := range p.report.Streams {
+		if p.report.Streams[i].Duration == 0 {
+			p.report.Streams[i].Duration = p.report.General.Duration
+		}
+	}
+	return nil
+}
+
+func readEBMLVInt(p *probe, off int64, keep bool) (uint64, int, bool, error) {
+	b, e := p.readAt(off, 1)
+	if e != nil {
+		return 0, 0, false, e
+	}
+	first := b[0]
+	if first == 0 {
+		return 0, 0, false, errors.New("invalid EBML variable integer")
+	}
+	n := 1
+	mask := byte(0x80)
+	for n <= 8 && first&mask == 0 {
+		n++
+		mask >>= 1
+	}
+	if n > 8 {
+		return 0, 0, false, errors.New("invalid EBML variable integer length")
+	}
+	all, e := p.readAt(off, n)
+	if e != nil {
+		return 0, 0, false, e
+	}
+	var v uint64
+	if keep {
+		for _, x := range all {
+			v = v<<8 | uint64(x)
+		}
+	} else {
+		v = uint64(all[0] &^ mask)
+		for _, x := range all[1:] {
+			v = v<<8 | uint64(x)
+		}
+	}
+	unknown := !keep && v == (uint64(1)<<(7*n))-1
+	return v, n, unknown, nil
+}
+
+func walkEBML(p *probe, st *ebmlState, start, end int64, depth int, ctx ebmlContext) error {
+	if depth > 24 {
+		return &ParseError{Format: "Matroska", Offset: start, Err: errors.New("EBML nesting too deep")}
+	}
+	for pos := start; pos < end; {
+		if err := p.step(); err != nil {
+			return err
+		}
+		id, idn, _, e := readEBMLVInt(p, pos, true)
+		if e != nil {
+			if errors.Is(e, io.EOF) && pos == end {
+				return nil
+			}
+			return &ParseError{Format: "Matroska", Offset: pos, Err: e}
+		}
+		sz, szn, unknown, e := readEBMLVInt(p, pos+int64(idn), false)
+		if e != nil {
+			return &ParseError{Format: "Matroska", Offset: pos, Err: e}
+		}
+		data := pos + int64(idn+szn)
+		size := int64(sz)
+		if unknown {
+			size = end - data
+		}
+		if size < 0 || data > end || size > end-data {
+			return &ParseError{Format: "Matroska", Offset: pos, Err: errors.New("element exceeds parent")}
+		}
+		if id == 0x1f43b675 || id == 0x1941a469 {
+			pos = data + size
+			continue
+		} // Cluster, Attachments
+		child := ctx
+		if id == 0xae {
+			if len(p.report.Streams) >= p.opts.MaxStreams {
+				p.report.Truncated = true
+				pos = data + size
+				continue
+			}
+			p.report.Streams = append(p.report.Streams, Stream{Index: len(p.report.Streams), ID: fmt.Sprint(len(p.report.Streams) + 1)})
+			child.track = &p.report.Streams[len(p.report.Streams)-1]
+		}
+		if id == 0xb6 && inEBMLMaster(depth, ctx, "chapter") {
+			if len(p.report.Chapters) >= p.opts.MaxChapters {
+				p.report.Truncated = true
+				pos = data + size
+				continue
+			}
+			p.report.Chapters = append(p.report.Chapters, Chapter{ID: fmt.Sprint(len(p.report.Chapters) + 1)})
+			child.chapter = &p.report.Chapters[len(p.report.Chapters)-1]
+		}
+		if id == 0x67c8 {
+			child.tagName = ""
+		}
+		if id == 0x7373 {
+			target := ""
+			child.tagTarget = &target
+		}
+		if isEBMLMaster(id) {
+			if e := walkEBML(p, st, data, data+size, depth+1, child); e != nil {
+				return e
+			}
+		} else if e := parseEBMLLeaf(p, st, id, data, size, &ctx); e != nil {
+			return e
+		}
+		if data+size <= pos {
+			return &ParseError{Format: "Matroska", Offset: pos, Err: errors.New("non-advancing element")}
+		}
+		pos = data + size
+	}
+	return nil
+}
+
+func inEBMLMaster(_ int, _ ebmlContext, _ string) bool { return true }
+func isEBMLMaster(id uint64) bool {
+	switch id {
+	case 0x1a45dfa3, 0x18538067, 0x114d9b74, 0x1549a966, 0x1654ae6b, 0xae, 0xe0, 0xe1, 0x55b0, 0x1254c367, 0x7373, 0x63c0, 0x67c8, 0x1043a770, 0x45b9, 0xb6, 0x80, 0x6d80, 0x6240, 0x5035:
+		return true
+	}
+	return false
+}
+
+func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebmlContext) error {
+	kind := classifyEBMLLeaf(id)
+	if kind == ebmlLeafUnknown || !needEBMLLeaf(id, ctx) {
+		// Most EBML leaves are codec private data, checksums, seek indexes, or
+		// other values this normalized report does not expose. Do not spend the
+		// metadata budget reading them merely to discard them.
+		return nil
+	}
+
+	var (
+		uintValue  uint64
+		floatValue float64
+		textValue  string
+		ok         bool
+		e          error
+	)
+	switch kind {
+	case ebmlLeafUint:
+		uintValue, ok, e = readEBMLUint(p, off, size)
+	case ebmlLeafFloat:
+		floatValue, ok, e = readEBMLFloat(p, off, size)
+	case ebmlLeafText:
+		textValue, ok, e = readEBMLText(p, off, size)
+	case ebmlLeafDocType:
+		textValue, ok, e = readEBMLDocType(p, off, size)
+	}
+	if e != nil || !ok {
+		return e
+	}
+	u := func() uint64 { return uintValue }
+	str := func() string { return textValue }
+	flt := func() float64 { return floatValue }
+	switch id {
+	case 0x4282:
+		st.docType = str()
+	case 0x2ad7b1:
+		st.timecodeScale = u()
+	case 0x4489:
+		st.duration = flt()
+	case 0x7ba9:
+		p.addTag("", "Title", str())
+	case 0x4d80:
+		p.report.General.MuxingApp = str()
+	case 0x5741:
+		p.report.General.WritingApp = str()
+	case 0xd7:
+		if ctx.track != nil {
+			ctx.track.ID = fmt.Sprint(u())
+		}
+	case 0x73c5:
+		if ctx.track != nil && ctx.track.ID == "" {
+			ctx.track.ID = fmt.Sprint(u())
+		}
+	case 0x83:
+		if ctx.track != nil {
+			setMatroskaTrackType(ctx.track, u())
+		}
+	case 0x88:
+		if ctx.track != nil {
+			ctx.track.Default = boolPtr(u() != 0)
+		}
+	case 0x55aa:
+		if ctx.track != nil {
+			ctx.track.Forced = boolPtr(u() != 0)
+		}
+	case 0x536e:
+		if ctx.track != nil {
+			ctx.track.Title = str()
+		}
+	case 0x22b59d, 0x22b59c:
+		if ctx.track != nil {
+			ctx.track.Language = str()
+		}
+	case 0x86:
+		if ctx.track != nil {
+			ctx.track.CodecID = str()
+			ctx.track.Format = matroskaCodec(ctx.track.CodecID)
+		}
+	case 0x258688:
+		if ctx.track != nil {
+			ctx.track.CodecName = str()
+		}
+	case 0x23e383:
+		if ctx.track != nil && u() > 0 {
+			ctx.track.FrameRate = 1e9 / float64(u())
+		}
+	case 0xb0:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).Width = int(u())
+		}
+	case 0xba:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).Height = int(u())
+		}
+	case 0x54b0:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).DisplayWidth = int(u())
+		}
+	case 0x54ba:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).DisplayHeight = int(u())
+		}
+	case 0x9a:
+		if ctx.track != nil && u() != 0 {
+			ensureVideo(ctx.track).ScanType = "Interlaced"
+		}
+	case 0x55b1:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).MatrixCoefficients = fmt.Sprint(u())
+		}
+	case 0x55b9:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).ColorRange = map[uint64]string{1: "Limited", 2: "Full"}[u()]
+		}
+	case 0x55ba:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).TransferCharacteristics = fmt.Sprint(u())
+		}
+	case 0x55bb:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).ColorPrimaries = fmt.Sprint(u())
+		}
+	case 0x55b2:
+		if ctx.track != nil {
+			ensureVideo(ctx.track).BitDepth = int(u())
+		}
+	case 0xb5:
+		if ctx.track != nil {
+			ensureAudio(ctx.track).SampleRate = int(flt())
+		}
+	case 0x9f:
+		if ctx.track != nil {
+			ensureAudio(ctx.track).Channels = int(u())
+		}
+	case 0x6264:
+		if ctx.track != nil {
+			ensureAudio(ctx.track).BitDepth = int(u())
+		}
+	case 0x45a3:
+		ctx.tagName = str()
+	case 0x4487:
+		if ctx.tagName != "" {
+			target := ""
+			if ctx.tagTarget != nil {
+				target = *ctx.tagTarget
+			}
+			p.addTag(target, canonicalTag(ctx.tagName), str())
+		}
+	case 0x63c5:
+		if ctx.tagTarget != nil {
+			*ctx.tagTarget = fmt.Sprint(u())
+		}
+	case 0x91:
+		if ctx.chapter != nil {
+			ctx.chapter.Start = time.Duration(u())
+		}
+	case 0x92:
+		if ctx.chapter != nil {
+			ctx.chapter.End = time.Duration(u())
+		}
+	case 0x85:
+		if ctx.chapter != nil {
+			ctx.chapter.Title = str()
+		}
+	case 0x437c:
+		if ctx.chapter != nil {
+			ctx.chapter.Language = str()
+		}
+	}
+	return nil
+}
+
+type ebmlLeafKind uint8
+
+const (
+	ebmlLeafUnknown ebmlLeafKind = iota
+	ebmlLeafUint
+	ebmlLeafFloat
+	ebmlLeafText
+	ebmlLeafDocType
+)
+
+// classifyEBMLLeaf is intentionally exhaustive for the fields handled by
+// parseEBMLLeaf. Classification happens before any payload read so an unknown
+// multi-gigabyte leaf costs only its EBML header.
+func classifyEBMLLeaf(id uint64) ebmlLeafKind {
+	switch id {
+	case 0x4282:
+		return ebmlLeafDocType
+	case 0x2ad7b1, 0xd7, 0x73c5, 0x83, 0x88, 0x55aa, 0x23e383,
+		0xb0, 0xba, 0x54b0, 0x54ba, 0x9a, 0x55b1, 0x55b9, 0x55ba,
+		0x55bb, 0x55b2, 0x9f, 0x6264, 0x63c5, 0x91, 0x92:
+		return ebmlLeafUint
+	case 0x4489, 0xb5:
+		return ebmlLeafFloat
+	case 0x7ba9, 0x4d80, 0x5741, 0x536e, 0x22b59d, 0x22b59c,
+		0x86, 0x258688, 0x45a3, 0x4487, 0x85, 0x437c:
+		return ebmlLeafText
+	default:
+		return ebmlLeafUnknown
+	}
+}
+
+// needEBMLLeaf avoids bounded-but-still-unnecessary reads for fields outside
+// a track/chapter/tag context.
+func needEBMLLeaf(id uint64, ctx *ebmlContext) bool {
+	switch id {
+	case 0xd7, 0x83, 0x88, 0x55aa, 0x536e, 0x22b59d, 0x22b59c,
+		0x86, 0x258688, 0x23e383, 0xb0, 0xba, 0x54b0, 0x54ba, 0x9a,
+		0x55b1, 0x55b9, 0x55ba, 0x55bb, 0x55b2, 0xb5, 0x9f, 0x6264:
+		return ctx.track != nil
+	case 0x73c5:
+		return ctx.track != nil && ctx.track.ID == ""
+	case 0x4487:
+		return ctx.tagName != ""
+	case 0x63c5:
+		return ctx.tagTarget != nil
+	case 0x91, 0x92, 0x85, 0x437c:
+		return ctx.chapter != nil
+	default:
+		return true
+	}
+}
+
+func readEBMLUint(p *probe, off, size int64) (uint64, bool, error) {
+	if size < 1 || size > 8 {
+		if size > 8 {
+			p.report.Truncated = true
+		}
+		return 0, false, nil
+	}
+	b, err := p.readAt(off, int(size))
+	if err != nil {
+		return 0, false, err
+	}
+	var value uint64
+	for _, x := range b {
+		value = value<<8 | uint64(x)
+	}
+	return value, true, nil
+}
+
+func readEBMLFloat(p *probe, off, size int64) (float64, bool, error) {
+	if size != 4 && size != 8 {
+		if size > 8 {
+			p.report.Truncated = true
+		}
+		return 0, false, nil
+	}
+	b, err := p.readAt(off, int(size))
+	if err != nil {
+		return 0, false, err
+	}
+	if size == 4 {
+		return float64(math.Float32frombits(binary.BigEndian.Uint32(b))), true, nil
+	}
+	return math.Float64frombits(binary.BigEndian.Uint64(b)), true, nil
+}
+
+func readEBMLText(p *probe, off, size int64) (string, bool, error) {
+	if size < 0 {
+		return "", false, nil
+	}
+	if size == 0 {
+		return "", true, nil
+	}
+	limit := int64(p.opts.MaxValueBytes)
+	if p.opts.MaxSingleMetadataBytes < limit {
+		limit = p.opts.MaxSingleMetadataBytes
+	}
+	readSize := size
+	if readSize > limit {
+		readSize = limit
+		p.report.Truncated = true
+	}
+	b, err := p.readAt(off, int(readSize))
+	if err != nil {
+		return "", false, err
+	}
+	// Clone after trimming so the report owns exactly the retained bytes and
+	// never keeps a larger metadata allocation alive.
+	return strings.Clone(cleanText(b)), true, nil
+}
+
+func readEBMLDocType(p *probe, off, size int64) (string, bool, error) {
+	// The Matroska/WebM DocType values are tiny. Refuse implausibly large
+	// declarations rather than reading or accepting an unverified prefix.
+	const maxDocTypeBytes = 32
+	if size < 1 || size > maxDocTypeBytes || size > p.opts.MaxSingleMetadataBytes {
+		if size > maxDocTypeBytes || size > p.opts.MaxSingleMetadataBytes {
+			p.report.Truncated = true
+		}
+		return "", false, nil
+	}
+	b, err := p.readAt(off, int(size))
+	if err != nil {
+		return "", false, err
+	}
+	return strings.Clone(cleanText(b)), true, nil
+}
+
+func setMatroskaTrackType(s *Stream, v uint64) {
+	switch v {
+	case 1:
+		s.Kind = StreamVideo
+		s.Video = &Video{}
+	case 2:
+		s.Kind = StreamAudio
+		s.Audio = &Audio{}
+	case 17:
+		s.Kind = StreamText
+		s.Text = &Text{}
+	default:
+		s.Kind = StreamText
+	}
+}
+func ensureVideo(s *Stream) *Video {
+	if s.Video == nil {
+		s.Video = &Video{}
+	}
+	return s.Video
+}
+func ensureAudio(s *Stream) *Audio {
+	if s.Audio == nil {
+		s.Audio = &Audio{}
+	}
+	return s.Audio
+}
+func matroskaCodec(id string) string {
+	switch id {
+	case "V_MPEG4/ISO/AVC":
+		return "AVC"
+	case "V_MPEGH/ISO/HEVC":
+		return "HEVC"
+	case "V_AV1":
+		return "AV1"
+	case "V_VP8":
+		return "VP8"
+	case "V_VP9":
+		return "VP9"
+	case "V_THEORA":
+		return "Theora"
+	case "A_AAC":
+		return "AAC"
+	case "A_OPUS":
+		return "Opus"
+	case "A_VORBIS":
+		return "Vorbis"
+	case "A_FLAC":
+		return "FLAC"
+	case "A_MPEG/L3":
+		return "MPEG Audio Layer 3"
+	case "A_AC3":
+		return "AC-3"
+	case "A_EAC3":
+		return "E-AC-3"
+	case "A_DTS":
+		return "DTS"
+	case "S_TEXT/UTF8":
+		return "SubRip"
+	case "S_TEXT/ASS":
+		return "ASS"
+	case "S_TEXT/SSA":
+		return "SSA"
+	case "S_TEXT/WEBVTT":
+		return "WebVTT"
+	case "S_HDMV/PGS":
+		return "PGS"
+	case "S_VOBSUB":
+		return "VobSub"
+	}
+	if i := strings.LastIndexByte(id, '/'); i >= 0 {
+		return strings.Clone(id[i+1:])
+	}
+	return strings.Clone(id)
+}

--- a/plugins/mediainfo/parse_riff.go
+++ b/plugins/mediainfo/parse_riff.go
@@ -1,0 +1,352 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+type riffChunk struct {
+	id, listType string
+	offset, size int64
+	path         []string
+}
+
+func parseRIFF(p *probe, _ []byte) error {
+	h, err := p.readAt(0, 12)
+	if err != nil {
+		return &ParseError{Format: "RIFF", Offset: 0, Err: err}
+	}
+	var order binary.ByteOrder = binary.LittleEndian
+	if string(h[:4]) == "RIFX" {
+		order = binary.BigEndian
+	}
+	switch string(h[8:12]) {
+	case "WAVE":
+		return parseWave(p, order, string(h[:4]))
+	case "AVI ":
+		return parseAVI(p, order, string(h[:4]))
+	default:
+		return ErrUnsupported
+	}
+}
+
+func walkRIFF(p *probe, order binary.ByteOrder, start, end int64, path []string, fn func(riffChunk) error) error {
+	if end > p.src.Size {
+		end = p.src.Size
+	}
+	for pos := start; pos+8 <= end; {
+		if err := p.step(); err != nil {
+			return err
+		}
+		h, err := p.readAt(pos, 8)
+		if err != nil {
+			return err
+		}
+		id := string(h[:4])
+		sz := int64(u32(h[4:8], order))
+		data := pos + 8
+		// RF64/BW64 use 0xffffffff as a placeholder for the data chunk;
+		// its exact 64-bit length lives in the earlier ds64 chunk. Treat the
+		// payload as extending to this RIFF segment's bound so it can be skipped
+		// without trying to read audio data.
+		if id == "data" && sz == int64(^uint32(0)) {
+			sz = end - data
+		}
+		if sz < 0 || data > end || sz > end-data {
+			return &ParseError{Format: "RIFF", Offset: pos, Err: fmt.Errorf("chunk %q exceeds file", id)}
+		}
+		c := riffChunk{id: id, offset: data, size: sz, path: append([]string(nil), path...)}
+		if (id == "LIST" || id == "RIFF") && sz >= 4 {
+			t, err := p.readAt(data, 4)
+			if err != nil {
+				return err
+			}
+			c.listType = string(t)
+			if err := fn(c); err != nil {
+				return err
+			}
+			if c.listType != "movi" && len(path) < 6 {
+				if err := walkRIFF(p, order, data+4, data+sz, append(path, c.listType), fn); err != nil {
+					return err
+				}
+			}
+		} else if err := fn(c); err != nil {
+			return err
+		}
+		next := data + sz
+		if next&1 != 0 {
+			next++
+		}
+		if next <= pos {
+			return &ParseError{Format: "RIFF", Offset: pos, Err: errors.New("non-advancing chunk")}
+		}
+		pos = next
+	}
+	return nil
+}
+
+func parseWave(p *probe, order binary.ByteOrder, riffID string) error {
+	p.report.General.Format = "Wave"
+	p.report.General.CodecID = riffID
+	p.report.General.MIME = "audio/wav"
+	stream := Stream{Index: 0, ID: "1", Kind: StreamAudio, Format: "PCM", Audio: &Audio{}}
+	var dataSize uint64
+	var sampleCount uint64
+	err := walkRIFF(p, order, 12, p.src.Size, nil, func(c riffChunk) error {
+		switch c.id {
+		case "fmt ":
+			if c.size < 16 {
+				return &ParseError{Format: "Wave", Offset: c.offset, Err: errors.New("short fmt chunk")}
+			}
+			n := c.size
+			if n > 80 {
+				n = 80
+			}
+			b, err := p.readAt(c.offset, int(n))
+			if err != nil {
+				return err
+			}
+			tag := u16(b[0:2], order)
+			stream.CodecID = fmt.Sprintf("0x%04X", tag)
+			stream.Format = waveCodec(tag, b)
+			stream.Audio.Channels = int(u16(b[2:4], order))
+			stream.Audio.SampleRate = int(u32(b[4:8], order))
+			stream.BitRate = int64(u32(b[8:12], order)) * 8
+			stream.Audio.BitDepth = int(u16(b[14:16], order))
+			if tag == 1 || tag == 3 {
+				stream.Audio.CompressionMode = "Lossless"
+			}
+		case "fact":
+			if c.size >= 4 {
+				b, e := p.readAt(c.offset, 4)
+				if e == nil {
+					sampleCount = uint64(u32(b, order))
+				}
+			}
+		case "data":
+			if dataSize == 0 || (riffID != "RF64" && riffID != "BW64") {
+				dataSize = uint64(c.size)
+			}
+		case "ds64":
+			if c.size >= 24 {
+				b, e := p.readAt(c.offset, 24)
+				if e == nil {
+					dataSize = u64(b[8:16], binary.LittleEndian)
+					sampleCount = u64(b[16:24], binary.LittleEndian)
+				}
+			}
+		case "bext":
+			n := c.size
+			if n > 602 {
+				n = 602
+			}
+			b, e := p.readAt(c.offset, int(n))
+			if e == nil && len(b) >= 256 {
+				p.addTag("", "Description", cleanText(b[:256]))
+			}
+		default:
+			if len(c.path) > 0 && c.path[len(c.path)-1] == "INFO" && c.size <= p.opts.MaxSingleMetadataBytes {
+				b, e := p.readAt(c.offset, int(c.size))
+				if e == nil {
+					p.addTag("", canonicalTag(c.id), cleanText(b))
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if stream.Audio.SampleRate > 0 && sampleCount > 0 {
+		stream.Duration = durationFromUnits(sampleCount, uint64(stream.Audio.SampleRate))
+	}
+	if stream.Duration == 0 && stream.BitRate > 0 && dataSize > 0 {
+		stream.Duration = time.Duration(float64(dataSize*8) / float64(stream.BitRate) * float64(time.Second))
+	}
+	p.report.General.Duration = stream.Duration
+	p.report.Streams = append(p.report.Streams, stream)
+	return nil
+}
+
+func waveCodec(tag uint16, b []byte) string {
+	switch tag {
+	case 0x0001:
+		return "PCM"
+	case 0x0003:
+		return "IEEE Float"
+	case 0x0006:
+		return "A-law"
+	case 0x0007:
+		return "Mu-law"
+	case 0x0011:
+		return "IMA ADPCM"
+	case 0x0050:
+		return "MPEG Audio"
+	case 0x0055:
+		return "MPEG Audio Layer 3"
+	case 0x00ff:
+		return "AAC"
+	case 0x0161, 0x0162:
+		return "Windows Media Audio"
+	case 0x2000:
+		return "AC-3"
+	case 0xfffe:
+		if len(b) >= 40 {
+			return "WaveFormatExtensible"
+		}
+		return "Extensible"
+	default:
+		return "Unknown"
+	}
+}
+
+func parseAVI(p *probe, order binary.ByteOrder, riffID string) error {
+	p.report.General.Format = "AVI"
+	p.report.General.CodecID = riffID
+	p.report.General.MIME = "video/x-msvideo"
+	var current *Stream
+	var microseconds, totalFrames uint32
+	err := walkRIFF(p, order, 12, p.src.Size, nil, func(c riffChunk) error {
+		switch c.id {
+		case "avih":
+			if c.size < 40 {
+				return nil
+			}
+			b, err := p.readAt(c.offset, 40)
+			if err != nil {
+				return err
+			}
+			microseconds, totalFrames = u32(b[0:4], order), u32(b[16:20], order)
+			if microseconds > 0 {
+				p.report.General.Duration = time.Duration(uint64(microseconds)*uint64(totalFrames)) * time.Microsecond
+				p.report.General.FrameRate = 1e6 / float64(microseconds)
+				p.report.General.FrameCount = int64(totalFrames)
+			}
+		case "dmlh":
+			if c.size >= 4 {
+				b, err := p.readAt(c.offset, 4)
+				if err != nil {
+					return err
+				}
+				if frames := u32(b, order); frames > 0 {
+					totalFrames = frames
+				}
+			}
+		case "strh":
+			// A following strf always belongs to this strh. Clear the previous
+			// association even if the new stream is rejected or malformed.
+			current = nil
+			if len(p.report.Streams) >= p.opts.MaxStreams {
+				p.report.Truncated = true
+				return nil
+			}
+			if c.size < 48 {
+				return nil
+			}
+			b, err := p.readAt(c.offset, 48)
+			if err != nil {
+				return err
+			}
+			typ, handler := string(b[:4]), fourCC(b[4:8])
+			s := Stream{Index: len(p.report.Streams), ID: fmt.Sprint(len(p.report.Streams) + 1), CodecID: handler}
+			scale, rate, length := u32(b[20:24], order), u32(b[24:28], order), u32(b[32:36], order)
+			if scale > 0 && rate > 0 {
+				s.Duration = durationFromUnits(uint64(length)*uint64(scale), uint64(rate))
+				s.FrameCount = int64(length)
+				s.FrameRate = float64(rate) / float64(scale)
+			}
+			switch typ {
+			case "vids":
+				s.Kind, s.Format, s.Video = StreamVideo, videoCodec(handler), &Video{}
+			case "auds":
+				s.Kind, s.Format, s.Audio = StreamAudio, "Audio", &Audio{}
+			case "txts":
+				s.Kind, s.Format, s.Text = StreamText, "Text", &Text{}
+			default:
+				s.Kind, s.Format = StreamText, strings.TrimSpace(typ)
+			}
+			p.report.Streams = append(p.report.Streams, s)
+			current = &p.report.Streams[len(p.report.Streams)-1]
+		case "strf":
+			if current == nil {
+				return nil
+			}
+			n := c.size
+			if n > 128 {
+				n = 128
+			}
+			b, err := p.readAt(c.offset, int(n))
+			if err != nil {
+				return err
+			}
+			if current.Kind == StreamVideo && len(b) >= 20 {
+				current.Video.Width = int(int32(u32(b[4:8], order)))
+				current.Video.Height = int(int32(u32(b[8:12], order)))
+				current.Video.BitDepth = int(u16(b[14:16], order))
+				current.CodecID = fourCC(b[16:20])
+				current.Format = videoCodec(current.CodecID)
+			} else if current.Kind == StreamAudio && len(b) >= 16 {
+				tag := u16(b[:2], order)
+				current.CodecID = fmt.Sprintf("0x%04X", tag)
+				current.Format = waveCodec(tag, b)
+				current.Audio.Channels = int(u16(b[2:4], order))
+				current.Audio.SampleRate = int(u32(b[4:8], order))
+				current.BitRate = int64(u32(b[8:12], order)) * 8
+				current.Audio.BitDepth = int(u16(b[14:16], order))
+			}
+		default:
+			if len(c.path) > 0 && c.path[len(c.path)-1] == "INFO" && c.size <= p.opts.MaxSingleMetadataBytes {
+				b, e := p.readAt(c.offset, int(c.size))
+				if e == nil {
+					p.addTag("", canonicalTag(c.id), cleanText(b))
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if microseconds > 0 && totalFrames > 0 {
+		p.report.General.Duration = time.Duration(uint64(microseconds)*uint64(totalFrames)) * time.Microsecond
+		p.report.General.FrameRate = 1e6 / float64(microseconds)
+		p.report.General.FrameCount = int64(totalFrames)
+	}
+	if p.report.General.Duration == 0 {
+		for _, s := range p.report.Streams {
+			if s.Duration > p.report.General.Duration {
+				p.report.General.Duration = s.Duration
+			}
+		}
+	}
+	return nil
+}
+
+func videoCodec(id string) string {
+	switch strings.ToUpper(strings.TrimSpace(id)) {
+	case "H264", "X264", "AVC1":
+		return "AVC"
+	case "H265", "HEVC", "HVC1", "HEV1":
+		return "HEVC"
+	case "AV01":
+		return "AV1"
+	case "VP80":
+		return "VP8"
+	case "VP90":
+		return "VP9"
+	case "DIVX", "DX50", "XVID", "MP4V":
+		return "MPEG-4 Visual"
+	case "MJPG", "JPEG":
+		return "Motion JPEG"
+	case "THEO":
+		return "Theora"
+	default:
+		if id == "" {
+			return "Video"
+		}
+		return id
+	}
+}

--- a/plugins/mediainfo/parse_subtitle.go
+++ b/plugins/mediainfo/parse_subtitle.go
@@ -1,0 +1,470 @@
+package mediainfo
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/xml"
+	"errors"
+	"io"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+var subtitleExts = map[string]bool{".srt": true, ".vtt": true, ".ass": true, ".ssa": true, ".ttml": true, ".dfxp": true, ".sub": true, ".stl": true}
+
+func isSubtitleExtension(ext string) bool { return subtitleExts[strings.ToLower(ext)] }
+func looksLikeText(b []byte) bool {
+	if len(b) >= 2 && ((b[0] == 0xff && b[1] == 0xfe) || (b[0] == 0xfe && b[1] == 0xff)) {
+		return true
+	}
+	if !utf8.Valid(b) {
+		return false
+	}
+	zeros := bytes.Count(b, []byte{0})
+	return zeros == 0 || zeros*100 < len(b)
+}
+
+func parseSubtitle(p *probe, _ []byte) error {
+	n := p.src.Size
+	if n > p.opts.MaxTextBytes {
+		n = p.opts.MaxTextBytes
+		p.report.Truncated = true
+	}
+	b, e := p.readBounded(0, n)
+	if e != nil && !errors.Is(e, io.EOF) {
+		return e
+	}
+	text, enc := decodeSubtitleBytes(b)
+	ext := strings.ToLower(filepath.Ext(p.src.Name))
+	t := &Text{Encoding: enc}
+	s := Stream{Index: 0, ID: "1", Kind: StreamText, Text: t}
+	switch ext {
+	case ".srt":
+		s.Format = "SubRip"
+		if e := parseSRT(text, t, p); e != nil {
+			return &ParseError{Format: s.Format, Offset: -1, Err: e}
+		}
+	case ".vtt":
+		s.Format = "WebVTT"
+		if e := parseVTT(text, t, p); e != nil {
+			if errors.Is(e, ErrUnsupported) {
+				return ErrUnsupported
+			}
+			return &ParseError{Format: s.Format, Offset: -1, Err: e}
+		}
+	case ".ass", ".ssa":
+		s.Format = strings.ToUpper(strings.TrimPrefix(ext, "."))
+		if e := parseASS(text, t, p); e != nil {
+			return &ParseError{Format: s.Format, Offset: -1, Err: e}
+		}
+	case ".ttml", ".dfxp":
+		s.Format = "TTML"
+		if e := parseTTML(text, t, p); e != nil {
+			return &ParseError{Format: "TTML", Offset: 0, Err: e}
+		}
+	case ".sub":
+		s.Format = "MicroDVD"
+		if e := parseMicroDVD(text, t, p); e != nil {
+			return &ParseError{Format: s.Format, Offset: -1, Err: e}
+		}
+	default:
+		return ErrUnsupported
+	}
+	if t.CueCount == 0 && s.Format != "TTML" {
+		return ErrUnsupported
+	}
+	if t.LastCue > 0 {
+		s.Duration = t.LastCue
+		p.report.General.Duration = t.LastCue
+	}
+	p.report.General.Format = s.Format
+	p.report.General.MIME = "text/plain"
+	p.report.Streams = append(p.report.Streams, s)
+	return nil
+}
+
+func decodeSubtitleBytes(b []byte) (string, string) {
+	if len(b) >= 2 && b[0] == 0xff && b[1] == 0xfe {
+		return decodeUTF16(b[2:], true), "UTF-16LE"
+	}
+	if len(b) >= 2 && b[0] == 0xfe && b[1] == 0xff {
+		return decodeUTF16(b[2:], false), "UTF-16BE"
+	}
+	b = bytes.TrimPrefix(b, []byte{0xef, 0xbb, 0xbf})
+	return string(b), "UTF-8"
+}
+
+var srtTimeRE = regexp.MustCompile(`(?m)(?:(\d{1,3}):)?(\d{2}):(\d{2})[,.](\d{3})\s*-->\s*(?:(\d{1,3}):)?(\d{2}):(\d{2})[,.](\d{3})`)
+
+func subtitleTime(parts []string, off int) time.Duration {
+	vals := make([]int, 4)
+	for i := range vals {
+		vals[i], _ = strconv.Atoi(parts[off+i])
+	}
+	return time.Duration(vals[0])*time.Hour + time.Duration(vals[1])*time.Minute + time.Duration(vals[2])*time.Second + time.Duration(vals[3])*time.Millisecond
+}
+func newSubtitleScanner(s string, p *probe) *bufio.Scanner {
+	scan := bufio.NewScanner(strings.NewReader(s))
+	initial := p.opts.MaxValueBytes
+	if initial > 4096 {
+		initial = 4096
+	}
+	if initial < 1 {
+		initial = 1
+	}
+	scan.Buffer(make([]byte, initial), p.opts.MaxValueBytes)
+	return scan
+}
+
+func scanSubtitleLines(s string, p *probe, visit func(string) error) error {
+	scan := newSubtitleScanner(s, p)
+	for scan.Scan() {
+		if err := p.step(); err != nil {
+			return err
+		}
+		if err := visit(scan.Text()); err != nil {
+			return err
+		}
+	}
+	return scan.Err()
+}
+
+func parseSRT(s string, t *Text, p *probe) error {
+	return scanSubtitleLines(s, p, func(line string) error {
+		parseSubtitleTimingLine(line, t)
+		return nil
+	})
+}
+func parseVTT(s string, t *Text, p *probe) error {
+	t.FormatVersion = "WebVTT"
+	first := true
+	err := scanSubtitleLines(s, p, func(line string) error {
+		if first {
+			first = false
+			if !strings.HasPrefix(strings.TrimSpace(line), "WEBVTT") {
+				return ErrUnsupported
+			}
+			return nil
+		}
+		parseSubtitleTimingLine(line, t)
+		return nil
+	})
+	if err == nil && first {
+		return ErrUnsupported
+	}
+	return err
+}
+
+func parseSubtitleTimingLine(line string, t *Text) {
+	x := srtTimeRE.FindStringSubmatch(line)
+	if len(x) == 0 {
+		return
+	}
+	t.CueCount++
+	start, end := subtitleTime(x, 1), subtitleTime(x, 5)
+	if t.CueCount == 1 || start < t.FirstCue {
+		t.FirstCue = start
+	}
+	if end > t.LastCue {
+		t.LastCue = end
+	}
+}
+
+var assTimeRE = regexp.MustCompile(`(?i)^Dialogue\s*:[^,]*,([0-9]+):([0-9]{2}):([0-9]{2})[.]([0-9]{2}),([0-9]+):([0-9]{2}):([0-9]{2})[.]([0-9]{2}),`)
+
+func parseASS(s string, t *Text, p *probe) error {
+	return scanSubtitleLines(s, p, func(rawLine string) error {
+		line := strings.TrimSpace(rawLine)
+		if strings.HasPrefix(strings.ToLower(line), "style:") {
+			t.StyleCount++
+		}
+		m := assTimeRE.FindStringSubmatch(line)
+		if len(m) == 9 {
+			t.CueCount++
+			vals := make([]int, 8)
+			for i := range vals {
+				vals[i], _ = strconv.Atoi(m[i+1])
+			}
+			start := time.Duration(vals[0])*time.Hour + time.Duration(vals[1])*time.Minute + time.Duration(vals[2])*time.Second + time.Duration(vals[3])*10*time.Millisecond
+			end := time.Duration(vals[4])*time.Hour + time.Duration(vals[5])*time.Minute + time.Duration(vals[6])*time.Second + time.Duration(vals[7])*10*time.Millisecond
+			if t.CueCount == 1 || start < t.FirstCue {
+				t.FirstCue = start
+			}
+			if end > t.LastCue {
+				t.LastCue = end
+			}
+		}
+		return nil
+	})
+}
+
+func parseTTML(s string, t *Text, p *probe) error {
+	// encoding/xml materializes every attribute of a start element before it
+	// returns the token.  Preflight markup boundaries and attribute counts so a
+	// single hostile tag cannot turn the bounded subtitle input into an
+	// unbounded []xml.Attr allocation.
+	if err := validateTTMLMarkup(s, p); err != nil {
+		return err
+	}
+	dec := xml.NewDecoder(strings.NewReader(s))
+	depth := 0
+	for {
+		if e := p.step(); e != nil {
+			return e
+		}
+		tok, e := dec.Token()
+		if e == io.EOF {
+			break
+		}
+		if e != nil {
+			return e
+		}
+		switch x := tok.(type) {
+		case xml.StartElement:
+			depth++
+			if depth > 64 {
+				return errors.New("XML nesting too deep")
+			}
+			if x.Name.Local == "tt" {
+				for _, a := range x.Attr {
+					if a.Name.Local == "lang" {
+						p.addTag("", "Language", a.Value)
+					}
+				}
+			}
+			if x.Name.Local == "p" {
+				var begin, end, dur time.Duration
+				for _, a := range x.Attr {
+					switch a.Name.Local {
+					case "begin":
+						begin = parseClock(a.Value)
+					case "end":
+						end = parseClock(a.Value)
+					case "dur":
+						dur = parseClock(a.Value)
+					}
+				}
+				if end == 0 {
+					end = begin + dur
+				}
+				t.CueCount++
+				if t.CueCount == 1 || begin < t.FirstCue {
+					t.FirstCue = begin
+				}
+				if end > t.LastCue {
+					t.LastCue = end
+				}
+			}
+		case xml.EndElement:
+			depth--
+		}
+	}
+	if t.CueCount == 0 {
+		return errors.New("no TTML cues")
+	}
+	return nil
+}
+
+const (
+	maxTTMLMarkupBytes = 64 << 10
+	maxTTMLAttributes  = 256
+)
+
+// validateTTMLMarkup bounds the pieces that encoding/xml buffers as one
+// token. Attribute work is charged to the same element budget as decoded XML
+// tokens. This is intentionally a lexical preflight; encoding/xml remains the
+// authority for XML well-formedness.
+func validateTTMLMarkup(s string, p *probe) error {
+	for start := 0; start < len(s); {
+		if start&0xfff == 0 {
+			if err := p.ctx.Err(); err != nil {
+				return err
+			}
+		}
+		markupStart, err := nextTTMLMarkup(s, start, p)
+		if err != nil {
+			return err
+		}
+		if markupStart < 0 {
+			return p.ctx.Err()
+		}
+		start = markupStart
+
+		end, attributes, err := scanTTMLMarkup(s, start, p)
+		if err != nil {
+			if errors.Is(err, ErrLimit) {
+				p.report.Truncated = true
+			}
+			return err
+		}
+		if attributes > maxTTMLAttributes {
+			p.report.Truncated = true
+			return ErrLimit
+		}
+		for range attributes {
+			if err := p.step(); err != nil {
+				if errors.Is(err, ErrLimit) {
+					p.report.Truncated = true
+				}
+				return err
+			}
+		}
+		start = end
+	}
+	return p.ctx.Err()
+}
+
+func nextTTMLMarkup(s string, start int, p *probe) (int, error) {
+	for start < len(s) {
+		if err := p.ctx.Err(); err != nil {
+			return -1, err
+		}
+		end := start + 4096
+		if end > len(s) {
+			end = len(s)
+		}
+		if relative := strings.IndexByte(s[start:end], '<'); relative >= 0 {
+			return start + relative, nil
+		}
+		start = end
+	}
+	return -1, nil
+}
+
+func scanTTMLMarkup(s string, start int, p *probe) (end, attributes int, err error) {
+	if start < 0 || start >= len(s) || s[start] != '<' {
+		return 0, 0, io.ErrUnexpectedEOF
+	}
+
+	// Comments, CDATA and processing instructions have terminators that may
+	// contain a plain '>'. Bound the entire token rather than stopping early.
+	type delimiter struct {
+		prefix string
+		close  string
+	}
+	for _, candidate := range []delimiter{
+		{prefix: "<!--", close: "-->"},
+		{prefix: "<![CDATA[", close: "]]>"},
+		{prefix: "<?", close: "?>"},
+	} {
+		if !strings.HasPrefix(s[start:], candidate.prefix) {
+			continue
+		}
+		searchEnd := start + maxTTMLMarkupBytes + len(candidate.close)
+		if searchEnd > len(s) {
+			searchEnd = len(s)
+		}
+		closeAt := strings.Index(s[start+len(candidate.prefix):searchEnd], candidate.close)
+		if closeAt < 0 {
+			if searchEnd < len(s) {
+				return 0, 0, ErrLimit
+			}
+			return 0, 0, io.ErrUnexpectedEOF
+		}
+		end = start + len(candidate.prefix) + closeAt + len(candidate.close)
+		if end-start > maxTTMLMarkupBytes {
+			return 0, 0, ErrLimit
+		}
+		return end, 0, nil
+	}
+
+	isStartElement := start+1 < len(s) && s[start+1] != '/' && s[start+1] != '!'
+	quote := byte(0)
+	bracketDepth := 0
+	for index := start + 1; index < len(s); index++ {
+		if index-start > maxTTMLMarkupBytes {
+			return 0, 0, ErrLimit
+		}
+		if index&0xfff == 0 {
+			if err := p.ctx.Err(); err != nil {
+				return 0, attributes, err
+			}
+		}
+		ch := s[index]
+		if quote != 0 {
+			if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+		switch ch {
+		case '\'', '"':
+			quote = ch
+		case '[':
+			bracketDepth++
+		case ']':
+			if bracketDepth > 0 {
+				bracketDepth--
+			}
+		case '=':
+			if isStartElement {
+				attributes++
+				if attributes > maxTTMLAttributes {
+					return 0, attributes, ErrLimit
+				}
+			}
+		case '>':
+			if bracketDepth == 0 {
+				return index + 1, attributes, nil
+			}
+		}
+	}
+	return 0, attributes, io.ErrUnexpectedEOF
+}
+
+func parseClock(v string) time.Duration {
+	v = strings.TrimSpace(v)
+	if strings.HasSuffix(v, "ms") {
+		f, _ := strconv.ParseFloat(strings.TrimSuffix(v, "ms"), 64)
+		return time.Duration(f * float64(time.Millisecond))
+	}
+	if strings.HasSuffix(v, "s") {
+		f, _ := strconv.ParseFloat(strings.TrimSuffix(v, "s"), 64)
+		return time.Duration(f * float64(time.Second))
+	}
+	parts := strings.Split(v, ":")
+	if len(parts) == 3 {
+		h, _ := strconv.ParseFloat(parts[0], 64)
+		m, _ := strconv.ParseFloat(parts[1], 64)
+		sec, _ := strconv.ParseFloat(parts[2], 64)
+		return time.Duration((h*3600 + m*60 + sec) * float64(time.Second))
+	}
+	return 0
+}
+
+var microDVDRE = regexp.MustCompile(`(?m)^\{(\d+)\}\{(\d+)\}([^\r\n]*)`)
+
+func parseMicroDVD(s string, t *Text, p *probe) error {
+	fps := 25.0
+	matched := 0
+	return scanSubtitleLines(s, p, func(line string) error {
+		x := microDVDRE.FindStringSubmatch(line)
+		if len(x) == 0 {
+			return nil
+		}
+		a, _ := strconv.Atoi(x[1])
+		b, _ := strconv.Atoi(x[2])
+		if matched == 0 && ((a == 1 && b == 1) || (a == 0 && b == 0)) {
+			if declared := parseDecimal(strings.Replace(strings.TrimSpace(x[3]), ",", ".", 1)); declared > 0 {
+				fps = declared
+			}
+			matched++
+			return nil
+		}
+		matched++
+		start := time.Duration(float64(a) / fps * float64(time.Second))
+		end := time.Duration(float64(b) / fps * float64(time.Second))
+		t.CueCount++
+		if t.CueCount == 1 || start < t.FirstCue {
+			t.FirstCue = start
+		}
+		if end > t.LastCue {
+			t.LastCue = end
+		}
+		return nil
+	})
+}

--- a/plugins/mediainfo/parse_tiff.go
+++ b/plugins/mediainfo/parse_tiff.go
@@ -1,0 +1,349 @@
+package mediainfo
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+func isTIFFMagic(b []byte) bool {
+	return len(b) >= 4 && (string(b[:4]) == "II*\x00" || string(b[:4]) == "MM\x00*")
+}
+
+type tiffImageScanner struct {
+	p           *probe
+	b           []byte
+	order       binary.ByteOrder
+	seen        map[uint32]bool
+	pending     map[uint32]bool
+	width       uint32
+	height      uint32
+	bitDepth    int
+	compression uint16
+	isDNG       bool
+}
+
+const (
+	maxTIFFIFDDepth             = 8
+	maxTIFFIFDNodes             = 4096
+	maxTIFFBitsPerSampleValues  = 64
+	maxTIFFSubIFDReferenceCount = 256
+)
+
+func parseTIFFImage(p *probe, _ []byte) error {
+	n := min64(p.src.Size, p.opts.MaxSingleMetadataBytes)
+	if n < 8 {
+		return &ParseError{Format: "TIFF", Offset: 0, Err: errors.New("short TIFF header")}
+	}
+	b, err := p.readAt(0, int(n))
+	if err != nil {
+		return err
+	}
+	var order binary.ByteOrder
+	switch string(b[:2]) {
+	case "II":
+		order = binary.LittleEndian
+	case "MM":
+		order = binary.BigEndian
+	default:
+		return ErrUnsupported
+	}
+	if order.Uint16(b[2:4]) != 42 {
+		return ErrUnsupported
+	}
+	scanner := &tiffImageScanner{
+		p: p, b: b, order: order,
+		seen: make(map[uint32]bool), pending: make(map[uint32]bool),
+	}
+	if err := scanner.walkIFD(order.Uint32(b[4:8]), 0); err != nil {
+		return err
+	}
+	if scanner.width == 0 || scanner.height == 0 {
+		return &ParseError{Format: "TIFF", Offset: 0, Err: errors.New("image dimensions not found")}
+	}
+	im := &Image{
+		Width: int(scanner.width), Height: int(scanner.height), BitDepth: scanner.bitDepth,
+		Compression: tiffCompression(scanner.compression), FrameCount: 1,
+	}
+	parseTIFFMeta(p, b, im)
+	format, mime := tiffFormat(p.src.Name, b, scanner.isDNG)
+	p.report.General.Format = format
+	p.report.General.MIME = mime
+	p.report.Streams = append(p.report.Streams, Stream{
+		Index: 0, ID: "1", Kind: StreamImage, Format: format, Image: im,
+	})
+	if n < p.src.Size {
+		p.warn("metadata_window", "TIFF metadata outside the bounded header window was not inspected", n)
+	}
+	return nil
+}
+
+func (s *tiffImageScanner) walkIFD(off uint32, depth int) error {
+	if err := s.p.ctx.Err(); err != nil {
+		return err
+	}
+	delete(s.pending, off)
+	if depth > maxTIFFIFDDepth {
+		return nil
+	}
+	// The next-IFD link keeps the same logical depth. Follow that chain in a
+	// loop so a valid but very long multipage file cannot grow the Go stack.
+	for off != 0 {
+		if err := s.p.ctx.Err(); err != nil {
+			return err
+		}
+		delete(s.pending, off)
+		if s.seen[off] || uint64(off)+2 > uint64(len(s.b)) {
+			return nil
+		}
+		if len(s.seen) >= maxTIFFIFDNodes {
+			return ErrLimit
+		}
+		s.seen[off] = true
+
+		count := int(s.order.Uint16(s.b[off : off+2]))
+		if count > 4096 {
+			return &ParseError{Format: "TIFF", Offset: int64(off), Err: errors.New("too many IFD entries")}
+		}
+		end := uint64(off) + 2 + uint64(count)*12
+		if end > uint64(len(s.b)) {
+			return nil
+		}
+		var width, height uint32
+		nested := make([]uint32, 0, 4)
+		for i := 0; i < count; i++ {
+			if err := s.p.step(); err != nil {
+				return err
+			}
+			pos := int(off) + 2 + i*12
+			entry := s.b[pos : pos+12]
+			tag := s.order.Uint16(entry[:2])
+
+			// Classify first. In particular, do not materialize the declared
+			// values of an unknown tag: hostile files commonly make thousands
+			// of entries point at one large shared payload.
+			switch tag {
+			case 0x0100: // ImageWidth
+				if value, ok, err := s.firstValue(entry); err != nil {
+					return err
+				} else if ok {
+					width = value
+				}
+			case 0x0101: // ImageLength
+				if value, ok, err := s.firstValue(entry); err != nil {
+					return err
+				} else if ok {
+					height = value
+				}
+			case 0x0102: // BitsPerSample
+				values, ok, err := s.valueSet(entry, maxTIFFBitsPerSampleValues)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+				for i := uint32(0); i < values.count; i++ {
+					if err := s.p.step(); err != nil {
+						return err
+					}
+					if value := values.at(i); int(value) > s.bitDepth && value <= 64 {
+						s.bitDepth = int(value)
+					}
+				}
+			case 0x0103: // Compression
+				if value, ok, err := s.firstValue(entry); err != nil {
+					return err
+				} else if ok {
+					s.compression = uint16(value)
+				}
+			case 0x014a: // SubIFDs
+				values, ok, err := s.valueSet(entry, maxTIFFSubIFDReferenceCount)
+				if err != nil {
+					return err
+				}
+				if !ok {
+					continue
+				}
+				for i := uint32(0); i < values.count; i++ {
+					if err := s.p.step(); err != nil {
+						return err
+					}
+					if err := s.queueIFD(&nested, values.at(i)); err != nil {
+						return err
+					}
+				}
+			case 0x8769: // Exif IFD
+				if value, ok, err := s.firstValue(entry); err != nil {
+					return err
+				} else if ok {
+					if err := s.queueIFD(&nested, value); err != nil {
+						return err
+					}
+				}
+			case 0xc612: // DNGVersion
+				if _, ok, err := s.firstValue(entry); err != nil {
+					return err
+				} else if ok {
+					s.isDNG = true
+				}
+			}
+		}
+		if width > 0 && height > 0 && uint64(width)*uint64(height) > uint64(s.width)*uint64(s.height) {
+			s.width, s.height = width, height
+		}
+		for _, child := range nested {
+			if err := s.p.ctx.Err(); err != nil {
+				return err
+			}
+			if err := s.walkIFD(child, depth+1); err != nil {
+				return err
+			}
+		}
+
+		var next uint32
+		if end+4 <= uint64(len(s.b)) {
+			next = s.order.Uint32(s.b[end : end+4])
+			if next != 0 {
+				// The link itself is another decoded reference. Charge it even
+				// when it points at an IFD that has already been visited.
+				if err := s.p.step(); err != nil {
+					return err
+				}
+			}
+		}
+		off = next
+	}
+	return nil
+}
+
+type tiffValueSet struct {
+	raw   []byte
+	typ   uint16
+	count uint32
+	order binary.ByteOrder
+}
+
+func (s *tiffImageScanner) valueSet(entry []byte, maxValues uint32) (tiffValueSet, bool, error) {
+	if len(entry) < 12 {
+		return tiffValueSet{}, false, nil
+	}
+	typ := s.order.Uint16(entry[2:4])
+	count := s.order.Uint32(entry[4:8])
+	var unit uint64
+	switch typ {
+	case 1:
+		unit = 1
+	case 3:
+		unit = 2
+	case 4, 9:
+		unit = 4
+	}
+	if unit == 0 || count == 0 {
+		return tiffValueSet{}, false, nil
+	}
+	if maxValues > 0 && count > maxValues {
+		return tiffValueSet{}, false, ErrLimit
+	}
+	if count > 4096 {
+		return tiffValueSet{}, false, nil
+	}
+	sz := uint64(count) * unit
+	var raw []byte
+	if sz <= 4 {
+		raw = entry[8 : 8+int(sz)]
+	} else {
+		off := uint64(s.order.Uint32(entry[8:12]))
+		if off > uint64(len(s.b)) || sz > uint64(len(s.b))-off {
+			return tiffValueSet{}, false, nil
+		}
+		raw = s.b[off : off+sz]
+	}
+	return tiffValueSet{raw: raw, typ: typ, count: count, order: s.order}, true, nil
+}
+
+func (s *tiffImageScanner) firstValue(entry []byte) (uint32, bool, error) {
+	values, ok, err := s.valueSet(entry, 0)
+	if err != nil || !ok {
+		return 0, ok, err
+	}
+	if err := s.p.step(); err != nil {
+		return 0, false, err
+	}
+	return values.at(0), true, nil
+}
+
+func (s *tiffImageScanner) queueIFD(nested *[]uint32, off uint32) error {
+	if off == 0 || s.seen[off] || s.pending[off] || uint64(off)+2 > uint64(len(s.b)) {
+		return nil
+	}
+	if len(s.seen)+len(s.pending) >= maxTIFFIFDNodes {
+		return ErrLimit
+	}
+	s.pending[off] = true
+	*nested = append(*nested, off)
+	return nil
+}
+
+func (v tiffValueSet) at(i uint32) uint32 {
+	switch v.typ {
+	case 1:
+		return uint32(v.raw[i])
+	case 3:
+		i *= 2
+		return uint32(v.order.Uint16(v.raw[i : i+2]))
+	case 4, 9:
+		i *= 4
+		return v.order.Uint32(v.raw[i : i+4])
+	default:
+		return 0
+	}
+}
+
+func tiffFormat(name string, b []byte, dng bool) (string, string) {
+	if dng || strings.EqualFold(filepath.Ext(name), ".dng") {
+		return "DNG", "image/x-adobe-dng"
+	}
+	switch strings.ToLower(filepath.Ext(name)) {
+	case ".cr2":
+		if len(b) >= 12 && string(b[8:12]) == "CR\x02\x00" {
+			return "Canon CR2", "image/x-canon-cr2"
+		}
+		return "Canon RAW", "image/x-canon-cr2"
+	case ".nef":
+		return "Nikon NEF", "image/x-nikon-nef"
+	case ".pef":
+		return "Pentax PEF", "image/x-pentax-pef"
+	case ".arw":
+		return "Sony ARW", "image/x-sony-arw"
+	default:
+		return "TIFF", "image/tiff"
+	}
+}
+
+func tiffCompression(v uint16) string {
+	switch v {
+	case 1:
+		return "Uncompressed"
+	case 5:
+		return "LZW"
+	case 6, 7:
+		return "JPEG"
+	case 8, 32946:
+		return "Deflate"
+	case 32773:
+		return "PackBits"
+	case 34712:
+		return "JPEG 2000"
+	case 34892, 34893:
+		return "Lossy JPEG"
+	case 65000:
+		return "Kodak DCR"
+	case 0:
+		return ""
+	default:
+		return fmt.Sprintf("TIFF compression %d", v)
+	}
+}

--- a/plugins/mediainfo/parse_tiff_limits_test.go
+++ b/plugins/mediainfo/parse_tiff_limits_test.go
@@ -1,0 +1,142 @@
+package mediainfo
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"testing"
+)
+
+func sharedTIFFValueFixture(tag, typ uint16, valueCount uint32, entries int, value uint32) []byte {
+	unit := 4
+	if typ == 1 {
+		unit = 1
+	} else if typ == 3 {
+		unit = 2
+	}
+	ifdSize := 2 + entries*12 + 4
+	payloadOffset := 8 + ifdSize
+	b := make([]byte, payloadOffset+int(valueCount)*unit)
+	copy(b, "II*\x00")
+	binary.LittleEndian.PutUint32(b[4:8], 8)
+	binary.LittleEndian.PutUint16(b[8:10], uint16(entries))
+	for i := 0; i < entries; i++ {
+		pos := 10 + i*12
+		binary.LittleEndian.PutUint16(b[pos:pos+2], tag)
+		binary.LittleEndian.PutUint16(b[pos+2:pos+4], typ)
+		binary.LittleEndian.PutUint32(b[pos+4:pos+8], valueCount)
+		binary.LittleEndian.PutUint32(b[pos+8:pos+12], uint32(payloadOffset))
+	}
+	for i := uint32(0); i < valueCount; i++ {
+		pos := payloadOffset + int(i)*unit
+		switch typ {
+		case 1:
+			b[pos] = byte(value)
+		case 3:
+			binary.LittleEndian.PutUint16(b[pos:pos+2], uint16(value))
+		default:
+			binary.LittleEndian.PutUint32(b[pos:pos+4], value)
+		}
+	}
+	return b
+}
+
+func scanTIFFFixture(ctx context.Context, b []byte, opts Options) (*probe, *tiffImageScanner, error) {
+	p := &probe{ctx: ctx, opts: opts.normalized()}
+	s := &tiffImageScanner{
+		p: p, b: b, order: binary.LittleEndian,
+		seen: make(map[uint32]bool), pending: make(map[uint32]bool),
+	}
+	return p, s, s.walkIFD(8, 0)
+}
+
+func TestTIFFScannerClassifiesBeforeSharedValueDecode(t *testing.T) {
+	const entries = 4096
+	// Every unknown entry claims the same 4096-value payload. Decoding before
+	// checking the tag used to allocate and discard more than 16 million
+	// uint32 values.
+	b := sharedTIFFValueFixture(0xeeee, 4, 4096, entries, 0)
+	opts := DefaultOptions(ModeDetailed)
+	opts.MaxElements = entries + 16
+
+	var elements int
+	var scanErr error
+	allocs := testing.AllocsPerRun(5, func() {
+		p, _, err := scanTIFFFixture(context.Background(), b, opts)
+		elements, scanErr = p.elements, err
+	})
+	if scanErr != nil {
+		t.Fatal(scanErr)
+	}
+	if elements != entries {
+		t.Fatalf("elements = %d, want %d", elements, entries)
+	}
+	if allocs > 128 {
+		t.Fatalf("shared-value scan allocations = %.0f, want <= 128", allocs)
+	}
+}
+
+func TestTIFFScannerDuplicateSubIFDsAreElementBounded(t *testing.T) {
+	const entries = 4096
+	// All references point back to the root. Duplicate references still consume
+	// the element budget but never grow a duplicate child-offset slice.
+	b := sharedTIFFValueFixture(0x014a, 4, 64, entries, 8)
+	opts := DefaultOptions(ModeDetailed)
+	opts.MaxElements = 1024
+
+	var p *probe
+	var scanner *tiffImageScanner
+	var scanErr error
+	allocs := testing.AllocsPerRun(5, func() {
+		p, scanner, scanErr = scanTIFFFixture(context.Background(), b, opts)
+	})
+	if !errors.Is(scanErr, ErrLimit) {
+		t.Fatalf("error = %v, want ErrLimit", scanErr)
+	}
+	if p.elements != opts.MaxElements+1 {
+		t.Fatalf("elements = %d, want %d", p.elements, opts.MaxElements+1)
+	}
+	if len(scanner.pending) != 0 || len(scanner.seen) != 1 {
+		t.Fatalf("IFD state: seen=%d pending=%d", len(scanner.seen), len(scanner.pending))
+	}
+	if allocs > 128 {
+		t.Fatalf("duplicate-reference scan allocations = %.0f, want <= 128", allocs)
+	}
+}
+
+func TestTIFFScannerCapsArrayValueCounts(t *testing.T) {
+	tests := []struct {
+		name  string
+		tag   uint16
+		typ   uint16
+		count uint32
+	}{
+		{"bits per sample", 0x0102, 3, maxTIFFBitsPerSampleValues + 1},
+		{"SubIFDs", 0x014a, 4, maxTIFFSubIFDReferenceCount + 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b := sharedTIFFValueFixture(tc.tag, tc.typ, tc.count, 1, 8)
+			p, _, err := scanTIFFFixture(context.Background(), b, DefaultOptions(ModeDetailed))
+			if !errors.Is(err, ErrLimit) {
+				t.Fatalf("error = %v, want ErrLimit", err)
+			}
+			if p.elements != 1 {
+				t.Fatalf("elements = %d, want 1", p.elements)
+			}
+		})
+	}
+}
+
+func TestTIFFScannerCancellationWinsForVisitedIFD(t *testing.T) {
+	b := sharedTIFFValueFixture(0xeeee, 4, 1, 0, 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	p, scanner, err := scanTIFFFixture(ctx, b, DefaultOptions(ModeFast))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancel()
+	if err := scanner.walkIFD(8, 0); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled (elements=%d)", err, p.elements)
+	}
+}

--- a/plugins/mediainfo/plugin.go
+++ b/plugins/mediainfo/plugin.go
@@ -1,0 +1,234 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/unxed/f4/vfs"
+)
+
+const (
+	panelCommandID  = "f4.mediainfo.open"
+	configCommandID = "f4.mediainfo.configure"
+	prefixID        = "f4.mediainfo.prefix"
+	quickViewID     = "f4.mediainfo.quickview"
+	macroID         = "f4.mediainfo"
+	legacyMacroGUID = "919C1FC6-A571-4642-99DF-BDACE840ED18"
+)
+
+// Plugin is the built-in, CGO-free MediaInfo-style plugin. Its backend reads
+// through vfs.VFS only; it never materializes a remote file to the OS.
+type Plugin struct {
+	mu          sync.Mutex
+	configDir   string
+	api         vfs.HostAPI
+	store       *settingsStore
+	cache       *reportCache
+	registrars  []vfs.Registration
+	prefix      vfs.CommandPrefixRegistration
+	initialized bool
+}
+
+func NewPlugin(configDir string) *Plugin {
+	return &Plugin{configDir: configDir, cache: newReportCache(reportCacheCapacity)}
+}
+
+func (plugin *Plugin) GetName() string { return "MediaInfo" }
+
+func (plugin *Plugin) Init(api vfs.HostAPI) error {
+	if api == nil {
+		return errors.New("MediaInfo: nil host API")
+	}
+	host, ok := api.(vfs.ContributionHost)
+	if !ok {
+		return errors.New("MediaInfo: this host does not support plugin contributions")
+	}
+
+	plugin.mu.Lock()
+	if plugin.initialized {
+		plugin.mu.Unlock()
+		return errors.New("MediaInfo: plugin is already initialized")
+	}
+	plugin.api = api
+	if plugin.cache == nil {
+		plugin.cache = newReportCache(reportCacheCapacity)
+	}
+	plugin.mu.Unlock()
+
+	store, loadErr := newSettingsStore(plugin.settingsDirectory())
+	plugin.mu.Lock()
+	plugin.store = store
+	plugin.mu.Unlock()
+	if loadErr != nil {
+		api.Log(loadErr.Error() + "; using defaults")
+	}
+	settings := store.snapshot()
+
+	var registrations []vfs.Registration
+	rollback := func(err error) error {
+		for i := len(registrations) - 1; i >= 0; i-- {
+			registrations[i].Unregister()
+		}
+		plugin.mu.Lock()
+		plugin.api = nil
+		plugin.store = nil
+		plugin.prefix = nil
+		plugin.mu.Unlock()
+		return err
+	}
+
+	panelRegistration, err := host.RegisterPluginCommand(vfs.PluginCommand{
+		ID:       panelCommandID,
+		Location: vfs.PluginCommandPanel,
+		Label:    plugin.text("MediaInfo.Menu", "&Media information", "&Информация о медиа"),
+		Visible: func(vfs.App) bool {
+			return plugin.settings().ShowInPluginMenu
+		},
+		Run: plugin.openCurrent,
+	})
+	if err != nil {
+		return rollback(fmt.Errorf("MediaInfo: register panel command: %w", err))
+	}
+	registrations = append(registrations, panelRegistration)
+
+	configRegistration, err := host.RegisterPluginCommand(vfs.PluginCommand{
+		ID:       configCommandID,
+		Location: vfs.PluginCommandConfig,
+		Label:    plugin.text("MediaInfo.ConfigMenu", "MediaInfo", "MediaInfo"),
+		Run:      plugin.configure,
+	})
+	if err != nil {
+		return rollback(fmt.Errorf("MediaInfo: register configuration command: %w", err))
+	}
+	registrations = append(registrations, configRegistration)
+
+	quickRegistration, err := host.RegisterQuickViewProvider(&mediaQuickViewProvider{plugin: plugin})
+	if err != nil {
+		return rollback(fmt.Errorf("MediaInfo: register Quick View provider: %w", err))
+	}
+	registrations = append(registrations, quickRegistration)
+
+	prefixRegistration, err := host.RegisterCommandPrefix(prefixID, settings.Prefix, plugin.handlePrefix)
+	if err != nil {
+		return rollback(fmt.Errorf("MediaInfo: register command prefix: %w", err))
+	}
+	registrations = append(registrations, prefixRegistration)
+	plugin.mu.Lock()
+	plugin.prefix = prefixRegistration
+	plugin.mu.Unlock()
+
+	macroRegistration, err := host.RegisterMacroCallProvider(vfs.MacroCallProvider{
+		IDs:  []string{macroID, legacyMacroGUID},
+		Call: plugin.callMacro,
+	})
+	if err != nil {
+		return rollback(fmt.Errorf("MediaInfo: register macro provider: %w", err))
+	}
+	registrations = append(registrations, macroRegistration)
+
+	plugin.mu.Lock()
+	plugin.registrars = registrations
+	plugin.initialized = true
+	plugin.mu.Unlock()
+	return nil
+}
+
+func (plugin *Plugin) Close() error {
+	plugin.mu.Lock()
+	registrations := append([]vfs.Registration(nil), plugin.registrars...)
+	plugin.registrars = nil
+	plugin.prefix = nil
+	plugin.api = nil
+	plugin.initialized = false
+	cache := plugin.cache
+	plugin.mu.Unlock()
+	for i := len(registrations) - 1; i >= 0; i-- {
+		registrations[i].Unregister()
+	}
+	cache.clear()
+	return nil
+}
+
+func (plugin *Plugin) settingsDirectory() string {
+	if strings.TrimSpace(plugin.configDir) != "" {
+		return plugin.configDir
+	}
+	if strings.TrimSpace(vfs.CustomConfigDir) != "" {
+		return vfs.CustomConfigDir
+	}
+	if directory, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(directory, "f4")
+	}
+	return "."
+}
+
+func (plugin *Plugin) settings() Settings {
+	plugin.mu.Lock()
+	store := plugin.store
+	plugin.mu.Unlock()
+	if store == nil {
+		return DefaultSettings()
+	}
+	return store.snapshot()
+}
+
+func (plugin *Plugin) log(message string, args ...any) {
+	plugin.mu.Lock()
+	api := plugin.api
+	plugin.mu.Unlock()
+	if api != nil {
+		api.Log(fmt.Sprintf(message, args...))
+	}
+}
+
+func (plugin *Plugin) analyzePath(ctx context.Context, fs vfs.VFS, path string, item vfs.VFSItem, mode Mode) (Report, error) {
+	if fs == nil {
+		return Report{}, errors.New("media source has no VFS")
+	}
+	if item.Name == "" && !item.IsDir {
+		stat, err := fs.Stat(ctx, path)
+		if err != nil {
+			return Report{}, err
+		}
+		item = stat
+	}
+	if item.IsDir {
+		return Report{}, errors.New("media source is a directory")
+	}
+	plugin.mu.Lock()
+	cache := plugin.cache
+	if cache == nil {
+		cache = newReportCache(reportCacheCapacity)
+		plugin.cache = cache
+	}
+	plugin.mu.Unlock()
+	key := reportCacheKey(fs, path, item, mode)
+	if report, ok := cache.get(key); ok {
+		return report, nil
+	}
+	reader, err := fs.Open(ctx, path)
+	if err != nil {
+		return Report{}, err
+	}
+	defer reader.Close()
+	size := reader.Size()
+	if size < 0 {
+		size = item.Size
+	}
+	report, err := Analyze(ctx, Source{
+		Name:    fs.Base(path),
+		Size:    size,
+		ModTime: item.MTime,
+		Reader:  reader,
+	}, DefaultOptions(mode))
+	if err != nil {
+		return Report{}, err
+	}
+	cache.put(key, report)
+	return report, nil
+}

--- a/plugins/mediainfo/plugin_test.go
+++ b/plugins/mediainfo/plugin_test.go
@@ -1,0 +1,122 @@
+package mediainfo
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+type pluginTestRegistration struct {
+	mu           sync.Mutex
+	unregistered int
+}
+
+func (registration *pluginTestRegistration) Unregister() {
+	registration.mu.Lock()
+	registration.unregistered++
+	registration.mu.Unlock()
+}
+
+type pluginTestPrefixRegistration struct {
+	pluginTestRegistration
+	prefix string
+}
+
+func (registration *pluginTestPrefixRegistration) SetPrefix(prefix string) error {
+	registration.prefix = prefix
+	return nil
+}
+
+type pluginTestHost struct {
+	commands []vfs.PluginCommand
+	quick    vfs.QuickViewProvider
+	prefix   *pluginTestPrefixRegistration
+	macro    vfs.MacroCallProvider
+	regs     []*pluginTestRegistration
+	logs     []string
+}
+
+func (host *pluginTestHost) registration() *pluginTestRegistration {
+	registration := &pluginTestRegistration{}
+	host.regs = append(host.regs, registration)
+	return registration
+}
+
+func (*pluginTestHost) GetVersion() string                           { return "test" }
+func (host *pluginTestHost) Log(message string)                      { host.logs = append(host.logs, message) }
+func (*pluginTestHost) Message(string)                               {}
+func (*pluginTestHost) RegisterHighlighter(vtui.HighlighterProvider) {}
+func (*pluginTestHost) RegisterVFSProvider(vfs.VFSProvider)          {}
+func (*pluginTestHost) RegisterURIProvider(vfs.URIProvider) error    { return nil }
+func (*pluginTestHost) RegisterDrive(string, func() vfs.VFS)         {}
+func (*pluginTestHost) RegisterGlobalHotkey(uint16, vtinput.ControlKeyState, func(vfs.App)) {
+}
+func (*pluginTestHost) RegisterPluginMenuItem(string, func(vfs.App)) {}
+func (*pluginTestHost) RunAction(string) bool                        { return false }
+
+func (host *pluginTestHost) RegisterQuickViewProvider(provider vfs.QuickViewProvider) (vfs.Registration, error) {
+	host.quick = provider
+	return host.registration(), nil
+}
+
+func (host *pluginTestHost) RegisterPluginCommand(command vfs.PluginCommand) (vfs.Registration, error) {
+	host.commands = append(host.commands, command)
+	return host.registration(), nil
+}
+
+func (host *pluginTestHost) RegisterCommandPrefix(_ string, prefix string, _ func(vfs.App, string)) (vfs.CommandPrefixRegistration, error) {
+	host.prefix = &pluginTestPrefixRegistration{prefix: prefix}
+	host.regs = append(host.regs, &host.prefix.pluginTestRegistration)
+	return host.prefix, nil
+}
+
+func (host *pluginTestHost) RegisterMacroCallProvider(provider vfs.MacroCallProvider) (vfs.Registration, error) {
+	host.macro = provider
+	return host.registration(), nil
+}
+
+func TestPluginRegistersAndUnregistersEveryContribution(t *testing.T) {
+	host := &pluginTestHost{}
+	plugin := NewPlugin(t.TempDir())
+	if err := plugin.Init(host); err != nil {
+		t.Fatal(err)
+	}
+	if len(host.commands) != 2 || host.commands[0].ID != panelCommandID || host.commands[1].ID != configCommandID {
+		t.Fatalf("commands = %#v", host.commands)
+	}
+	if host.quick == nil || host.quick.Name() != quickViewID {
+		t.Fatalf("quick provider = %#v", host.quick)
+	}
+	if host.prefix == nil || host.prefix.prefix != "MediaInfo" {
+		t.Fatalf("prefix = %#v", host.prefix)
+	}
+	if len(host.macro.IDs) != 2 || host.macro.IDs[0] != macroID || host.macro.IDs[1] != legacyMacroGUID {
+		t.Fatalf("macro IDs = %#v", host.macro.IDs)
+	}
+	if err := plugin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := plugin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	for index, registration := range host.regs {
+		registration.mu.Lock()
+		count := registration.unregistered
+		registration.mu.Unlock()
+		if count != 1 {
+			t.Errorf("registration %d unregistered %d times", index, count)
+		}
+	}
+}
+
+func TestAnalyzePathRejectsDirectoryBeforeOpening(t *testing.T) {
+	plugin := NewPlugin(t.TempDir())
+	_, err := plugin.analyzePath(context.Background(), vfs.NewOSVFS(t.TempDir()), "folder", vfs.VFSItem{Name: "folder", IsDir: true}, ModeFast)
+	if err == nil {
+		t.Fatal("directory was accepted")
+	}
+}

--- a/plugins/mediainfo/quickview_provider.go
+++ b/plugins/mediainfo/quickview_provider.go
@@ -1,0 +1,71 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/unxed/f4/vfs"
+)
+
+var quickViewMediaExtensions = map[string]struct{}{
+	".3g2": {}, ".3gp": {}, ".aif": {}, ".aifc": {}, ".aiff": {},
+	".avi": {}, ".bw64": {}, ".flac": {}, ".m1a": {}, ".m2a": {},
+	".m4a": {}, ".m4b": {}, ".m4v": {}, ".mka": {}, ".mks": {}, ".mkv": {},
+	".mov": {}, ".mp1": {}, ".mp2": {}, ".mp3": {}, ".mp4": {},
+	".oga": {}, ".ogg": {}, ".ogm": {}, ".ogv": {}, ".opus": {},
+	".rf64": {}, ".rifx": {}, ".spx": {}, ".wav": {}, ".webm": {},
+}
+
+type mediaQuickViewProvider struct {
+	plugin *Plugin
+}
+
+func (provider *mediaQuickViewProvider) Name() string  { return quickViewID }
+func (provider *mediaQuickViewProvider) Priority() int { return 40 }
+
+func (provider *mediaQuickViewProvider) CanPreview(request vfs.QuickViewRequest) bool {
+	if provider == nil || provider.plugin == nil || !provider.plugin.settings().EnableQuickView {
+		return false
+	}
+	if request.VFS == nil || request.Item.IsDir {
+		return false
+	}
+	name := request.Item.Name
+	if name == "" {
+		name = request.Path
+	}
+	_, supported := quickViewMediaExtensions[strings.ToLower(filepath.Ext(name))]
+	return supported
+}
+
+func (provider *mediaQuickViewProvider) Preview(ctx context.Context, request vfs.QuickViewRequest) (vfs.QuickViewResult, error) {
+	if !provider.CanPreview(request) {
+		return vfs.QuickViewResult{}, vfs.ErrQuickViewUnsupported
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	report, err := provider.plugin.analyzePath(ctx, request.VFS, request.Path, request.Item, ModeFast)
+	if err != nil {
+		var parseError *ParseError
+		if errors.Is(err, ErrUnsupported) || errors.As(err, &parseError) {
+			return vfs.QuickViewResult{}, vfs.ErrQuickViewUnsupported
+		}
+		return vfs.QuickViewResult{}, err
+	}
+	text := provider.plugin.render(report, false)
+	lines, _ := splitRenderedTextLines(text, renderedTruncationNotice(provider.plugin.reportLanguage()))
+	if len(lines) == 1 && lines[0] == "" {
+		return vfs.QuickViewResult{}, vfs.ErrQuickViewUnsupported
+	}
+	label := report.General.Format
+	if label == "" {
+		label = provider.plugin.text("MediaInfo.QuickViewLabel", "Media information", "Информация о медиа")
+	}
+	return vfs.QuickViewResult{Label: label, Lines: lines}, nil
+}

--- a/plugins/mediainfo/quickview_provider_test.go
+++ b/plugins/mediainfo/quickview_provider_test.go
@@ -1,0 +1,90 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestMediaQuickViewClaimsOnlyBinaryMedia(t *testing.T) {
+	store, err := newSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plugin := &Plugin{store: store}
+	provider := &mediaQuickViewProvider{plugin: plugin}
+	fs := vfs.NewOSVFS(t.TempDir())
+
+	for _, name := range []string{"movie.mp4", "sound.FLAC", "clip.webm"} {
+		if !provider.CanPreview(vfs.QuickViewRequest{VFS: fs, Path: name, Item: vfs.VFSItem{Name: name}}) {
+			t.Errorf("provider did not claim %q", name)
+		}
+	}
+	for _, name := range []string{"poster.jpg", "captions.srt", "notes.txt", "folder.mp4"} {
+		item := vfs.VFSItem{Name: name, IsDir: name == "folder.mp4"}
+		if provider.CanPreview(vfs.QuickViewRequest{VFS: fs, Path: name, Item: item}) {
+			t.Errorf("provider unexpectedly claimed %q", name)
+		}
+	}
+}
+
+func TestMediaQuickViewPreviewsWaveAndDeclinesCorruptContainer(t *testing.T) {
+	directory := t.TempDir()
+	store, err := newSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	plugin := &Plugin{store: store, cache: newReportCache(4)}
+	provider := &mediaQuickViewProvider{plugin: plugin}
+	fs := vfs.NewOSVFS(directory)
+
+	wavePath := filepath.Join(directory, "tone.wav")
+	if err := os.WriteFile(wavePath, minimalWave(), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	waveItem, err := fs.Stat(context.Background(), wavePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := provider.Preview(context.Background(), vfs.QuickViewRequest{VFS: fs, Path: wavePath, Item: waveItem})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Label != "Wave" || len(result.Lines) == 0 {
+		t.Fatalf("preview = %#v", result)
+	}
+
+	brokenPath := filepath.Join(directory, "broken.wav")
+	if err := os.WriteFile(brokenPath, []byte("RIFF\x0c\x00\x00\x00WAVEfmt \x64\x00\x00\x00"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	brokenItem, err := fs.Stat(context.Background(), brokenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = provider.Preview(context.Background(), vfs.QuickViewRequest{VFS: fs, Path: brokenPath, Item: brokenItem})
+	if !errors.Is(err, vfs.ErrQuickViewUnsupported) {
+		t.Fatalf("corrupt preview error = %v", err)
+	}
+}
+
+func TestMediaQuickViewCanBeDisabledAtRuntime(t *testing.T) {
+	store, err := newSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := store.snapshot()
+	settings.EnableQuickView = false
+	if err := store.save(settings); err != nil {
+		t.Fatal(err)
+	}
+	plugin := &Plugin{store: store}
+	provider := &mediaQuickViewProvider{plugin: plugin}
+	if provider.CanPreview(vfs.QuickViewRequest{VFS: vfs.NewOSVFS(t.TempDir()), Path: "movie.mp4", Item: vfs.VFSItem{Name: "movie.mp4"}}) {
+		t.Fatal("disabled provider claimed a file")
+	}
+}

--- a/plugins/mediainfo/render.go
+++ b/plugins/mediainfo/render.go
@@ -1,0 +1,998 @@
+package mediainfo
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/mattn/go-runewidth"
+)
+
+// CanonicalSection is the stable English-key representation used by Inform
+// templates and macro consumers. Fields preserve their source order and may
+// repeat.
+type CanonicalSection struct {
+	Name   string
+	Index  int
+	Fields []Field
+}
+
+// CanonicalSections returns General first, then streams in report order, then
+// chapters as Menu sections. It never localizes field names.
+func CanonicalSections(r Report) []CanonicalSection {
+	counts := map[StreamKind]int{}
+	for _, s := range r.Streams {
+		counts[s.Kind]++
+	}
+	targetedTags := make(map[string][]int)
+	for index, tag := range r.Tags {
+		if tag.Target != "" {
+			targetedTags[tag.Target] = append(targetedTags[tag.Target], index)
+		}
+	}
+	g := r.General
+	general := []Field{
+		{Name: "CompleteName", Value: g.FileName}, {Name: "FileName", Value: strings.TrimSuffix(g.FileName, filepath.Ext(g.FileName))},
+		{Name: "FileExtension", Value: strings.TrimPrefix(filepath.Ext(g.FileName), ".")}, {Name: "Format", Value: g.Format},
+		{Name: "Format_Profile", Value: g.FormatProfile}, {Name: "CodecID", Value: g.CodecID}, {Name: "FileSize", Value: fmt.Sprint(g.FileSize)},
+		{Name: "FileSize_String", Value: formatBytes(g.FileSize)}, {Name: "Duration", Value: formatDuration(g.Duration)}, {Name: "PlayTime", Value: formatDuration(g.Duration)},
+		{Name: "OverallBitRate", Value: fmt.Sprint(g.OverallBitRate)}, {Name: "OverallBitRate_String", Value: formatBitRate(g.OverallBitRate)},
+		{Name: "FrameRate", Value: plainFloat(g.FrameRate)}, {Name: "FrameCount", Value: plainInt(g.FrameCount)}, {Name: "StreamCount", Value: fmt.Sprint(len(r.Streams))},
+		{Name: "VideoCount", Value: fmt.Sprint(counts[StreamVideo])}, {Name: "AudioCount", Value: fmt.Sprint(counts[StreamAudio])},
+		{Name: "TextCount", Value: fmt.Sprint(counts[StreamText])}, {Name: "ImageCount", Value: fmt.Sprint(counts[StreamImage])},
+		{Name: "MenuCount", Value: fmt.Sprint(counts[StreamMenu])}, {Name: "Encoded_Application", Value: g.MuxingApp}, {Name: "Encoded_Library", Value: g.WritingApp},
+	}
+	for _, tag := range r.Tags {
+		if tag.Target == "" {
+			general = append(general, Field{Name: tag.Name, Value: tag.Value})
+		}
+	}
+	sections := []CanonicalSection{{Name: "General", Index: 0, Fields: general}}
+	kindIndex := map[StreamKind]int{}
+	// A malformed container can repeat a stream ID. Targeted metadata belongs
+	// to that identifier, not to every duplicate Stream struct: multiplying the
+	// same MaxTags collection by MaxStreams would turn a bounded report into a
+	// million-field macro/template allocation. Preserve tag order and repeats,
+	// but attach each target's collection to its first stream in report order.
+	attachedTargets := make(map[string]struct{}, len(targetedTags))
+	for _, s := range r.Streams {
+		idx := kindIndex[s.Kind]
+		kindIndex[s.Kind]++
+		fields := canonicalStreamFields(s)
+		if _, attached := attachedTargets[s.ID]; !attached && s.ID != "" {
+			for _, tagIndex := range targetedTags[s.ID] {
+				tag := r.Tags[tagIndex]
+				fields = append(fields, Field{Name: tag.Name, Value: tag.Value})
+			}
+			attachedTargets[s.ID] = struct{}{}
+		}
+		for _, tag := range s.Tags {
+			fields = append(fields, Field{Name: tag.Name, Value: tag.Value})
+		}
+		sections = append(sections, CanonicalSection{Name: string(s.Kind), Index: idx, Fields: fields})
+	}
+	for i, c := range r.Chapters {
+		sections = append(sections, CanonicalSection{Name: "Menu", Index: i, Fields: []Field{{Name: "ID", Value: c.ID}, {Name: "Start", Value: formatDuration(c.Start)}, {Name: "End", Value: formatDuration(c.End)}, {Name: "Title", Value: c.Title}, {Name: "Language", Value: c.Language}}})
+	}
+	return sections
+}
+
+func canonicalStreamFields(s Stream) []Field {
+	f := []Field{{Name: "StreamKind", Value: string(s.Kind)}, {Name: "StreamKindID", Value: fmt.Sprint(s.Index)}, {Name: "StreamOrder", Value: fmt.Sprint(s.Index)}, {Name: "ID", Value: s.ID}, {Name: "Format", Value: s.Format}, {Name: "Format_Profile", Value: s.Profile}, {Name: "Format_Level", Value: s.Level}, {Name: "CodecID", Value: s.CodecID}, {Name: "Codec", Value: s.CodecName}, {Name: "Title", Value: s.Title}, {Name: "Language", Value: s.Language}, {Name: "Duration", Value: formatDuration(s.Duration)}, {Name: "PlayTime", Value: formatDuration(s.Duration)}, {Name: "BitRate", Value: plainInt(s.BitRate)}, {Name: "BitRate_String", Value: formatBitRate(s.BitRate)}, {Name: "BitRate_Mode", Value: s.BitRateMode}, {Name: "FrameRate", Value: plainFloat(s.FrameRate)}, {Name: "FrameCount", Value: plainInt(s.FrameCount)}, {Name: "Default", Value: yesNo(s.Default)}, {Name: "Forced", Value: yesNo(s.Forced)}, {Name: "Encryption", Value: yesNo(s.Encrypted)}}
+	if v := s.Video; v != nil {
+		f = append(f, Field{Name: "Width", Value: plainInt(int64(v.Width))}, Field{Name: "Height", Value: plainInt(int64(v.Height))}, Field{Name: "DisplayAspectRatio", Value: plainFloat(v.DisplayAspectRatio)}, Field{Name: "PixelAspectRatio", Value: plainFloat(v.PixelAspectRatio)}, Field{Name: "Rotation", Value: plainFloat(v.Rotation)}, Field{Name: "BitDepth", Value: plainInt(int64(v.BitDepth))}, Field{Name: "ColorSpace", Value: v.ColorSpace}, Field{Name: "ChromaSubsampling", Value: v.ChromaSubsampling}, Field{Name: "ScanType", Value: v.ScanType}, Field{Name: "ColorRange", Value: v.ColorRange}, Field{Name: "colour_primaries", Value: v.ColorPrimaries}, Field{Name: "transfer_characteristics", Value: v.TransferCharacteristics}, Field{Name: "matrix_coefficients", Value: v.MatrixCoefficients}, Field{Name: "HDR_Format", Value: v.HDRFormat})
+	}
+	if a := s.Audio; a != nil {
+		f = append(f, Field{Name: "Channel_s_", Value: plainInt(int64(a.Channels))}, Field{Name: "ChannelLayout", Value: a.ChannelLayout}, Field{Name: "SamplingRate", Value: plainInt(int64(a.SampleRate))}, Field{Name: "BitDepth", Value: plainInt(int64(a.BitDepth))}, Field{Name: "Compression_Mode", Value: a.CompressionMode})
+	}
+	if x := s.Text; x != nil {
+		f = append(f, Field{Name: "Format_Version", Value: x.FormatVersion}, Field{Name: "Encoding", Value: x.Encoding}, Field{Name: "ElementCount", Value: plainInt(x.CueCount)}, Field{Name: "FirstFrameTimeCode", Value: formatDuration(x.FirstCue)}, Field{Name: "LastFrameTimeCode", Value: formatDuration(x.LastCue)})
+	}
+	if im := s.Image; im != nil {
+		f = append(f,
+			Field{Name: "Width", Value: plainInt(int64(im.Width))}, Field{Name: "Height", Value: plainInt(int64(im.Height))},
+			Field{Name: "BitDepth", Value: plainInt(int64(im.BitDepth))}, Field{Name: "ColorSpace", Value: im.ColorModel},
+			Field{Name: "Compression_Mode", Value: im.Compression}, Field{Name: "FrameCount", Value: plainInt(int64(im.FrameCount))},
+			Field{Name: "Duration", Value: formatDuration(im.AnimationDuration)}, Field{Name: "Orientation", Value: plainInt(int64(im.Orientation))},
+			Field{Name: "DPIX", Value: plainFloat(im.DPIX)}, Field{Name: "DPIY", Value: plainFloat(im.DPIY)},
+			Field{Name: "Make", Value: im.CameraMake}, Field{Name: "Model", Value: im.CameraModel}, Field{Name: "LensModel", Value: im.LensModel},
+		)
+		if im.TakenAt != nil {
+			f = append(f, Field{Name: "DateTimeOriginal", Value: im.TakenAt.Format("2006-01-02 15:04:05")})
+		}
+		if im.Latitude != nil {
+			f = append(f, Field{Name: "GPSLatitude", Value: plainFloat(*im.Latitude)})
+		}
+		if im.Longitude != nil {
+			f = append(f, Field{Name: "GPSLongitude", Value: plainFloat(*im.Longitude)})
+		}
+		if im.GPSAltitude != nil {
+			f = append(f, Field{Name: "GPSAltitude", Value: plainFloat(*im.GPSAltitude)})
+		}
+		f = append(f, im.EXIF...)
+	}
+	return f
+}
+
+func yesNo(v *bool) string {
+	if v == nil {
+		return ""
+	}
+	if *v {
+		return "Yes"
+	}
+	return "No"
+}
+func plainInt(v int64) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprint(v)
+}
+func plainFloat(v float64) string {
+	if v == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.6g", v)
+}
+
+// RenderOptions controls deterministic human-readable report output.
+type RenderOptions struct {
+	// Language selects display labels. "ru" uses Russian; other values use
+	// English. Template and macro field keys remain canonical English.
+	Language string
+	// Technical includes codec IDs, profiles, flags, and parser warnings.
+	Technical bool
+	// Compact omits empty separators and less useful secondary fields.
+	Compact bool
+}
+
+const (
+	maxRenderedTextBytes         = maxTemplateOutputBytes
+	maxRenderedCollectionItems   = 8 << 10
+	maxRenderedTextLines         = 8 << 10
+	renderTextTruncationNotice   = "[Report truncated]"
+	renderTextTruncationNoticeRU = "[Отчёт сокращён]"
+)
+
+// RenderText renders aligned MediaInfo-style sections with canonical keys.
+func RenderText(r Report, o RenderOptions) string {
+	out := newReportTextWriter(maxRenderedTextBytes, renderedTruncationNotice(o.Language))
+	out.labelWidth = renderedTextLabelWidth(r, o, out.contentCap)
+	if walkRenderedTextSections(r, o, func(title string, fields [][2]string) bool {
+		renderTextSection(out, title, fields, o.Language)
+		return !out.truncated
+	}) {
+		out.truncated = true
+	}
+	return out.String()
+}
+
+// renderedTextLabelWidth uses the same bounded section walk as the writer so
+// every visible field is aligned to one report-wide column. Values and labels
+// are normalized here exactly as they are by renderTextSection; empty fields
+// therefore cannot widen the report.
+func renderedTextLabelWidth(r Report, o RenderOptions, contentCap int) int {
+	width := 0
+	walkRenderedTextSections(r, o, func(_ string, fields [][2]string) bool {
+		for _, field := range fields {
+			if normalizeRenderedInline(field[1]) == "" {
+				continue
+			}
+			label := normalizeRenderedInline(renderLabel(o.Language, field[0]))
+			if len(label) > contentCap {
+				return false
+			}
+			if current := runewidth.StringWidth(label); current > width {
+				width = current
+			}
+		}
+		return true
+	})
+	return width
+}
+
+// walkRenderedTextSections centralizes section and field selection for both
+// the width preflight and output pass. It returns true when the report must be
+// marked truncated, either because source collections exceed their rendering
+// limits or because the visitor cannot accept another section.
+func walkRenderedTextSections(r Report, o RenderOptions, visit func(string, [][2]string) bool) bool {
+	g := r.General
+	gf := [][2]string{{"File name", g.FileName}, {"Format", g.Format}, {"Format profile", g.FormatProfile}, {"File size", formatBytes(g.FileSize)}, {"Duration", formatDuration(g.Duration)}, {"Overall bit rate", formatBitRate(g.OverallBitRate)}, {"Frame rate", formatFloat(g.FrameRate)}, {"Muxing application", g.MuxingApp}, {"Writing application", g.WritingApp}}
+	if o.Compact {
+		gf = [][2]string{{"Format", g.Format}, {"File size", formatBytes(g.FileSize)}, {"Duration", formatDuration(g.Duration)}, {"Overall bit rate", formatBitRate(g.OverallBitRate)}}
+	}
+	brandsTruncated := false
+	if o.Technical {
+		brands, complete := joinRenderedStrings(g.CompatibleBrands, ", ", maxRenderedTextBytes)
+		brandsTruncated = !complete
+		gf = append(gf, [2]string{"Codec ID", g.CodecID}, [2]string{"Compatible brands", brands})
+	}
+	if !visit(renderLabel(o.Language, "General"), gf) || brandsTruncated {
+		return true
+	}
+	for _, s := range r.Streams {
+		title := renderLabel(o.Language, string(s.Kind))
+		if s.ID != "" {
+			if !renderedConcatFits(title, " #", s.ID) {
+				return true
+			}
+			title += " #" + s.ID
+		}
+		f := [][2]string{{"Format", s.Format}, {"Format profile", s.Profile}, {"Title", s.Title}, {"Language", s.Language}, {"Duration", formatDuration(s.Duration)}, {"Bit rate", formatBitRate(s.BitRate)}, {"Frame rate", formatFloat(s.FrameRate)}}
+		if o.Compact {
+			f = [][2]string{{"Format", s.Format}, {"Title", s.Title}, {"Language", s.Language}, {"Bit rate", formatBitRate(s.BitRate)}}
+		}
+		if o.Technical {
+			f = append(f, [2]string{"Codec ID", s.CodecID}, [2]string{"Codec name", s.CodecName}, [2]string{"Frame count", formatInt(s.FrameCount)})
+		}
+		if s.Video != nil {
+			f = append(f, [2]string{"Width", formatPixels(s.Video.Width)}, [2]string{"Height", formatPixels(s.Video.Height)})
+			if !o.Compact {
+				f = append(f, [2]string{"Bit depth", formatBits(s.Video.BitDepth)}, [2]string{"Color space", s.Video.ColorSpace}, [2]string{"HDR format", s.Video.HDRFormat})
+			}
+		}
+		if s.Audio != nil {
+			f = append(f, [2]string{"Channels", formatInt(int64(s.Audio.Channels))}, [2]string{"Sample rate", formatHz(s.Audio.SampleRate)})
+			if !o.Compact {
+				f = append(f, [2]string{"Bit depth", formatBits(s.Audio.BitDepth)}, [2]string{"Compression mode", s.Audio.CompressionMode})
+			}
+		}
+		if s.Text != nil {
+			f = append(f, [2]string{"Encoding", s.Text.Encoding}, [2]string{"Cue count", formatInt(s.Text.CueCount)})
+			if !o.Compact {
+				f = append(f, [2]string{"First cue", formatDuration(s.Text.FirstCue)}, [2]string{"Last cue", formatDuration(s.Text.LastCue)})
+			}
+		}
+		if s.Image != nil {
+			f = append(f, [2]string{"Width", formatPixels(s.Image.Width)}, [2]string{"Height", formatPixels(s.Image.Height)}, [2]string{"Frame count", formatInt(int64(s.Image.FrameCount))})
+			if !o.Compact {
+				f = append(f,
+					[2]string{"Bit depth", formatBits(s.Image.BitDepth)}, [2]string{"Color model", s.Image.ColorModel}, [2]string{"Compression", s.Image.Compression},
+					[2]string{"Animation duration", formatDuration(s.Image.AnimationDuration)}, [2]string{"Camera make", s.Image.CameraMake},
+					[2]string{"Camera model", s.Image.CameraModel}, [2]string{"Lens model", s.Image.LensModel}, [2]string{"Captured at", formatImageTakenAt(s.Image.TakenAt)},
+					[2]string{"Orientation", formatImageOrientation(s.Image.Orientation)}, [2]string{"Horizontal resolution", formatImageDPI(s.Image.DPIX)},
+					[2]string{"Vertical resolution", formatImageDPI(s.Image.DPIY)}, [2]string{"GPS latitude", formatGPSCoordinate(s.Image.Latitude)},
+					[2]string{"GPS longitude", formatGPSCoordinate(s.Image.Longitude)}, [2]string{"GPS altitude", formatGPSAltitude(s.Image.GPSAltitude)},
+				)
+				for _, field := range s.Image.EXIF {
+					f = append(f, [2]string{field.Name, field.Value})
+				}
+			}
+		}
+		if !visit(title, f) {
+			return true
+		}
+	}
+	chapterLimit := len(r.Chapters)
+	if o.Compact && chapterLimit > 3 {
+		chapterLimit = 3
+	}
+	for index := 0; index < chapterLimit; index++ {
+		chapter := r.Chapters[index]
+		title := renderLabel(o.Language, "Menu")
+		if chapter.ID != "" {
+			if !renderedConcatFits(title, " #", chapter.ID) {
+				return true
+			}
+			title += " #" + chapter.ID
+		}
+		fields := [][2]string{
+			{"Start", formatDuration(chapter.Start)},
+			{"End", formatDuration(chapter.End)},
+			{"Title", chapter.Title},
+			{"Language", chapter.Language},
+		}
+		if o.Technical {
+			fields = append([][2]string{{"ID", chapter.ID}}, fields...)
+		}
+		if !visit(title, fields) {
+			return true
+		}
+	}
+	if len(r.Tags) > 0 {
+		tagCount := len(r.Tags)
+		if tagCount > maxRenderedCollectionItems {
+			tagCount = maxRenderedCollectionItems
+		}
+		tags := append([]Field(nil), r.Tags[:tagCount]...)
+		sort.SliceStable(tags, func(i, j int) bool {
+			if tags[i].Target == tags[j].Target {
+				return tags[i].Name < tags[j].Name
+			}
+			return tags[i].Target < tags[j].Target
+		})
+		f := make([][2]string, 0, len(tags))
+		tagsTruncated := !o.Compact && tagCount < len(r.Tags)
+		for _, tag := range tags {
+			if o.Compact && len(f) >= 6 {
+				break
+			}
+			name := tag.Name
+			if tag.Target != "" {
+				if !renderedConcatFits(name, " [", tag.Target, "]") {
+					tagsTruncated = true
+					break
+				}
+				name += " [" + tag.Target + "]"
+			}
+			f = append(f, [2]string{name, tag.Value})
+		}
+		if !visit(renderLabel(o.Language, "Metadata"), f) || tagsTruncated {
+			return true
+		}
+	}
+	if o.Technical && len(r.Warnings) > 0 {
+		warningCount := len(r.Warnings)
+		if warningCount > maxRenderedCollectionItems {
+			warningCount = maxRenderedCollectionItems
+		}
+		f := make([][2]string, 0, warningCount)
+		for _, w := range r.Warnings[:warningCount] {
+			f = append(f, [2]string{w.Code, w.Message})
+		}
+		if !visit(renderLabel(o.Language, "Warnings"), f) || warningCount < len(r.Warnings) {
+			return true
+		}
+	}
+	return false
+}
+
+func renderedTruncationNotice(language string) string {
+	if strings.EqualFold(language, "ru") {
+		return renderTextTruncationNoticeRU
+	}
+	return renderTextTruncationNotice
+}
+
+type reportTextWriter struct {
+	out        *cappedTemplateWriter
+	limit      int
+	notice     string
+	truncated  bool
+	finalized  bool
+	contentCap int
+	labelWidth int
+}
+
+func newReportTextWriter(limit int, notice string) *reportTextWriter {
+	contentCap := limit - len(notice) - 2 // reserve a blank line and notice
+	if contentCap < 0 {
+		contentCap = 0
+	}
+	return &reportTextWriter{
+		out:        newCappedTemplateWriter(contentCap),
+		limit:      limit,
+		notice:     notice,
+		contentCap: contentCap,
+	}
+}
+
+func (writer *reportTextWriter) String() string {
+	if !writer.truncated || writer.finalized {
+		return writer.out.String()
+	}
+	writer.finalized = true
+	writer.out.limit = writer.limit
+	if writer.out.b.Len() > 0 {
+		_ = writer.out.WriteString("\n\n")
+	}
+	_ = writer.out.WriteString(writer.notice)
+	return writer.out.String()
+}
+
+func (writer *reportTextWriter) reserve(size int) bool {
+	if writer.truncated || size < 0 || size > writer.contentCap-writer.out.b.Len() {
+		writer.truncated = true
+		return false
+	}
+	return true
+}
+
+func renderTextSection(out *reportTextWriter, title string, fields [][2]string, language string) {
+	if out.truncated {
+		return
+	}
+	title = normalizeRenderedInline(title)
+	filtered := fields[:0]
+	width := out.labelWidth
+	for _, f := range fields {
+		f[1] = normalizeRenderedInline(f[1])
+		if f[1] == "" {
+			continue
+		}
+		f[0] = normalizeRenderedInline(renderLabel(language, f[0]))
+		if len(f[0]) > out.contentCap {
+			out.truncated = true
+			return
+		}
+		filtered = append(filtered, f)
+		if n := runewidth.StringWidth(f[0]); n > width {
+			width = n
+		}
+	}
+	if len(filtered) == 0 {
+		return
+	}
+	prefixBytes := 0
+	if out.out.b.Len() > 0 {
+		prefixBytes = 2
+	}
+	first := filtered[0]
+	firstLineBytes := renderedLineBytes(first[0], first[1], width)
+	if firstLineBytes < 0 || !out.reserve(prefixBytes+len(title)+1+firstLineBytes) {
+		return
+	}
+	if prefixBytes > 0 {
+		_ = out.out.WriteString("\n\n")
+	}
+	_ = out.out.WriteString(title)
+	_ = out.out.WriteByte('\n')
+	writeRenderedLine(out.out, first[0], first[1], width)
+	for _, f := range filtered[1:] {
+		lineBytes := renderedLineBytes(f[0], f[1], width)
+		if lineBytes < 0 || !out.reserve(1+lineBytes) {
+			return
+		}
+		_ = out.out.WriteByte('\n')
+		writeRenderedLine(out.out, f[0], f[1], width)
+	}
+}
+
+// normalizeRenderedInline keeps the default human-readable report a sequence
+// of actual report lines. Metadata is untrusted: embedded CR/LF, tabs, NULs
+// and terminal control bytes must not inject rows or terminal commands into a
+// label or value. Inform templates deliberately retain their raw field-value
+// semantics and do not call this helper.
+func normalizeRenderedInline(value string) string {
+	if strings.IndexFunc(value, isRenderedInlineControl) < 0 {
+		return value
+	}
+	var normalized strings.Builder
+	normalized.Grow(len(value))
+	lastSpace := false
+	for _, r := range value {
+		if isRenderedInlineControl(r) {
+			if normalized.Len() > 0 && !lastSpace {
+				normalized.WriteByte(' ')
+				lastSpace = true
+			}
+			continue
+		}
+		normalized.WriteRune(r)
+		lastSpace = unicode.IsSpace(r)
+	}
+	return strings.TrimSpace(normalized.String())
+}
+
+func isRenderedInlineControl(r rune) bool {
+	return unicode.IsControl(r) || r == '\u2028' || r == '\u2029'
+}
+
+func renderedLineBytes(label, value string, width int) int {
+	padding := width - runewidth.StringWidth(label)
+	if padding < 0 || len(label) > int(^uint(0)>>1)-padding-3 || len(value) > int(^uint(0)>>1)-len(label)-padding-3 {
+		return -1
+	}
+	return len(label) + padding + 3 + len(value)
+}
+
+func writeRenderedLine(out *cappedTemplateWriter, label, value string, width int) {
+	_ = out.WriteString(label)
+	padding := width - runewidth.StringWidth(label)
+	const spaces = "                                                                "
+	for padding > len(spaces) {
+		_ = out.WriteString(spaces)
+		padding -= len(spaces)
+	}
+	if padding > 0 {
+		_ = out.WriteString(spaces[:padding])
+	}
+	_ = out.WriteString(" : ")
+	_ = out.WriteString(value)
+}
+
+func renderedConcatFits(parts ...string) bool {
+	remaining := maxRenderedTextBytes
+	for _, part := range parts {
+		if len(part) > remaining {
+			return false
+		}
+		remaining -= len(part)
+	}
+	return true
+}
+
+func joinRenderedStrings(values []string, separator string, limit int) (string, bool) {
+	length := 0
+	for index, value := range values {
+		if index > 0 {
+			if len(separator) > limit-length {
+				return "", false
+			}
+			length += len(separator)
+		}
+		if len(value) > limit-length {
+			return "", false
+		}
+		length += len(value)
+	}
+	return strings.Join(values, separator), true
+}
+
+func renderLabel(language, key string) string {
+	if !strings.EqualFold(language, "ru") {
+		return key
+	}
+	if value, ok := russianLabels[key]; ok {
+		return value
+	}
+	return key
+}
+
+var russianLabels = map[string]string{
+	"General": "Общее", "Video": "Видео", "Audio": "Аудио", "Text": "Текст", "Image": "Изображение", "Menu": "Меню",
+	"Metadata": "Метаданные", "Warnings": "Предупреждения", "File name": "Имя файла", "Format": "Формат",
+	"Format profile": "Профиль формата", "File size": "Размер файла", "Duration": "Продолжительность",
+	"Overall bit rate": "Общий битрейт", "Frame rate": "Частота кадров", "Muxing application": "Приложение-мультиплексор",
+	"Writing application": "Приложение записи", "Codec ID": "Идентификатор кодека", "Compatible brands": "Совместимые марки",
+	"Title": "Название", "Language": "Язык", "Bit rate": "Битрейт", "Codec name": "Название кодека", "Frame count": "Количество кадров",
+	"Width": "Ширина", "Height": "Высота", "Bit depth": "Глубина цвета", "Color space": "Цветовое пространство", "HDR format": "Формат HDR",
+	"Channels": "Каналы", "Sample rate": "Частота дискретизации", "Compression mode": "Режим сжатия", "Encoding": "Кодировка",
+	"Cue count": "Количество реплик", "First cue": "Первая реплика", "Last cue": "Последняя реплика", "Color model": "Цветовая модель",
+	"Camera make": "Производитель камеры", "Camera model": "Модель камеры", "Artist": "Исполнитель", "Album": "Альбом", "Comment": "Комментарий",
+	"Compression": "Сжатие", "Animation duration": "Длительность анимации", "Lens model": "Модель объектива", "Captured at": "Дата съёмки",
+	"Orientation": "Ориентация", "Horizontal resolution": "Разрешение по горизонтали", "Vertical resolution": "Разрешение по вертикали",
+	"GPS latitude": "Широта GPS", "GPS longitude": "Долгота GPS", "GPS altitude": "Высота GPS", "Exposure time": "Выдержка",
+	"F-number": "Диафрагма", "ISO speed": "Светочувствительность ISO", "Exposure bias": "Экспокоррекция", "Focal length": "Фокусное расстояние",
+	"Focal length in 35mm": "Фокусное расстояние в 35-мм эквиваленте", "Metering mode": "Режим экспозамера", "Flash": "Вспышка",
+	"White balance": "Баланс белого", "Exposure program": "Программа экспозиции", "Exposure mode": "Режим экспозиции",
+	"Brightness": "Яркость", "Subject distance": "Расстояние до объекта", "Light source": "Источник света", "Digital zoom": "Цифровой зум",
+	"Scene capture type": "Тип сцены", "Contrast": "Контраст", "Saturation": "Насыщенность", "Sharpness": "Резкость",
+	"Software": "Программа", "Copyright": "Авторские права", "Camera serial number": "Серийный номер камеры", "Lens make": "Производитель объектива",
+	"Lens serial number": "Серийный номер объектива", "User comment": "Комментарий пользователя", "Image unique ID": "Уникальный ID изображения",
+	"Start": "Начало", "End": "Конец", "ID": "Идентификатор",
+}
+
+// ExecuteTemplate executes a bounded MediaInfo Inform template. The supported
+// subset is `Section;template`, %Field%, optional `[ ... ]` groups, common
+// backslash escapes, and Section_Begin/Section_Middle/Section_End. Go template
+// actions remain available as an extension when the source contains `{{`.
+func ExecuteTemplate(r Report, src string) (string, error) {
+	if len(src) > maxTemplateSourceBytes {
+		return "", errors.New("template is too large")
+	}
+	if !utf8.ValidString(src) {
+		return "", errors.New("template is not valid UTF-8")
+	}
+	src = strings.TrimPrefix(src, "\ufeff")
+	if !strings.Contains(src, "{{") {
+		return executeInformTemplate(r, src)
+	}
+	funcs := template.FuncMap{"duration": formatDuration, "bytes": formatBytes, "bitrate": formatBitRate, "join": strings.Join}
+	t, e := template.New("mediainfo").Option("missingkey=zero").Funcs(funcs).Parse(src)
+	if e != nil {
+		return "", e
+	}
+	b := newCappedTemplateWriter(maxTemplateOutputBytes)
+	if e = t.Execute(b, r); e != nil {
+		return "", e
+	}
+	return b.String(), nil
+}
+
+const (
+	maxTemplateSourceBytes = 64 << 10
+	maxTemplateOutputBytes = 2 << 20
+	maxInformNesting       = 64
+)
+
+var errTemplateOutputTooLarge = errors.New("template output is too large")
+
+// cappedTemplateWriter rejects a write before it can grow the backing buffer
+// beyond the configured limit. This matters for templates that range over a
+// large chapter or stream list: checking the size after execution is too late.
+type cappedTemplateWriter struct {
+	b          strings.Builder
+	limit      int
+	overflowed bool
+}
+
+func newCappedTemplateWriter(limit int) *cappedTemplateWriter {
+	return &cappedTemplateWriter{limit: limit}
+}
+
+func (writer *cappedTemplateWriter) Write(data []byte) (int, error) {
+	if writer.overflowed {
+		return 0, errTemplateOutputTooLarge
+	}
+	if len(data) > writer.limit-writer.b.Len() {
+		writer.overflowed = true
+		return 0, errTemplateOutputTooLarge
+	}
+	return writer.b.Write(data)
+}
+
+func (writer *cappedTemplateWriter) WriteString(value string) error {
+	if writer.overflowed {
+		return errTemplateOutputTooLarge
+	}
+	if len(value) > writer.limit-writer.b.Len() {
+		writer.overflowed = true
+		return errTemplateOutputTooLarge
+	}
+	_, _ = writer.b.WriteString(value)
+	return nil
+}
+
+func (writer *cappedTemplateWriter) WriteByte(value byte) error {
+	if writer.overflowed {
+		return errTemplateOutputTooLarge
+	}
+	if writer.b.Len() >= writer.limit {
+		writer.overflowed = true
+		return errTemplateOutputTooLarge
+	}
+	return writer.b.WriteByte(value)
+}
+
+func (writer *cappedTemplateWriter) String() string { return writer.b.String() }
+
+func executeInformTemplate(r Report, src string) (string, error) {
+	definitions := map[string]string{}
+	directives := 0
+	for _, line := range strings.Split(strings.ReplaceAll(src, "\r\n", "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, ";", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := canonicalInformSection(parts[0])
+		if key == "" {
+			continue
+		}
+		definitions[key] += parts[1]
+		directives++
+	}
+	sections := CanonicalSections(r)
+	if directives == 0 {
+		out := newCappedTemplateWriter(maxTemplateOutputBytes)
+		if err := renderInformFragment(out, src, sectionLookup(sections[0]), 0); err != nil {
+			return "", err
+		}
+		return out.String(), nil
+	}
+	byKind := map[string][]CanonicalSection{}
+	for _, s := range sections {
+		byKind[s.Name] = append(byKind[s.Name], s)
+	}
+	out := newCappedTemplateWriter(maxTemplateOutputBytes)
+	for _, kind := range []string{"General", "Video", "Audio", "Text", "Image", "Menu"} {
+		items := byKind[kind]
+		if len(items) == 0 {
+			continue
+		}
+		main := definitions[kind]
+		begin := definitions[kind+"_Begin"]
+		middle := definitions[kind+"_Middle"]
+		end := definitions[kind+"_End"]
+		if begin != "" {
+			if err := renderInformFragment(out, begin, sectionLookup(items[0]), 0); err != nil {
+				return "", err
+			}
+		}
+		for i, item := range items {
+			fields := sectionLookup(item)
+			if i > 0 && middle != "" {
+				if err := renderInformFragment(out, middle, fields, 0); err != nil {
+					return "", err
+				}
+			}
+			if main != "" {
+				if err := renderInformFragment(out, main, fields, 0); err != nil {
+					return "", err
+				}
+			}
+		}
+		if end != "" {
+			if err := renderInformFragment(out, end, sectionLookup(items[len(items)-1]), 0); err != nil {
+				return "", err
+			}
+		}
+	}
+	return out.String(), nil
+}
+
+func canonicalInformSection(raw string) string {
+	raw = strings.TrimSpace(raw)
+	suffix := ""
+	for _, s := range []string{"_Begin", "_Middle", "_End"} {
+		if strings.HasSuffix(strings.ToLower(raw), strings.ToLower(s)) {
+			raw = raw[:len(raw)-len(s)]
+			suffix = s
+			break
+		}
+	}
+	for _, kind := range []string{"General", "Video", "Audio", "Text", "Image", "Menu"} {
+		if strings.EqualFold(raw, kind) {
+			return kind + suffix
+		}
+	}
+	return ""
+}
+
+func sectionLookup(section CanonicalSection) map[string]string {
+	m := make(map[string]string, len(section.Fields)*2)
+	for _, f := range section.Fields {
+		k := normalizeInformField(f.Name)
+		if _, exists := m[k]; !exists {
+			m[k] = f.Value
+		}
+	}
+	return m
+}
+
+func normalizeInformField(s string) string {
+	var b strings.Builder
+	for _, r := range strings.ToLower(strings.TrimSpace(s)) {
+		if r == '_' || r == ' ' || r == '/' || r == '-' || r == '(' || r == ')' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	key := b.String()
+	switch key {
+	case "playtime", "durationstring", "playtimestring":
+		return "duration"
+	case "formatprofile":
+		return "formatprofile"
+	case "channels", "channel", "channelsstring":
+		return "channels"
+	}
+	return key
+}
+
+func renderInformFragment(out *cappedTemplateWriter, src string, fields map[string]string, depth int) error {
+	if depth > maxInformNesting {
+		return errors.New("Inform template nesting is too deep")
+	}
+	for i := 0; i < len(src); {
+		switch src[i] {
+		case '[':
+			end := matchingInformBracket(src, i)
+			if end < 0 {
+				if err := out.WriteByte(src[i]); err != nil {
+					return err
+				}
+				i++
+				continue
+			}
+			inner := src[i+1 : end]
+			if optionalInformGroupIncluded(inner, fields) {
+				if err := renderInformFragment(out, inner, fields, depth+1); err != nil {
+					return err
+				}
+			}
+			i = end + 1
+		case '%':
+			relativeEnd := strings.IndexByte(src[i+1:], '%')
+			if relativeEnd <= 0 {
+				if err := out.WriteByte(src[i]); err != nil {
+					return err
+				}
+				i++
+				continue
+			}
+			end := i + 1 + relativeEnd
+			if err := writeInformEscaped(out, fields[normalizeInformField(src[i+1:end])]); err != nil {
+				return err
+			}
+			i = end + 1
+		case '\\':
+			if i+1 >= len(src) {
+				return out.WriteByte(src[i])
+			}
+			i++
+			value := src[i]
+			switch value {
+			case 'n':
+				value = '\n'
+			case 'r':
+				value = '\r'
+			case 't':
+				value = '\t'
+			}
+			if err := out.WriteByte(value); err != nil {
+				return err
+			}
+			i++
+		default:
+			if err := out.WriteByte(src[i]); err != nil {
+				return err
+			}
+			i++
+		}
+	}
+	return nil
+}
+
+func matchingInformBracket(src string, start int) int {
+	depth := 1
+	for i := start + 1; i < len(src); i++ {
+		switch src[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func optionalInformGroupIncluded(src string, fields map[string]string) bool {
+	foundField := false
+	for i := 0; i < len(src); {
+		if src[i] != '%' {
+			i++
+			continue
+		}
+		relativeEnd := strings.IndexByte(src[i+1:], '%')
+		if relativeEnd <= 0 {
+			i++
+			continue
+		}
+		end := i + 1 + relativeEnd
+		foundField = true
+		if fields[normalizeInformField(src[i+1:end])] != "" {
+			return true
+		}
+		i = end + 1
+	}
+	return !foundField
+}
+
+func writeInformEscaped(out *cappedTemplateWriter, value string) error {
+	for i := 0; i < len(value); i++ {
+		if value[i] != '\\' || i+1 >= len(value) {
+			if err := out.WriteByte(value[i]); err != nil {
+				return err
+			}
+			continue
+		}
+		i++
+		next := value[i]
+		switch next {
+		case 'n':
+			next = '\n'
+		case 'r':
+			next = '\r'
+		case 't':
+			next = '\t'
+		}
+		if err := out.WriteByte(next); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+func formatDuration(d time.Duration) string {
+	if d <= 0 {
+		return ""
+	}
+	h := int64(d / time.Hour)
+	d -= time.Duration(h) * time.Hour
+	m := int64(d / time.Minute)
+	d -= time.Duration(m) * time.Minute
+	s := float64(d) / float64(time.Second)
+	if h > 0 {
+		return fmt.Sprintf("%d h %02d min %06.3f s", h, m, s)
+	}
+	if m > 0 {
+		return fmt.Sprintf("%d min %06.3f s", m, s)
+	}
+	return fmt.Sprintf("%.3f s", s)
+}
+func formatBytes(n int64) string {
+	if n <= 0 {
+		return ""
+	}
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
+	v := float64(n)
+	i := 0
+	for v >= 1024 && i < len(units)-1 {
+		v /= 1024
+		i++
+	}
+	if i == 0 {
+		return fmt.Sprintf("%d B", n)
+	}
+	return fmt.Sprintf("%.2f %s", v, units[i])
+}
+func formatBitRate(n int64) string {
+	if n <= 0 {
+		return ""
+	}
+	if n >= 1000000 {
+		return fmt.Sprintf("%.3f Mb/s", float64(n)/1e6)
+	}
+	if n >= 1000 {
+		return fmt.Sprintf("%.0f kb/s", float64(n)/1e3)
+	}
+	return fmt.Sprintf("%d b/s", n)
+}
+func formatFloat(v float64) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.3f FPS", v)
+}
+
+func formatImageTakenAt(value *time.Time) string {
+	if value == nil {
+		return ""
+	}
+	return value.Format("2006-01-02 15:04:05")
+}
+
+func formatImageOrientation(value int) string {
+	return map[int]string{
+		1: "Normal", 2: "Mirrored horizontally", 3: "Rotated 180°", 4: "Mirrored vertically",
+		5: "Transposed", 6: "Rotated 90° clockwise", 7: "Transverse", 8: "Rotated 270° clockwise",
+	}[value]
+}
+
+func formatImageDPI(value float64) string {
+	if value == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%.4g dpi", value)
+}
+
+func formatGPSCoordinate(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.6f°", *value)
+}
+
+func formatGPSAltitude(value *float64) string {
+	if value == nil {
+		return ""
+	}
+	return fmt.Sprintf("%.3f m", *value)
+}
+func formatInt(v int64) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprint(v)
+}
+func formatPixels(v int) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d pixels", v)
+}
+func formatBits(v int) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d bits", v)
+}
+func formatHz(v int) string {
+	if v <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d Hz", v)
+}

--- a/plugins/mediainfo/render_limits_test.go
+++ b/plugins/mediainfo/render_limits_test.go
@@ -1,0 +1,252 @@
+package mediainfo
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestRenderTextPreservesSmallOutput(t *testing.T) {
+	report := Report{
+		General: General{FileName: "sample.flac", Format: "FLAC"},
+		Tags:    []Field{{Name: "Artist", Value: "Example"}},
+	}
+	want := "General\n" +
+		"File name : sample.flac\n" +
+		"Format    : FLAC\n\n" +
+		"Metadata\n" +
+		"Artist    : Example"
+	if got := RenderText(report, RenderOptions{}); got != want {
+		t.Fatalf("RenderText() changed small output:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestRenderTextAlignsLabelColumnAcrossSections(t *testing.T) {
+	report := Report{
+		General: General{Format: "Matroska"},
+		Streams: []Stream{{Kind: StreamAudio, Format: "Opus", Audio: &Audio{CompressionMode: "Lossy"}}},
+		Tags:    []Field{{Name: "Artist", Value: "Example"}},
+	}
+
+	got := RenderText(report, RenderOptions{})
+	for _, want := range []string{
+		"Format           : Matroska",
+		"Format           : Opus",
+		"Compression mode : Lossy",
+		"Artist           : Example",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rendered report does not use one label column; missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRenderTextAlignsWideLabelsByTerminalCellWidth(t *testing.T) {
+	report := Report{
+		General: General{Format: "Matroska"},
+		Tags:    []Field{{Name: "映像情報", Value: "Example"}},
+	}
+
+	got := RenderText(report, RenderOptions{})
+	if !strings.Contains(got, "Format   : Matroska") ||
+		!strings.Contains(got, "映像情報 : Example") {
+		t.Fatalf("rendered report does not align a wide label by terminal cells:\n%s", got)
+	}
+}
+
+func TestRenderTextGlobalWidthRespectsCompactAndTechnicalFields(t *testing.T) {
+	report := Report{
+		General: General{Format: "Matroska", CodecID: "matroska"},
+		Streams: []Stream{{Kind: StreamAudio, Format: "Opus", Audio: &Audio{CompressionMode: "Lossy"}}},
+	}
+
+	compact := RenderText(report, RenderOptions{Compact: true})
+	if !strings.Contains(compact, "Format : Matroska") ||
+		strings.Contains(compact, "Codec ID") || strings.Contains(compact, "Compression mode") {
+		t.Fatalf("compact report used fields excluded by its selection:\n%s", compact)
+	}
+
+	technical := RenderText(report, RenderOptions{Compact: true, Technical: true})
+	if !strings.Contains(technical, "Format   : Matroska") ||
+		!strings.Contains(technical, "Codec ID : matroska") || strings.Contains(technical, "Compression mode") {
+		t.Fatalf("technical compact report used the wrong global label width:\n%s", technical)
+	}
+}
+
+func TestRenderTextCapsOversizedFieldBeforeWritingIt(t *testing.T) {
+	report := Report{
+		General: General{Format: "FLAC"},
+		Tags: []Field{{
+			Name:  "Comment",
+			Value: strings.Repeat("x", maxRenderedTextBytes*2),
+		}},
+	}
+	got := RenderText(report, RenderOptions{})
+	if len(got) > maxRenderedTextBytes {
+		t.Fatalf("rendered %d bytes, limit is %d", len(got), maxRenderedTextBytes)
+	}
+	if !strings.HasSuffix(got, "\n\n"+renderTextTruncationNotice) {
+		t.Fatalf("missing deterministic truncation notice: %q", got[len(got)-min(len(got), 128):])
+	}
+	if strings.Contains(got, "Comment") {
+		t.Fatal("oversized section was partially written")
+	}
+}
+
+func TestRenderTextLocalizesTruncationNotice(t *testing.T) {
+	report := Report{General: General{FileName: strings.Repeat("x", maxRenderedTextBytes*2)}}
+	got := RenderText(report, RenderOptions{Language: "ru"})
+	if !strings.HasSuffix(got, renderTextTruncationNoticeRU) {
+		t.Fatalf("Russian truncation notice is not localized: %q", got[len(got)-min(len(got), 128):])
+	}
+	if strings.HasSuffix(got, renderTextTruncationNotice) {
+		t.Fatal("Russian report ended with the English truncation notice")
+	}
+}
+
+func TestRenderTextNormalizesUntrustedInlineControls(t *testing.T) {
+	report := Report{
+		General: General{Format: "FLAC\nforged", FileName: "sample\tname.flac"},
+		Tags: []Field{{
+			Name:  "Com\x1bment\rname",
+			Value: "first\r\nsecond\tthird\x00fourth\u2028fifth",
+		}},
+	}
+	got := RenderText(report, RenderOptions{})
+	if strings.ContainsAny(got, "\r\t\x00\x1b") || strings.ContainsRune(got, '\u2028') {
+		t.Fatalf("rendered report retained an inline control: %q", got)
+	}
+	if !strings.Contains(got, "Format        : FLAC forged") ||
+		!strings.Contains(got, "File name     : sample name.flac") ||
+		!strings.Contains(got, "Com ment name : first second third fourth fifth") {
+		t.Fatalf("rendered report did not normalize fields onto one line:\n%s", got)
+	}
+	if gotLines := strings.Count(got, "\n") + 1; gotLines != 6 {
+		t.Fatalf("rendered report has %d lines after injected newlines, want 6:\n%s", gotLines, got)
+	}
+}
+
+func TestSplitRenderedTextLinesCapsRowAmplification(t *testing.T) {
+	text := strings.Repeat("line\n", maxRenderedTextLines+100)
+	lines, truncated := splitRenderedTextLines(text, renderTextTruncationNotice)
+	if !truncated {
+		t.Fatal("oversized line collection was not marked truncated")
+	}
+	if len(lines) != maxRenderedTextLines {
+		t.Fatalf("split retained %d lines, want %d", len(lines), maxRenderedTextLines)
+	}
+	if lines[len(lines)-1] != renderTextTruncationNotice {
+		t.Fatalf("last line = %q, want truncation notice", lines[len(lines)-1])
+	}
+
+	exact := strings.TrimSuffix(strings.Repeat("line\n", maxRenderedTextLines), "\n")
+	lines, truncated = splitRenderedTextLines(exact, renderTextTruncationNotice)
+	if truncated || len(lines) != maxRenderedTextLines || lines[len(lines)-1] != "line" {
+		t.Fatalf("exact-limit split = len %d truncated %v last %q", len(lines), truncated, lines[len(lines)-1])
+	}
+}
+
+func TestCanonicalSectionsDoNotMultiplyTargetedTagsAcrossDuplicateStreamIDs(t *testing.T) {
+	const streamCount = 256
+	tagCount := DefaultOptions(ModeDetailed).MaxTags
+	report := Report{Streams: make([]Stream, streamCount), Tags: make([]Field, tagCount)}
+	for index := range report.Streams {
+		report.Streams[index] = Stream{Index: index, ID: "duplicate", Kind: StreamVideo, Format: "AVC"}
+	}
+	for index := range report.Tags {
+		report.Tags[index] = Field{Target: "duplicate", Name: "TargetTag", Value: fmt.Sprintf("value-%04d", index)}
+	}
+
+	sections := CanonicalSections(report)
+	attached := 0
+	sectionsWithTags := 0
+	for _, section := range sections[1:] {
+		sectionTags := 0
+		for _, field := range section.Fields {
+			if field.Name == "TargetTag" {
+				sectionTags++
+			}
+		}
+		if sectionTags > 0 {
+			sectionsWithTags++
+		}
+		attached += sectionTags
+	}
+	if attached != tagCount || sectionsWithTags != 1 {
+		t.Fatalf("targeted tags attached %d times across %d sections, want %d tags on one section", attached, sectionsWithTags, tagCount)
+	}
+
+	pairs := macroTechnicalPairs(report)
+	pairTags := 0
+	for _, pair := range pairs {
+		if pair.key == "TargetTag" {
+			pairTags++
+		}
+	}
+	if pairTags != tagCount {
+		t.Fatalf("macro pairs contain %d targeted tags, want %d", pairTags, tagCount)
+	}
+
+	got, err := ExecuteTemplate(report, "Video;[%TargetTag%|]")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "value-0000|" {
+		t.Fatalf("Inform output = %q, want first duplicate target only", got)
+	}
+}
+
+func TestRenderTextCollectionLimitIsDeterministic(t *testing.T) {
+	tags := make([]Field, maxRenderedCollectionItems+1)
+	for index := range tags {
+		tags[index] = Field{Name: "Tag", Value: "value"}
+	}
+	report := Report{General: General{Format: "Matroska"}, Tags: tags}
+	first := RenderText(report, RenderOptions{})
+	second := RenderText(report, RenderOptions{})
+	if first != second {
+		t.Fatal("collection truncation is not deterministic")
+	}
+	if len(first) > maxRenderedTextBytes {
+		t.Fatalf("rendered %d bytes, limit is %d", len(first), maxRenderedTextBytes)
+	}
+	if !strings.HasSuffix(first, "\n\n"+renderTextTruncationNotice) {
+		t.Fatal("collection limit did not append truncation notice")
+	}
+}
+
+func TestReportTextWriterNeverGrowsPastContentCap(t *testing.T) {
+	writer := newReportTextWriter(128, renderTextTruncationNotice)
+	renderTextSection(writer, "Metadata", [][2]string{{"Comment", strings.Repeat("x", 256)}}, "")
+	if !writer.truncated {
+		t.Fatal("oversized section did not mark the writer truncated")
+	}
+	if writer.out.b.Len() > writer.contentCap {
+		t.Fatalf("content buffer grew to %d bytes, cap is %d", writer.out.b.Len(), writer.contentCap)
+	}
+	first := writer.String()
+	if second := writer.String(); second != first {
+		t.Fatal("finalizing a truncated writer is not idempotent")
+	}
+	if first != renderTextTruncationNotice {
+		t.Fatalf("truncated empty report = %q", first)
+	}
+}
+
+func TestCappedTemplateWriterLatchesOverflow(t *testing.T) {
+	writer := newCappedTemplateWriter(4)
+	if err := writer.WriteString("1234"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.WriteByte('5'); !errors.Is(err, errTemplateOutputTooLarge) {
+		t.Fatalf("overflow error = %v", err)
+	}
+	writer.limit = 8 // Raising the ceiling must not resume a failed stream.
+	if err := writer.WriteString("6"); !errors.Is(err, errTemplateOutputTooLarge) {
+		t.Fatalf("write after overflow = %v", err)
+	}
+	if got := writer.String(); got != "1234" {
+		t.Fatalf("writer resumed after overflow: %q", got)
+	}
+}

--- a/plugins/mediainfo/report_text.go
+++ b/plugins/mediainfo/report_text.go
@@ -1,0 +1,51 @@
+package mediainfo
+
+import "strings"
+
+// splitRenderedTextLines bounds the number of string headers retained by UI
+// consumers. A byte ceiling alone is insufficient: a hostile metadata value
+// or a multiline Inform template can fit millions of empty lines in 2 MiB.
+// The final slot is replaced with a deterministic notice when more rows exist.
+func splitRenderedTextLines(text, notice string) ([]string, bool) {
+	text = strings.TrimSuffix(text, "\n")
+	lines := strings.SplitN(text, "\n", maxRenderedTextLines)
+	if len(lines) == maxRenderedTextLines && strings.Contains(lines[len(lines)-1], "\n") {
+		lines[len(lines)-1] = notice
+		return lines, true
+	}
+	return lines, false
+}
+
+func (plugin *Plugin) render(report Report, technical bool) string {
+	text, _ := plugin.renderReport(report, technical)
+	return text
+}
+
+// renderReport also reports whether the text came from the canonical default
+// renderer. The dialog uses that bit to style known field-name spans without
+// guessing at the structure of an arbitrary user-supplied Inform template.
+func (plugin *Plugin) renderReport(report Report, technical bool) (string, bool) {
+	settings := plugin.settings()
+	text := ""
+	defaultLayout := false
+	if settings.Template != "" {
+		var err error
+		text, err = ExecuteTemplate(report, settings.Template)
+		if err != nil {
+			plugin.log("MediaInfo template failed: %v", err)
+			text = ""
+		}
+	}
+	if text == "" {
+		defaultLayout = true
+		text = RenderText(report, RenderOptions{
+			Language:  plugin.reportLanguage(),
+			Technical: technical,
+			Compact:   !technical,
+		})
+	}
+	if text != "" && !strings.HasSuffix(text, "\n") {
+		text += "\n"
+	}
+	return text, defaultLayout
+}

--- a/plugins/mediainfo/report_view.go
+++ b/plugins/mediainfo/report_view.go
@@ -1,0 +1,152 @@
+package mediainfo
+
+import (
+	"strings"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+type reportDisplayLine struct {
+	text        string
+	fieldName   string
+	fieldColumn int
+	value       string
+}
+
+// reportTextView is a scrollable, dialog-themed report control. A ListBox
+// cannot color only part of a row, so this view draws field names with a
+// dimmed foreground and leaves values at the normal dialog text color.
+type reportTextView struct {
+	vtui.ScrollView
+	lines []reportDisplayLine
+}
+
+func newReportTextView(x, y, width, height int, lines []string, styleFieldNames bool) *reportTextView {
+	view := &reportTextView{lines: make([]reportDisplayLine, len(lines))}
+	for index, line := range lines {
+		view.lines[index] = parseReportDisplayLine(line, styleFieldNames)
+	}
+	view.SetCanFocus(true)
+	view.ShowScrollBar = true
+	view.InitScrollBar(view)
+	view.ScrollBar.ColorIdx = vtui.ColDialogBox
+	view.ItemCount = len(view.lines)
+	view.SetPosition(x, y, x+width-1, y+height-1)
+	return view
+}
+
+func (view *reportTextView) SetPosition(x1, y1, x2, y2 int) {
+	view.ScrollView.SetPosition(x1, y1, x2, y2)
+	if view.ItemCount == 0 {
+		view.SelectPos = 0
+		view.TopPos = 0
+		return
+	}
+	if view.SelectPos >= view.ItemCount {
+		view.SelectPos = view.ItemCount - 1
+	}
+	view.EnsureVisible()
+	maxTop := view.ItemCount - view.ViewHeight
+	if maxTop < 0 {
+		maxTop = 0
+	}
+	if view.TopPos > maxTop {
+		view.TopPos = maxTop
+	}
+}
+
+func parseReportDisplayLine(line string, styleFieldName bool) reportDisplayLine {
+	display := reportDisplayLine{text: line}
+	if !styleFieldName {
+		return display
+	}
+	delimiter := strings.Index(line, " : ")
+	if delimiter <= 0 {
+		return display
+	}
+	prefix := line[:delimiter]
+	name := strings.TrimRight(prefix, " ")
+	if name == "" {
+		return display
+	}
+	display.fieldName = name
+	display.fieldColumn = runewidth.StringWidth(prefix)
+	display.value = line[delimiter:]
+	return display
+}
+
+func (view *reportTextView) Show(screen *vtui.ScreenBuf) {
+	view.ScreenObject.Show(screen)
+	if !view.IsVisible() {
+		return
+	}
+
+	base := view.GetStateAttr(vtui.ColDialogText, vtui.ColDialogText)
+	cursor := view.GetStateAttr(vtui.ColDialogSelectedButton, vtui.ColDialogSelectedButton)
+	// X2 is the dialog-border column. Content always stops before it; when
+	// overflowing, DrawScrollBar replaces that border with the scroll track.
+	contentWidth := view.X2 - view.X1
+	visibleRows := view.Y2 - view.Y1 + 1
+	for row := 0; row < visibleRows; row++ {
+		y := view.Y1 + row
+		lineIndex := view.TopPos + row
+		attr := base
+		if lineIndex < len(view.lines) && lineIndex == view.SelectPos && view.IsFocused() {
+			attr = cursor
+		}
+		if contentWidth > 0 {
+			screen.FillRect(view.X1, y, view.X2-1, y, ' ', attr)
+		}
+		if lineIndex >= len(view.lines) || contentWidth <= 0 {
+			continue
+		}
+		view.drawLine(screen, y, contentWidth, view.lines[lineIndex], attr)
+	}
+	view.DrawScrollBar(screen)
+}
+
+func (view *reportTextView) drawLine(screen *vtui.ScreenBuf, y, width int, line reportDisplayLine, attr uint64) {
+	if line.fieldName == "" {
+		text := runewidth.Truncate(line.text, width, "")
+		screen.Write(view.X1, y, vtui.StringToCharInfo(text, attr))
+		return
+	}
+
+	name := runewidth.Truncate(line.fieldName, width, "")
+	screen.Write(view.X1, y, vtui.StringToCharInfo(name, subduedReportFieldAttr(attr)))
+	if line.fieldColumn >= width {
+		return
+	}
+	value := runewidth.Truncate(line.value, width-line.fieldColumn, "")
+	screen.Write(view.X1+line.fieldColumn, y, vtui.StringToCharInfo(value, attr))
+}
+
+// subduedReportFieldAttr keeps captions distinguishable without the 50%
+// brightness drop of vtui.DimColor. True-color themes retain 75% of their
+// foreground intensity; indexed themes merely drop the bright flag.
+func subduedReportFieldAttr(attr uint64) uint64 {
+	if attr&vtui.IsFgRGB == 0 {
+		return attr &^ vtui.ForegroundIntensity
+	}
+	fg := vtui.GetRGBFore(attr)
+	r := ((fg >> 16) & 0xff) * 3 / 4
+	g := ((fg >> 8) & 0xff) * 3 / 4
+	b := (fg & 0xff) * 3 / 4
+	return vtui.SetRGBFore(attr, r<<16|g<<8|b)
+}
+
+func (view *reportTextView) ProcessKey(event *vtinput.InputEvent) bool {
+	if event == nil || !event.KeyDown || view.IsDisabled() {
+		return false
+	}
+	return view.HandleKey(event)
+}
+
+func (view *reportTextView) ProcessMouse(event *vtinput.InputEvent) bool {
+	if event == nil || view.IsDisabled() {
+		return false
+	}
+	return view.HandleMouse(event)
+}

--- a/plugins/mediainfo/settings.go
+++ b/plugins/mediainfo/settings.go
@@ -1,0 +1,162 @@
+package mediainfo
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"unicode/utf8"
+)
+
+const maxTemplateSize = 64 << 10
+
+var commandPrefixPattern = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9_-]*$`)
+
+// Settings are intentionally small and backend-independent so changing UI
+// preferences never invalidates an analysis result.
+type Settings struct {
+	ShowInPluginMenu bool   `json:"showInPluginMenu"`
+	EnableQuickView  bool   `json:"enableQuickView"`
+	UseEditor        bool   `json:"useEditor"`
+	Prefix           string `json:"prefix"`
+	Language         string `json:"language"`
+	Template         string `json:"template,omitempty"`
+}
+
+func DefaultSettings() Settings {
+	return Settings{
+		ShowInPluginMenu: true,
+		EnableQuickView:  true,
+		Prefix:           "MediaInfo",
+		Language:         "auto",
+	}
+}
+
+func (settings Settings) validate() error {
+	settings.Prefix = strings.TrimSpace(settings.Prefix)
+	if settings.Prefix != "" && !commandPrefixPattern.MatchString(settings.Prefix) {
+		return errors.New("prefix must start with a letter and contain only letters, digits, '_' or '-'")
+	}
+	switch strings.ToLower(strings.TrimSpace(settings.Language)) {
+	case "auto", "en", "ru":
+	default:
+		return errors.New("language must be auto, en, or ru")
+	}
+	if len(settings.Template) > maxTemplateSize {
+		return fmt.Errorf("template is larger than %d KiB", maxTemplateSize>>10)
+	}
+	if !utf8.ValidString(settings.Template) {
+		return errors.New("template is not valid UTF-8")
+	}
+	if settings.Template != "" {
+		if _, err := ExecuteTemplate(Report{}, settings.Template); err != nil {
+			return fmt.Errorf("invalid Inform template: %w", err)
+		}
+	}
+	return nil
+}
+
+func normalizeSettings(settings Settings) Settings {
+	settings.Prefix = strings.TrimSpace(settings.Prefix)
+	settings.Language = strings.ToLower(strings.TrimSpace(settings.Language))
+	if settings.Language == "" {
+		settings.Language = "auto"
+	}
+	return settings
+}
+
+type settingsStore struct {
+	mu      sync.RWMutex
+	saveMu  sync.Mutex
+	path    string
+	current Settings
+}
+
+func newSettingsStore(configDir string) (*settingsStore, error) {
+	store := &settingsStore{
+		path:    filepath.Join(configDir, "plugins", "mediainfo.json"),
+		current: DefaultSettings(),
+	}
+	data, err := os.ReadFile(store.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return store, nil
+	}
+	if err != nil {
+		return store, fmt.Errorf("read MediaInfo settings: %w", err)
+	}
+	settings := DefaultSettings()
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return store, fmt.Errorf("decode MediaInfo settings: %w", err)
+	}
+	settings = normalizeSettings(settings)
+	if err := settings.validate(); err != nil {
+		return store, fmt.Errorf("validate MediaInfo settings: %w", err)
+	}
+	store.current = settings
+	return store, nil
+}
+
+func (store *settingsStore) snapshot() Settings {
+	if store == nil {
+		return DefaultSettings()
+	}
+	store.mu.RLock()
+	defer store.mu.RUnlock()
+	return store.current
+}
+
+func (store *settingsStore) save(settings Settings) error {
+	if store == nil {
+		return errors.New("MediaInfo settings store is unavailable")
+	}
+	// Keep the on-disk rename and the in-memory publication in one save order.
+	// Without this lock, two valid dialog submissions could publish A in memory
+	// after B had already won the atomic rename on disk.
+	store.saveMu.Lock()
+	defer store.saveMu.Unlock()
+	settings = normalizeSettings(settings)
+	if err := settings.validate(); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode MediaInfo settings: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(store.path), 0o755); err != nil {
+		return fmt.Errorf("create MediaInfo settings directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(store.path), ".mediainfo-*.json")
+	if err != nil {
+		return fmt.Errorf("create MediaInfo settings file: %w", err)
+	}
+	temporaryPath := temporary.Name()
+	committed := false
+	defer func() {
+		_ = temporary.Close()
+		if !committed {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if _, err := temporary.Write(data); err != nil {
+		return fmt.Errorf("write MediaInfo settings: %w", err)
+	}
+	if err := temporary.Sync(); err != nil {
+		return fmt.Errorf("sync MediaInfo settings: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close MediaInfo settings: %w", err)
+	}
+	if err := os.Rename(temporaryPath, store.path); err != nil {
+		return fmt.Errorf("replace MediaInfo settings: %w", err)
+	}
+	committed = true
+	store.mu.Lock()
+	store.current = settings
+	store.mu.Unlock()
+	return nil
+}

--- a/plugins/mediainfo/settings_test.go
+++ b/plugins/mediainfo/settings_test.go
@@ -1,0 +1,111 @@
+package mediainfo
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestSettingsStoreDefaultsAndRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	store, err := newSettingsStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := store.snapshot(); got != DefaultSettings() {
+		t.Fatalf("defaults = %#v, want %#v", got, DefaultSettings())
+	}
+
+	want := Settings{
+		ShowInPluginMenu: false,
+		EnableQuickView:  false,
+		UseEditor:        true,
+		Prefix:           "media_info-2",
+		Language:         "RU",
+		Template:         "General;%Format%",
+	}
+	if err := store.save(want); err != nil {
+		t.Fatal(err)
+	}
+	reloaded, err := newSettingsStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want.Language = "ru"
+	if got := reloaded.snapshot(); got != want {
+		t.Fatalf("reloaded = %#v, want %#v", got, want)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "plugins", "mediainfo.json")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSettingsConcurrentSavesKeepMemoryAndDiskInSync(t *testing.T) {
+	store, err := newSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var group sync.WaitGroup
+	for index := 0; index < 16; index++ {
+		group.Add(1)
+		go func(index int) {
+			defer group.Done()
+			settings := DefaultSettings()
+			settings.Prefix = "MediaInfo" + string(rune('A'+index))
+			if err := store.save(settings); err != nil {
+				t.Errorf("save %d: %v", index, err)
+			}
+		}(index)
+	}
+	group.Wait()
+
+	data, err := os.ReadFile(store.path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var disk Settings
+	if err := json.Unmarshal(data, &disk); err != nil {
+		t.Fatal(err)
+	}
+	if disk != store.snapshot() {
+		t.Fatalf("disk settings = %#v, memory settings = %#v", disk, store.snapshot())
+	}
+}
+
+func TestSettingsRejectInvalidPrefixAndOversizedTemplate(t *testing.T) {
+	store, err := newSettingsStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	invalid := DefaultSettings()
+	invalid.Prefix = "9 media"
+	if err := store.save(invalid); err == nil {
+		t.Fatal("invalid prefix was accepted")
+	}
+	invalid = DefaultSettings()
+	invalid.Template = strings.Repeat("x", maxTemplateSize+1)
+	if err := store.save(invalid); err == nil {
+		t.Fatal("oversized template was accepted")
+	}
+}
+
+func TestSettingsMalformedFileFallsBackToDefaults(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "plugins", "mediainfo.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	store, err := newSettingsStore(dir)
+	if err == nil {
+		t.Fatal("malformed settings did not report an error")
+	}
+	if got := store.snapshot(); got != DefaultSettings() {
+		t.Fatalf("fallback = %#v, want defaults", got)
+	}
+}

--- a/plugins/mediainfo/source.go
+++ b/plugins/mediainfo/source.go
@@ -1,0 +1,287 @@
+package mediainfo
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+// ContextReaderAt is implemented by vfs.ReadAtCloser and by test sources.
+type ContextReaderAt interface {
+	ReadAt(context.Context, []byte, int64) (int, error)
+}
+
+// Source identifies a bounded random-access input. Reader ownership remains
+// with the caller; Analyze never closes it.
+type Source struct {
+	Name    string
+	Size    int64
+	ModTime time.Time
+	Reader  ContextReaderAt
+}
+
+// Options controls parser resource use. Zero values are filled from the
+// selected mode by normalized().
+type Options struct {
+	Mode                   Mode
+	MaxReadBytes           int64
+	MaxReadOps             int
+	MaxElements            int
+	MaxSingleMetadataBytes int64
+	MaxStreams             int
+	MaxTags                int
+	MaxChapters            int
+	MaxTextBytes           int64
+	MaxValueBytes          int
+}
+
+// DefaultOptions returns conservative defaults for interactive use.
+func DefaultOptions(mode Mode) Options {
+	if mode == ModeDetailed {
+		return Options{Mode: mode, MaxReadBytes: 64 << 20, MaxReadOps: 500000,
+			MaxElements: 250000, MaxSingleMetadataBytes: 8 << 20,
+			MaxStreams: 256, MaxTags: 4096, MaxChapters: 50000,
+			MaxTextBytes: 32 << 20, MaxValueBytes: 64 << 10}
+	}
+	return Options{Mode: ModeFast, MaxReadBytes: 8 << 20, MaxReadOps: 50000,
+		MaxElements: 20000, MaxSingleMetadataBytes: 512 << 10,
+		MaxStreams: 64, MaxTags: 256, MaxChapters: 512,
+		MaxTextBytes: 2 << 20, MaxValueBytes: 16 << 10}
+}
+
+func (o Options) normalized() Options {
+	d := DefaultOptions(o.Mode)
+	if o.MaxReadBytes <= 0 {
+		o.MaxReadBytes = d.MaxReadBytes
+	}
+	if o.MaxReadOps <= 0 {
+		o.MaxReadOps = d.MaxReadOps
+	}
+	if o.MaxElements <= 0 {
+		o.MaxElements = d.MaxElements
+	}
+	if o.MaxSingleMetadataBytes <= 0 {
+		o.MaxSingleMetadataBytes = d.MaxSingleMetadataBytes
+	}
+	if o.MaxStreams <= 0 {
+		o.MaxStreams = d.MaxStreams
+	}
+	if o.MaxTags <= 0 {
+		o.MaxTags = d.MaxTags
+	}
+	if o.MaxChapters <= 0 {
+		o.MaxChapters = d.MaxChapters
+	}
+	if o.MaxTextBytes <= 0 {
+		o.MaxTextBytes = d.MaxTextBytes
+	}
+	if o.MaxValueBytes <= 0 {
+		o.MaxValueBytes = d.MaxValueBytes
+	}
+	return o
+}
+
+var (
+	// ErrUnsupported means no parser confidently recognized the source.
+	ErrUnsupported = errors.New("media format unsupported")
+	// ErrLimit is used internally when a configured I/O cap is exhausted.
+	ErrLimit = errors.New("media probe resource limit reached")
+)
+
+// ParseError reports structural damage in an otherwise identified format.
+type ParseError struct {
+	Format string
+	Offset int64
+	Err    error
+}
+
+func (e *ParseError) Error() string {
+	if e.Offset >= 0 {
+		return fmt.Sprintf("%s parse error at %d: %v", e.Format, e.Offset, e.Err)
+	}
+	return fmt.Sprintf("%s parse error: %v", e.Format, e.Err)
+}
+func (e *ParseError) Unwrap() error { return e.Err }
+
+type boundedReaderAt struct {
+	ctx      context.Context
+	src      Source
+	maxBytes int64
+	maxOps   int
+	mu       sync.Mutex
+	bytes    int64
+	ops      int
+}
+
+func (r *boundedReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	if off < 0 || off >= r.src.Size {
+		if off == r.src.Size && len(p) == 0 {
+			return 0, nil
+		}
+		return 0, io.EOF
+	}
+	r.mu.Lock()
+	if r.ops >= r.maxOps || r.bytes >= r.maxBytes {
+		r.mu.Unlock()
+		return 0, ErrLimit
+	}
+	r.ops++
+	remaining := r.maxBytes - r.bytes
+	limited := false
+	if int64(len(p)) > remaining {
+		p = p[:remaining]
+		limited = true
+	}
+	r.mu.Unlock()
+	if len(p) == 0 {
+		return 0, ErrLimit
+	}
+	n, err := r.src.Reader.ReadAt(r.ctx, p, off)
+	r.mu.Lock()
+	r.bytes += int64(n)
+	r.mu.Unlock()
+	if err == nil && n < len(p) {
+		err = io.ErrUnexpectedEOF
+	}
+	if limited && (err == nil || errors.Is(err, io.EOF)) {
+		err = ErrLimit
+	}
+	return n, err
+}
+
+func (r *boundedReaderAt) stats() (int64, int) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.bytes, r.ops
+}
+
+type probe struct {
+	ctx      context.Context
+	src      Source
+	opts     Options
+	r        *boundedReaderAt
+	report   Report
+	elements int
+}
+
+func newProbe(ctx context.Context, src Source, opts Options) (*probe, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if src.Reader == nil || src.Size < 0 {
+		return nil, fmt.Errorf("invalid media source")
+	}
+	opts = opts.normalized()
+	br := &boundedReaderAt{ctx: ctx, src: src, maxBytes: opts.MaxReadBytes, maxOps: opts.MaxReadOps}
+	p := &probe{ctx: ctx, src: src, opts: opts, r: br}
+	p.report.Mode = opts.Mode
+	p.report.General.FileName = src.Name
+	p.report.General.FileSize = src.Size
+	return p, nil
+}
+
+func (p *probe) readAt(off int64, n int) ([]byte, error) {
+	if n < 0 || int64(n) > p.opts.MaxSingleMetadataBytes {
+		return nil, ErrLimit
+	}
+	if off < 0 || off > p.src.Size || int64(n) > p.src.Size-off {
+		return nil, io.ErrUnexpectedEOF
+	}
+	b := make([]byte, n)
+	read, err := p.r.ReadAt(b, off)
+	if err != nil && !(err == io.EOF && read == n) {
+		return b[:read], err
+	}
+	if read != n {
+		return b[:read], io.ErrUnexpectedEOF
+	}
+	return b, nil
+}
+
+func (p *probe) readBounded(off, n int64) ([]byte, error) {
+	if off < 0 || n < 0 || off > p.src.Size || n > p.src.Size-off {
+		return nil, io.ErrUnexpectedEOF
+	}
+	var out bytes.Buffer
+	for n > 0 {
+		if err := p.ctx.Err(); err != nil {
+			return nil, err
+		}
+		chunk := n
+		if chunk > 64<<10 {
+			chunk = 64 << 10
+		}
+		b := make([]byte, int(chunk))
+		got, err := p.r.ReadAt(b, off)
+		out.Write(b[:got])
+		off += int64(got)
+		n -= int64(got)
+		if err != nil {
+			return out.Bytes(), err
+		}
+		if got == 0 {
+			return out.Bytes(), io.ErrNoProgress
+		}
+	}
+	return out.Bytes(), nil
+}
+
+func (p *probe) section(off, n int64) (*io.SectionReader, error) {
+	if off < 0 || n < 0 || off > p.src.Size || n > p.src.Size-off {
+		return nil, io.ErrUnexpectedEOF
+	}
+	return io.NewSectionReader(p.r, off, n), nil
+}
+
+func (p *probe) step() error {
+	if err := p.ctx.Err(); err != nil {
+		return err
+	}
+	p.elements++
+	if p.elements > p.opts.MaxElements {
+		return ErrLimit
+	}
+	return nil
+}
+
+func (p *probe) warn(code, message string, off int64) {
+	p.report.Warnings = append(p.report.Warnings, Warning{Code: code, Message: message, Offset: off})
+}
+
+func (p *probe) addTag(target, name, value string) {
+	if name == "" || value == "" {
+		return
+	}
+	if len(p.report.Tags) >= p.opts.MaxTags {
+		p.report.Truncated = true
+		return
+	}
+	if len(value) > p.opts.MaxValueBytes {
+		value = value[:p.opts.MaxValueBytes]
+		p.report.Truncated = true
+	}
+	const maxTagIdentityBytes = 1024
+	if len(name) > maxTagIdentityBytes {
+		name = name[:maxTagIdentityBytes]
+		p.report.Truncated = true
+	}
+	if len(target) > maxTagIdentityBytes {
+		target = target[:maxTagIdentityBytes]
+		p.report.Truncated = true
+	}
+	// Parsers often derive a short key or value by slicing a much larger
+	// metadata string. Own every accepted field so the report cannot retain
+	// that backing allocation after the parser returns.
+	target = strings.Clone(target)
+	name = strings.Clone(name)
+	value = strings.Clone(value)
+	p.report.Tags = append(p.report.Tags, Field{Target: target, Name: name, Value: value})
+}

--- a/plugins/mediainfo/subtitle_limits_test.go
+++ b/plugins/mediainfo/subtitle_limits_test.go
@@ -1,0 +1,166 @@
+package mediainfo
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+type subtitleParser func(string, *Text, *probe) error
+
+func subtitleProbe(t *testing.T, ctx context.Context, maxElements, maxValueBytes int) *probe {
+	t.Helper()
+	opts := DefaultOptions(ModeFast)
+	opts.MaxElements = maxElements
+	opts.MaxValueBytes = maxValueBytes
+	p, err := newProbe(ctx, Source{Name: "subtitle", Reader: memorySource{}}, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestSubtitleParsersStopAtElementLimit(t *testing.T) {
+	const records = 4096
+	timing := "00:00:01,000 --> 00:00:02,000\n"
+	tests := []struct {
+		name  string
+		parse subtitleParser
+		text  string
+	}{
+		{name: "SRT", parse: parseSRT, text: strings.Repeat(timing, records)},
+		{name: "WebVTT", parse: parseVTT, text: "WEBVTT\n" + strings.Repeat(timing, records)},
+		{name: "ASS", parse: parseASS, text: strings.Repeat("Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,x\n", records)},
+		{name: "MicroDVD", parse: parseMicroDVD, text: strings.Repeat("{25}{50}x\n", records)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const maxElements = 32
+			p := subtitleProbe(t, context.Background(), maxElements, 1024)
+			text := &Text{}
+			err := tt.parse(tt.text, text, p)
+			if !errors.Is(err, ErrLimit) {
+				t.Fatalf("error = %v, want ErrLimit", err)
+			}
+			if p.elements != maxElements+1 {
+				t.Fatalf("elements = %d, want %d", p.elements, maxElements+1)
+			}
+			if text.CueCount == 0 || text.CueCount > maxElements {
+				t.Fatalf("cue count = %d", text.CueCount)
+			}
+		})
+	}
+}
+
+func TestSubtitleParsersHonorCancellation(t *testing.T) {
+	tests := []struct {
+		name  string
+		parse subtitleParser
+		text  string
+	}{
+		{name: "SRT", parse: parseSRT, text: "00:00:01,000 --> 00:00:02,000\n"},
+		{name: "WebVTT", parse: parseVTT, text: "WEBVTT\n00:01.000 --> 00:02.000\n"},
+		{name: "ASS", parse: parseASS, text: "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,x\n"},
+		{name: "MicroDVD", parse: parseMicroDVD, text: "{25}{50}x\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			p := subtitleProbe(t, ctx, 100, 1024)
+			err := tt.parse(tt.text, &Text{}, p)
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("error = %v, want context.Canceled", err)
+			}
+			if p.elements != 0 {
+				t.Fatalf("elements processed after cancellation = %d", p.elements)
+			}
+		})
+	}
+}
+
+func TestSubtitleParsersPropagateOversizedLine(t *testing.T) {
+	oversized := strings.Repeat("x", 256)
+	tests := []struct {
+		name  string
+		parse subtitleParser
+		text  string
+	}{
+		{name: "SRT", parse: parseSRT, text: oversized},
+		{name: "WebVTT", parse: parseVTT, text: "WEBVTT\n" + oversized},
+		{name: "ASS", parse: parseASS, text: oversized},
+		{name: "MicroDVD", parse: parseMicroDVD, text: oversized},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := subtitleProbe(t, context.Background(), 100, 64)
+			err := tt.parse(tt.text, &Text{}, p)
+			if err == nil || !strings.Contains(err.Error(), "token too long") {
+				t.Fatalf("error = %v, want Scanner token-too-long error", err)
+			}
+		})
+	}
+}
+
+func TestAnalyzeASSPropagatesScannerError(t *testing.T) {
+	data := []byte("[Events]\nDialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,," + strings.Repeat("x", 256))
+	opts := DefaultOptions(ModeFast)
+	opts.MaxValueBytes = 64
+	_, err := Analyze(context.Background(), Source{Name: "oversized.ass", Size: int64(len(data)), Reader: memorySource(data)}, opts)
+	if err == nil || !strings.Contains(err.Error(), "ASS parse error") || !strings.Contains(err.Error(), "token too long") {
+		t.Fatalf("error = %v, want propagated ASS scanner error", err)
+	}
+}
+
+func TestTTMLPreflightAllowsBoundedDocument(t *testing.T) {
+	p := subtitleProbe(t, context.Background(), 100, 1024)
+	text := &Text{}
+	err := parseTTML(`<tt xml:lang="en"><body><div><p begin="1s" end="2s">cue</p></div></body></tt>`, text, p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text.CueCount != 1 || text.FirstCue != time.Second || text.LastCue != 2*time.Second {
+		t.Fatalf("unexpected TTML timing: %#v", text)
+	}
+	if len(p.report.Tags) != 1 || p.report.Tags[0].Name != "Language" || p.report.Tags[0].Value != "en" {
+		t.Fatalf("unexpected TTML language tags: %#v", p.report.Tags)
+	}
+}
+
+func TestTTMLPreflightRejectsAttributeAmplification(t *testing.T) {
+	p := subtitleProbe(t, context.Background(), 10000, maxTTMLMarkupBytes)
+	document := "<tt" + strings.Repeat(` a=""`, maxTTMLAttributes+1) + `><body><p begin="0s" end="1s"/></body></tt>`
+	err := parseTTML(document, &Text{}, p)
+	if !errors.Is(err, ErrLimit) {
+		t.Fatalf("error = %v, want ErrLimit", err)
+	}
+	if !p.report.Truncated {
+		t.Fatal("attribute limit must mark report truncated")
+	}
+}
+
+func TestTTMLPreflightRejectsOversizedMarkupToken(t *testing.T) {
+	p := subtitleProbe(t, context.Background(), 10000, maxTTMLMarkupBytes)
+	document := "<tt " + strings.Repeat("x", maxTTMLMarkupBytes) + `><body><p begin="0s" end="1s"/></body></tt>`
+	err := parseTTML(document, &Text{}, p)
+	if !errors.Is(err, ErrLimit) {
+		t.Fatalf("error = %v, want ErrLimit", err)
+	}
+	if !p.report.Truncated {
+		t.Fatal("markup limit must mark report truncated")
+	}
+}
+
+func TestTTMLPreflightChargesAttributesToElementBudget(t *testing.T) {
+	p := subtitleProbe(t, context.Background(), 4, 1024)
+	document := `<tt a="" b="" c="" d="" e=""><body><p begin="0s" end="1s"/></body></tt>`
+	err := parseTTML(document, &Text{}, p)
+	if !errors.Is(err, ErrLimit) {
+		t.Fatalf("error = %v, want ErrLimit", err)
+	}
+	if p.elements != 5 {
+		t.Fatalf("elements = %d, want 5", p.elements)
+	}
+}

--- a/plugins/mediainfo/util.go
+++ b/plugins/mediainfo/util.go
@@ -1,0 +1,166 @@
+package mediainfo
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+	"unicode/utf16"
+)
+
+func u16(b []byte, order binary.ByteOrder) uint16 {
+	if len(b) < 2 {
+		return 0
+	}
+	return order.Uint16(b)
+}
+
+func u32(b []byte, order binary.ByteOrder) uint32 {
+	if len(b) < 4 {
+		return 0
+	}
+	return order.Uint32(b)
+}
+
+func u64(b []byte, order binary.ByteOrder) uint64 {
+	if len(b) < 8 {
+		return 0
+	}
+	return order.Uint64(b)
+}
+
+func fourCC(b []byte) string {
+	if len(b) < 4 {
+		return ""
+	}
+	s := string(b[:4])
+	for _, r := range s {
+		if r < 0x20 || r > 0x7e {
+			return fmt.Sprintf("0x%08X", binary.BigEndian.Uint32(b[:4]))
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
+func cleanText(b []byte) string {
+	// Trim while this is still a byte slice, then allocate only the compact
+	// result. Converting first would let a tiny trimmed string retain a large
+	// backing allocation in reports and their cache.
+	b = bytes.TrimRight(b, "\x00")
+	b = bytes.TrimSpace(b)
+	return string(b)
+}
+
+func durationFromUnits(value uint64, scale uint64) time.Duration {
+	if value == 0 || scale == 0 {
+		return 0
+	}
+	seconds := float64(value) / float64(scale)
+	if seconds > float64(math.MaxInt64)/float64(time.Second) {
+		return 0
+	}
+	return time.Duration(seconds * float64(time.Second))
+}
+
+func parseISO639(v uint16) string {
+	if v == 0 {
+		return ""
+	}
+	b := []byte{byte((v>>10)&0x1f) + 0x60, byte((v>>5)&0x1f) + 0x60, byte(v&0x1f) + 0x60}
+	for _, c := range b {
+		if c < 'a' || c > 'z' {
+			return ""
+		}
+	}
+	return string(b)
+}
+
+func boolPtr(v bool) *bool { return &v }
+
+func decodeUTF16(b []byte, little bool) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	words := make([]uint16, 0, len(b)/2)
+	for len(b) >= 2 {
+		var w uint16
+		if little {
+			w = binary.LittleEndian.Uint16(b)
+		} else {
+			w = binary.BigEndian.Uint16(b)
+		}
+		if w == 0 {
+			break
+		}
+		words = append(words, w)
+		b = b[2:]
+	}
+	decoded := utf16.Decode(words)
+	start, end := 0, len(decoded)
+	for start < end && unicode.IsSpace(decoded[start]) {
+		start++
+	}
+	for end > start && unicode.IsSpace(decoded[end-1]) {
+		end--
+	}
+	return string(decoded[start:end])
+}
+
+func parseDecimal(s string) float64 {
+	v, _ := strconv.ParseFloat(strings.TrimSpace(s), 64)
+	return v
+}
+
+func canonicalTag(code string) string {
+	if len(code) == 4 && code[0] == 0xa9 {
+		switch strings.ToUpper(code[1:]) {
+		case "NAM":
+			return "Title"
+		case "ART":
+			return "Artist"
+		case "ALB":
+			return "Album"
+		case "CMT":
+			return "Comment"
+		case "GEN":
+			return "Genre"
+		case "DAY":
+			return "Date"
+		case "TOO":
+			return "Encoded application"
+		case "WRT":
+			return "Composer"
+		}
+	}
+	switch strings.ToUpper(strings.TrimSpace(code)) {
+	case "INAM", "TITLE", "TIT2", "©NAM":
+		return "Title"
+	case "IART", "ARTIST", "TPE1", "©ART":
+		return "Artist"
+	case "IPRD", "ALBUM", "TALB", "©ALB":
+		return "Album"
+	case "ICMT", "COMMENT", "COMM", "©CMT":
+		return "Comment"
+	case "ICOP", "COPYRIGHT", "TCOP", "CPRT":
+		return "Copyright"
+	case "IGNR", "GENRE", "TCON", "©GEN":
+		return "Genre"
+	case "ICRD", "DATE", "YEAR", "TDRC", "TYER", "©DAY":
+		return "Date"
+	case "ISFT", "ENCODER", "TSSE", "©TOO":
+		return "Encoded application"
+	case "TRACKNUMBER", "TRCK":
+		return "Track"
+	case "DISCNUMBER", "TPOS":
+		return "Disc"
+	case "ALBUMARTIST", "TPE2", "AART":
+		return "Album artist"
+	case "COMPOSER", "TCOM", "©WRT":
+		return "Composer"
+	}
+	return strings.TrimSpace(code)
+}


### PR DESCRIPTION
## Summary

- add a built-in, CGO-free MediaInfo-style plugin backed by bounded pure-Go parsers
- provide detailed themed reports, configurable Inform templates, editor handoff, command prefix, and Far-compatible `Plugin.Call`
- register a fast Ctrl+Q provider for supported audio/video formats while preserving native image-preview precedence
- expose useful EXIF metadata, including camera/lens data, exposure settings, orientation, DPI, GPS coordinates, and altitude

## Format coverage

MP4/MOV/3GP, Matroska/WebM, AVI, WAVE/RF64/BW64, AIFF, MP3/MPEG audio, FLAC, Ogg Vorbis/Opus/FLAC/Theora, common still/animated image and RAW formats, and SRT/WebVTT/ASS/SSA/TTML/MicroDVD/EBU STL subtitles.

The package README documents intentionally unsupported format families and known partial-decoding limitations.

## Safety and performance

- reads directly through local or remote VFS `ReaderAt` sources; no temporary media copy
- separate bounded fast and detailed modes with context cancellation
- two-second Quick View timeout
- weighted 64-entry / 16 MiB report cache
- bounded reads, operations, elements, streams, tags, chapters, retained values, templates, and rendered output
- no MediaInfoLib, native DLL, external process, or CGO dependency

## Validation

- `go test ./plugins/mediainfo -count=1 -timeout 60s`
- `go vet ./plugins/mediainfo`
- `go test ./vfs -run QuickViewProvider -count=1 -timeout 60s`
- `go test . -run 'QuickView|PluginContributions' -count=1 -timeout 60s`