### PR TITLE
editor: let a file system search its own copy

### DIFF
--- a/editor_index_status.go
+++ b/editor_index_status.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"time"
+
+	"github.com/unxed/vtui"
+)
+
+// IndexPhase is where the line index stands. The editor can work with an index
+// that is still filling — it just cannot answer questions about lines it has
+// not reached yet — so the phase is what tells the difference between "there is
+// no more to find" and "there is more, we are looking".
+type IndexPhase int
+
+const (
+	// IndexIdle: nothing has been scanned and nothing is scanning.
+	IndexIdle IndexPhase = iota
+	// IndexScanning: a scan is running and the index is still growing.
+	IndexScanning
+	// IndexComplete: the index describes every line of the buffer.
+	IndexComplete
+	// IndexFailed: the scan stopped on an error and the index is short.
+	IndexFailed
+)
+
+func (p IndexPhase) String() string {
+	switch p {
+	case IndexScanning:
+		return "scanning"
+	case IndexComplete:
+		return "complete"
+	case IndexFailed:
+		return "failed"
+	default:
+		return "idle"
+	}
+}
+
+// IndexStatus is what the editor knows about its line index right now. Lines is
+// how many are indexed, which equals the file's line count only once the phase
+// is IndexComplete — anything reporting a total before then is guessing.
+type IndexStatus struct {
+	Phase   IndexPhase
+	Scanned int64
+	Total   int64
+	Lines   int
+	Err     error
+}
+
+// Percent is how far the scan has read, for anything that wants to show it.
+func (s IndexStatus) Percent() int {
+	if s.Total <= 0 {
+		return 100
+	}
+	if s.Scanned >= s.Total {
+		return 100
+	}
+	return int(s.Scanned * 100 / s.Total)
+}
+
+// indexNotifyInterval throttles progress updates. A scan reports every batch it
+// applies, which on a fast local file is hundreds a second; subscribers exist
+// to draw a percentage, and a percentage does not need drawing that often.
+const indexNotifyInterval = 100 * time.Millisecond
+
+// IndexState returns the current status. It reads UI-thread state and is meant
+// for the paint path, which is where a status line asks.
+func (ev *EditorView) IndexState() IndexStatus {
+	return ev.indexStatus
+}
+
+// SubscribeIndex registers a callback for index progress. It fires on the UI
+// thread, throttled while scanning but never for a phase change, so a listener
+// waiting for completion hears about it immediately. The returned function
+// unsubscribes.
+func (ev *EditorView) SubscribeIndex(fn func(IndexStatus)) func() {
+	if fn == nil {
+		return func() {}
+	}
+	ev.indexSubID++
+	id := ev.indexSubID
+	if ev.indexSubs == nil {
+		ev.indexSubs = make(map[int]func(IndexStatus))
+	}
+	ev.indexSubs[id] = fn
+	return func() { delete(ev.indexSubs, id) }
+}
+
+// setIndexStatus records a new status and tells the subscribers, on the UI
+// thread. Progress within a phase is throttled; a change of phase is not.
+func (ev *EditorView) setIndexStatus(s IndexStatus) {
+	phaseChanged := s.Phase != ev.indexStatus.Phase
+	ev.indexStatus = s
+
+	if !phaseChanged && time.Since(ev.indexNotifiedAt) < indexNotifyInterval {
+		return
+	}
+	ev.indexNotifiedAt = time.Now()
+	for _, fn := range ev.indexSubs {
+		fn(s)
+	}
+	if phaseChanged {
+		vtui.FrameManager.Redraw()
+	}
+}
+
+// noteIndexProgress is what the scan reports through: how far it has read and
+// how many lines that came to. It keeps the phase as it is.
+func (ev *EditorView) noteIndexProgress(scanned int64, lines int) {
+	s := ev.indexStatus
+	s.Scanned = scanned
+	s.Lines = lines
+	ev.setIndexStatus(s)
+}
+
+// indexIsComplete reports whether the index describes the whole buffer, which
+// is the question every caller that needs a line number for a far-away offset
+// actually wants answered.
+func (ev *EditorView) indexIsComplete() bool {
+	return ev.indexStatus.Phase == IndexComplete
+}

