### PR TITLE
pty: mark master and slave close-on-exec so shells die with f4

### DIFF
--- a/pty_bsd.go
+++ b/pty_bsd.go
@@ -40,7 +40,15 @@ func ptyStep(step string, err error) error {
 }
 
 func NewPTY() (*PTY, error) {
-	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	// O_CLOEXEC matters as much as O_NOCTTY here. Go sets close-on-exec on
+	// every descriptor it opens itself, but a raw unix.Open wrapped in
+	// os.NewFile keeps whatever flags the fd was created with, and forkExec
+	// closes nothing on its own. Without the flag the shell inherits a copy
+	// of its own master, so the master never drops to zero references when
+	// f4 dies: the kernel sends no SIGHUP, the shell survives as an orphan
+	// holding its pts node, and enough restarts exhaust the pty limit until
+	// allocation fails.
+	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, ptyStep("open /dev/ptmx", err)
 	}
@@ -56,7 +64,11 @@ func NewPTY() (*PTY, error) {
 		return nil, ptyStep("ptySlaveName", err)
 	}
 
-	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY, 0)
+	// The slave is marked close-on-exec too. Run() hands it to the child as
+	// stdin, stdout and stderr, and the dup2 that installs it on 0, 1 and 2
+	// clears the flag on those copies, so the child still gets its terminal
+	// -- what the flag drops is only the surplus inherited descriptor.
+	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		master.Close()
 		return nil, ptyStep("open "+slaveName, err)

--- a/pty_cloexec_test.go
+++ b/pty_cloexec_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestPTYDescriptorsAreCloseOnExec guards the fix for the pty leak that
+// exhausted the host's pty table.
+//
+// Go marks close-on-exec every descriptor it opens itself, but a raw
+// unix.Open wrapped in os.NewFile keeps whatever flags the fd was created
+// with, and forkExec closes nothing on its own. When the master was left
+// without FD_CLOEXEC, every shell f4 spawned inherited a copy of its own
+// master. The master then never dropped to zero references once f4 died, so
+// the kernel never delivered SIGHUP to the slave side: the shell survived as
+// an orphan holding its pty node forever. Enough f4 restarts walked the host
+// into kern.tty.ptmx_max and the next allocation failed with ENXIO, which
+// looks to the person like "openpty failed" and no terminal anywhere.
+//
+// Checking the flag is the whole regression: Run() installs the slave on the
+// child's 0/1/2 with dup2, which clears FD_CLOEXEC on those copies, so the
+// child still gets a working terminal either way. The flag only decides
+// whether the surplus descriptors tag along.
+func TestPTYDescriptorsAreCloseOnExec(t *testing.T) {
+	pty, err := NewPTY()
+	if err != nil {
+		t.Skipf("PTY allocation unavailable in this environment: %v", err)
+	}
+	defer pty.Close()
+
+	for _, d := range []struct {
+		name string
+		file *os.File
+	}{
+		{"master", pty.Master},
+		{"slave", pty.Slave},
+	} {
+		if d.file == nil {
+			t.Fatalf("%s descriptor is nil", d.name)
+		}
+		flags, err := unix.FcntlInt(d.file.Fd(), unix.F_GETFD, 0)
+		if err != nil {
+			t.Fatalf("F_GETFD on %s: %v", d.name, err)
+		}
+		if flags&unix.FD_CLOEXEC == 0 {
+			t.Errorf("%s descriptor lacks FD_CLOEXEC; a spawned shell would "+
+				"inherit it and keep the pty alive after f4 exits", d.name)
+		}
+	}
+}
+
+// TestPTYChildDoesNotInheritMaster is the behavioural half: it spawns a child
+// through the real Run() path and confirms the master is absent from the
+// child's descriptor table. This is what the flag above buys, verified
+// end to end rather than by proxy.
+func TestPTYChildDoesNotInheritMaster(t *testing.T) {
+	if _, err := exec.LookPath("lsof"); err != nil {
+		t.Skip("lsof not available to inspect the child's descriptors")
+	}
+
+	pty, err := NewPTY()
+	if err != nil {
+		t.Skipf("PTY allocation unavailable in this environment: %v", err)
+	}
+	defer pty.Close()
+
+	// A bare sleep keeps the child parked without a shell of its own, so
+	// every descriptor it holds came from the exec, not from job control.
+	if err := pty.Run("/bin/sh", "-c", "exec sleep 30"); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	pid := pty.Cmd.Process.Pid
+
+	out, err := exec.Command("lsof", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		t.Skipf("lsof refused to inspect pid %d: %v", pid, err)
+	}
+
+	// The child legitimately holds the slave on 0, 1 and 2. Holding the
+	// multiplexer clone is the bug: that is the master.
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "/dev/ptmx") {
+			t.Errorf("child inherited the pty master, which prevents the "+
+				"hangup that reaps it when f4 dies:\n  %s", strings.TrimSpace(line))
+		}
+	}
+}

