### PR TITLE
editor: stop building a menu item for every occurrence found

### DIFF
--- a/editor_find_all.go
+++ b/editor_find_all.go
@@ -34,32 +34,138 @@ type editorMatch struct {
 	Col      int // 1-based rune column within the line
 }
 
-// findAllRow holds per-item metrics for painting the match highlight over
-// the menu text. Byte offsets index the untruncated display string; cell
-// values are terminal columns.
+// findAllRow is one occurrence resolved for painting: where it sits, the text
+// of its line, and where inside that text the match falls. Rows are produced
+// on demand for the dozen or so visible items and thrown away after the paint,
+// so the list costs nothing per occurrence.
 type findAllRow struct {
-	byteStart, byteEnd int // match range in the display string
-	cellStart          int // columns before the match
-	cellWidth          int // 0 = nothing to highlight (match truncated away)
-	visW               int // width of the currently truncated item text
+	match editorMatch
+	text  string // line text, tabs flattened, capped at findAllMaxItemWidth
+	// Match range within text. byteEnd == byteStart means there is nothing to
+	// highlight: the match starts past the cap, or truncation rewrote the
+	// bytes it would have covered.
+	byteStart, byteEnd int
 }
 
-// findAllFrame wraps the occurrences VMenu to draw the key hint on the
-// bottom border and repaint each visible match in the highlight color,
-// following the userMenuFrame pattern (vtui ships as a separate module,
-// so the menu itself is not extended).
+// findAllAnchor remembers where the last resolved row landed so the next one
+// can count runes from there.
+type findAllAnchor struct {
+	valid    bool
+	line     int
+	off, col int
+}
+
+// findAllFrame is the occurrences list. It renders straight out of the span
+// slice the search produced: VMenu keeps the scroll and selection state
+// (ItemCount, TopPos, SelectPos, the scrollbar), but its Items slice stays
+// empty, because one MenuItem per occurrence costs ~2 µs and ~210 bytes and a
+// short pattern in a large file hits millions of times — 21M matches in a
+// 200 MB buffer took ~43 s and ~4.4 GB to materialize, all inside the single
+// RunOnUI callback that opened the menu. Painting only ever touches the
+// visible rows, so nothing about the list needed to exist in the first place.
+//
+// The price is that the parts of VMenu that read Items — item painting, hover,
+// click, Enter — are re-implemented here (vtui ships as a separate module, so
+// the menu itself is not extended).
 type findAllFrame struct {
 	*vtui.VMenu
+	ev    *EditorView
+	data  []byte
+	spans []matchSpan
+
 	bottomHint string
-	accentW    int      // width of the "line│col│ " prefix, same for all items
-	displays   []string // untruncated (but capped) display line per item
-	rows       []findAllRow
+	lineW      int // digits reserved for the line number
+	colW       int // digits reserved for the column; grows, never shrinks
+	accentW    int // width of the "line│col│ " prefix as last painted
 	normalRect [4]int
 	zoomed     bool
+
+	anchor findAllAnchor
+}
+
+// columnAt returns the 1-based rune column of off within its line. Counting
+// starts from the previously resolved row when that row was on the same line,
+// which keeps scrolling through one minified megabyte-long line proportional
+// to the distance moved instead of rescanning from the line start per row.
+func (f *findAllFrame) columnAt(line, lineStart, off int) int {
+	var col int
+	switch a := f.anchor; {
+	case a.valid && a.line == line && off >= a.off:
+		col = a.col + utf8.RuneCount(f.data[a.off:off])
+	case a.valid && a.line == line:
+		col = a.col - utf8.RuneCount(f.data[off:a.off])
+	default:
+		col = 1 + utf8.RuneCount(f.data[lineStart:off])
+	}
+	col = max(col, 1)
+	f.anchor = findAllAnchor{valid: true, line: line, off: off, col: col}
+	return col
+}
+
+// resolveRow turns occurrence i into everything needed to paint its row.
+func (f *findAllFrame) resolveRow(i int) findAllRow {
+	s := f.spans[i]
+	line := f.ev.li.GetLineAtOffset(s.Off)
+	// The background indexer may still be catching up on a large file; clamp
+	// every bound against the buffer so a partially indexed file cannot panic
+	// or render the rest of the buffer as one line.
+	lineStart := min(max(f.ev.li.GetLineOffset(line), 0), len(f.data))
+	lineEnd := min(lineStart+max(f.ev.getLineLength(line), 0), len(f.data))
+	raw := strings.TrimRight(string(f.data[lineStart:lineEnd]), "\r\n")
+	// Tabs become single spaces: a 1-byte-for-1-byte substitution keeps the
+	// match's byte offsets valid in the display string, which keeps the
+	// highlight math trivial.
+	raw = strings.ReplaceAll(raw, "\t", " ")
+	text := vtui.TruncateString(raw, findAllMaxItemWidth, "")
+
+	row := findAllRow{
+		match: editorMatch{
+			Off:  s.Off,
+			Len:  s.Len,
+			Line: line,
+			Col:  f.columnAt(line, lineStart, min(max(s.Off, lineStart), len(f.data))),
+		},
+		text: text,
+	}
+
+	start := s.Off - lineStart
+	end := min(start+s.Len, len(text))
+	if start < 0 || start >= len(text) || start >= end ||
+		// Truncation sanitizes control characters while rebuilding the
+		// string, which shifts byte offsets; highlight only when the display
+		// bytes still hold the match where the buffer had it.
+		end > len(raw) || text[start:end] != raw[start:end] {
+		return row
+	}
+	row.byteStart, row.byteEnd = start, end
+	return row
+}
+
+// prefixFor renders the "line│col│ " accent. Every row on a page is formatted
+// with the same widths, so the item texts line up.
+func (f *findAllFrame) prefixFor(m editorMatch) string {
+	return fmt.Sprintf("%*d│%*d│ ", f.lineW, m.Line+1, f.colW, m.Col)
+}
+
+// resolvePage resolves the rows currently in view and reserves enough digits
+// for the widest column among them.
+func (f *findAllFrame) resolvePage(height int) []findAllRow {
+	rows := make([]findAllRow, 0, max(height, 0))
+	for i := 0; i < height; i++ {
+		idx := f.TopPos + i
+		if idx < 0 || idx >= len(f.spans) {
+			break
+		}
+		rows = append(rows, f.resolveRow(idx))
+	}
+	for _, r := range rows {
+		f.colW = max(f.colW, len(strconv.Itoa(r.match.Col)))
+	}
+	return rows
 }
 
 func (f *findAllFrame) Show(scr *vtui.ScreenBuf) {
-	f.VMenu.Show(scr)
+	f.VMenu.Show(scr) // box, title and scrollbar; Items is empty, so no rows
 	x1, y1, x2, y2 := f.VMenu.GetPosition()
 	p := vtui.NewPainter(scr)
 	if f.bottomHint != "" {
@@ -67,50 +173,101 @@ func (f *findAllFrame) Show(scr *vtui.ScreenBuf) {
 	}
 
 	// Same visible-row bounds as VMenu.DisplayObject.
-	height := y2 - y1 - 1
-	for i := 0; i < height; i++ {
+	rows := f.resolvePage(y2 - y1 - 1)
+
+	prefixes := make([]string, len(rows))
+	accentW := 0
+	for i, r := range rows {
+		prefixes[i] = f.prefixFor(r.match)
+		accentW = max(accentW, vtui.StringWidth(prefixes[i]))
+	}
+	f.accentW = accentW
+
+	// The Painter does not clip, so every string is cut to the room left
+	// inside the border. A terminal narrower than the prefix leaves nothing
+	// for the text; keep one column so rows degrade instead of going blank.
+	innerW := max((x2-x1+1)-4-accentW, 1)
+
+	for i, r := range rows {
 		idx := f.TopPos + i
-		if idx >= len(f.rows) {
-			break
+		y := y1 + 1 + i
+		attr := vtui.Palette[vtui.ColMenuText]
+		hiAttr := vtui.Palette[vtui.ColMenuHighlight]
+		if idx == f.SelectPos {
+			attr = vtui.Palette[vtui.ColMenuSelectedText]
+			hiAttr = vtui.Palette[vtui.ColMenuSelectedHighlight]
 		}
-		r := f.rows[idx]
-		if r.cellWidth == 0 {
+		p.Fill(x1+1, y, x2-1, y, ' ', attr)
+		p.DrawString(x1+2, y, vtui.TruncateString(prefixes[i], max(x2-2-x1, 0), ""), hiAttr)
+
+		textX := x1 + 2 + accentW
+		if textX > x2-1 {
 			continue
 		}
-		textX := x1 + 2 + f.accentW
-		startX := textX + r.cellStart
-		maxX := textX + r.visW - 1
-		if maxX > x2-1 {
-			maxX = x2 - 1
+		text := vtui.TruncateString(r.text, min(innerW, x2-textX), "")
+		p.DrawString(textX, y, text, attr)
+
+		if r.byteEnd == r.byteStart {
+			continue
 		}
+		startX := textX + vtui.StringWidth(r.text[:r.byteStart])
+		maxX := min(textX+vtui.StringWidth(text)-1, x2-1)
 		if startX > maxX {
 			continue
 		}
-		attr := vtui.Palette[vtui.ColMenuHighlight]
-		if idx == f.SelectPos {
-			attr = vtui.Palette[vtui.ColMenuSelectedHighlight]
-		}
-		sub := f.displays[idx][r.byteStart:r.byteEnd]
-		p.DrawString(startX, y1+1+i, vtui.TruncateString(sub, maxX-startX+1, ""), attr)
+		sub := vtui.TruncateString(r.text[r.byteStart:r.byteEnd], maxX-startX+1, "")
+		p.DrawString(startX, y, sub, hiAttr)
 	}
 }
 
-// retruncate refits every item text to the menu's current inner width.
-// Needed after each geometry change: the Painter does not clip, so an item
-// longer than the box would bleed past the border.
-func (f *findAllFrame) retruncate() {
-	x1, _, x2, _ := f.VMenu.GetPosition()
-	innerW := (x2 - x1 + 1) - 4 - f.accentW
-	// A terminal narrower than the line/col prefix leaves no room for text;
-	// keep one column so the items degrade instead of going blank.
-	if innerW < 1 {
-		innerW = 1
+// GetItemCount reports the occurrence count. The embedded VMenu would answer
+// with len(Items), which this frame deliberately keeps at zero.
+func (f *findAllFrame) GetItemCount() int { return f.ItemCount }
+
+// activate jumps to occurrence idx and closes the menu. VMenu's own Enter and
+// click paths read Items to find the action, so the frame runs them instead.
+func (f *findAllFrame) activate(idx int) {
+	if idx < 0 || idx >= len(f.spans) {
+		return
 	}
-	for i := range f.Items {
-		trunc := vtui.TruncateString(f.displays[i], innerW, "")
-		f.Items[i].Text = escapeAmpersand(trunc)
-		f.rows[i].visW = vtui.StringWidth(trunc)
+	s := f.spans[idx]
+	// vtui pops the menu after the key handler returns, so the jump is posted
+	// for after the frame stack has settled.
+	vtui.FrameManager.PostTask(func() {
+		f.ev.selectFoundPattern(s.Off, s.Len)
+	})
+	f.SetExitCode(idx)
+}
+
+// ProcessMouse re-implements VMenu's hover and click handling against the
+// span slice, for the same reason as activate.
+func (f *findAllFrame) ProcessMouse(e *vtinput.InputEvent) bool {
+	if f.IsDisabled() || e.Type != vtinput.MouseEventType {
+		return false
 	}
+	if f.HandleMouseScroll(e) {
+		return true
+	}
+	if (e.MouseEventFlags & vtinput.MouseMoved) != 0 {
+		x1, _, x2, _ := f.VMenu.GetPosition()
+		if mx := int(e.MouseX); mx <= x1 || mx >= x2 {
+			return false
+		}
+		idx := f.GetClickIndex(int(e.MouseY))
+		if idx == -1 {
+			return false
+		}
+		f.SetSelectPos(idx)
+		return true
+	}
+	if e.ButtonState == vtinput.FromLeft1stButtonPressed && e.KeyDown {
+		if idx := f.GetClickIndex(int(e.MouseY)); idx != -1 {
+			f.SetSelectPos(idx)
+			f.activate(idx)
+			return true
+		}
+	}
+	return false
 }
 
 // zoomRect is the near-full-screen position used while F5-zoomed.
@@ -140,13 +297,52 @@ func (f *findAllFrame) ResizeConsole(w, h int) {
 		r = clampMenuRect([4]int{x1, y1, x2, y2}, w, h)
 	}
 	f.SetPosition(r[0], r[1], r[2], r[3])
-	f.retruncate()
 	f.SetSelectPos(f.SelectPos) // re-clamp TopPos to the new height
 }
 
 // findAllMaxItemWidth caps the stored display text so a single minified
 // megabyte-long line cannot bloat the menu.
 const findAllMaxItemWidth = 512
+
+// findAllWidthSample is how many occurrences are measured to pick the menu
+// width. The list itself is unbounded, and the longest of twenty million
+// matching lines cannot be found without resolving all of them, so the width
+// hugs the longest line in the first sample instead. Lists shorter than this
+// are still sized exactly; longer ones get F5 to zoom.
+const findAllWidthSample = 1000
+
+// findAllDumpMaxLines caps the F4 dump. The list renders lazily, but the dump
+// materializes real text into a new editor, and dumping every matching line of
+// a file that matches on all 21M of them would be a second copy of the file.
+// A var so the test can reach the cap without a file that large.
+var findAllDumpMaxLines = 100000
+
+// countMatchLines returns how many distinct lines the occurrences fall on.
+// Two consecutive matches sit on different lines exactly when a '\n' separates
+// them, so the whole list costs one forward pass over the bytes between the
+// first and the last match: the spans are ordered and non-overlapping, so the
+// gaps scanned are disjoint. Resolving each match against the line index
+// instead would be a locked binary search per occurrence, seconds of them at
+// the counts this path exists for. Runs on the collecting goroutine, off the
+// UI thread.
+func countMatchLines(ctx context.Context, data []byte, spans []matchSpan) int {
+	if len(spans) == 0 {
+		return 0
+	}
+	lines := 1
+	off := min(max(spans[0].Off, 0), len(data))
+	for i, s := range spans[1:] {
+		if ctx != nil && i%1024 == 0 && ctx.Err() != nil {
+			return lines
+		}
+		end := min(max(s.Off, off), len(data))
+		if bytes.IndexByte(data[off:end], '\n') >= 0 {
+			lines++
+		}
+		off = end
+	}
+	return lines
+}
 
 // findAllMatchSpans returns every non-overlapping occurrence of pattern in
 // data, using the same pattern-building rules as EditorView.Search. A nil
@@ -245,6 +441,12 @@ func (ev *EditorView) FindAll(pattern string, caseSensitive, useRegex, wholeWord
 			}
 
 			spans, err := findAllMatchSpans(ctx, bytes, pattern, caseSensitive, useRegex, wholeWord)
+			// Counted here rather than in the menu, so that opening it stays
+			// O(one screenful) however many occurrences there are.
+			uniqueLines := 0
+			if err == nil {
+				uniqueLines = countMatchLines(ctx, bytes, spans)
+			}
 
 			ctx.RunOnUI(func() {
 				// Closing the dialog cancels the task via OnResult; read the
@@ -265,103 +467,47 @@ func (ev *EditorView) FindAll(pattern string, caseSensitive, useRegex, wholeWord
 					vtui.ShowMessage(Msg("Search.Title"), Msg("Search.NotFound"), []string{Msg("vtui.Ok")})
 					return
 				}
-				ev.showFindAllMenu(pattern, bytes, spans)
+				ev.showFindAllMenu(pattern, bytes, spans, uniqueLines)
 			})
 		})
 	})
 }
 
-func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []matchSpan) {
-	matches := make([]editorMatch, len(spans))
-	displays := make([]string, len(spans))
-	rows := make([]findAllRow, len(spans))
+func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []matchSpan, uniqueLines int) {
+	menuTitle := " " + fmt.Sprintf(Msg("Search.AllStatistics"), len(spans), uniqueLines) + " "
+	menu := vtui.NewVMenu(menuTitle)
+	// The menu holds no items: it is a window onto the spans, and everything
+	// VMenu would read out of Items the frame answers from them instead.
+	menu.ItemCount = len(spans)
+	menu.IsSelectable = func(i int) bool { return i >= 0 && i < len(spans) }
 
-	uniqueLines := 0
-	prevLine := -1
-	prevLineStart := 0
-	prevRaw := ""     // tab-replaced line text, offsets 1:1 with the buffer
-	prevDisplay := "" // prevRaw truncated (and sanitized) to findAllMaxItemWidth
-	prevRuneOff := 0
-	prevCol := 1
-	maxCol := 1
-	for i, s := range spans {
-		line := ev.li.GetLineAtOffset(s.Off)
-		if line != prevLine {
-			uniqueLines++
-			prevLine = line
-			// The background indexer may still be catching up on a large
-			// file; clamp every bound against the snapshot so a partially
-			// indexed file cannot panic or materialize the rest of the
-			// buffer as one line.
-			prevLineStart = min(ev.li.GetLineOffset(line), len(data))
-			lineEnd := min(prevLineStart+max(ev.getLineLength(line), 0), len(data))
-			raw := strings.TrimRight(string(data[prevLineStart:lineEnd]), "\r\n")
-			// Tabs become single spaces: a 1-byte-for-1-byte substitution
-			// keeps the match's byte offsets valid in the display string,
-			// which keeps the highlight math trivial.
-			prevRaw = strings.ReplaceAll(raw, "\t", " ")
-			prevDisplay = vtui.TruncateString(prevRaw, findAllMaxItemWidth, "")
-			prevRuneOff = prevLineStart
-			prevCol = 1
-		}
-		// Spans arrive in offset order, so the column is counted from the
-		// previous match on the same line: a long line with many matches is
-		// scanned once overall, not once per match.
-		if prevRuneOff > s.Off {
-			prevRuneOff = s.Off
-		}
-		col := prevCol + utf8.RuneCount(data[prevRuneOff:s.Off])
-		prevRuneOff = s.Off
-		prevCol = col
-		matches[i] = editorMatch{Off: s.Off, Len: s.Len, Line: line, Col: col}
-		if col > maxCol {
-			maxCol = col
-		}
-
-		display := prevDisplay
-		displays[i] = display
-
-		start := s.Off - prevLineStart
-		end := min(start+s.Len, len(display))
-		if start < 0 || start >= len(display) || start >= end ||
-			// Truncation sanitizes control characters while rebuilding the
-			// string, which shifts byte offsets; highlight only when the
-			// display bytes still hold the match where the buffer had it.
-			end > len(prevRaw) || display[start:end] != prevRaw[start:end] {
-			rows[i] = findAllRow{}
-			continue
-		}
-		rows[i] = findAllRow{
-			byteStart: start,
-			byteEnd:   end,
-			cellStart: vtui.StringWidth(display[:start]),
-			cellWidth: vtui.StringWidth(display[start:end]),
-		}
+	frame := &findAllFrame{
+		VMenu:      menu,
+		ev:         ev,
+		data:       data,
+		spans:      spans,
+		bottomHint: Msg("Search.AllBottomHint"),
+		// The last occurrence sits on the highest line number in the list, so
+		// one lookup fixes the width of the line column for good.
+		lineW: len(strconv.Itoa(ev.li.GetLineAtOffset(spans[len(spans)-1].Off) + 1)),
+		colW:  1,
 	}
 
-	lineW := len(strconv.Itoa(matches[len(matches)-1].Line + 1))
-	colW := len(strconv.Itoa(maxCol))
-	prefixFor := func(m editorMatch) string {
-		return fmt.Sprintf("%*d│%*d│ ", lineW, m.Line+1, colW, m.Col)
+	// Sizing needs real rows, so a bounded sample of the head is resolved
+	// here; every other row is resolved when it is painted.
+	maxDisplayW := 0
+	for i := 0; i < min(len(spans), findAllWidthSample); i++ {
+		r := frame.resolveRow(i)
+		maxDisplayW = max(maxDisplayW, vtui.StringWidth(r.text))
+		frame.colW = max(frame.colW, len(strconv.Itoa(r.match.Col)))
 	}
+	frame.anchor = findAllAnchor{}
 	// Measured, not counted: '│' is East-Asian-Ambiguous and renders two
 	// cells wide under CJK locales, where a lineW+colW+3 guess would paint
-	// the highlight two columns off.
-	accentW := vtui.StringWidth(prefixFor(matches[0]))
-
-	menuTitle := " " + fmt.Sprintf(Msg("Search.AllStatistics"), len(matches), uniqueLines) + " "
-	menu := vtui.NewVMenu(menuTitle)
-	maxDisplayW := 0
-	for i := range matches {
-		if w := vtui.StringWidth(displays[i]); w > maxDisplayW {
-			maxDisplayW = w
-		}
-		menu.AddItem(vtui.MenuItem{
-			AccentPrefix: prefixFor(matches[i]),
-			// Text is filled by the initial retruncate below.
-			UserData: i,
-		})
-	}
+	// the highlight two columns off. The numbers formatted here do not matter,
+	// only the widths they are padded to.
+	accentW := vtui.StringWidth(frame.prefixFor(editorMatch{}))
+	frame.accentW = accentW
 
 	scrW := vtui.FrameManager.GetScreenSize()
 	scrH := vtui.FrameManager.GetScreenHeight()
@@ -378,7 +524,7 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 	if w < 10 {
 		w = 10
 	}
-	h := len(matches) + 2
+	h := len(spans) + 2
 	if h > 12 {
 		h = 12 // Far caps the list at 10 rows plus the borders
 	}
@@ -391,28 +537,8 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 	x := max((scrW-w)/2, 0)
 	y := max((scrH-h)/2, 0)
 	menu.SetPosition(x, y, x+w-1, y+h-1)
-
-	frame := &findAllFrame{
-		VMenu:      menu,
-		bottomHint: Msg("Search.AllBottomHint"),
-		accentW:    accentW,
-		displays:   displays,
-		rows:       rows,
-		normalRect: [4]int{x, y, x + w - 1, y + h - 1},
-	}
-	frame.retruncate()
-
-	// vtui pops the menu after OnAction returns, so the jump is posted for
-	// after the frame stack has settled.
-	menu.OnAction = func(idx int) {
-		if idx < 0 || idx >= len(matches) {
-			return
-		}
-		m := matches[idx]
-		vtui.FrameManager.PostTask(func() {
-			ev.selectFoundPattern(m.Off, m.Len)
-		})
-	}
+	menu.SetSelectPos(0) // AddItem would have done this for a normal menu
+	frame.normalRect = [4]int{x, y, x + w - 1, y + h - 1}
 
 	menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
 		if !e.KeyDown {
@@ -428,9 +554,9 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 			switch e.VirtualKeyCode {
 			case vtinput.VK_RETURN:
 				// Jump to the occurrence but keep the menu open.
-				if idx := menu.SelectPos; idx >= 0 && idx < len(matches) {
-					m := matches[idx]
-					ev.selectFoundPattern(m.Off, m.Len)
+				if idx := menu.SelectPos; idx >= 0 && idx < len(spans) {
+					s := spans[idx]
+					ev.selectFoundPattern(s.Off, s.Len)
 				}
 				return true
 			case vtinput.VK_UP, vtinput.VK_DOWN:
@@ -450,10 +576,15 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 
 		if noMods {
 			switch e.VirtualKeyCode {
+			case vtinput.VK_RETURN:
+				// VMenu's own Enter handling reads Items to find the action,
+				// and this menu has none.
+				frame.activate(menu.SelectPos)
+				return true
 			case vtinput.VK_F4:
 				menu.Close()
 				vtui.FrameManager.PostTask(func() {
-					ev.openFoundLinesEditor(pattern, matches, data)
+					ev.openFoundLinesEditor(pattern, data, spans)
 				})
 				return true
 			case vtinput.VK_F5:
@@ -470,7 +601,6 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 					frame.zoomed = false
 				}
 				frame.SetPosition(r[0], r[1], r[2], r[3])
-				frame.retruncate()
 				frame.SetSelectPos(frame.SelectPos) // re-clamp TopPos to the new height
 				vtui.FrameManager.Redraw()
 				return true
@@ -493,24 +623,36 @@ func (ev *EditorView) showFindAllMenu(pattern string, data []byte, spans []match
 
 // openFoundLinesEditor dumps the unique matching lines, each prefixed with
 // its 1-based line number, into a fresh editor (Far's F4 in the find-all
-// list).
-func (ev *EditorView) openFoundLinesEditor(pattern string, matches []editorMatch, data []byte) {
-	if len(matches) == 0 {
+// list). Unlike the list, this one materializes text, so it stops after
+// findAllDumpMaxLines and says how much it left out.
+func (ev *EditorView) openFoundLinesEditor(pattern string, data []byte, spans []matchSpan) {
+	if len(spans) == 0 {
 		return
 	}
-	lineW := len(strconv.Itoa(matches[len(matches)-1].Line + 1))
+	lineW := len(strconv.Itoa(ev.li.GetLineAtOffset(spans[len(spans)-1].Off) + 1))
 
 	var b strings.Builder
-	prev := -1
-	for _, m := range matches {
-		if m.Line == prev {
+	lines, i, lineEnd, prevLine := 0, 0, 0, -1
+	for ; i < len(spans) && lines < findAllDumpMaxLines; i++ {
+		// Spans are ordered, so every match before the end of the line just
+		// written is on that line: skipping them by offset keeps a line with
+		// millions of matches from costing a line-index lookup each.
+		if lines > 0 && spans[i].Off < lineEnd {
 			continue
 		}
-		prev = m.Line
-		lineStart := min(ev.li.GetLineOffset(m.Line), len(data))
-		lineEnd := min(lineStart+max(ev.getLineLength(m.Line), 0), len(data))
+		line := ev.li.GetLineAtOffset(spans[i].Off)
+		if line == prevLine {
+			continue // a still-indexing file can report a zero-length line
+		}
+		prevLine = line
+		lineStart := min(max(ev.li.GetLineOffset(line), 0), len(data))
+		lineEnd = min(lineStart+max(ev.getLineLength(line), 0), len(data))
 		raw := strings.TrimRight(string(data[lineStart:lineEnd]), "\r\n")
-		fmt.Fprintf(&b, "%*d: %s\n", lineW, m.Line+1, raw)
+		fmt.Fprintf(&b, "%*d: %s\n", lineW, line+1, raw)
+		lines++
+	}
+	if left := len(spans) - i; left > 0 {
+		fmt.Fprintf(&b, Msg("Search.AllEditorMore")+"\n", left)
 	}
 
 	editor := NewEditorView(piecetable.New([]byte(b.String())), nil, "")

--- a/editor_find_all_test.go
+++ b/editor_find_all_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -236,6 +237,24 @@ func newFindAllEditor(t *testing.T, content string) *EditorView {
 	return newFindAllEditorSized(t, content, 80, 25)
 }
 
+// paintFindAll renders the frame and returns the text of each row inside the
+// border. The list holds no items, so painting is the only place its contents
+// exist; asserting on the screen is asserting on the list.
+func paintFindAll(t *testing.T, frame *findAllFrame) []string {
+	t.Helper()
+	w, h := vtui.FrameManager.GetScreenSize(), vtui.FrameManager.GetScreenHeight()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(w, h)
+	frame.Show(scr)
+
+	x1, y1, x2, y2 := frame.VMenu.GetPosition()
+	rows := make([]string, 0, max(y2-y1-1, 0))
+	for y := y1 + 1; y < y2; y++ {
+		rows = append(rows, strings.TrimRight(vtui.ScreenRow(scr, y, x1+2, x2-1), " "))
+	}
+	return rows
+}
+
 func keyEvent(vk uint16, ctrlState vtinput.ControlKeyState) *vtinput.InputEvent {
 	return &vtinput.InputEvent{
 		Type:            vtinput.KeyEventType,
@@ -255,14 +274,13 @@ func TestEditorFindAll_MenuContents(t *testing.T) {
 	if !strings.Contains(frame.GetTitle(), "2") {
 		t.Errorf("title should mention occurrence count, got %q", frame.GetTitle())
 	}
-	if frame.Items[0].AccentPrefix != "1│1│ " {
-		t.Errorf("unexpected accent prefix %q", frame.Items[0].AccentPrefix)
+	// The list holds no menu items at all: rows are resolved as they are
+	// painted, which is what keeps a million occurrences openable.
+	if len(frame.Items) != 0 {
+		t.Errorf("menu materialized %d items, want none", len(frame.Items))
 	}
-	if frame.Items[1].AccentPrefix != "3│1│ " {
-		t.Errorf("unexpected accent prefix %q", frame.Items[1].AccentPrefix)
-	}
-	if frame.Items[0].Text != "Unit 15 The Avenue" {
-		t.Errorf("unexpected item text %q", frame.Items[0].Text)
+	if got := paintFindAll(t, frame); got[0] != "1│1│ Unit 15 The Avenue" || got[1] != "3│1│ United Kingdom" {
+		t.Errorf("unexpected painted rows %q", got[:2])
 	}
 }
 
@@ -381,12 +399,14 @@ func TestEditorFindAll_F5Zoom(t *testing.T) {
 	}
 }
 
-func TestEditorFindAll_AmpersandEscaping(t *testing.T) {
+func TestEditorFindAll_AmpersandRendersLiterally(t *testing.T) {
+	// Rows are painted as plain strings, not as vtui control text, so a '&'
+	// in the file reaches the screen as itself and eats no following letter.
 	ev := newFindAllEditor(t, "a & unit b")
 	frame := openFindAllMenu(t, ev, "unit", false, false, false)
 
-	if !strings.Contains(frame.Items[0].Text, "&&") {
-		t.Errorf("literal '&' must be doubled for vtui, got %q", frame.Items[0].Text)
+	if got := paintFindAll(t, frame)[0]; !strings.HasSuffix(got, "a & unit b") {
+		t.Errorf("literal '&' should survive to the screen, got %q", got)
 	}
 }
 
@@ -394,8 +414,8 @@ func TestEditorFindAll_TabsBecomeSpaces(t *testing.T) {
 	ev := newFindAllEditor(t, "a\tunit\tb")
 	frame := openFindAllMenu(t, ev, "unit", false, false, false)
 
-	if frame.Items[0].Text != "a unit b" {
-		t.Errorf("tabs should render as single spaces, got %q", frame.Items[0].Text)
+	if got := paintFindAll(t, frame)[0]; !strings.HasSuffix(got, "a unit b") {
+		t.Errorf("tabs should render as single spaces, got %q", got)
 	}
 }
 
@@ -498,16 +518,17 @@ func TestEditorFindAll_HighlightMatchesDisplayBytes(t *testing.T) {
 	}
 	// The invariant behind the highlight overpaint: whenever a row claims a
 	// highlight, its byte range in the display string must hold the match.
-	for i, r := range frame.rows {
-		if r.cellWidth == 0 {
+	for i := 0; i < frame.GetItemCount(); i++ {
+		r := frame.resolveRow(i)
+		if r.byteEnd == r.byteStart {
 			continue
 		}
-		if got := frame.displays[i][r.byteStart:r.byteEnd]; got != "needle" {
+		if got := r.text[r.byteStart:r.byteEnd]; got != "needle" {
 			t.Errorf("row %d highlight bytes = %q, want \"needle\"", i, got)
 		}
 	}
 	// The control-free line must keep its highlight.
-	if frame.rows[1].cellWidth == 0 {
+	if r := frame.resolveRow(1); r.byteEnd == r.byteStart {
 		t.Error("control-free long line should still highlight its match")
 	}
 }
@@ -516,7 +537,8 @@ func TestEditorFindAll_AccentWidthMeasured(t *testing.T) {
 	ev := newFindAllEditor(t, "unit\n\n\n\n\n\n\n\n\n\nunit at line eleven")
 	frame := openFindAllMenu(t, ev, "unit", false, false, false)
 
-	if want := vtui.StringWidth(frame.Items[0].AccentPrefix); frame.accentW != want {
+	paintFindAll(t, frame)
+	if want := vtui.StringWidth(frame.prefixFor(frame.resolveRow(0).match)); frame.accentW != want {
 		t.Errorf("accentW = %d, want measured width %d", frame.accentW, want)
 	}
 }
@@ -548,9 +570,165 @@ func TestEditorFindAll_NarrowTerminalKeepsText(t *testing.T) {
 	ev := newFindAllEditorSized(t, "unit and more text here\nunit", 24, 10)
 	frame := openFindAllMenu(t, ev, "unit", false, false, false)
 
-	for i := range frame.Items {
-		if frame.Items[i].Text == "" {
+	for i, row := range paintFindAll(t, frame)[:frame.GetItemCount()] {
+		if strings.TrimSpace(row) == "" {
 			t.Errorf("item %d text blanked out on a narrow terminal", i)
 		}
+	}
+}
+
+// --- the list is a window onto the spans, not a copy of them ---
+
+func TestCountMatchLines(t *testing.T) {
+	cases := []struct {
+		name    string
+		data    string
+		pattern string
+		want    int
+	}{
+		{"one per line", "aa\naa\naa\n", "aa", 3},
+		{"several per line", "aa aa aa\nbb\naa aa\n", "aa", 2},
+		{"all on one line", "aa aa aa aa", "aa", 1},
+		{"single match", "xx\nyy aa\n", "aa", 1},
+		{"match ends a line", "aa\nbb aa\naa cc\n", "aa", 3},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			spans, err := findAllMatchSpans(nil, []byte(c.data), c.pattern, true, false, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := countMatchLines(nil, []byte(c.data), spans); got != c.want {
+				t.Errorf("countMatchLines = %d, want %d (%d occurrences)", got, c.want, len(spans))
+			}
+		})
+	}
+}
+
+func TestEditorFindAll_LargeListOpensWithoutMaterializing(t *testing.T) {
+	// Half a million occurrences. Materializing one menu item each cost ~2 µs
+	// and ~210 bytes, so this used to be a second of frozen UI and 100 MB; it
+	// is now bounded by the width sample.
+	const n = 500_000
+	ev := newFindAllEditor(t, strings.Repeat("aaa bbbbb\n", n))
+	data := []byte(strings.Repeat("aaa bbbbb\n", n))
+	spans, err := findAllMatchSpans(nil, data, "aaa", true, false, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(spans) != n {
+		t.Fatalf("expected %d occurrences, got %d", n, len(spans))
+	}
+
+	start := time.Now()
+	ev.showFindAllMenu("aaa", data, spans, countMatchLines(nil, data, spans))
+	elapsed := time.Since(start)
+
+	frame, ok := vtui.FrameManager.GetTopFrame().(*findAllFrame)
+	if !ok {
+		t.Fatal("occurrences menu did not open")
+	}
+	defer frame.Close()
+	if elapsed > 200*time.Millisecond {
+		t.Errorf("opening a %d-occurrence list took %v; it should not scale with the list", n, elapsed)
+	}
+	if len(frame.Items) != 0 {
+		t.Errorf("menu materialized %d items, want none", len(frame.Items))
+	}
+	if got := frame.GetItemCount(); got != n {
+		t.Errorf("item count = %d, want %d", got, n)
+	}
+	if !strings.Contains(frame.GetTitle(), "500000") {
+		t.Errorf("title should report the true total, got %q", frame.GetTitle())
+	}
+
+	// The last occurrence must paint as cheaply as the first.
+	frame.SetSelectPos(n - 1)
+	start = time.Now()
+	rows := paintFindAll(t, frame)
+	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
+		t.Errorf("painting the end of the list took %v", elapsed)
+	}
+	last := rows[len(rows)-1]
+	if want := "500000│1│ aaa bbbbb"; last != want {
+		t.Errorf("last row = %q, want %q", last, want)
+	}
+}
+
+func TestEditorFindAll_ColumnsResolveInAnyOrder(t *testing.T) {
+	// One long line, many matches: columns are counted from wherever the last
+	// resolved row left off, so they have to come out right whichever way the
+	// list is scrolled.
+	ev := newFindAllEditor(t, strings.Repeat("word ", 50))
+	frame := openFindAllMenu(t, ev, "word", false, false, false)
+
+	for _, i := range []int{0, 5, 3, 49, 2, 48, 0} {
+		if got := frame.resolveRow(i).match.Col; got != i*5+1 {
+			t.Errorf("row %d column = %d, want %d", i, got, i*5+1)
+		}
+	}
+}
+
+func TestEditorFindAll_ColumnsCountRunesNotBytes(t *testing.T) {
+	ev := newFindAllEditor(t, "ёжикёжик unit\nunit")
+	frame := openFindAllMenu(t, ev, "unit", false, false, false)
+
+	if got := frame.resolveRow(0).match.Col; got != 10 {
+		t.Errorf("column = %d, want 10 (runes, not bytes)", got)
+	}
+}
+
+func TestEditorFindAll_MouseClickJumps(t *testing.T) {
+	ev := newFindAllEditor(t, "Unit 15 The Avenue\nno match here\nUnited Kingdom")
+	frame := openFindAllMenu(t, ev, "unit", false, false, false)
+
+	x1, y1, _, _ := frame.VMenu.GetPosition()
+	click := &vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		MouseX:      int16(x1 + 2),
+		MouseY:      int16(y1 + 2), // second row
+	}
+	if !frame.ProcessMouse(click) {
+		t.Fatal("click on an occurrence was not handled")
+	}
+	pumpFindAll(t, func() bool { return ev.selActive })
+
+	wantOff := len("Unit 15 The Avenue\nno match here\n")
+	if ev.selAnchorOffset != wantOff {
+		t.Errorf("clicked occurrence anchor = %d, want %d", ev.selAnchorOffset, wantOff)
+	}
+	if !frame.IsDone() {
+		t.Error("clicking an occurrence should close the menu")
+	}
+}
+
+func TestEditorFindAll_F4DumpCapped(t *testing.T) {
+	old := findAllDumpMaxLines
+	findAllDumpMaxLines = 2
+	defer func() { findAllDumpMaxLines = old }()
+
+	ev := newFindAllEditor(t, "unit one\nunit two\nunit three\nunit four")
+	frame := openFindAllMenu(t, ev, "unit", false, false, false)
+
+	frame.ProcessKey(keyEvent(vtinput.VK_F4, 0))
+	var newEd *EditorView
+	pumpFindAll(t, func() bool {
+		ed, ok := vtui.FrameManager.GetTopFrame().(*EditorView)
+		if ok && ed != ev {
+			newEd = ed
+		}
+		return newEd != nil
+	})
+	defer newEd.Close()
+
+	data, err := newEd.pt.Bytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "1: unit one\n2: unit two\n" + fmt.Sprintf(Msg("Search.AllEditorMore"), 2) + "\n"
+	if string(data) != want {
+		t.Errorf("dump mismatch:\n got %q\nwant %q", string(data), want)
 	}
 }

--- a/lang/en.lng
+++ b/lang/en.lng
@@ -1063,6 +1063,7 @@ Search.BtnFind=&Find
 Search.BtnAll=&All
 Search.Searching= Searching...
 Search.AllStatistics=Occurrences: %d, lines: %d
+Search.AllEditorMore=... and %d more occurrences, not listed
 Search.AllBottomHint= Ctrl+Enter Ctrl+Up/Down F4 F5
 Search.AllEditorTitle=Found: %s
 Replace.Title= Replace

--- a/lang/ru.lng
+++ b/lang/ru.lng
@@ -1059,6 +1059,7 @@ Search.BtnFind=&Найти
 Search.BtnAll=&Все
 Search.Searching= Поиск...
 Search.AllStatistics=Вхождений: %d, строк: %d
+Search.AllEditorMore=... и ещё %d вхождений, не показаны
 Search.AllBottomHint= Ctrl+Enter Ctrl+Up/Down F4 F5
 Search.AllEditorTitle=Найдено: %s
 Replace.Title= Замена


### PR DESCRIPTION
Find All on a file that matches everywhere did not appear to finish. The scan was never the problem — 21M occurrences in a 200 MB buffer are found in under half a second. What followed was one `vtui.MenuItem` per occurrence.

### What it cost

Measured per occurrence: a line-index lookup, a display string, a highlight row and a menu item, spread evenly across three phases (resolve, `AddItem`, `retruncate`) at ~2 µs and ~210 bytes each.

| occurrences | menu opens in | heap |
|---|---|---|
| 100k | 197 ms | 20 MB |
| 1M | 2.0 s | 214 MB |
| 4M | 8.0 s | 840 MB |
| 21M (a 200 MB file matching on every line) | ~43 s | ~4.4 GB |

All of it inside the one `ctx.RunOnUI` callback that opens the menu. The heap is the part that matters: 43 s of frozen UI is bad, 4.4 GB on top of the buffer and the spans is a menu that never arrives. `retruncate` also re-ran the whole list on every resize and every F5 — ~0.8 s per keypress at 1M.

### None of it was needed

`VMenu.DisplayObject` paints only the rows between `TopPos` and the bottom border. A page costs ~50 µs to draw whether the list holds three occurrences or twenty million, so the per-item state existed only to be skipped.

The list is now a window onto the `[]matchSpan` the search already produced. `findAllFrame` keeps `Items` empty, sets `ScrollView.ItemCount` itself, and resolves a row's line, column, text and highlight range when that row is painted.

| | before | after |
|---|---|---|
| open, 21M | ~43 s, ~4.4 GB | **1 ms, 0 B** |
| paint a page | ~50 µs | ~100 µs (head or tail) |
| resize / F5, 1M | ~0.8 s | free |
| whole flow, 21M | never finished | 468 ms scan + 60 ms count + 1 ms open |

### What the frame had to take over

`VMenu` reads `Items` to paint rows, to hover, to click and to act on Enter, so those are re-implemented on the frame. Two are worth calling out:

- **`IsSelectable`.** `NewVMenu` installs a closure that indexes `Items`. Left alone it answers "not selectable" for everything, and `MoveSelection` scans all 21M entries looking for one that is — on every keypress. It is replaced with a bounds check.
- **Columns.** Counting runes from the line start per row is fine until the line *is* the file. Each row counts from the previously resolved row when that row was on the same line, forwards or backwards, so scrolling costs the distance moved.

### What changed for the user

- **No cap.** The title reports the true totals, and every occurrence is reachable.
- **Width** hugged the longest of all matching lines; that cannot be known without resolving all of them, so it is sized from the first 1000 (`findAllWidthSample`). Identical for lists shorter than that; F5 still zooms.
- **The line count** in the title is still exact, but counted off the UI thread — a newline between two consecutive matches means a new line, so one forward pass over the bytes between the first match and the last does the whole list (60 ms for 21M) instead of a locked binary search per occurrence.
- **F4** does materialize text, so it stops after 100k lines and appends how many occurrences it left out (`Search.AllEditorMore`, en + ru).
- **A literal `&`** in a file now reaches the screen as itself: rows are drawn as plain strings, not as vtui control text.

### Tests

The existing find-all tests keep their intent; the ones that read `frame.Items` now read the painted screen back out of a `ScreenBuf` through the same `Show` path `FrameManager` calls, which is what covers the re-implemented painting. New: 500k occurrences open in 0.04 s with zero materialized items and a true title; columns resolve correctly in scrambled scroll order and in runes rather than bytes; a mouse click jumps and closes; the F4 dump cap and its note; and `countMatchLines` against several matches per line, all on one line, and a match ending a line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