--- a/editor_index_status_test.go
+++ b/editor_index_status_test.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/vtui"
+)
+
+// pumpUntil drains UI tasks until cond holds, which is how these tests wait for
+// work the indexer posts back to the UI thread.
+func pumpUntil(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for !cond() {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-deadline.C:
+			t.Fatalf("timeout waiting for %s", what)
+		case <-time.After(2 * time.Millisecond):
+		}
+	}
+}
+
+// TestIndexStatus_ReachesCompleteAndNotifies covers the state machine end to
+// end: a scan announces itself, reports progress, and settles on complete,
+// telling subscribers about every phase it passes through.
+func TestIndexStatus_ReachesCompleteAndNotifies(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	content, _, _ := bigSearchCorpus()
+	pt, buf := lazyEditorBuffer(t, content)
+	ev := newEditorView(pt, nil, "", false)
+	ev.asyncBuf = buf
+
+	var phases []IndexPhase
+	unsubscribe := ev.SubscribeIndex(func(s IndexStatus) {
+		if len(phases) == 0 || phases[len(phases)-1] != s.Phase {
+			phases = append(phases, s.Phase)
+		}
+	})
+	defer unsubscribe()
+
+	if got := ev.IndexState().Phase; got != IndexIdle {
+		t.Fatalf("phase before indexing = %v, want idle", got)
+	}
+
+	ev.StartIndexing()
+	if got := ev.IndexState().Phase; got != IndexScanning {
+		t.Fatalf("phase after StartIndexing = %v, want scanning", got)
+	}
+
+	pumpUntil(t, "the index to complete", func() bool { return ev.indexIsComplete() })
+
+	st := ev.IndexState()
+	if st.Lines != strings.Count(content, "\n")+1 {
+		t.Errorf("indexed %d lines, want %d", st.Lines, strings.Count(content, "\n")+1)
+	}
+	if st.Percent() != 100 {
+		t.Errorf("percent = %d at completion, want 100", st.Percent())
+	}
+	if len(phases) < 2 || phases[0] != IndexScanning || phases[len(phases)-1] != IndexComplete {
+		t.Errorf("phases seen = %v, want scanning through to complete", phases)
+	}
+}
+
+// TestIndexStatus_ResumesAfterAnEdit is the behaviour that replaced cancelling
+// the scan for good: an edit stops the run, and the index picks up from the
+// line it had reached rather than staying short for the rest of the session.
+func TestIndexStatus_ResumesAfterAnEdit(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	content, _, _ := bigSearchCorpus()
+	pt, buf := lazyEditorBuffer(t, content)
+	ev := newEditorView(pt, nil, "", false)
+	ev.asyncBuf = buf
+
+	ev.StartIndexing()
+	pumpUntil(t, "the index to complete", func() bool { return ev.indexIsComplete() })
+	before := ev.li.LineCount()
+
+	// Interrupt it the way a keystroke does, then let the debounce fire.
+	ev.noteBufferEdit()
+	ev.pt.Insert(0, []byte("typed\n"))
+	ev.li.UpdateAfterInsert(0, []byte("typed\n"))
+	ev.setIndexStatus(IndexStatus{Phase: IndexIdle, Total: int64(ev.pt.Size())})
+
+	pumpUntil(t, "the scan to resume and finish", func() bool { return ev.indexIsComplete() })
+
+	if got, want := ev.li.LineCount(), before+1; got != want {
+		t.Errorf("line count after the edit = %d, want %d", got, want)
+	}
+	if got := ev.IndexState().Lines; got != ev.li.LineCount() {
+		t.Errorf("status reports %d lines, index holds %d", got, ev.li.LineCount())
+	}
+}
+
+// TestEnsureIndexedTo_ResolvesAMatchPastTheScan covers the wrong-cursor bug: a
+// search reads the whole buffer and can land on text the index has not reached,
+// where asking for its line used to answer with the last line it knew and a
+// column counted from there.
+func TestEnsureIndexedTo_ResolvesAMatchPastTheScan(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	const lines = 4000
+	var sb strings.Builder
+	for i := 0; i < lines; i++ {
+		sb.WriteString("a line of text\n")
+	}
+	content := sb.String()
+	needleOff := len(content)
+	content += "NEEDLE here\n"
+
+	ev := newEditorView(piecetable.New([]byte(content)), nil, "", false)
+	// An index that stopped early, which is what a scan in progress looks like.
+	ev.li.Rebuild(piecetable.New([]byte(content[:1000])))
+	ev.setIndexStatus(IndexStatus{Phase: IndexScanning, Total: int64(len(content))})
+
+	shortLines := ev.li.LineCount()
+	if shortLines >= lines {
+		t.Fatalf("precondition: index should be short, holds %d lines", shortLines)
+	}
+
+	ev.selectFoundPattern(needleOff, len("NEEDLE"))
+
+	if got, want := ev.CursorLine, lines; got != want {
+		t.Errorf("cursor line = %d, want %d", got, want)
+	}
+	if got, want := ev.CursorPos, len("NEEDLE"); got != want {
+		t.Errorf("cursor column = %d, want %d", got, want)
+	}
+	if ev.li.LineCount() <= shortLines {
+		t.Error("the index was not extended to cover the match")
+	}
+}

