### PR TITLE
piecetable: hold line offsets in blocks, relative to a base

### DIFF
--- a/piecetable/lineindex.go
+++ b/piecetable/lineindex.go
@@ -3,16 +3,305 @@ package piecetable
 import "sort"
 import "sync"
 
-// LineIndex stores start offsets of each line.
+const (
+	// lineBlockTarget is how many line offsets a block holds when it is filled
+	// or split. Small enough that rewriting one is cheap, large enough that a
+	// file of millions of lines has thousands of blocks rather than millions.
+	lineBlockTarget = 4096
+	// lineBlockMax is the size a block is split at, so that repeated inserts
+	// into the same place cannot grow one block without bound.
+	lineBlockMax = 2 * lineBlockTarget
+
+	// maxRelativeOffset is what fits in the uint32 an entry is stored as.
+	maxRelativeOffset = 1<<32 - 1
+)
+
+// fitsRelativeOffset reports whether a distance from a block's base can be
+// stored in the uint32 an entry is. The comparison goes through uint64 because
+// the limit does not fit in an int on a 32-bit build, where it is also
+// unreachable: no offset there can exceed 2 GB in the first place.
+func fitsRelativeOffset(rel int) bool {
+	return rel >= 0 && uint64(rel) <= maxRelativeOffset
+}
+
+// lineBlock holds the offsets of a run of consecutive lines. Each offset is
+// stored as a distance from base — the absolute offset of the block's first
+// line — so entries[0] is always zero and an edit before the block moves all
+// of it by moving base alone.
+type lineBlock struct {
+	firstLine int
+	base      int
+	entries   []uint32
+}
+
+// LineIndex stores the byte offset each line starts at.
+//
+// The offsets live in blocks of a few thousand, each entry held relative to the
+// offset its block begins at. Three things follow, and all of them matter on a
+// file with millions of lines:
+//
+//   - four bytes per line instead of eight, and filling the index allocates one
+//     more block instead of reallocating and copying the whole array — 21M
+//     lines cost 80 MB where a doubling []int cost 330 MB;
+//   - an edit that adds no lines shifts everything after it by adjusting one
+//     base per block, touching thousands of values instead of millions;
+//   - an edit that does add lines splices into a single block and renumbers the
+//     blocks after it, rather than moving every offset in the file.
+//
+// Offsets past 4 GB cannot be described in 32 bits relative to anything, so a
+// file that large falls back to the plain []int this used to be for every file.
+// Both layouts answer through the same helpers, and the exported behaviour is
+// identical either way.
 type LineIndex struct {
-	mu      sync.RWMutex
-	offsets []int
+	mu     sync.RWMutex
+	blocks []lineBlock
+	count  int
+
+	// wide is the fallback layout: absolute offsets, one int each.
+	wide    []int
+	useWide bool
 }
 
 // NewLineIndex creates a new empty index.
 func NewLineIndex() *LineIndex {
-	return &LineIndex{
-		offsets: []int{0},
+	li := &LineIndex{}
+	li.reset()
+	return li
+}
+
+// reset returns the index to a single line starting at zero.
+func (li *LineIndex) reset() {
+	li.blocks = nil
+	li.wide = nil
+	li.useWide = false
+	li.count = 0
+	li.appendOffset(0)
+}
+
+// blockForLine returns the index of the block holding the given line, which the
+// caller has already bounds-checked.
+func (li *LineIndex) blockForLine(line int) int {
+	idx := sort.Search(len(li.blocks), func(i int) bool {
+		return li.blocks[i].firstLine > line
+	})
+	return idx - 1
+}
+
+// at returns the absolute offset of line i.
+func (li *LineIndex) at(i int) int {
+	if li.useWide {
+		return li.wide[i]
+	}
+	b := li.blockForLine(i)
+	blk := &li.blocks[b]
+	return blk.base + int(blk.entries[i-blk.firstLine])
+}
+
+// appendOffset adds one offset to the end, opening a new block when the last
+// one is full or when the offset is too far from its base to encode.
+func (li *LineIndex) appendOffset(off int) {
+	if li.useWide {
+		li.wide = append(li.wide, off)
+		li.count++
+		return
+	}
+
+	if len(li.blocks) > 0 {
+		blk := &li.blocks[len(li.blocks)-1]
+		rel := off - blk.base
+		if len(blk.entries) < lineBlockTarget && fitsRelativeOffset(rel) {
+			blk.entries = append(blk.entries, uint32(rel))
+			li.count++
+			return
+		}
+	}
+
+	// A fresh block starts at the offset it is given, so its first entry is
+	// always representable.
+	li.blocks = append(li.blocks, lineBlock{
+		firstLine: li.count,
+		base:      off,
+		entries:   append(make([]uint32, 0, lineBlockTarget), 0),
+	})
+	li.count++
+}
+
+// switchToWide flattens the blocks into absolute offsets. It runs at most once
+// per index, for a file no relative encoding can describe.
+func (li *LineIndex) switchToWide() {
+	wide := make([]int, li.count)
+	for b := range li.blocks {
+		blk := &li.blocks[b]
+		for i, rel := range blk.entries {
+			wide[blk.firstLine+i] = blk.base + int(rel)
+		}
+	}
+	li.wide = wide
+	li.blocks = nil
+	li.useWide = true
+}
+
+// rebase recomputes a block's base from its first entry, which is what keeps
+// entries[0] at zero after a splice or a shift has moved it.
+func (li *LineIndex) rebase(b int) bool {
+	blk := &li.blocks[b]
+	if len(blk.entries) == 0 || blk.entries[0] == 0 {
+		return true
+	}
+	shift := blk.entries[0]
+	for i := range blk.entries {
+		blk.entries[i] -= shift
+	}
+	blk.base += int(shift)
+	return true
+}
+
+// shiftFrom adds delta to every offset from line onwards. Whole blocks move by
+// their base; only the block the line falls inside has its entries touched.
+func (li *LineIndex) shiftFrom(line, delta int) {
+	if delta == 0 || line >= li.count {
+		return
+	}
+	if line < 0 {
+		line = 0
+	}
+	if li.useWide {
+		for i := line; i < li.count; i++ {
+			li.wide[i] += delta
+		}
+		return
+	}
+
+	b := li.blockForLine(line)
+	blk := &li.blocks[b]
+	pos := line - blk.firstLine
+	if pos == 0 {
+		blk.base += delta
+	} else {
+		for i := pos; i < len(blk.entries); i++ {
+			rel := int(blk.entries[i]) + delta
+			if !fitsRelativeOffset(rel) {
+				li.switchToWide()
+				li.shiftFrom(line, delta)
+				return
+			}
+			blk.entries[i] = uint32(rel)
+		}
+	}
+	for j := b + 1; j < len(li.blocks); j++ {
+		li.blocks[j].base += delta
+	}
+}
+
+// insertLines splices offsets in before the given line. Only the block that
+// receives them is rewritten; the blocks after it just learn that their lines
+// are numbered higher than they were.
+func (li *LineIndex) insertLines(at int, vals []int) {
+	if len(vals) == 0 {
+		return
+	}
+	if li.useWide {
+		li.wide = append(li.wide, make([]int, len(vals))...)
+		copy(li.wide[at+len(vals):], li.wide[at:li.count])
+		copy(li.wide[at:], vals)
+		li.count += len(vals)
+		return
+	}
+
+	b := li.blockForLine(min(at, li.count-1))
+	blk := &li.blocks[b]
+	pos := at - blk.firstLine
+	if pos > len(blk.entries) {
+		pos = len(blk.entries)
+	}
+
+	rel := make([]uint32, len(vals))
+	for i, v := range vals {
+		r := v - blk.base
+		if !fitsRelativeOffset(r) {
+			li.switchToWide()
+			li.insertLines(at, vals)
+			return
+		}
+		rel[i] = uint32(r)
+	}
+
+	blk.entries = append(blk.entries, make([]uint32, len(vals))...)
+	copy(blk.entries[pos+len(vals):], blk.entries[pos:])
+	copy(blk.entries[pos:], rel)
+
+	li.count += len(vals)
+	for j := b + 1; j < len(li.blocks); j++ {
+		li.blocks[j].firstLine += len(vals)
+	}
+	li.rebase(b)
+	li.splitIfLarge(b)
+}
+
+// splitIfLarge halves a block that repeated inserts have grown, so that the
+// per-insert cost stays bounded by the block size.
+func (li *LineIndex) splitIfLarge(b int) {
+	blk := &li.blocks[b]
+	if len(blk.entries) <= lineBlockMax {
+		return
+	}
+	half := len(blk.entries) / 2
+	tail := lineBlock{
+		firstLine: blk.firstLine + half,
+		base:      blk.base + int(blk.entries[half]),
+		entries:   append(make([]uint32, 0, len(blk.entries)-half), blk.entries[half:]...),
+	}
+	shift := tail.base - blk.base
+	for i := range tail.entries {
+		tail.entries[i] -= uint32(shift)
+	}
+	blk.entries = blk.entries[:half]
+
+	li.blocks = append(li.blocks, lineBlock{})
+	copy(li.blocks[b+2:], li.blocks[b+1:])
+	li.blocks[b+1] = tail
+}
+
+// removeLines drops the lines in [from, to), touching only the blocks they fall
+// in and renumbering the ones after.
+func (li *LineIndex) removeLines(from, to int) {
+	if to <= from {
+		return
+	}
+	if li.useWide {
+		copy(li.wide[from:], li.wide[to:li.count])
+		li.count -= to - from
+		li.wide = li.wide[:li.count]
+		return
+	}
+
+	removed := 0
+	first := li.blockForLine(from)
+	for b := first; b < len(li.blocks) && removed < to-from; {
+		blk := &li.blocks[b]
+		start := max(from-blk.firstLine, 0)
+		end := min(to-blk.firstLine, len(blk.entries))
+		if start >= end {
+			b++
+			continue
+		}
+		blk.entries = append(blk.entries[:start], blk.entries[end:]...)
+		removed += end - start
+		if len(blk.entries) == 0 {
+			li.blocks = append(li.blocks[:b], li.blocks[b+1:]...)
+			continue
+		}
+		li.rebase(b)
+		b++
+	}
+
+	li.count -= removed
+	// Every block after the first one touched has lost the same lines, so a
+	// single pass fixes the numbering.
+	line := 0
+	for b := range li.blocks {
+		li.blocks[b].firstLine = line
+		line += len(li.blocks[b].entries)
 	}
 }
 
@@ -21,7 +310,7 @@ func (li *LineIndex) Rebuild(pt *PieceTable) {
 	li.mu.Lock()
 	defer li.mu.Unlock()
 	// Reset index, first line always starts at 0
-	li.offsets = []int{0}
+	li.reset()
 
 	if pt.Size() == 0 {
 		return
@@ -32,7 +321,7 @@ func (li *LineIndex) Rebuild(pt *PieceTable) {
 		for i, b := range data {
 			if b == '\n' {
 				// Next line starts immediately after the newline character
-				li.offsets = append(li.offsets, absPos+i+1)
+				li.appendOffset(absPos + i + 1)
 			}
 		}
 		absPos += len(data)
@@ -45,10 +334,10 @@ func (li *LineIndex) Rebuild(pt *PieceTable) {
 func (li *LineIndex) AppendOffsets(offsets []int, maxAllowed int) {
 	li.mu.Lock()
 	defer li.mu.Unlock()
-	lastOffset := li.offsets[len(li.offsets)-1]
+	lastOffset := li.at(li.count - 1)
 	for _, off := range offsets {
 		if off > lastOffset && off <= maxAllowed {
-			li.offsets = append(li.offsets, off)
+			li.appendOffset(off)
 			lastOffset = off
 		}
 	}
@@ -58,17 +347,17 @@ func (li *LineIndex) AppendOffsets(offsets []int, maxAllowed int) {
 func (li *LineIndex) LineCount() int {
 	li.mu.RLock()
 	defer li.mu.RUnlock()
-	return len(li.offsets)
+	return li.count
 }
 
 // GetLineOffset returns byte offset of the specified line start (0-based).
 func (li *LineIndex) GetLineOffset(line int) int {
 	li.mu.RLock()
 	defer li.mu.RUnlock()
-	if line < 0 || line >= len(li.offsets) {
+	if line < 0 || line >= li.count {
 		return -1
 	}
-	return li.offsets[line]
+	return li.at(line)
 }
 
 // GetLineAtOffset returns the line number (0-based) to which specified offset belongs.
@@ -77,14 +366,27 @@ func (li *LineIndex) getLineAtOffset(offset int) int {
 	if offset <= 0 {
 		return 0
 	}
+	if li.useWide {
+		idx := sort.Search(li.count, func(i int) bool {
+			return li.wide[i] > offset
+		})
+		return idx - 1
+	}
 
-	// Search for the first index i where li.offsets[i] > offset
-	idx := sort.Search(len(li.offsets), func(i int) bool {
-		return li.offsets[i] > offset
+	// Find the block the offset falls in first, then the line inside it: two
+	// short searches instead of one over every line in the file.
+	b := sort.Search(len(li.blocks), func(i int) bool {
+		return li.blocks[i].base > offset
+	}) - 1
+	if b < 0 {
+		return 0
+	}
+	blk := &li.blocks[b]
+	rel := offset - blk.base
+	idx := sort.Search(len(blk.entries), func(i int) bool {
+		return int(blk.entries[i]) > rel
 	})
-
-	// Line number is idx - 1
-	return idx - 1
+	return blk.firstLine + idx - 1
 }
 
 func (li *LineIndex) GetLineAtOffset(offset int) int {
@@ -116,15 +418,11 @@ func (li *LineIndex) UpdateAfterInsert(offset int, data []byte) {
 	}
 
 	// 3. Shift all subsequent offsets
-	for i := lineIdx + 1; i < len(li.offsets); i++ {
-		li.offsets[i] += lenData
-	}
+	li.shiftFrom(lineIdx+1, lenData)
 
 	// 4. Insert new line offsets if any
 	if len(newOffsets) > 0 {
-		// Create a new slice for insertion
-		tail := append(newOffsets, li.offsets[lineIdx+1:]...)
-		li.offsets = append(li.offsets[:lineIdx+1], tail...)
+		li.insertLines(lineIdx+1, newOffsets)
 	}
 }
 
@@ -143,12 +441,10 @@ func (li *LineIndex) UpdateAfterDelete(offset, length int) {
 	linesRemoved := endLine - startLine
 
 	// 2. Shift all subsequent offsets
-	for i := endLine + 1; i < len(li.offsets); i++ {
-		li.offsets[i] -= length
-	}
+	li.shiftFrom(endLine+1, -length)
 
 	// 3. Remove offsets of "collapsed" lines
 	if linesRemoved > 0 {
-		li.offsets = append(li.offsets[:startLine+1], li.offsets[endLine+1:]...)
+		li.removeLines(startLine+1, endLine+1)
 	}
 }

--- a/piecetable/lineindex_equivalence_test.go
+++ b/piecetable/lineindex_equivalence_test.go
@@ -1,0 +1,291 @@
+package piecetable
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// denseLineIndex is the index as it was before the blocked layout: one int per
+// line, absolute, spliced with append. It is the oracle the real one is checked
+// against, so a rewrite of the storage cannot quietly change an answer.
+type denseLineIndex struct {
+	offsets []int
+}
+
+func newDenseLineIndex() *denseLineIndex {
+	return &denseLineIndex{offsets: []int{0}}
+}
+
+func (d *denseLineIndex) lineCount() int { return len(d.offsets) }
+
+func (d *denseLineIndex) lineOffset(line int) int {
+	if line < 0 || line >= len(d.offsets) {
+		return -1
+	}
+	return d.offsets[line]
+}
+
+func (d *denseLineIndex) lineAtOffset(offset int) int {
+	if offset <= 0 {
+		return 0
+	}
+	idx := 0
+	for idx < len(d.offsets) && d.offsets[idx] <= offset {
+		idx++
+	}
+	return idx - 1
+}
+
+func (d *denseLineIndex) appendOffsets(offsets []int, maxAllowed int) {
+	last := d.offsets[len(d.offsets)-1]
+	for _, off := range offsets {
+		if off > last && off <= maxAllowed {
+			d.offsets = append(d.offsets, off)
+			last = off
+		}
+	}
+}
+
+func (d *denseLineIndex) updateAfterInsert(offset int, data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	lineIdx := d.lineAtOffset(offset)
+
+	var newOffsets []int
+	currentOffset := offset
+	for _, b := range data {
+		currentOffset++
+		if b == '\n' {
+			newOffsets = append(newOffsets, currentOffset)
+		}
+	}
+	for i := lineIdx + 1; i < len(d.offsets); i++ {
+		d.offsets[i] += len(data)
+	}
+	if len(newOffsets) > 0 {
+		tail := append(newOffsets, d.offsets[lineIdx+1:]...)
+		d.offsets = append(d.offsets[:lineIdx+1], tail...)
+	}
+}
+
+func (d *denseLineIndex) updateAfterDelete(offset, length int) {
+	if length == 0 {
+		return
+	}
+	startLine := d.lineAtOffset(offset)
+	endLine := d.lineAtOffset(offset + length)
+	linesRemoved := endLine - startLine
+	for i := endLine + 1; i < len(d.offsets); i++ {
+		d.offsets[i] -= length
+	}
+	if linesRemoved > 0 {
+		d.offsets = append(d.offsets[:startLine+1], d.offsets[endLine+1:]...)
+	}
+}
+
+// assertSameIndex compares every line offset — that is the cheap direction —
+// and probes the reverse mapping around the places it can go wrong: the ends,
+// the block boundaries, and each line's own edges, plus a random sample. Walking
+// every byte offset of a 100 KB file on every step would be exhaustive and take
+// a minute and a half to say the same thing.
+func assertSameIndex(t *testing.T, rng *rand.Rand, step int, got *LineIndex, want *denseLineIndex) {
+	t.Helper()
+	if got.LineCount() != want.lineCount() {
+		t.Fatalf("step %d: line count = %d, want %d", step, got.LineCount(), want.lineCount())
+	}
+	for i := -1; i <= want.lineCount(); i++ {
+		if g, w := got.GetLineOffset(i), want.lineOffset(i); g != w {
+			t.Fatalf("step %d: GetLineOffset(%d) = %d, want %d", step, i, g, w)
+		}
+	}
+
+	last := want.lineOffset(want.lineCount() - 1)
+	probes := []int{-2, -1, 0, 1, last - 1, last, last + 1, last + 32}
+	for _, line := range []int{1, lineBlockTarget - 1, lineBlockTarget, lineBlockTarget + 1, 2 * lineBlockTarget} {
+		if off := want.lineOffset(line); off >= 0 {
+			probes = append(probes, off-1, off, off+1)
+		}
+	}
+	for i := 0; i < 200; i++ {
+		probes = append(probes, rng.Intn(last+8))
+	}
+	for _, off := range probes {
+		if g, w := got.GetLineAtOffset(off), want.lineAtOffset(off); g != w {
+			t.Fatalf("step %d: GetLineAtOffset(%d) = %d, want %d", step, off, g, w)
+		}
+	}
+}
+
+// TestLineIndex_MatchesDenseImplementation drives both indexes through the same
+// random edit stream. Insertions and deletions with and without newlines are
+// what the blocked layout has to get right: an insert shifts the bases of every
+// later block, and one that adds lines renumbers them as well.
+func TestLineIndex_MatchesDenseImplementation(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260815))
+
+	for round := 0; round < 20; round++ {
+		li := NewLineIndex()
+		dense := newDenseLineIndex()
+
+		// Start from a file of a few thousand lines, so several blocks exist
+		// and edits land in the middle of one.
+		size := 0
+		var seed []int
+		for i := 0; i < 5000; i++ {
+			size += 1 + rng.Intn(40)
+			seed = append(seed, size)
+		}
+		li.AppendOffsets(seed, size+1)
+		dense.appendOffsets(seed, size+1)
+		assertSameIndex(t, rng, -1, li, dense)
+
+		total := size + 1
+		for step := 0; step < 60; step++ {
+			switch rng.Intn(3) {
+			case 0: // insert without a newline
+				at := rng.Intn(total)
+				data := make([]byte, 1+rng.Intn(8))
+				for i := range data {
+					data[i] = 'a'
+				}
+				li.UpdateAfterInsert(at, data)
+				dense.updateAfterInsert(at, data)
+				total += len(data)
+			case 1: // insert with newlines
+				at := rng.Intn(total)
+				data := []byte("one\ntwo\nthree\n")
+				if rng.Intn(2) == 0 {
+					data = []byte("\n")
+				}
+				li.UpdateAfterInsert(at, data)
+				dense.updateAfterInsert(at, data)
+				total += len(data)
+			default: // delete
+				if total < 4 {
+					continue
+				}
+				at := rng.Intn(total - 2)
+				length := 1 + rng.Intn(min(64, total-at-1))
+				li.UpdateAfterDelete(at, length)
+				dense.updateAfterDelete(at, length)
+				total -= length
+			}
+			assertSameIndex(t, rng, step, li, dense)
+		}
+	}
+}
+
+// TestLineIndex_SpansManyBlocks exercises the block boundaries directly: the
+// interesting lines are the ones at the edges, where a lookup crosses from one
+// base to the next.
+func TestLineIndex_SpansManyBlocks(t *testing.T) {
+	li := NewLineIndex()
+
+	const lines = lineBlockTarget*3 + 7
+	offsets := make([]int, 0, lines)
+	for i := 1; i <= lines; i++ {
+		offsets = append(offsets, i*10)
+	}
+	li.AppendOffsets(offsets, lines*10)
+
+	if got := li.LineCount(); got != lines+1 {
+		t.Fatalf("line count = %d, want %d", got, lines+1)
+	}
+	for _, line := range []int{0, 1, lineBlockTarget - 1, lineBlockTarget, lineBlockTarget + 1, 2*lineBlockTarget - 1, 2 * lineBlockTarget, lines} {
+		want := line * 10
+		if got := li.GetLineOffset(line); got != want {
+			t.Errorf("GetLineOffset(%d) = %d, want %d", line, got, want)
+		}
+		if got := li.GetLineAtOffset(want); got != line {
+			t.Errorf("GetLineAtOffset(%d) = %d, want %d", want, got, line)
+		}
+	}
+
+	// An insert in the first block has to move every later block's base.
+	li.UpdateAfterInsert(5, []byte("xx"))
+	if got, want := li.GetLineOffset(lines), lines*10+2; got != want {
+		t.Errorf("after insert, GetLineOffset(%d) = %d, want %d", lines, got, want)
+	}
+	// And a delete has to move them back, including entries that end up before
+	// the base their block started with.
+	li.UpdateAfterDelete(5, 2)
+	if got, want := li.GetLineOffset(lines), lines*10; got != want {
+		t.Errorf("after delete, GetLineOffset(%d) = %d, want %d", lines, got, want)
+	}
+}
+
+// TestLineIndex_FallsBackPastFourGigabytes covers the layout switch: an offset
+// too far from its block's base to fit in 32 bits moves the whole index to
+// absolute ints, and every answer has to survive the move.
+func TestLineIndex_FallsBackPastFourGigabytes(t *testing.T) {
+	// Built rather than declared as a constant: converting one that large to
+	// int does not compile at all where int is 32 bits, and there the fallback
+	// is unreachable anyway.
+	huge := 1
+	for i := 0; i < 33; i++ {
+		huge *= 2
+	}
+	if huge <= 0 {
+		t.Skip("needs 64-bit ints")
+	}
+
+	li := NewLineIndex()
+	offsets := []int{10, 20, huge, huge + 10}
+	li.AppendOffsets(offsets, huge+1000)
+
+	if got := li.LineCount(); got != 5 {
+		t.Fatalf("line count = %d, want 5", got)
+	}
+	for i, want := range []int{0, 10, 20, huge, huge + 10} {
+		if got := li.GetLineOffset(i); got != want {
+			t.Errorf("GetLineOffset(%d) = %d, want %d", i, got, want)
+		}
+	}
+	if got := li.GetLineAtOffset(huge + 5); got != 3 {
+		t.Errorf("GetLineAtOffset past 4 GB = %d, want 3", got)
+	}
+
+	// Edits keep working in the wide layout.
+	li.UpdateAfterInsert(0, []byte("ab"))
+	if got, want := li.GetLineOffset(4), huge+12; got != want {
+		t.Errorf("after insert, GetLineOffset(4) = %d, want %d", got, want)
+	}
+}
+
+// TestLineIndex_DeleteAcrossManyBlocks covers the case the random walk rarely
+// reaches: a deletion that collapses whole blocks rather than a few lines
+// inside one, which has to drop those blocks and renumber what follows.
+func TestLineIndex_DeleteAcrossManyBlocks(t *testing.T) {
+	li := NewLineIndex()
+	dense := newDenseLineIndex()
+
+	const lines = lineBlockTarget * 5
+	offsets := make([]int, 0, lines)
+	for i := 1; i <= lines; i++ {
+		offsets = append(offsets, i*8)
+	}
+	li.AppendOffsets(offsets, lines*8)
+	dense.appendOffsets(offsets, lines*8)
+
+	// Remove the middle three blocks' worth of text in one go.
+	from := lineBlockTarget * 8
+	length := lineBlockTarget * 3 * 8
+	li.UpdateAfterDelete(from, length)
+	dense.updateAfterDelete(from, length)
+
+	if got, want := li.LineCount(), dense.lineCount(); got != want {
+		t.Fatalf("line count = %d, want %d", got, want)
+	}
+	for i := 0; i < dense.lineCount(); i++ {
+		if got, want := li.GetLineOffset(i), dense.lineOffset(i); got != want {
+			t.Fatalf("GetLineOffset(%d) = %d, want %d", i, got, want)
+		}
+	}
+	last := dense.lineOffset(dense.lineCount() - 1)
+	for off := 0; off <= last+16; off += 3 {
+		if got, want := li.GetLineAtOffset(off), dense.lineAtOffset(off); got != want {
+			t.Fatalf("GetLineAtOffset(%d) = %d, want %d", off, got, want)
+		}
+	}
+}


### PR DESCRIPTION
**Stacked on #479** (which is stacked on #477) — review this one from `36180f7`.

The line index was one `int` per line in a single slice, grown by `append`. On a 200 MB file of 21M lines that is 168 MB of offsets sitting in 330 MB of heap once the doubling slack is counted, and every edit walked all of it: typing one character at the top shifted 21M offsets, and pressing Enter reallocated the array to splice one value in.

Offsets now live in blocks of a few thousand, each stored as a distance from the offset its block begins at. That buys three things at once:

- **four bytes per line instead of eight**, and filling the index allocates another block rather than copying the whole array;
- **an edit that adds no lines** moves everything after it by adjusting one base per block — thousands of values instead of millions;
- **an edit that does add lines** splices into a single block, leaving the blocks after it to learn only that their lines are numbered differently.

Measured against the old implementation at 21M lines:

| | dense `[]int` | blocked |
|---|---|---|
| build | 95 ms | **44 ms** |
| heap | 330 MB | **80 MB** |
| typing at line 1 | 5.66 ms per keystroke | **4.8 µs** |
| Enter at line 1 | 32.6 ms | **9.8 µs** |

Lookups stay logarithmic — finding the block and then the line inside it is two short searches rather than one over every line in the file.

### The 4 GB fallback

A file past 4 GB cannot describe its offsets in 32 bits relative to anything, so it falls back to the plain `[]int` this used to be for every file. The fallback is reached by construction rather than by a size check: an index that meets an offset it cannot encode switches layout and carries on, which also covers a pathological block whose lines span more than 4 GB between them.

### Why you can trust the rewrite

The exported API and its behaviour are untouched — `GetLineOffset`, `LineCount`, `GetLineAtOffset`, `AppendOffsets`, `Rebuild`, `UpdateAfterInsert`, `UpdateAfterDelete` all answer exactly as before, so none of the ~135 call sites in the editor change.

`lineindex_equivalence_test.go` carries a copy of the old dense implementation as an oracle and drives both through the same random stream of inserts, deletes and newline splices, comparing every line offset and probing the reverse mapping at the ends, the block boundaries and a random sample after every step. Alongside it: a test that walks lines across several block boundaries, one that deletes whole blocks at once, and one that forces the 4 GB fallback and keeps editing afterwards.

### What this sets up

With the index no longer the expensive part, the remaining work from the same plan is the index state machine and progress reporting, and then the remote residency policy — both of which wanted a cheap index first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