--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -23,7 +23,15 @@ type PTY struct {
 }
 
 func NewPTY() (*PTY, error) {
-	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	// O_CLOEXEC matters as much as O_NOCTTY here. Go sets close-on-exec on
+	// every descriptor it opens itself, but a raw unix.Open wrapped in
+	// os.NewFile keeps whatever flags the fd was created with, and forkExec
+	// closes nothing on its own. Without the flag the shell inherits a copy
+	// of its own master, so the master never drops to zero references when
+	// f4 dies: the kernel sends no SIGHUP, the shell survives as an orphan
+	// holding its /dev/ttys node, and enough restarts exhaust ptmx_max until
+	// allocation fails with ENXIO.
+	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +59,11 @@ func NewPTY() (*PTY, error) {
 	}
 	slaveName := string(ptyName[:nameLen])
 
-	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY, 0)
+	// The slave is marked close-on-exec too. Run() hands it to the child as
+	// stdin, stdout and stderr, and the dup2 that installs it on 0, 1 and 2
+	// clears the flag on those copies, so the child still gets its terminal
+	// -- what the flag drops is only the surplus inherited descriptor.
+	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		master.Close()
 		return nil, err

--- a/pty_ptm_netbsd.go
+++ b/pty_ptm_netbsd.go
@@ -25,6 +25,14 @@ func NewPTY() (*PTY, error) {
 		return nil, err
 	}
 
+	// The O_CLOEXEC above covers only the /dev/ptm handle, which is closed
+	// on the way out anyway. TIOCPTMGET hands back two freshly opened
+	// descriptors that carry no FD_CLOEXEC of their own, so they must be
+	// flagged here: otherwise the shell inherits a copy of its own master,
+	// the master never drops to zero references when f4 dies, no SIGHUP is
+	// delivered, and the shell survives as an orphan pinning its pty.
+	setCloseOnExec([]int{int(pg.Cfd), int(pg.Sfd)})
+
 	master := os.NewFile(uintptr(pg.Cfd), "/dev/ptmx")
 	slave := os.NewFile(uintptr(pg.Sfd), "slave")
 

--- a/pty_ptm_openbsd.go
+++ b/pty_ptm_openbsd.go
@@ -41,6 +41,14 @@ func NewPTY() (*PTY, error) {
 		return nil, errno
 	}
 
+	// The O_CLOEXEC above covers only the /dev/ptm handle, which is closed
+	// on the way out anyway. PTMGET hands back two freshly opened
+	// descriptors that carry no FD_CLOEXEC of their own, so they must be
+	// flagged here: otherwise the shell inherits a copy of its own master,
+	// the master never drops to zero references when f4 dies, no SIGHUP is
+	// delivered, and the shell survives as an orphan pinning its pty.
+	setCloseOnExec([]int{int(pg.Cfd), int(pg.Sfd)})
+
 	master := os.NewFile(uintptr(pg.Cfd), "/dev/ptmx")
 	slave := os.NewFile(uintptr(pg.Sfd), "slave")
 

--- a/pty_unix.go
+++ b/pty_unix.go
@@ -23,7 +23,15 @@ type PTY struct {
 }
 
 func NewPTY() (*PTY, error) {
-	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	// O_CLOEXEC matters as much as O_NOCTTY here. Go sets close-on-exec on
+	// every descriptor it opens itself, but a raw unix.Open wrapped in
+	// os.NewFile keeps whatever flags the fd was created with, and forkExec
+	// closes nothing on its own. Without the flag the shell inherits a copy
+	// of its own master, so the master never drops to zero references when
+	// f4 dies: the kernel sends no SIGHUP, the shell survives as an orphan
+	// holding its /dev/pts node, and enough restarts exhaust the pty limit
+	// until allocation fails.
+	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -42,8 +50,15 @@ func NewPTY() (*PTY, error) {
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, uintptr(masterFd), unix.TIOCSPTLCK, uintptr(unsafe.Pointer(&unlock)))
 
 	slaveName := fmt.Sprintf("/dev/pts/%d", res)
-	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY, 0)
+	// The slave is marked close-on-exec too. Run() hands it to the child as
+	// stdin, stdout and stderr, and the dup2 that installs it on 0, 1 and 2
+	// clears the flag on those copies, so the child still gets its terminal
+	// -- what the flag drops is only the surplus inherited descriptor.
+	slaveFd, err := unix.Open(slaveName, unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
+		// Every other failure above closes the master before giving up; this
+		// path used to return without doing so, leaking the master fd.
+		master.Close()
 		return nil, err
 	}
 