--- a/editor_search_remote.go
+++ b/editor_search_remote.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/charlievieth/strcase"
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// searchDelegate is what the editor needs to ask a file system to do its own
+// searching, captured on the UI thread so the background scan touches none of
+// the editor's fields.
+type searchDelegate struct {
+	fs   vfs.VFS
+	path string
+}
+
+// searchDelegation decides whether this search can be handed to the file
+// system, and returns what the worker needs if it can.
+//
+// Reading a remote file to search it means downloading it. A host that can grep
+// its own copy answers in one round trip whatever the size, which is the whole
+// reason vfs.Search exists — the viewer has used it for a while, the editor
+// never has.
+//
+// Four things have to hold. The file system must offer the capability. The
+// buffer must still be the file: the offsets come back as positions in what is
+// on disk, and an edit moves the text away from that. The content must be raw
+// UTF-8, since a decoded buffer's offsets are not the file's either. And the
+// pattern must be one a fixed-string grep can express, which rules out regular
+// expressions and whole-word matching.
+//
+// Call it on the UI thread.
+func (ev *EditorView) searchDelegation(useRegex, wholeWord bool) (searchDelegate, bool) {
+	if ev.vfs == nil || ev.filePath == "" || useRegex || wholeWord {
+		return searchDelegate{}, false
+	}
+	if ev.Codepage != 65001 {
+		return searchDelegate{}, false
+	}
+	if !ev.vfs.GetCapabilities().HasSearch {
+		return searchDelegate{}, false
+	}
+	// GetState against the state the file was last read or written at is the
+	// exact question "is this buffer still the file on disk".
+	if !ev.pt.GetState().Equals(ev.cleanState) {
+		return searchDelegate{}, false
+	}
+	return searchDelegate{fs: ev.vfs, path: ev.filePath}, true
+}
+
+// searchViaFileSystem asks the file system for the occurrences and returns the
+// one this search wants. handled is false whenever the caller should scan the
+// buffer itself, which covers every uncertainty: no answer, an error, or a list
+// that contains nothing usable.
+//
+// That last case matters more than it looks. A host-side search caps how many
+// matches it reports — FISH+ stops at ten thousand — so a list can be short of
+// the truth. Coming up empty therefore cannot mean "not in the file"; it means
+// "ask the buffer", which is slower and certain.
+func (ev *EditorView) searchViaFileSystem(ctx context.Context, d searchDelegate, pattern string,
+	caseSensitive, reverse, next bool, startOff int) (int, int, bool) {
+
+	matches, err := d.fs.Search(ctx, d.path, pattern)
+	if err != nil || matches == nil {
+		return 0, 0, false
+	}
+
+	var offsets []int
+	for at := range matches {
+		if at >= 0 {
+			offsets = append(offsets, int(at))
+		}
+	}
+	if len(offsets) == 0 {
+		return 0, 0, false
+	}
+
+	// The host folds case and matches fixed strings, so what comes back is a
+	// superset of what this search wants. Each candidate is confirmed against
+	// the buffer's own rules before it is used.
+	if !reverse {
+		from := startOff
+		if next {
+			from++
+		}
+		best, bestLen, found := 0, 0, false
+		for _, off := range offsets {
+			if off < from {
+				continue
+			}
+			if found && off >= best {
+				continue
+			}
+			if mLen, ok := ev.confirmMatchAt(off, pattern, caseSensitive); ok {
+				best, bestLen, found = off, mLen, true
+			}
+		}
+		if found {
+			return best, bestLen, true
+		}
+		return 0, 0, false
+	}
+
+	until := startOff
+	if next {
+		until--
+	}
+	best, bestLen, found := 0, 0, false
+	for _, off := range offsets {
+		if off >= until || (found && off <= best) {
+			continue
+		}
+		if mLen, ok := ev.confirmMatchAt(off, pattern, caseSensitive); ok && off+mLen <= until {
+			best, bestLen, found = off, mLen, true
+		}
+	}
+	if found {
+		return best, bestLen, true
+	}
+	return 0, 0, false
+}
+
+// confirmMatchAt checks that the pattern really starts at off under this
+// search's own rules, and reports how many bytes it covers there. A folded
+// match can be longer or shorter than the pattern — K U+212A matches "k" — so
+// the length is measured rather than assumed.
+func (ev *EditorView) confirmMatchAt(off int, pattern string, caseSensitive bool) (int, bool) {
+	if off < 0 || pattern == "" {
+		return 0, false
+	}
+	// Four bytes of buffer per pattern byte is enough for any folding that
+	// grows what it matches, and costs one small read.
+	window := len(pattern) * 4
+	if window < len(pattern)+8 {
+		window = len(pattern) + 8
+	}
+	if off+window > ev.pt.Size() {
+		window = ev.pt.Size() - off
+	}
+	if window <= 0 {
+		return 0, false
+	}
+
+	data, err := ev.pt.GetRange(off, window)
+	if err != nil || len(data) == 0 {
+		return 0, false
+	}
+
+	if caseSensitive {
+		if bytes.HasPrefix(data, []byte(pattern)) {
+			return len(pattern), true
+		}
+		return 0, false
+	}
+	text := bytesToString(data)
+	after, ok := strcase.CutPrefix(text, pattern)
+	if !ok {
+		return 0, false
+	}
+	return len(text) - len(after), true
+}
+
+// logSearchDelegation records which way a search went, which is the one thing
+// that is hard to tell from the outside when the answer is the same either way.
+func logSearchDelegation(delegated bool, pattern string) {
+	if delegated {
+		vtui.DebugLog("EDITOR_SEARCH: %q answered by the file system", pattern)
+		return
+	}
+	vtui.DebugLog("EDITOR_SEARCH: %q scanned locally", pattern)
+}

