### PR TITLE
macos: stamp the icon onto the binary instead of setting it at runtime

### DIFF
--- a/window_icon_darwin.go
+++ b/window_icon_darwin.go
@@ -4,23 +4,41 @@ package main
 
 import (
 	_ "embed"
+	"os"
+	"path/filepath"
+	"strings"
 	"unsafe"
 
 	"github.com/ebitengine/purego"
 	"github.com/ebitengine/purego/objc"
 	"github.com/unxed/vtui"
+	"golang.org/x/sys/unix"
 )
 
-//go:embed assets/icon/generated/f4-512.png
-var darwinDockIconPNG []byte
+//go:embed assets/icon/generated/f4.icns
+var darwinIconICNS []byte
 
-// applyDarwinDockIcon gives the Dock tile an image. gogpu switches the
-// process to NSApplicationActivationPolicyRegular, which is what makes the
-// tile appear at all, but the tile's image comes from the app bundle's
-// Info.plist — and a bare binary launched from a terminal has no bundle, so
-// the Dock shows the generic executable icon. [NSApp setApplicationIconImage:]
-// is the runtime override for exactly that case; when running from F4.app it
-// simply matches the bundled icns.
+// applyDarwinDockIcon gives a bare-binary launch a real icon instead of the
+// generic green "exec" tile.
+//
+// gogpu switches the process to NSApplicationActivationPolicyRegular, which is
+// what makes the Dock tile appear at all, but the tile's image comes from the
+// app bundle — and a binary launched from a terminal has no bundle. The
+// documented runtime override for that case is
+// [NSApp setApplicationIconImage:], but on macOS 26 it has no effect for a
+// bundle-less process: the Dock and NSRunningApplication.icon both keep
+// returning the generic executable icon, whether it is called before or after
+// finishLaunching, and whether or not a bundle is present.
+//
+// What does work is stamping a custom icon onto the executable file itself via
+// [NSWorkspace setIcon:forFile:options:]. Launch Services picks that up
+// immediately — the running process's Dock tile updates in place — and Finder
+// shows the same icon for the binary from then on. The stamp lives in the
+// file's com.apple.FinderInfo/com.apple.ResourceFork extended attributes; it
+// does not touch the executable's contents or its code signature.
+//
+// Running from F4.app needs none of this: the bundle's CFBundleIconFile
+// already supplies the icon, so the stamp is skipped there.
 //
 // AppKit calls must happen on the main OS thread: the main goroutine is
 // pinned to it by gogpu's darwin platform package init, and RunGui runs on
@@ -30,9 +48,27 @@ func applyDarwinDockIcon(backend string) {
 		// x11/wayland windows (XQuartz) are not Cocoa apps; leave AppKit alone.
 		return
 	}
