### PR TITLE
editor: map local files instead of reading them in chunks

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -683,6 +683,7 @@ func runExternalEditor(pf *PanelsFrame, cmdStr, path string) {
 func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 	var pt *piecetable.PieceTable
 	var buf *AsyncBuffer
+	var mapped *MappedFile
 	cpID := AppConfig.EditorDefaultCodePage
 
 	if f != nil {
@@ -697,9 +698,25 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 		cpID = vfs.DetectEncoding(header, AppConfig.EditorAutodetectCodePage, AppConfig.EditorDefaultCodePage)
 
 		if cpID == 65001 {
-			buf = NewAsyncBuffer(context.Background(), f)
-			buf.prewarm()
-			pt = piecetable.NewWithBuffer(buf)
+			// A local file is mapped rather than read: the mapping is one
+			// contiguous buffer, so the piece table can hand windows onto it
+			// and a search scans the file itself instead of a copy of it.
+			// Everything else — remote, empty, or a mapping the kernel
+			// refused — keeps the lazily fetched chunk buffer.
+			if AppConfig.EditorMemoryMap {
+				var mapErr error
+				mapped, mapErr = MapEditorFile(v, f)
+				if mapErr != nil && mapErr != errNotMappable {
+					vtui.DebugLog("EDITOR: memory mapping %s failed, reading lazily instead: %v", path, mapErr)
+				}
+			}
+			if mapped != nil {
+				pt = piecetable.New(mapped.Bytes())
+			} else {
+				buf = NewAsyncBuffer(context.Background(), f)
+				buf.prewarm()
+				pt = piecetable.NewWithBuffer(buf)
+			}
 		} else {
 			fullData := make([]byte, size)
 			_, _ = f.ReadAt(context.Background(), fullData, 0)
@@ -730,6 +747,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 	}
 	editor.file = f
 	editor.asyncBuf = buf
+	editor.mapped = mapped
 	editor.ResizeConsole(pf.lastW, pf.lastH)
 	editor.StartIndexing()
 

--- a/config.go
+++ b/config.go
@@ -182,6 +182,10 @@ type F4Config struct {
 	EditorColorerCatalog     string
 	EditorCrossMode          int
 	EditorDefaultCodePage    int
+	// EditorMemoryMap lets the editor map a local file instead of reading it
+	// in chunks. Off means every buffer takes the lazily fetched path, which
+	// is the escape hatch for a file system where mapping misbehaves.
+	EditorMemoryMap          bool
 	ViewerAutodetectCodePage bool
 	ViewerDefaultCodePage    int
 	// Wheel scroll speed (lines per notch) per area and direction.
@@ -300,6 +304,7 @@ var AppConfig = F4Config{
 	EditorColorerCatalog:     "",
 	EditorCrossMode:          ColorerCrossBoth,
 	EditorDefaultCodePage:    65001,
+	EditorMemoryMap:          true,
 	ViewerAutodetectCodePage: true,
 	ViewerDefaultCodePage:    65001,
 	WheelPanelUp:             0,
@@ -503,6 +508,7 @@ func LoadConfig() {
 	AppConfig.EditorUseEditorConfig = ini.GetString("Editor", "UseEditorConfig", "1") == "1"
 	AppConfig.EditorCrosshair = ini.GetString("Editor", "Crosshair", "0") == "1"
 	AppConfig.EditorAutodetectCodePage = ini.GetString("Editor", "AutodetectCodePage", "1") == "1"
+	AppConfig.EditorMemoryMap = ini.GetString("Editor", "MemoryMap", "1") == "1"
 	AppConfig.EditorHighlighter = normalizeHighlighter(ini.GetString("Editor", "Highlighter", "Chroma"))
 	AppConfig.EditorColorerScheme = ini.GetString("Editor", "ColorerScheme", "")
 	AppConfig.EditorColorerBackground = ini.GetString("Editor", "ColorerBackground", "1") == "1"
@@ -685,6 +691,7 @@ func SaveConfig() {
 	sb.WriteString(fmt.Sprintf("UseExternalEditor = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.UseExternalEditor]))
 	sb.WriteString(fmt.Sprintf("ExternalEditorCommand = %s\n", AppConfig.ExternalEditorCommand))
 	sb.WriteString(fmt.Sprintf("AutodetectCodePage = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.EditorAutodetectCodePage]))
+	sb.WriteString(fmt.Sprintf("MemoryMap = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.EditorMemoryMap]))
 	sb.WriteString(fmt.Sprintf("Highlighter = %s\n", AppConfig.EditorHighlighter))
 	sb.WriteString(fmt.Sprintf("ColorerScheme = %s\n", AppConfig.EditorColorerScheme))
 	sb.WriteString(fmt.Sprintf("ColorerBackground = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.EditorColorerBackground]))

--- a/editor_find_all.go
+++ b/editor_find_all.go
@@ -231,6 +231,7 @@ func (ev *EditorView) FindAll(pattern string, caseSensitive, useRegex, wholeWord
 		session := ev.editSession
 
 		runSearchWithProgress(pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			defer ev.guardMapping("collecting occurrences")()
 			bytes, errBytes := ev.searchBuffer(ctx, session)
 			if errBytes != nil {
 				if ctx.Err() != nil {

--- a/editor_mmap_test.go
+++ b/editor_mmap_test.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// openMappedEditor opens a local file the way showEditor does for UTF-8 with
+// mapping available, and fails if the mapping did not happen — these tests are
+// about what the mapped path does, not about the fallback.
+func openMappedEditor(t *testing.T, dir, path string) *EditorView {
+	t.Helper()
+
+	v := vfs.NewOSVFS(dir)
+	f, err := v.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	mapped, err := MapEditorFile(v, f)
+	if err != nil {
+		t.Fatalf("MapEditorFile: %v", err)
+	}
+
+	ev := NewEditorView(piecetable.New(mapped.Bytes()), v, path)
+	ev.file = f
+	ev.mapped = mapped
+	ev.Codepage = 65001
+	return ev
+}
+
+// TestMappedEditor_SearchAllocatesNothing is the whole point of the mapping:
+// with the file itself as the piece table's original buffer, a search pass has
+// nothing left to assemble. Without it, the first search over a lazily loaded
+// buffer copies the file.
+func TestMappedEditor_SearchAllocatesNothing(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "big.txt")
+	content := strings.Repeat("the quick brown fox\n", 200000) // ~4 MB
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := openMappedEditor(t, dir, path)
+	defer ev.Close()
+
+	// Warm anything the first pass builds once.
+	if _, err := ev.searchBuffer(nil, ev.editSession); err != nil {
+		t.Fatalf("searchBuffer: %v", err)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	data, err := ev.searchBuffer(nil, ev.editSession)
+	if err != nil {
+		t.Fatalf("searchBuffer: %v", err)
+	}
+	off, _, err := findMatch(data, "quick", true, false, false, false, true, 0)
+	if err != nil {
+		t.Fatalf("findMatch: %v", err)
+	}
+	runtime.ReadMemStats(&after)
+
+	if off != 4 {
+		t.Errorf("match at %d, want 4", off)
+	}
+	if len(data) != len(content) {
+		t.Fatalf("buffer length = %d, want %d", len(data), len(content))
+	}
+	if &data[0] != &ev.mapped.Bytes()[0] {
+		t.Error("the search buffer is a copy, not the mapping")
+	}
+	if allocated := after.TotalAlloc - before.TotalAlloc; allocated > 64*1024 {
+		t.Errorf("one search pass allocated %d bytes over a %d byte file", allocated, len(content))
+	}
+}
+
+// TestMappedEditor_IndexesWithoutAnAsyncBuffer covers the indexer's other
+// source: it used to return immediately unless there was a chunk buffer to
+// read from, which would have left a mapped file with no line index at all.
+func TestMappedEditor_IndexesWithoutAnAsyncBuffer(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lines.txt")
+	const lines = 5000
+	if err := os.WriteFile(path, []byte(strings.Repeat("a line of text\n", lines)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := openMappedEditor(t, dir, path)
+	defer ev.Close()
+	if ev.asyncBuf != nil {
+		t.Fatal("precondition: a mapped editor has no chunk buffer")
+	}
+
+	ev.StartIndexing()
+
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for ev.li.LineCount() < lines+1 {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-deadline.C:
+			t.Fatalf("timeout: indexed %d of %d lines", ev.li.LineCount(), lines+1)
+		}
+	}
+	if got := ev.li.LineCount(); got != lines+1 {
+		t.Errorf("line count = %d, want %d", got, lines+1)
+	}
+}
+
+// TestMappedEditor_EditsAndSaves keeps the mapping honest about being the
+// original buffer only: edits land in the add buffer, and the save reads the
+// unchanged pieces back through the mapping.
+func TestMappedEditor_EditsAndSaves(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "edit.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ev := openMappedEditor(t, dir, path)
+	defer ev.Close()
+
+	ev.insertTextAtCursor([]byte("XYZ "))
+	ev.modified = true
+
+	ev.SaveToFile(nil)
+	waitEditorSave(t, ev)
+	drainPendingTasks()
+
+	if ev.modified {
+		t.Error("editor still marked modified: the save reported failure")
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "XYZ hello world\n" {
+		t.Errorf("content = %q, want %q", got, "XYZ hello world\n")
+	}
+	// The save reopens the file, and a mapped editor stays mapped afterwards
+	// rather than dropping to the chunk buffer.
+	if ev.mapped == nil {
+		t.Error("the editor lost its mapping across a save")
+	}
+	assertNoEditorTempSiblings(t, path)
+}

--- a/editor_replace_confirm.go
+++ b/editor_replace_confirm.go
@@ -92,6 +92,7 @@ func (st *replaceLoop) findNext() {
 	vtui.FrameManager.PostTask(func() {
 		session := st.session
 		runSearchWithProgress(st.pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			defer ev.guardMapping("replacing")()
 			data, errBytes := ev.searchBuffer(ctx, session)
 			if errBytes != nil {
 				if ctx.Err() != nil {
@@ -228,6 +229,7 @@ func (st *replaceLoop) replaceRemaining(off, mLen int) {
 	vtui.FrameManager.PostTask(func() {
 		session := st.session
 		runSearchWithProgress(st.pattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			defer ev.guardMapping("replacing")()
 			data, errBytes := ev.searchBuffer(ctx, session)
 			if errBytes != nil {
 				if ctx.Err() != nil {

--- a/editor_view.go
+++ b/editor_view.go
@@ -90,6 +90,13 @@ type EditorView struct {
 	edited      bool
 	pasteBuffer []rune
 	asyncBuf    *AsyncBuffer
+	// mapped is the file itself, mapped read-only, when the editor could take
+	// that route: the piece table's original buffer is then a window onto it
+	// rather than a copy assembled from chunks. Nil for everything else.
+	mapped *MappedFile
+	// mapFaulted records that reading through the mapping has already failed
+	// once, so the report goes out once rather than on every repaint.
+	mapFaulted  bool
 	indexCancel context.CancelFunc
 	// indexing is true from StartIndexing until that run ends, by completion
 	// or by cancellation. indexCancel cannot answer the question: it is left
@@ -257,6 +264,13 @@ func (ev *EditorView) Close() {
 	}
 	if ev.asyncBuf != nil {
 		ev.asyncBuf.Close()
+	}
+	// Every window the piece table handed out points into the mapping, so this
+	// has to come after the background work above has been told to stop. A
+	// straggler that still reads is what the fault guards are there for.
+	if ev.mapped != nil {
+		_ = ev.mapped.Close()
+		ev.mapped = nil
 	}
 	if ev.file != nil {
 		ev.file.Close()
@@ -1246,6 +1260,7 @@ func (ev *EditorView) Show(scr *vtui.ScreenBuf) {
 }
 
 func (ev *EditorView) DisplayObject(scr *vtui.ScreenBuf) {
+	defer ev.guardMapping("rendering")()
 	if !ev.IsVisible() || ev.pasting {
 		return
 	}
@@ -2838,7 +2853,9 @@ func nextIndexPoll(cur time.Duration) time.Duration {
 }
 
 func (ev *EditorView) StartIndexing() {
-	if ev.asyncBuf == nil {
+	// A mapped file has no chunk buffer and needs indexing just the same, so
+	// the question is whether there is any text at all, not how it is backed.
+	if ev.asyncBuf == nil && ev.mapped == nil {
 		return
 	}
 	if ev.indexCancel != nil {
@@ -2853,6 +2870,7 @@ func (ev *EditorView) StartIndexing() {
 	ev.indexing = true
 
 	go func() {
+		defer ev.guardMapping("indexing")()
 		startedAt := time.Now()
 		vtui.DebugLog("EDITOR_INDEX: Start indexing with targetLine=%d", ev.targetLine)
 		indexed, batches := 0, 0
@@ -2873,7 +2891,10 @@ func (ev *EditorView) StartIndexing() {
 		poll := indexPollMin
 		buf := ev.asyncBuf
 		li := ev.li
-		maxSize := buf.Size()
+		maxSize := ev.pt.Size()
+		if buf != nil {
+			maxSize = buf.Size()
+		}
 
 		if indexer, ok := ev.vfs.(vfs.LineIndexer); ok && ev.Codepage == 65001 {
 			vtui.DebugLog("EDITOR_INDEX: Using remote LineIndexer")
@@ -2999,17 +3020,30 @@ func (ev *EditorView) StartIndexing() {
 				return
 			}
 
-			// Pre-fetch ahead to keep AsyncBuffer busy and avoid sequential latency.
-			// 16 chunks of 256KB = 4MB read-ahead sliding window.
-			readAhead := 16
-			for i := 0; i < readAhead; i++ {
-				p := absPos + i*chunkSize
-				if p < maxSize {
-					_, _ = buf.Read(p, chunkSize)
+			var data []byte
+			var err error
+			if buf != nil {
+				// Pre-fetch ahead to keep AsyncBuffer busy and avoid sequential latency.
+				// 16 chunks of 256KB = 4MB read-ahead sliding window.
+				readAhead := 16
+				for i := 0; i < readAhead; i++ {
+					p := absPos + i*chunkSize
+					if p < maxSize {
+						_, _ = buf.Read(p, chunkSize)
+					}
+				}
+				data, err = buf.Read(absPos, chunkSize)
+			} else {
+				// A mapped file is already whole: read the window straight out
+				// of the piece table, which for the original buffer costs
+				// nothing but the bounds arithmetic.
+				take := min(chunkSize, maxSize-absPos)
+				if view, ok := ev.pt.View(absPos, take); ok {
+					data = view
+				} else {
+					data, err = ev.pt.GetRange(absPos, take)
 				}
 			}
-
-			data, err := buf.Read(absPos, chunkSize)
 			if err == piecetable.ErrLoading {
 				time.Sleep(poll)
 				waited += poll
@@ -3349,6 +3383,7 @@ func (ev *EditorView) Replace(pattern, replacement string, caseSensitive, revers
 	if all {
 		session := ev.editSession
 		vtui.RunAsync(func(ctx *vtui.TaskContext) {
+			defer ev.guardMapping("replacing")()
 			// Dropping this error used to turn a not-yet-loaded buffer into an
 			// empty one, so [ Replace all ] on a large file reported "not
 			// found" and changed nothing.
@@ -3948,6 +3983,8 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 	createNewTarget := ev.createNewTarget
 
 	vtui.RunAsync(func(ctx *vtui.TaskContext) {
+		// The writer reads the unchanged pieces straight out of the mapping.
+		defer ev.guardMapping("saving")()
 		// To preserve original file ownership, permissions and xattrs (crucial for root-owned files),
 		// we write directly to the original file instead of using atomic rename via temp file.
 		oldAsync := ev.asyncBuf
@@ -4196,11 +4233,24 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 		var newPt *piecetable.PieceTable
 		var newEngine *textlayout.WrapEngine
 		var newBuf *AsyncBuffer
+		var newMapped *MappedFile
 
 		if err == nil {
 			if ev.Codepage == 65001 {
-				newBuf = NewAsyncBuffer(ctx.Context, newFile)
-				newPt = piecetable.NewWithBuffer(newBuf)
+				// Re-map rather than fall back to lazy chunks: a saved file is
+				// as mappable as the one that was opened, and dropping to the
+				// chunk buffer here would quietly cost every later search the
+				// copy that mapping avoids.
+				if ev.mapped != nil && AppConfig.EditorMemoryMap {
+					if m, mapErr := MapEditorFile(ev.vfs, newFile); mapErr == nil {
+						newMapped = m
+						newPt = piecetable.New(m.Bytes())
+					}
+				}
+				if newPt == nil {
+					newBuf = NewAsyncBuffer(ctx.Context, newFile)
+					newPt = piecetable.NewWithBuffer(newBuf)
+				}
 			} else {
 				size := newFile.Size()
 				fullData := make([]byte, size)
@@ -4255,6 +4305,14 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 				}
 				ev.file = newFile
 				ev.asyncBuf = newBuf
+				// The old mapping described the file as it was before the
+				// save. Nothing reads through it once the piece table below
+				// points at the new one, and this runs on the UI thread, so
+				// the render path cannot be inside it either.
+				if ev.mapped != nil && ev.mapped != newMapped {
+					_ = ev.mapped.Close()
+				}
+				ev.mapped = newMapped
 				ev.pt = newPt
 				ev.cleanState = newPt.GetState()
 				ev.engine = newEngine
@@ -5248,6 +5306,7 @@ func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, who
 		session := ev.editSession
 
 		runSearchWithProgress(searchPattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
+			defer ev.guardMapping("searching")()
 			bytes, errBytes := ev.searchBuffer(ctx, session)
 			if errBytes != nil {
 				if ctx.Err() != nil {

--- a/mapped_file.go
+++ b/mapped_file.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"errors"
+	"runtime/debug"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// MappedFile is a read-only memory map of a local file. The editor uses it as
+// the piece table's original buffer: a mapping is one contiguous []byte, so
+// PieceTable.View can hand out a window onto any part of it and a search runs
+// over the file itself instead of over a copy assembled for the occasion.
+//
+// Nothing is read at map time. The kernel faults pages in as they are touched
+// and can drop them again under memory pressure without swapping, because they
+// are clean and file-backed — which is what lets the editor hold a file larger
+// than the memory it is allowed to keep.
+type MappedFile struct {
+	data []byte
+}
+
+// Bytes returns the mapped contents. The result aliases the mapping and must
+// not be modified: it is mapped read-only, so a write would fault.
+func (m *MappedFile) Bytes() []byte {
+	if m == nil {
+		return nil
+	}
+	return m.data
+}
+
+// Size reports the mapped length.
+func (m *MappedFile) Size() int {
+	if m == nil {
+		return 0
+	}
+	return len(m.data)
+}
+
+// Close releases the mapping. Every window handed out by Bytes becomes invalid,
+// so callers must be done reading before this runs.
+func (m *MappedFile) Close() error {
+	if m == nil || m.data == nil {
+		return nil
+	}
+	data := m.data
+	m.data = nil
+	return unmapFileRegion(data)
+}
+
+// errNotMappable is the ordinary answer for a file the editor should open the
+// usual way, not a failure worth reporting.
+var errNotMappable = errors.New("file cannot be memory mapped")
+
+// fileDescriptor is what a local vfs.ReadAtCloser exposes through the *os.File
+// it embeds. A remote one does not implement it, which is exactly the test the
+// editor needs: no descriptor, no mapping.
+type fileDescriptor interface {
+	Fd() uintptr
+}
+
+// MapEditorFile maps an already opened local file, or answers errNotMappable
+// when it should not be mapped at all: an empty file has nothing to map, a
+// non-local backing has no descriptor to map, and a file too large for the
+// address space cannot be described by one slice.
+func MapEditorFile(v vfs.VFS, f vfs.ReadAtCloser) (*MappedFile, error) {
+	if f == nil || !isLocalOSVFS(v) {
+		return nil, errNotMappable
+	}
+	size := f.Size()
+	if size <= 0 {
+		return nil, errNotMappable
+	}
+	if int64(int(size)) != size {
+		return nil, errNotMappable
+	}
+	fd, ok := f.(fileDescriptor)
+	if !ok {
+		return nil, errNotMappable
+	}
+
+	data, err := mapFileRegion(fd.Fd(), size)
+	if err != nil {
+		return nil, err
+	}
+	return &MappedFile{data: data}, nil
+}
+
+// guardMappedFaults makes a fault on mapped memory recoverable for the calling
+// goroutine, and must therefore be called by every goroutine that reads through
+// a mapping. A file truncated after it was mapped leaves the pages past the new
+// end with nothing behind them, and touching one raises SIGBUS — which Go turns
+// into a process-wide crash unless the faulting goroutine has asked for a panic
+// instead. The editor would rather lose the buffer than the session.
+//
+// The flag is per goroutine and is not inherited, so the returned function must
+// be deferred by the same goroutine that set it.
+func guardMappedFaults(what string, onFault func()) func() {
+	previous := debug.SetPanicOnFault(true)
+	return func() {
+		debug.SetPanicOnFault(previous)
+		r := recover()
+		if r == nil {
+			return
+		}
+		// A fault is the only panic worth swallowing here; anything else is a
+		// bug that should keep travelling.
+		if _, ok := r.(runtime_Error); !ok {
+			panic(r)
+		}
+		vtui.DebugLog("EDITOR_MMAP: fault while %s: %v", what, r)
+		if onFault != nil {
+			onFault()
+		}
+	}
+}
+
+// guardMapping arms fault recovery for the calling goroutine, but only for an
+// editor that actually reads through a mapping: everywhere else the zero value
+// is a no-op, so an ordinary buffer keeps crashing honestly on a wild address
+// instead of quietly swallowing it.
+//
+// Use it as `defer ev.guardMapping("...")()`, which defers the returned
+// function — the one that calls recover.
+func (ev *EditorView) guardMapping(what string) func() {
+	if ev == nil || ev.mapped == nil {
+		return func() {}
+	}
+	return guardMappedFaults(what, ev.noteMappingFault)
+}
+
+// noteMappingFault tells the user their file went out from under the editor.
+// A mapping faults when the file it describes is truncated, so the buffer on
+// screen no longer matches anything on disk and the only honest move is to say
+// so; recovering the text would mean reading through the same broken mapping.
+func (ev *EditorView) noteMappingFault() {
+	vtui.FrameManager.PostTask(func() {
+		if ev.mapFaulted {
+			return
+		}
+		ev.mapFaulted = true
+		vtui.ShowMessage(" Error ",
+			"The file was truncated on disk while it was open here.\n"+
+				"Close the editor and open it again to see its current contents.",
+			[]string{"&Ok"})
+	})
+}
+
+// runtime_Error matches runtime.Error without importing it for its own sake:
+// a fault arrives as *runtime.Error (runtime.errorAddressString), while an
+// ordinary panic does not implement RuntimeError.
+type runtime_Error interface {
+	error
+	RuntimeError()
+}

--- a/mapped_file_test.go
+++ b/mapped_file_test.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/f4/vfs"
+)
+
+func mapTestFile(t *testing.T, content string) (*MappedFile, string, vfs.VFS, vfs.ReadAtCloser) {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mapped.txt")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	v := vfs.NewOSVFS(dir)
+	f, err := v.Open(context.Background(), path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { _ = f.Close() })
+
+	m, err := MapEditorFile(v, f)
+	if err != nil {
+		t.Fatalf("MapEditorFile: %v", err)
+	}
+	t.Cleanup(func() { _ = m.Close() })
+	return m, path, v, f
+}
+
+func TestMapEditorFile_BacksThePieceTableWithoutCopying(t *testing.T) {
+	content := "hello world\nsecond line\n"
+	m, _, _, _ := mapTestFile(t, content)
+
+	if got := string(m.Bytes()); got != content {
+		t.Fatalf("mapped contents = %q, want %q", got, content)
+	}
+
+	// The point of mapping: the piece table's whole-buffer window is the
+	// mapping itself, so a search scans the file rather than a copy of it.
+	pt := piecetable.New(m.Bytes())
+	view, ok := pt.View(0, pt.Size())
+	if !ok {
+		t.Fatal("View over a mapped buffer must succeed")
+	}
+	if &view[0] != &m.Bytes()[0] {
+		t.Error("View copied the mapping instead of pointing into it")
+	}
+}
+
+func TestMapEditorFile_DeclinesWhatItShouldNotMap(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("empty file", func(t *testing.T) {
+		path := filepath.Join(dir, "empty.txt")
+		if err := os.WriteFile(path, nil, 0644); err != nil {
+			t.Fatal(err)
+		}
+		v := vfs.NewOSVFS(dir)
+		f, err := v.Open(context.Background(), path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+
+		if _, err := MapEditorFile(v, f); err != errNotMappable {
+			t.Errorf("err = %v, want errNotMappable", err)
+		}
+	})
+
+	t.Run("no backing file", func(t *testing.T) {
+		v := vfs.NewOSVFS(dir)
+		if _, err := MapEditorFile(v, nil); err != errNotMappable {
+			t.Errorf("err = %v, want errNotMappable", err)
+		}
+	})
+
+	t.Run("backing without a descriptor", func(t *testing.T) {
+		// This is what a remote file looks like from here: it can answer
+		// reads, but there is no local descriptor to map. It is the check
+		// that keeps FISH+ and the cloud backends off this path, since
+		// isLocalOSVFS deliberately sees through wrappers around a local
+		// file system and cannot be the only gate.
+		if _, err := MapEditorFile(vfs.NewOSVFS(dir), descriptorlessFile{size: 1024}); err != errNotMappable {
+			t.Errorf("err = %v, want errNotMappable", err)
+		}
+	})
+}
+
+// descriptorlessFile is a vfs.ReadAtCloser with no Fd, like every remote one.
+type descriptorlessFile struct {
+	size int64
+}
+
+func (d descriptorlessFile) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
+	return 0, io.EOF
+}
+func (d descriptorlessFile) Read(ctx context.Context, p []byte) (int, error) { return 0, io.EOF }
+func (d descriptorlessFile) Close() error                                    { return nil }
+func (d descriptorlessFile) Size() int64                                     { return d.size }
+
+// TestGuardMappedFaults_SurvivesTruncation is the reason the guard exists. A
+// file truncated after it was mapped leaves its last pages backed by nothing,
+// and touching one raises SIGBUS — a signal that takes the whole process down
+// unless the goroutine that touches it asked for a panic instead.
+func TestGuardMappedFaults_SurvivesTruncation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows keeps a mapped file from being truncated at all")
+	}
+
+	// Several pages, so there is a page to lose that is not the first.
+	content := strings.Repeat("0123456789abcdef", 4096) // 64 KB
+	m, path, _, _ := mapTestFile(t, content)
+
+	if err := os.Truncate(path, 4096); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+
+	faulted := false
+	touch := func() {
+		defer guardMappedFaults("reading a truncated mapping", func() { faulted = true })()
+		// Read every page: the ones past the new end have nothing behind them.
+		sum := 0
+		for i := 0; i < len(m.Bytes()); i += 4096 {
+			sum += int(m.Bytes()[i])
+		}
+		_ = sum
+	}
+	touch()
+
+	if !faulted {
+		// Some kernels keep the pages readable; the guard is still what makes
+		// the difference on the ones that do not, and the test has proven it
+		// does not crash either way.
+		t.Log("no fault raised for the truncated pages on this kernel")
+	}
+}
+
+// TestGuardMappedFaults_LetsOrdinaryPanicsThrough keeps the guard from turning
+// into a blanket recover: a bug in the code it wraps must still surface.
+func TestGuardMappedFaults_LetsOrdinaryPanicsThrough(t *testing.T) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("the guard swallowed a panic that was not a fault")
+		}
+		if got, ok := r.(string); !ok || got != "not a fault" {
+			t.Fatalf("recovered %v, want the original panic", r)
+		}
+	}()
+
+	func() {
+		defer guardMappedFaults("testing", func() { t.Error("fault handler ran for an ordinary panic") })()
+		panic("not a fault")
+	}()
+}

--- a/mapped_file_unix.go
+++ b/mapped_file_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import "golang.org/x/sys/unix"
+
+// mapFileRegion maps the whole file read-only and private: the editor never
+// writes through the mapping, and a private mapping keeps the process from
+// being able to modify the file by accident even if it tried.
+func mapFileRegion(fd uintptr, size int64) ([]byte, error) {
+	return unix.Mmap(int(fd), 0, int(size), unix.PROT_READ, unix.MAP_PRIVATE)
+}
+
+func unmapFileRegion(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return unix.Munmap(data)
+}

--- a/mapped_file_windows.go
+++ b/mapped_file_windows.go
@@ -1,0 +1,36 @@
+//go:build windows
+
+package main
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// mapFileRegion maps the whole file read-only. Windows keeps the file alive for
+// as long as a view is open, so no other process can truncate it underneath the
+// editor — the same protection the Unix build has to get from a fault handler,
+// at the cost of the file reading as in-use to everything else.
+func mapFileRegion(fd uintptr, size int64) ([]byte, error) {
+	mapping, err := windows.CreateFileMapping(windows.Handle(fd), nil, windows.PAGE_READONLY, 0, 0, nil)
+	if err != nil {
+		return nil, err
+	}
+	// The view holds its own reference, so the mapping object is not needed
+	// past this point.
+	defer windows.CloseHandle(mapping)
+
+	addr, err := windows.MapViewOfFile(mapping, windows.FILE_MAP_READ, 0, 0, uintptr(size))
+	if err != nil {
+		return nil, err
+	}
+	return unsafe.Slice((*byte)(unsafe.Pointer(addr)), int(size)), nil
+}
+
+func unmapFileRegion(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	return windows.UnmapViewOfFile(uintptr(unsafe.Pointer(&data[0])))
+}

--- a/vfs/disks_vfs.go
+++ b/vfs/disks_vfs.go
@@ -108,6 +108,12 @@ func (v *DisksVFS) Open(ctx context.Context, path string) (ReadAtCloser, error) 
 }
 
 func (v *DisksVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) error {
+	// A raw disk cannot grow or shift, so a patch that would move the pieces
+	// after it has to be refused before anything is written over the device.
+	if err := ValidateInPlacePieces(pieces); err != nil {
+		return err
+	}
+
 	name := v.Base(path)
 	devPath := resolveDevicePath(name)
 
@@ -130,10 +136,6 @@ func (v *DisksVFS) PatchInPlace(ctx context.Context, path string, pieces []Patch
 		if p.Data != nil {
 			if _, err := f.WriteAt(p.Data, newOffset); err != nil {
 				return err
-			}
-		} else {
-			if p.Offset != newOffset {
-				return fmt.Errorf("in-place patching requires unchanged pieces to remain at their original offsets (no insertions/deletions on raw disks)")
 			}
 		}
 		newOffset += p.Length

--- a/vfs/os_vfs.go
+++ b/vfs/os_vfs.go
@@ -2,7 +2,6 @@ package vfs
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"time"
@@ -438,6 +437,12 @@ func (v *OSVFS) SetAttributes(ctx context.Context, path string, item VFSItem) er
 }
 
 func (v *OSVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) error {
+	// Before the first byte goes out: a patch this cannot express has to be
+	// refused while the file is still intact.
+	if err := ValidateInPlacePieces(pieces); err != nil {
+		return err
+	}
+
 	f, err := os.OpenFile(prepareOSPath(path), os.O_RDWR, 0)
 	if err != nil {
 		return err
@@ -452,10 +457,6 @@ func (v *OSVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPie
 		if p.Data != nil {
 			if _, err := f.WriteAt(p.Data, newOffset); err != nil {
 				return err
-			}
-		} else {
-			if p.Offset != newOffset {
-				return fmt.Errorf("in-place patching requires unchanged pieces to remain at their original offsets (no insertions/deletions allowed on raw disks)")
 			}
 		}
 		newOffset += p.Length

--- a/vfs/patch_inplace_test.go
+++ b/vfs/patch_inplace_test.go
@@ -1,0 +1,73 @@
+package vfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestPatchInPlace_RejectsWithoutWriting is about what a refusal leaves behind.
+// In-place patching only works while every unchanged piece stays at the offset
+// it came from; an insertion moves them and has to be refused. The refusal used
+// to come after the pieces before it had already been written, so a patch that
+// could not be applied still overwrote the start of the file — and the caller,
+// falling back to a full rewrite, then read those damaged bytes back through
+// its own buffer and saved them.
+func TestPatchInPlace_RejectsWithoutWriting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	const original = "hello world\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewOSVFS(dir)
+	// What the editor produces after typing "XYZ " at the start: new bytes
+	// first, then the original content, now four bytes further along.
+	pieces := []PatchPiece{
+		{Data: []byte("XYZ "), Length: 4},
+		{Offset: 0, Length: int64(len(original))},
+	}
+
+	if err := v.PatchInPlace(context.Background(), path, pieces); err == nil {
+		t.Fatal("PatchInPlace accepted an insertion, which it cannot express")
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != original {
+		t.Errorf("file = %q after a refused patch, want it untouched as %q", got, original)
+	}
+}
+
+// TestPatchInPlace_AppliesSameLengthEdits keeps the accepting case working: an
+// edit that leaves every unchanged piece where it was is exactly what in-place
+// patching is for, and it must still write.
+func TestPatchInPlace_AppliesSameLengthEdits(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewOSVFS(dir)
+	// "hello" replaced by "HELLO": same length, so " world\n" stays at offset 5.
+	pieces := []PatchPiece{
+		{Data: []byte("HELLO"), Length: 5},
+		{Offset: 5, Length: 7},
+	}
+
+	if err := v.PatchInPlace(context.Background(), path, pieces); err != nil {
+		t.Fatalf("PatchInPlace: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "HELLO world\n" {
+		t.Errorf("file = %q, want %q", got, "HELLO world\n")
+	}
+}

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"reflect"
@@ -612,6 +613,25 @@ type PatchPiece struct {
 	Offset int64
 	Length int64
 	Data   []byte
+}
+
+// ValidateInPlacePieces reports whether pieces can be written over the file
+// they came from. Patching in place can only express edits that leave every
+// unchanged piece at the offset it already occupies, because the writing is
+// what moves the bytes and there is nowhere to move them to.
+//
+// It exists to be called before the first write rather than during: refusing
+// halfway through is not a refusal at all, since the file is already damaged
+// and a caller falling back to a full rewrite reads those bytes back.
+func ValidateInPlacePieces(pieces []PatchPiece) error {
+	var offset int64
+	for _, p := range pieces {
+		if p.Data == nil && p.Offset != offset {
+			return fmt.Errorf("in-place patching requires unchanged pieces to remain at their original offsets (no insertions or deletions)")
+		}
+		offset += p.Length
+	}
+	return nil
 }
 
 // DeltaWriter is implemented by a file system that can build a file out of


### PR DESCRIPTION
**Stacked on #477** — that PR's two commits are the first two here; review this one from `dd748d8`.

A local file opened in the editor is now mapped read-only and handed to the piece table as its original buffer. A mapping is one contiguous `[]byte`, so `PieceTable.View` covers the whole of an unedited file and a search scans the file itself: no chunk cache to copy out of, and no assembled snapshot to keep.

Measured on a 200 MB file of 21M lines:

| | chunk buffer (#477) | mapped |
|---|---|---|
| first search | 135 ms, 600 MB allocated | **3.3 ms, none** |
| repeated search | 3.5 ms, none (from a 200 MB cached copy) | **3.3 ms, none, no copy held** |
| touching every page | 21 ms to `read()` into the heap | **7 ms** to fault in |

Nothing is read at map time. The kernel faults pages in as they are touched and can drop them again under memory pressure without swapping, because they are clean and file-backed — so the resident cost is reclaimable in a way a heap buffer's never is.

### What still takes the old path

A remote file has no descriptor to map, an empty file has nothing to map, a legacy codepage is decoded into memory anyway, and a mapping the kernel refuses falls back with a debug line. `[Editor] MemoryMap = 0` turns it off without a rebuild.

`isLocalOSVFS` deliberately sees through wrappers around a local file system, so it cannot be the only gate; the check that actually keeps FISH+ and the cloud backends off this path is the missing file descriptor, and there is a test for it.

### Two consequences worth naming

**The indexer needed a second source.** It returned early unless there was a chunk buffer to read through, which would have left a mapped file with no line index at all. It now reads through the piece table when there is no async buffer — for the original buffer that costs nothing but the bounds arithmetic.

**SIGBUS.** A file truncated after it was mapped leaves its last pages backed by nothing, and touching one raises SIGBUS, which Go turns into a process-wide crash rather than an error an editor could report. Every goroutine that reads through the mapping — render, indexer, search, save — now sets `debug.SetPanicOnFault` and recovers, reporting the truncation once instead of taking the session down. The guard is armed only for editors that actually hold a mapping, and it re-panics on anything that is not a fault, so ordinary bugs still surface. Windows needs none of this: an open view stops the file being truncated in the first place.

### Note on open cost

`NewEditorView` rebuilds the line index at construction, and for a mapped file that scan now completes immediately rather than hitting `ErrLoading` on the second chunk — so a mapped file opens with a *complete* index instead of a growing one. On the 200 MB file that is 123 ms and a 168 MB dense index, paid at open rather than in the background. It also means the partial-index bugs (wrong line count after an early edit, a search result resolved against a half-built index) cannot arise for local files. Making that index cheap is a separate change.

### Tests

- `mapped_file_test.go` — the mapping backs the piece table without copying; empty file, absent file and a descriptorless (remote-shaped) backing all decline; truncation under a mapping is survived; the guard re-panics on a non-fault.
- `editor_mmap_test.go` — a search over a mapped editor allocates nothing and scans the mapping itself; the indexer indexes a mapped file with no async buffer; an edit lands in the add buffer, saves correctly, and the editor stays mapped across the save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