--- a/editor_search_remote_test.go
+++ b/editor_search_remote_test.go
@@ -1,0 +1,193 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// searchableVFS is a file system that answers searches itself, the way FISH+
+// does with a remote grep: fixed strings, case folded, and capped — so what it
+// reports is a superset of some searches and short of others.
+type searchableVFS struct {
+	vfs.VFS
+	content string
+	// truncateAt drops everything past this many matches, standing in for the
+	// host-side limit.
+	truncateAt int
+	calls      int
+}
+
+func (s *searchableVFS) GetCapabilities() vfs.VFSCapabilities {
+	caps := s.VFS.GetCapabilities()
+	caps.HasSearch = true
+	return caps
+}
+
+func (s *searchableVFS) Search(ctx context.Context, path, pattern string) (chan int64, error) {
+	s.calls++
+	lowerContent := strings.ToLower(s.content)
+	lowerPattern := strings.ToLower(pattern)
+
+	var offsets []int64
+	for i := 0; ; {
+		idx := strings.Index(lowerContent[i:], lowerPattern)
+		if idx < 0 {
+			break
+		}
+		offsets = append(offsets, int64(i+idx))
+		i += idx + 1
+	}
+	if s.truncateAt > 0 && len(offsets) > s.truncateAt {
+		offsets = offsets[:s.truncateAt]
+	}
+
+	out := make(chan int64, len(offsets))
+	for _, off := range offsets {
+		out <- off
+	}
+	close(out)
+	return out, nil
+}
+
+func newSearchableEditor(t *testing.T, content string) (*EditorView, *searchableVFS) {
+	t.Helper()
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	fsys := &searchableVFS{VFS: vfs.NewOSVFS(t.TempDir()), content: content}
+	pt := piecetable.New([]byte(content))
+	ev := newEditorView(pt, fsys, "remote.txt", false)
+	ev.Codepage = 65001
+	return ev, fsys
+}
+
+func TestSearchDelegation_UsesTheFileSystemAndConfirmsLocally(t *testing.T) {
+	content := "alpha beta\nGAMMA gamma\ndelta\n"
+	ev, fsys := newSearchableEditor(t, content)
+
+	d, ok := ev.searchDelegation(false, false)
+	if !ok {
+		t.Fatal("an unedited UTF-8 buffer on a searchable file system should delegate")
+	}
+
+	// Case-insensitive: the host's own semantics, so the first hit stands.
+	off, mLen, handled := ev.searchViaFileSystem(context.Background(), d, "gamma", false, false, false, 0)
+	if !handled {
+		t.Fatal("search was not handled by the file system")
+	}
+	if want := strings.Index(content, "GAMMA"); off != want {
+		t.Errorf("offset = %d, want %d", off, want)
+	}
+	if mLen != len("gamma") {
+		t.Errorf("length = %d, want %d", mLen, len("gamma"))
+	}
+
+	// Case-sensitive: the host still reports both, and the folded one has to
+	// be rejected here rather than jumped to.
+	off, _, handled = ev.searchViaFileSystem(context.Background(), d, "gamma", true, false, false, 0)
+	if !handled {
+		t.Fatal("case-sensitive search was not handled")
+	}
+	if want := strings.LastIndex(content, "gamma"); off != want {
+		t.Errorf("case-sensitive offset = %d, want %d", off, want)
+	}
+	if got := content[off : off+len("gamma")]; got != "gamma" {
+		t.Errorf("case-sensitive search landed on %q, want the lowercase run", got)
+	}
+	if fsys.calls == 0 {
+		t.Error("the file system was never asked")
+	}
+}
+
+func TestSearchDelegation_DirectionAndNext(t *testing.T) {
+	content := "one match here, another match there, a third match at the end\n"
+	ev, _ := newSearchableEditor(t, content)
+	d, _ := ev.searchDelegation(false, false)
+
+	first := strings.Index(content, "match")
+	second := strings.Index(content[first+1:], "match") + first + 1
+	third := strings.LastIndex(content, "match")
+
+	off, _, ok := ev.searchViaFileSystem(context.Background(), d, "match", false, false, false, 0)
+	if !ok || off != first {
+		t.Errorf("forward from 0 = %d (handled=%v), want %d", off, ok, first)
+	}
+	off, _, ok = ev.searchViaFileSystem(context.Background(), d, "match", false, false, true, first)
+	if !ok || off != second {
+		t.Errorf("forward next from %d = %d (handled=%v), want %d", first, off, ok, second)
+	}
+	off, _, ok = ev.searchViaFileSystem(context.Background(), d, "match", false, true, true, third)
+	if !ok || off != second {
+		t.Errorf("backward next from %d = %d (handled=%v), want %d", third, off, ok, second)
+	}
+}
+
+// TestSearchDelegation_FallsBackWhenTheAnswerCouldBeShort is the one that keeps
+// a capped host-side search honest: a list that stops early can only miss
+// matches, so finding nothing usable in it has to mean "scan the buffer", never
+// "not in the file".
+func TestSearchDelegation_FallsBackWhenTheAnswerCouldBeShort(t *testing.T) {
+	content := strings.Repeat("needle\n", 50)
+	ev, fsys := newSearchableEditor(t, content)
+	fsys.truncateAt = 3 // the host reports only the first three
+	d, _ := ev.searchDelegation(false, false)
+
+	// Searching past the reported matches must not answer "not found".
+	after := strings.Index(content, "needle") + 10*len("needle\n")
+	if _, _, ok := ev.searchViaFileSystem(context.Background(), d, "needle", false, false, false, after); ok {
+		t.Error("a truncated list was treated as the whole truth")
+	}
+
+	// And the local scan, which is what the caller falls back to, does find it.
+	off, _, err := findMatch([]byte(content), "needle", false, false, false, false, false, after)
+	if err != nil || off < after {
+		t.Errorf("local scan from %d found %d (err=%v)", after, off, err)
+	}
+}
+
+func TestSearchDelegation_DeclinesWhatItCannotExpress(t *testing.T) {
+	content := "some text with a word in it\n"
+
+	t.Run("regular expression", func(t *testing.T) {
+		ev, _ := newSearchableEditor(t, content)
+		if _, ok := ev.searchDelegation(true, false); ok {
+			t.Error("delegated a regex search to a fixed-string grep")
+		}
+	})
+
+	t.Run("whole word", func(t *testing.T) {
+		ev, _ := newSearchableEditor(t, content)
+		if _, ok := ev.searchDelegation(false, true); ok {
+			t.Error("delegated a whole-word search")
+		}
+	})
+
+	t.Run("edited buffer", func(t *testing.T) {
+		ev, _ := newSearchableEditor(t, content)
+		ev.pt.Insert(0, []byte("typed "))
+		if _, ok := ev.searchDelegation(false, false); ok {
+			t.Error("delegated while the buffer no longer matches the file")
+		}
+	})
+
+	t.Run("decoded codepage", func(t *testing.T) {
+		ev, _ := newSearchableEditor(t, content)
+		ev.Codepage = 1251
+		if _, ok := ev.searchDelegation(false, false); ok {
+			t.Error("delegated for a buffer whose offsets are not the file's")
+		}
+	})
+
+	t.Run("file system without the capability", func(t *testing.T) {
+		vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+		ev := newEditorView(piecetable.New([]byte(content)), vfs.NewOSVFS(t.TempDir()), "local.txt", false)
+		ev.Codepage = 65001
+		if _, ok := ev.searchDelegation(false, false); ok {
+			t.Error("delegated to a file system that does not search")
+		}
+	})
+}

--- a/editor_view.go
+++ b/editor_view.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode"
 	"unicode/utf8"