-	if len(darwinDockIconPNG) == 0 {
+	if len(darwinIconICNS) == 0 {
 		return
 	}
+	exe, err := os.Executable()
+	if err != nil {
+		vtui.DebugLog("DOCK_ICON: os.Executable failed: %v", err)
+		return
+	}
+	if resolved, err := filepath.EvalSymlinks(exe); err == nil {
+		exe = resolved
+	}
+	if strings.Contains(exe, ".app/Contents/MacOS/") {
+		// Bundled: Info.plist's CFBundleIconFile already covers Dock and Finder.
+		return
+	}
+	if hasCustomIconFlag(exe) {
+		// Already stamped by an earlier run; rewriting the resource fork on
+		// every start would be pure disk churn.
+		return
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			vtui.DebugLog("DOCK_ICON: skipped after panic: %v", r)
@@ -46,23 +82,39 @@ func applyDarwinDockIcon(backend string) {
 		return
 	}
 
-	nsApp := objc.ID(objc.GetClass("NSApplication")).Send(objc.RegisterName("sharedApplication"))
-	if nsApp == 0 {
-		return
-	}
 	// alloc/init rather than the autoreleasing dataWithBytes:length: — this
 	// runs before gogpu sets up an NSAutoreleasePool, so an autoreleased
 	// object would never be drained.
 	data := objc.ID(objc.GetClass("NSData")).Send(objc.RegisterName("alloc")).Send(objc.RegisterName("initWithBytes:length:"),
-		unsafe.Pointer(&darwinDockIconPNG[0]), len(darwinDockIconPNG))
+		unsafe.Pointer(&darwinIconICNS[0]), len(darwinIconICNS))
 	if data == 0 {
 		return
 	}
 	img := objc.ID(objc.GetClass("NSImage")).Send(objc.RegisterName("alloc")).Send(objc.RegisterName("initWithData:"), data)
 	data.Send(objc.RegisterName("release"))
 	if img == 0 {
+		vtui.DebugLog("DOCK_ICON: icns decode failed")
 		return
 	}
-	nsApp.Send(objc.RegisterName("setApplicationIconImage:"), img)
-	img.Send(objc.RegisterName("release"))
+	defer img.Send(objc.RegisterName("release"))
+
+	path := objc.ID(objc.GetClass("NSString")).Send(objc.RegisterName("stringWithUTF8String:"), append([]byte(exe), 0))
+	ws := objc.ID(objc.GetClass("NSWorkspace")).Send(objc.RegisterName("sharedWorkspace"))
+	if ws.Send(objc.RegisterName("setIcon:forFile:options:"), img, path, 0) == 0 {
+		// Read-only location (/usr/local/bin without write access, a signed
+		// and sealed volume, ...). Nothing else to try; the tile stays generic.
+		vtui.DebugLog("DOCK_ICON: setIcon:forFile: rejected %s", exe)
+	}
+}
+
+// hasCustomIconFlag reports whether the file already carries a custom icon.
+// Finder stores its flags in bytes 8..9 of com.apple.FinderInfo, big-endian;
+// bit 10 (0x0400) is kHasCustomIcon.
+func hasCustomIconFlag(path string) bool {
+	var info [32]byte
+	n, err := unix.Getxattr(path, "com.apple.FinderInfo", info[:])
+	if err != nil || n < 10 {
+		return false
+	}
+	return info[8]&0x04 != 0
 }


### PR DESCRIPTION
#456 set the Dock tile with `[NSApp setApplicationIconImage:]`, the documented runtime override for a process that has no app bundle. On macOS 26 it turns out to do nothing for exactly that case: the Dock tile and `NSRunningApplication.icon` keep returning the generic green executable icon, whether the call happens before or after `finishLaunching`, and whether or not a bundle is present.

`[NSWorkspace setIcon:forFile:options:]` does work. Stamping the icon onto the executable file makes Launch Services pick it up immediately — the running process's tile updates in place — and Finder shows the same icon for the binary from then on. The stamp lives in the file's `com.apple.FinderInfo` / `com.apple.ResourceFork` extended attributes; it does not touch the executable's contents, so the code signature stays valid.

### When it does nothing

- **Running from F4.app** — the bundle's `CFBundleIconFile` already covers Dock and Finder, so the path returns early after resolving symlinks and matching `.app/Contents/MacOS/`.
- **Already stamped** — `com.apple.FinderInfo` bit `kHasCustomIcon` is checked first, so only the very first bare-binary launch writes anything. Rewriting a resource fork on every start would be pure disk churn.
- **Read-only location** — `/usr/local/bin` without write access, a sealed volume, and so on. `setIcon:forFile:` returns NO, that goes to the debug log, and the tile stays generic. Nothing fails.
- **X11/Wayland backends** (XQuartz) — unchanged, AppKit is left alone.

The embedded asset moves from `f4-512.png` to the already-present `f4.icns`, so every size the Dock and Finder ask for comes out of one stamp instead of being downsampled from a single 512px bitmap. `NSImage` still owns the decode; the `alloc`/`init` pairing (rather than the autoreleasing convenience constructors) is kept, since this still runs before gogpu sets up an autorelease pool.

Tested on macOS 26 with a bare `go build` binary launched from a terminal: first run stamps and the Dock tile turns into the F4 icon while the process is running; subsequent runs skip the write; running the same build from `F4.app` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