--- a/solaris_pty.go
+++ b/solaris_pty.go
@@ -88,8 +88,15 @@ func (p *SolarisPTY) IsBusy() bool {
 // OpenSolarisPTY реализует чистый алгоритм выделения PTY для Solaris/Illumos.
 // Он открывает мастер-клон, определяет подчиненное имя (ptsname) и настраивает STREAMS.
 func OpenSolarisPTY(api SolarisStreamsAPI) (*SolarisPTY, error) {
-	// 1. Открытие мультиплексора мастера
-	master, err := api.Open("/dev/ptmx", os.O_RDWR, 0)
+	// 1. Открытие мультиплексора мастера. O_CLOEXEC здесь так же важен, как
+	// O_NOCTTY ниже: Go выставляет close-on-exec на дескрипторы, которые
+	// открывает сам, но сырой unix.Open, обёрнутый в os.NewFile, сохраняет
+	// те флаги, с которыми дескриптор был создан, а forkExec сам ничего не
+	// закрывает. Без флага шелл наследует копию собственного мастера, число
+	// ссылок на мастер никогда не падает до нуля при смерти f4, ядро не
+	// шлёт SIGHUP, шелл остаётся сиротой и держит свой узел /dev/pts, а
+	// после достаточного числа перезапусков лимит pty исчерпывается.
+	master, err := api.Open("/dev/ptmx", os.O_RDWR|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +130,11 @@ func OpenSolarisPTY(api SolarisStreamsAPI) (*SolarisPTY, error) {
 	// открытие слейва в процессе без управляющего терминала само делает
 	// его управляющим, и им рискует стать терминал самого f4, а не только
 	// терминал дочернего шелла.
-	slave, err := api.Open(slaveName, os.O_RDWR|unix.O_NOCTTY, 0)
+	// Слейв тоже помечается close-on-exec. Run() отдаёт его ребёнку как
+	// stdin, stdout и stderr, а dup2, который ставит его на 0, 1 и 2,
+	// снимает флаг с этих копий, так что терминал ребёнок получает; флаг
+	// убирает только лишний унаследованный дескриптор.
+	slave, err := api.Open(slaveName, os.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		master.Close()
 		return nil, err


### PR DESCRIPTION
## The problem

A PTY allocated by f4 keeps its shell alive **forever** after f4 itself is gone, and each leaked shell holds a pty node. Enough restarts walk the host into its pty limit, after which allocation fails with `ENXIO` and no terminal can be opened anywhere on the machine — not f4's, not the system terminal's.

This is not theoretical. It was found on a host that had accumulated **497 orphaned shells against a `kern.tty.ptmx_max` of 511**, all spawned in one burst and idle for two days, each pinning a `/dev/ttys` node:

```
$ ps -eo tty,comm | awk '$1 ~ /^ttys/ {print $2}' | sort | uniq -c | sort -rn
 499 /bin/zsh
   5 claude
```

## Root cause

The descriptors are opened with a raw `unix.Open` and wrapped in `os.NewFile`. Go marks close-on-exec every descriptor it opens itself, but a wrapped fd keeps the flags it was created with, and `forkExec` closes nothing on its own — so **every shell inherits a copy of its own master**.

That extra reference is what breaks the teardown. When f4 dies its own master closes, but the reference count never reaches zero, so the kernel never delivers `SIGHUP` to the slave side and the shell keeps running as an orphan holding its pty.

Confirmed by reading the orphaned child's descriptor table, where the inherited master is plainly visible:

```
zsh  74707  0u  CHR  16,0  /dev/ttys000
zsh  74707  1u  CHR  16,0  /dev/ttys000
zsh  74707  2u  CHR  16,0  /dev/ttys000
zsh  74707  3u  CHR  15,0  /dev/ptmx     <-- inherited master: the bug
```

A minimal reproduction that spawns a shell and then exits, mimicking f4 dying:

- without `O_CLOEXEC` → `child SURVIVED -> pty leaked (no SIGHUP)`
- with `O_CLOEXEC` → `child died -> pty correctly hung up`

## The fix

Pass `O_CLOEXEC` on both master and slave for **darwin**, **linux**, **freebsd/dragonfly** and **solaris/illumos**.

**netbsd** and **openbsd** had the same bug in a different form: they already flag `/dev/ptm`, but the descriptors `TIOCPTMGET`/`PTMGET` hand back are freshly opened and carry no `FD_CLOEXEC` of their own. Those are flagged explicitly through the existing `setCloseOnExec` helper.

This does **not** take the terminal away from the child: `Run()` installs the slave on 0, 1 and 2 with `dup2`, which clears the flag on those copies. The flag only drops the surplus inherited descriptors.

Also closes the master on the slave-open error path in `pty_unix.go`, which returned without doing so and leaked the fd — unlike every other failure path in that function.

## Tests

`pty_cloexec_test.go` covers both halves: that the flag is set, and that a child spawned through the real `Run()` path has no master in its descriptor table. **Both fail before this change** with the right diagnosis, and pass after:

```
--- FAIL: TestPTYDescriptorsAreCloseOnExec
    master descriptor lacks FD_CLOEXEC; a spawned shell would inherit it
    and keep the pty alive after f4 exits
--- FAIL: TestPTYChildDoesNotInheritMaster
    child inherited the pty master, which prevents the hangup that reaps
    it when f4 dies:
      sleep 84139 4u CHR 15,0 /dev/ptmx
```

## Verification

Builds clean for `linux`, `dragonfly`, `netbsd`, `openbsd`, `solaris`, `illumos` and `darwin`; `gofmt` clean; `TestPTY_Lifecycle` still passes.

`freebsd` fails to cross-compile, but that is **pre-existing and unrelated** — it is in a third-party dep (`go-webgpu/goffi` `fakecgo`) and reproduces on a pristine checkout of `main` without this patch. `dragonfly` shares `pty_bsd.go` and builds, so the edited code is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)