@@ -102,6 +103,15 @@ type EditorView struct {
 	// or by cancellation. indexCancel cannot answer the question: it is left
 	// set after a normal finish, so it reads as "indexing forever".
 	indexing bool
+	// indexStatus and its subscribers are touched only on the UI thread: the
+	// scan reports through tasks posted there, and the paint path reads it.
+	indexStatus     IndexStatus
+	indexSubs       map[int]func(IndexStatus)
+	indexSubID      int
+	indexNotifiedAt time.Time
+	// indexResume debounces restarting the scan after an edit, so that typing
+	// does not start and cancel a goroutine per keystroke.
+	indexResume *time.Timer
 
 	// searchSnapshot caches the assembled buffer one search pass works on,
 	// for the buffers that cannot be scanned in place. Every search used to
@@ -262,6 +272,10 @@ func (ev *EditorView) Close() {
 	if ev.indexCancel != nil {
 		ev.indexCancel()
 	}
+	if ev.indexResume != nil {
+		ev.indexResume.Stop()
+		ev.indexResume = nil
+	}
 	if ev.asyncBuf != nil {
 		ev.asyncBuf.Close()
 	}
@@ -397,6 +411,14 @@ func newEditorView(pt *piecetable.PieceTable, v vfs.VFS, path string, useEditorC
 			return " " + base
 		},
 		func() string {
+			// While a scan is running the line number on the right is the one
+			// the index knows about, and the file may well have more. Say so
+			// rather than let it read as the whole truth.
+			if st := ev.IndexState(); st.Phase == IndexScanning {
+				return fmt.Sprintf(" %s │ %s %d%% │ %d,%d     ",
+					vfs.DisplayCodepageName(ev.Codepage), Msg("Editor.Indexing"),
+					st.Percent(), ev.CursorLine+1, ev.CursorPos)
+			}
 			cpName := vfs.DisplayCodepageName(ev.Codepage)
 			if ev.DecodeMode {
 				absPos := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
@@ -2868,6 +2890,12 @@ func (ev *EditorView) StartIndexing() {
 	ctx, cancel := context.WithCancel(context.Background())
 	ev.indexCancel = cancel
 	ev.indexing = true
+	ev.setIndexStatus(IndexStatus{
+		Phase:   IndexScanning,
+		Total:   int64(ev.pt.Size()),
+		Scanned: int64(ev.li.GetLineOffset(ev.li.LineCount() - 1)),
+		Lines:   ev.li.LineCount(),
+	})
 
 	go func() {
 		defer ev.guardMapping("indexing")()
@@ -2875,13 +2903,31 @@ func (ev *EditorView) StartIndexing() {
 		vtui.DebugLog("EDITOR_INDEX: Start indexing with targetLine=%d", ev.targetLine)
 		indexed, batches := 0, 0
 		var waited time.Duration
+		// How far the scan has read, for the task below that settles the phase
+		// after this goroutine is gone.
+		var scannedTo atomic.Int64
 
 		// Runs on completion and on cancellation alike, so the flag the
 		// highlight walker throttles on can never stay stuck at true.
 		defer func() {
+			reached := scannedTo.Load()
 			vtui.FrameManager.PostTask(func() {
 				if ev.editSession == sessionID {
 					ev.indexing = false
+					st := ev.indexStatus
+					st.Lines = ev.li.LineCount()
+					st.Scanned = reached
+					switch {
+					case ctx.Err() != nil:
+						// Cancelled, so the index is simply short: whatever
+						// stopped it decides whether a resume follows.
+						st.Phase = IndexIdle
+					case reached >= st.Total:
+						st.Phase = IndexComplete
+					default:
+						st.Phase = IndexFailed
+					}
+					ev.setIndexStatus(st)
 				}
 				vtui.DebugLog("EDITOR: Indexer stopped: %d lines in %v, %v of it waiting for data, %d UI batches",
 					indexed, time.Since(startedAt), waited, batches)
@@ -2891,10 +2937,9 @@ func (ev *EditorView) StartIndexing() {
 		poll := indexPollMin
 		buf := ev.asyncBuf
 		li := ev.li
+		// The logical size, not the file's: the scan reads the text as it is
+		// now, including whatever has been typed into it.
 		maxSize := ev.pt.Size()
-		if buf != nil {
-			maxSize = buf.Size()
-		}
 
 		if indexer, ok := ev.vfs.(vfs.LineIndexer); ok && ev.Codepage == 65001 {
 			vtui.DebugLog("EDITOR_INDEX: Using remote LineIndexer")
@@ -2919,7 +2964,7 @@ func (ev *EditorView) StartIndexing() {
 					}
 
 					vtui.FrameManager.PostTask(func() {
-						if ctx.Err() != nil || ev.edited || ev.editSession != sessionID {
+						if ctx.Err() != nil || ev.editSession != sessionID {
 							return
 						}
 						lastLineBefore := li.LineCount() - 1
@@ -2968,8 +3013,9 @@ func (ev *EditorView) StartIndexing() {
 			}
 
 			if remoteSuccess {
+				scannedTo.Store(int64(maxSize))
 				vtui.FrameManager.PostTask(func() {
-					if ctx.Err() == nil && !ev.edited && ev.editSession == sessionID {
+					if ctx.Err() == nil && ev.editSession == sessionID {
 						if ev.targetLine != -1 {
 							ev.CursorLine = ev.targetLine
 							if ev.CursorLine >= li.LineCount() {
@@ -3002,10 +3048,17 @@ func (ev *EditorView) StartIndexing() {
 			}
 		}
 
+		// Resume from the last line already indexed rather than from the top:
+		// the offsets before it were kept correct through any edits, and the
+		// text is read through the piece table, so they still describe it.
 		absPos := 0
 		if li.LineCount() > 1 {
 			absPos = li.GetLineOffset(li.LineCount() - 1)
 		}
+		// Record the starting point too, so that a resume with nothing left to
+		// read still reports having reached the end rather than looking as
+		// though it stopped short.
+		scannedTo.Store(int64(absPos))
 		chunkSize := 256 * 1024 // 256KB chunks to match AsyncBuffer
 
 		pendingOffsets := make([]int, 0, 10000)
@@ -3020,10 +3073,12 @@ func (ev *EditorView) StartIndexing() {
 				return
 			}
 
-			var data []byte
-			var err error
+			// Prefetching still goes to the chunk buffer, which is what has
+			// latency to hide; the read itself goes through the piece table,
+			// so the offsets this produces describe the text as edited rather
+			// than the file as it sits on disk. That is what lets a scan
+			// interrupted by an edit resume instead of starting over.
 			if buf != nil {
-				// Pre-fetch ahead to keep AsyncBuffer busy and avoid sequential latency.
 				// 16 chunks of 256KB = 4MB read-ahead sliding window.
 				readAhead := 16
 				for i := 0; i < readAhead; i++ {
@@ -3032,17 +3087,14 @@ func (ev *EditorView) StartIndexing() {
 						_, _ = buf.Read(p, chunkSize)
 					}
 				}
-				data, err = buf.Read(absPos, chunkSize)
+			}
+			var data []byte
+			var err error
+			take := min(chunkSize, maxSize-absPos)
+			if view, ok := ev.pt.View(absPos, take); ok {
+				data = view
 			} else {
-				// A mapped file is already whole: read the window straight out
-				// of the piece table, which for the original buffer costs
-				// nothing but the bounds arithmetic.
-				take := min(chunkSize, maxSize-absPos)
-				if view, ok := ev.pt.View(absPos, take); ok {
-					data = view
-				} else {
-					data, err = ev.pt.GetRange(absPos, take)
-				}
+				data, err = ev.pt.GetRange(absPos, take)
 			}
 			if err == piecetable.ErrLoading {
 				time.Sleep(poll)
@@ -3067,6 +3119,7 @@ func (ev *EditorView) StartIndexing() {
 			}
 
 			absPos += len(data)
+			scannedTo.Store(int64(absPos))
 
 			// Update UI in 5000-line batches, or immediately when targetLine is reached, to avoid UI thread congestion
 			if len(pendingOffsets) >= 5000 || absPos >= maxSize || (ev.targetLine != -1 && li.LineCount()+len(pendingOffsets) > ev.targetLine) {
@@ -3077,7 +3130,7 @@ func (ev *EditorView) StartIndexing() {
 				pendingOffsets = make([]int, 0, 10000)
 
 				vtui.FrameManager.PostTask(func() {
-					if ctx.Err() != nil || ev.edited || ev.editSession != sessionID {
+					if ctx.Err() != nil || ev.editSession != sessionID {
 						return
 					}
 					// Incremental update: we only need to invalidate visual cache
@@ -3114,7 +3167,7 @@ func (ev *EditorView) StartIndexing() {
 		}
 
 		vtui.FrameManager.PostTask(func() {
-			if ctx.Err() == nil && !ev.edited && ev.editSession == sessionID {
+			if ctx.Err() == nil && ev.editSession == sessionID {
 				if ev.targetLine != -1 {
 					ev.CursorLine = ev.targetLine
 					if ev.CursorLine >= li.LineCount() {
@@ -3460,11 +3513,88 @@ func (ev *EditorView) Replace(pattern, replacement string, caseSensitive, revers
 func (ev *EditorView) noteBufferEdit() {
 	if !ev.edited {
 		ev.edited = true
-		if ev.indexCancel != nil {
-			ev.indexCancel()
-		}
+	}
+	// The running scan is carrying offsets it worked out before this edit, so
+	// it has to stop — but only for as long as it takes the edit to settle.
+	// The offsets already in the index were moved along with the text by
+	// UpdateAfterInsert and UpdateAfterDelete, and the scan reads the text
+	// through the piece table, so it can pick up from the last line it knows.
+	if ev.indexCancel != nil {
+		ev.indexCancel()
+		ev.indexCancel = nil
 	}
 	ev.retireEditSession()
+	ev.scheduleIndexResume()
+}
+
+// ensureIndexedTo extends the line index far enough to describe offset, when
+// the running scan has not reached it yet. It counts newlines from the last
+// line the index knows about, which is the same work the scan would do — done
+// here, now, because a caller is about to ask a question the index cannot
+// otherwise answer.
+//
+// It runs on the UI thread and only ever covers the gap up to one offset, so
+// the cost is the distance between the scan's position and the match, not the
+// size of the file.
+func (ev *EditorView) ensureIndexedTo(offset int) {
+	if offset < 0 || ev.indexIsComplete() {
+		return
+	}
+	last := ev.li.LineCount() - 1
+	from := ev.li.GetLineOffset(last)
+	if from < 0 || offset < from {
+		return
+	}
+
+	const step = 256 * 1024
+	pending := make([]int, 0, 1024)
+	for pos := from; pos <= offset; {
+		take := min(step, ev.pt.Size()-pos)
+		if take <= 0 {
+			break
+		}
+		data, err := ev.pt.GetRange(pos, take)
+		if err != nil || len(data) == 0 {
+			break
+		}
+		for i := 0; i < len(data); {
+			idx := bytes.IndexByte(data[i:], '\n')
+			if idx == -1 {
+				break
+			}
+			pending = append(pending, pos+i+idx+1)
+			i += idx + 1
+		}
+		pos += len(data)
+	}
+	if len(pending) > 0 {
+		ev.li.AppendOffsets(pending, ev.pt.Size())
+	}
+}
+
+// indexResumeDelay is how long the editor waits for typing to stop before
+// resuming a scan. Restarting on every keystroke would spend more time
+// starting and cancelling goroutines than reading.
+const indexResumeDelay = 400 * time.Millisecond
+
+// scheduleIndexResume arranges for an interrupted scan to continue once the
+// edits stop arriving. A file whose index is already complete needs nothing:
+// the incremental updates keep it that way.
+func (ev *EditorView) scheduleIndexResume() {
+	if ev.indexResume != nil {
+		ev.indexResume.Stop()
+	}
+	ev.indexResume = time.AfterFunc(indexResumeDelay, func() {
+		vtui.FrameManager.PostTask(func() {
+			if ev.IsDone() || ev.indexing || ev.indexIsComplete() {
+				return
+			}
+			if ev.asyncBuf == nil && ev.mapped == nil {
+				return
+			}
+			ev.StartIndexing()
+		})
+	})
 }
 
 // replaceRange replaces bytes [min, max) with repBytes as a single
@@ -5354,6 +5484,11 @@ func (ev *EditorView) selectFoundPattern(off, length int) {
 	ev.selAnchorOffset = off
 
 	end := off + length
+	// A search reads the whole buffer, so it can find a match in text the
+	// index has not reached yet. Asking an index that stops short where such
+	// an offset lives answers with its last line and a column counted from
+	// there, which is not a position in the file at all.
+	ev.ensureIndexedTo(end)
 	ev.CursorLine = ev.li.GetLineAtOffset(end)
 	ev.CursorPos = end - ev.li.GetLineOffset(ev.CursorLine)
 

--- a/editor_view.go
+++ b/editor_view.go
@@ -5434,9 +5434,31 @@ func (ev *EditorView) Search(pattern string, caseSensitive, reverse, regexp, who
 		// Read on the UI thread, before the background scan starts.
 		startOff := ev.searchSeedOffset(reverse, false)
 		session := ev.editSession
+		delegate, canDelegate := ev.searchDelegation(regexp, wholeWord)
 
 		runSearchWithProgress(searchPattern, func(ctx *vtui.TaskContext, dlg *vtui.Window) {
 			defer ev.guardMapping("searching")()
+
+			// A file system that can search its own copy answers without the
+			// file having to travel. Anything it cannot answer for certain
+			// falls through to the scan below.
+			if canDelegate {
+				off, mLen, ok := ev.searchViaFileSystem(ctx.Context, delegate, searchPattern,
+					caseSensitive, reverse, next, startOff)
+				logSearchDelegation(ok, searchPattern)
+				if ok {
+					ctx.RunOnUI(func() {
+						canceled := ctx.Err() != nil
+						dlg.Close()
+						if canceled || ev.editSession != session {
+							return
+						}
+						ev.selectFoundPattern(off, mLen)
+					})
+					return
+				}
+			}
+
 			bytes, errBytes := ev.searchBuffer(ctx, session)
 			if errBytes != nil {
 				if ctx.Err() != nil {

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -1075,6 +1075,7 @@ Replace.AskWith=with
 Replace.BtnAll=&All
 Replace.BtnSkip=&Skip
 Replace.Replaced=%d occurrence(s) replaced
+Editor.Indexing=Indexing
 Search.Title= Search
 Search.NotFound=Pattern not found.
 Codepage.Title= Code pages

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -1071,6 +1071,7 @@ Replace.AskWith=на
 Replace.BtnAll=&Все
 Replace.BtnSkip=&Пропустить
 Replace.Replaced=Заменено вхождений: %d
+Editor.Indexing=Индексация
 Search.Title= Поиск
 Search.NotFound=Строка поиска не найдена.
 Codepage.Title= Кодировки

--- a/piecetable/concurrent_test.go
+++ b/piecetable/concurrent_test.go
@@ -1,0 +1,53 @@
+package piecetable
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestPieceTable_ReadsWhileEditing is the race this lock exists for: the editor
+// scans the buffer from background goroutines — a search assembling what it
+// scans, the line indexer walking the text — while the UI thread edits the same
+// table. Run this with -race; without the lock it reports a write to pt.pieces
+// racing with the reads below.
+func TestPieceTable_ReadsWhileEditing(t *testing.T) {
+	pt := New([]byte(strings.Repeat("a line of text\n", 2000)))
+
+	var wg sync.WaitGroup
+	done := make(chan struct{})
+
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+				size := pt.Size()
+				if size > 32 {
+					_, _ = pt.GetRange(size/2, 16)
+					_, _ = pt.View(size/2, 16)
+				}
+				_ = pt.GetState()
+				_ = pt.ForEachRange(func([]byte) error { return nil })
+			}
+		}()
+	}
+
+	for i := 0; i < 300; i++ {
+		pt.Insert(10, []byte("edit "))
+		if pt.Size() > 100 {
+			pt.Delete(20, 5)
+		}
+	}
+	close(done)
+	wg.Wait()
+
+	if pt.Size() <= 0 {
+		t.Fatalf("size = %d after the edits", pt.Size())
+	}
+}

--- a/piecetable/piecetable.go
+++ b/piecetable/piecetable.go
@@ -1,7 +1,10 @@
 package piecetable
 
 // BufferType indicates which buffer a text fragment is in.
-import "errors"
+import (
+	"errors"
+	"sync"
+)
 
 var ErrLoading = errors.New("data is loading")
 
@@ -62,7 +65,15 @@ type Piece struct {
 }
 
 // PieceTable is a structure for efficient editing of large texts.
+//
+// The piece list is read from background goroutines — a search assembling the
+// buffer it scans, the editor's line indexer walking the text — while the UI
+// thread edits it. mu is what makes that safe. It guards the piece list, the
+// add buffer's length and the size; the bytes those pieces point at never
+// change once written, so a window handed out under the lock stays readable
+// after it is released.
 type PieceTable struct {
+	mu     sync.RWMutex
 	orig   Buffer  // Original (Read-only) buffer
 	add    []byte  // Additive (Append-only) buffer
 	pieces []Piece // Piece table
@@ -83,11 +94,15 @@ func New(text []byte) *PieceTable {
 
 // Size returns current logical length of the text.
 func (pt *PieceTable) Size() int {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	return pt.size
 }
 
 // GetOriginalBuffer returns the underlying original buffer.
 func (pt *PieceTable) GetOriginalBuffer() Buffer {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	return pt.orig
 }
 
@@ -108,6 +123,8 @@ func (pt *PieceTable) offsetToPiece(offset int) (pieceIdx int, offsetInPiece int
 
 // Insert inserts data at the specified offset.
 func (pt *PieceTable) Insert(offset int, data []byte) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
 	if offset < 0 || offset > pt.size || len(data) == 0 {
 		return
 	}
@@ -165,6 +182,8 @@ func (pt *PieceTable) Insert(offset int, data []byte) {
 
 // Delete removes a text fragment of specified length starting from offset.
 func (pt *PieceTable) Delete(offset, length int) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
 	if offset < 0 || length <= 0 || offset+length > pt.size {
 		return
 	}
@@ -202,6 +221,8 @@ func (pt *PieceTable) Delete(offset, length int) {
 // Note: for large file rendering in future we'll write ReadAt methods,
 // so as not to unload entire buffer into memory.
 func (pt *PieceTable) Bytes() ([]byte, error) {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	res := make([]byte, 0, pt.size)
 	for _, p := range pt.pieces {
 		if p.Buf == Original {
@@ -219,6 +240,8 @@ func (pt *PieceTable) Bytes() ([]byte, error) {
 
 // AppendRange appends the specified range to the dest slice without new allocations.
 func (pt *PieceTable) AppendRange(dest []byte, offset, length int) ([]byte, error) {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	if offset < 0 || length <= 0 {
 		return dest, nil
 	}
@@ -263,7 +286,12 @@ func (pt *PieceTable) String() string {
 
 // ForEachRange sequentially calls a function for each data fragment.
 // This allows processing text without allocating a single large slice.
+//
+// fn runs while the table is read-locked, so it must not edit the table it is
+// walking; every caller here only reads what it is handed.
 func (pt *PieceTable) ForEachRange(fn func(data []byte) error) error {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	for _, p := range pt.pieces {
 		if p.Buf == Original {
 			const chunkSize = 1024 * 1024
@@ -297,6 +325,8 @@ type TableState struct {
 
 // GetState returns a snapshot of the current table structure.
 func (pt *PieceTable) GetState() TableState {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	ps := make([]Piece, len(pt.pieces))
 	copy(ps, pt.pieces)
 	return TableState{Pieces: ps, Size: pt.size}
@@ -304,6 +334,8 @@ func (pt *PieceTable) GetState() TableState {
 
 // LoadState restores the table structure from a snapshot.
 func (pt *PieceTable) LoadState(s TableState) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
 	pt.pieces = make([]Piece, len(s.Pieces))
 	copy(pt.pieces, s.Pieces)
 	pt.size = s.Size
@@ -334,6 +366,8 @@ func (s TableState) Equals(other TableState) bool {
 //
 // The result aliases the buffer and must not be modified.
 func (pt *PieceTable) View(offset, length int) ([]byte, bool) {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	if offset < 0 || length <= 0 || offset+length > pt.size {
 		return nil, false
 	}
@@ -361,6 +395,8 @@ func (pt *PieceTable) View(offset, length int) ([]byte, bool) {
 
 // GetRange returns a byte slice for the specified range.
 func (pt *PieceTable) GetRange(offset, length int) ([]byte, error) {
+	pt.mu.RLock()
+	defer pt.mu.RUnlock()
 	if offset < 0 || length <= 0 || offset+length > pt.size {
 		return nil, nil
 	}
@@ -403,6 +439,8 @@ func (pt *PieceTable) GetRange(offset, length int) ([]byte, error) {
 // without losing the current logical state and additions.
 // Used primarily for state recovery after a failed I/O operation.
 func (pt *PieceTable) UpdateOriginalBuffer(buf Buffer) {
+	pt.mu.Lock()
+	defer pt.mu.Unlock()
 	pt.orig = buf
 }
 func NewWithBuffer(buf Buffer) *PieceTable {


### PR DESCRIPTION
**Stacked on #485** — review this one from `d314090`.

Searching a remote file meant downloading it. The editor reads the whole buffer to scan it, and for a file on a FISH+ host that read is a transfer — of the entire file, to find a string the host could have found itself. `vfs.Search` has been there for a while and the viewer has used it since it was added; the editor never has.

### When the search is handed over

Four things have to hold:

| condition | why |
|---|---|
| the file system offers `HasSearch` | nothing to ask otherwise |
| the buffer is still the file on disk | the offsets come back as positions in what is stored; an edit moves the text away from that |
| the content is raw UTF-8 | a decoded buffer's offsets are not the file's either |
| no regex, no whole-word | not what a fixed-string grep answers |

The "still the file" test is `pt.GetState().Equals(cleanState)`, which is exactly the question already used to decide whether the buffer is modified.

### Confirming what comes back

FISH+ folds case and matches fixed strings, so its answer is a *superset* of some searches. Every candidate is confirmed against the buffer's own rules before it is used — reading a few bytes at that offset rather than the file — which is what makes a case-sensitive search over a case-folding host correct. A folded match can also cover a different number of bytes than the pattern (`K` U+212A matches `k`), so the length is measured there rather than assumed.

### The part that matters most

A host-side search caps how many matches it reports — FISH+ stops at ten thousand. So a list can be short of the truth, and finding nothing usable in it **cannot** mean "not in the file". It falls back to scanning the buffer, which is slower and certain. Every uncertainty resolves the same way: no answer, an error, or an unconfirmable candidate all end up on the local scan. The only thing delegation can do is answer faster, never differently.

There is a test for exactly this: a stub host that reports only the first three of fifty matches, and a search past them that must decline rather than claim not-found.

### Tests

`editor_search_remote_test.go` — a searchable file system stub with the host's semantics (fixed, folded, capped): delegation finds and confirms a match; a case-sensitive search rejects the folded candidate and lands on the right one; forward, backward and next all pick the correct occurrence; a truncated answer falls back; and delegation declines for regex, whole-word, an edited buffer, a decoded codepage, and a file system without the capability.

### What is left of the remote work

The other half of the plan's remote stage is a windowed residency policy — bounding what a remote file keeps resident instead of accumulating every chunk it has ever read. With host-side line indexing (already in `main`) and this, a large remote file no longer has to travel to be opened, indexed or searched, so what remains is memory rather than transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
