### PR TITLE
fix: Alt+F9 toggles window size in any area

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -1220,7 +1220,7 @@ func init() {
 	})
 	RegisterAction(Action{
 		Name:        "App.ToggleWindowSize",
-		Area:        "Shell",
+		Area:        "Common",
 		Label:       "Toggle Window Size",
 		LabelKey:    "Action.App.ToggleWindowSize",
 		Description: "Toggle between two window sizes",

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -1728,7 +1728,8 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	}
 
 	// F9 opens the main menu (other F-keys are action bindings now).
-	if e.VirtualKeyCode == vtinput.VK_F9 {
+	// Alt+F9 is App.ToggleWindowSize and must not fall through to this.
+	if e.VirtualKeyCode == vtinput.VK_F9 && !alt {
 		pos := 0 // Left
 		if pf.activeIdx == 1 {
 			pos = 4 // Right


### PR DESCRIPTION
Поведение соответствует FAR3

Alt+F9 (App.ToggleWindowSize) привязан к области "Shell", поэтому во вьюере,
редакторе и при открытом хелпе действие не срабатывало — событие проваливалось
до обработчика F9 и открывало главное меню.

- action_registry.go: Area "Shell" -> "Common" для App.ToggleWindowSize;
  теперь AltF9 разрешается из любой области (Common — fallback в GetAction),
  включая модальный диалог (EventFilter перехватывает событие до фрейма).
- panels_frame.go: F9-обработчик требует !alt, чтобы Alt+F9 не открывал меню.

Проверено: go build ./..., тесты F9/ShiftF9, меню, хоткеев, палитры и framework.
