### PR TITLE
Add panel selection keyboard shortcuts

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -402,7 +402,7 @@ func init() {
 		LabelKey:    "Menu.Files.View",
 		Description: "Open file in viewer",
 		DescKey:     "Action.File.View.Desc",
-		DefaultKeys: []string{"F3"},
+		DefaultKeys: []string{"F3", "Num5", "VK_C"},
 		MenuPath:    "Files",
 		Handler:     withPF(func(pf *PanelsFrame) { actionViewFile(pf) }),
 	})
@@ -622,7 +622,7 @@ func init() {
 		LabelKey:    "Action.Panel.SelectGroup",
 		Description: "Select files by mask",
 		DescKey:     "Action.Panel.SelectGroup.Desc",
-		DefaultKeys: []string{"Add"},
+		DefaultKeys: []string{"Add", "CtrlShift+", "CtrlShift=", "CtrlShiftVK_BB"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -639,7 +639,7 @@ func init() {
 		LabelKey:    "Action.Panel.DeselectGroup",
 		Description: "Deselect files by mask",
 		DescKey:     "Action.Panel.DeselectGroup.Desc",
-		DefaultKeys: []string{"Subtract"},
+		DefaultKeys: []string{"Subtract", "CtrlShift_", "CtrlShift-", "CtrlShiftVK_BD"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -650,13 +650,39 @@ func init() {
 		}),
 	})
 	RegisterAction(Action{
+		Name:        "Panel.SelectCurrentExtension",
+		Area:        "Shell",
+		Label:       "Select Current Extension",
+		Description: "Select files with the current extension, or all folders",
+		DefaultKeys: []string{"CtrlAdd", "Ctrl=", "CtrlVK_BB"},
+		MenuPath:    "Files",
+		Handler: withPF(func(pf *PanelsFrame) {
+			if fsp := pf.getActivePanel(); fsp != nil {
+				fsp.ApplyCurrentExtensionSelection(true)
+			}
+		}),
+	})
+	RegisterAction(Action{
+		Name:        "Panel.DeselectCurrentExtension",
+		Area:        "Shell",
+		Label:       "Deselect Current Extension",
+		Description: "Deselect files with the current extension, or all folders",
+		DefaultKeys: []string{"CtrlSubtract", "Ctrl-", "CtrlVK_BD"},
+		MenuPath:    "Files",
+		Handler: withPF(func(pf *PanelsFrame) {
+			if fsp := pf.getActivePanel(); fsp != nil {
+				fsp.ApplyCurrentExtensionSelection(false)
+			}
+		}),
+	})
+	RegisterAction(Action{
 		Name:        "Panel.InvertSelection",
 		Area:        "Shell",
 		Label:       "Invert Selection",
 		LabelKey:    "Action.Panel.InvertSelection",
 		Description: "Invert file selection",
 		DescKey:     "Action.Panel.InvertSelection.Desc",
-		DefaultKeys: []string{"Multiply"},
+		DefaultKeys: []string{"Multiply", "Alt=", "AltVK_BB"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {

--- a/action_registry.go
+++ b/action_registry.go
@@ -402,7 +402,7 @@ func init() {
 		LabelKey:    "Menu.Files.View",
 		Description: "Open file in viewer",
 		DescKey:     "Action.File.View.Desc",
-		DefaultKeys: []string{"F3", "Num5", "VK_C"},
+		DefaultKeys: []string{"F3", "Num5"},
 		MenuPath:    "Files",
 		Handler:     withPF(func(pf *PanelsFrame) { actionViewFile(pf) }),
 	})
@@ -622,7 +622,7 @@ func init() {
 		LabelKey:    "Action.Panel.SelectGroup",
 		Description: "Select files by mask",
 		DescKey:     "Action.Panel.SelectGroup.Desc",
-		DefaultKeys: []string{"Add", "CtrlShift+", "CtrlShift=", "CtrlShiftVK_BB"},
+		DefaultKeys: []string{"Add", "CtrlShift+"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -639,7 +639,7 @@ func init() {
 		LabelKey:    "Action.Panel.DeselectGroup",
 		Description: "Deselect files by mask",
 		DescKey:     "Action.Panel.DeselectGroup.Desc",
-		DefaultKeys: []string{"Subtract", "CtrlShift_", "CtrlShift-", "CtrlShiftVK_BD"},
+		DefaultKeys: []string{"Subtract", "CtrlShift_"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -654,7 +654,7 @@ func init() {
 		Area:        "Shell",
 		Label:       "Select Current Extension",
 		Description: "Select files with the current extension, or all folders",
-		DefaultKeys: []string{"CtrlAdd", "Ctrl=", "CtrlVK_BB"},
+		DefaultKeys: []string{"CtrlAdd", "Ctrl="},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -667,7 +667,7 @@ func init() {
 		Area:        "Shell",
 		Label:       "Deselect Current Extension",
 		Description: "Deselect files with the current extension, or all folders",
-		DefaultKeys: []string{"CtrlSubtract", "Ctrl-", "CtrlVK_BD"},
+		DefaultKeys: []string{"CtrlSubtract", "Ctrl-"},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {
@@ -682,7 +682,7 @@ func init() {
 		LabelKey:    "Action.Panel.InvertSelection",
 		Description: "Invert file selection",
 		DescKey:     "Action.Panel.InvertSelection.Desc",
-		DefaultKeys: []string{"Multiply", "Alt=", "AltVK_BB"},
+		DefaultKeys: []string{"Multiply", "Alt="},
 		MenuPath:    "Files",
 		Handler: withPF(func(pf *PanelsFrame) {
 			if fsp := pf.getActivePanel(); fsp != nil {

--- a/action_registry_test.go
+++ b/action_registry_test.go
@@ -55,6 +55,38 @@ func TestActionRegistry(t *testing.T) {
 		t.Error("RunAction should return false for missing action")
 	}
 }
+
+func TestPanelNumpadAndExtensionSelectionDefaultKeys(t *testing.T) {
+	tests := []struct {
+		action string
+		keys   []string
+	}{
+		{"File.View", []string{"F3", "Num5", "VK_C"}},
+		{"Panel.SelectGroup", []string{"Add", "CtrlShift+", "CtrlShift=", "CtrlShiftVK_BB"}},
+		{"Panel.DeselectGroup", []string{"Subtract", "CtrlShift_", "CtrlShift-", "CtrlShiftVK_BD"}},
+		{"Panel.InvertSelection", []string{"Multiply", "Alt=", "AltVK_BB"}},
+		{"Panel.SelectCurrentExtension", []string{"CtrlAdd", "Ctrl=", "CtrlVK_BB"}},
+		{"Panel.DeselectCurrentExtension", []string{"CtrlSubtract", "Ctrl-", "CtrlVK_BD"}},
+	}
+	for _, tc := range tests {
+		action, ok := GetAction(tc.action)
+		if !ok {
+			t.Fatalf("action %q is not registered", tc.action)
+		}
+		for _, want := range tc.keys {
+			found := false
+			for _, got := range action.DefaultKeys {
+				if got == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("action %q is missing default key %q: %v", tc.action, want, action.DefaultKeys)
+			}
+		}
+	}
+}
 func TestRegistry_HexModeAndWorkspaceActions(t *testing.T) {
 	a, ok := GetAction("Editor.HexMode")
 	if !ok {

--- a/action_registry_test.go
+++ b/action_registry_test.go
@@ -61,12 +61,12 @@ func TestPanelNumpadAndExtensionSelectionDefaultKeys(t *testing.T) {
 		action string
 		keys   []string
 	}{
-		{"File.View", []string{"F3", "Num5", "VK_C"}},
-		{"Panel.SelectGroup", []string{"Add", "CtrlShift+", "CtrlShift=", "CtrlShiftVK_BB"}},
-		{"Panel.DeselectGroup", []string{"Subtract", "CtrlShift_", "CtrlShift-", "CtrlShiftVK_BD"}},
-		{"Panel.InvertSelection", []string{"Multiply", "Alt=", "AltVK_BB"}},
-		{"Panel.SelectCurrentExtension", []string{"CtrlAdd", "Ctrl=", "CtrlVK_BB"}},
-		{"Panel.DeselectCurrentExtension", []string{"CtrlSubtract", "Ctrl-", "CtrlVK_BD"}},
+		{"File.View", []string{"F3", "Num5"}},
+		{"Panel.SelectGroup", []string{"Add", "CtrlShift+"}},
+		{"Panel.DeselectGroup", []string{"Subtract", "CtrlShift_"}},
+		{"Panel.InvertSelection", []string{"Multiply", "Alt="}},
+		{"Panel.SelectCurrentExtension", []string{"CtrlAdd", "Ctrl="}},
+		{"Panel.DeselectCurrentExtension", []string{"CtrlSubtract", "Ctrl-"}},
 	}
 	for _, tc := range tests {
 		action, ok := GetAction(tc.action)

--- a/file_panel.go
+++ b/file_panel.go
@@ -3393,6 +3393,50 @@ func (fp *FileSystemPanel) ApplyMaskSelection(mask string, state bool) {
 	vtui.FrameManager.Redraw()
 }
 
+// ApplyCurrentExtensionSelection selects or deselects every item whose
+// extension matches the item under the cursor. When the current item is a
+// directory, all directories are treated as one group; ".." is never marked.
+func (fp *FileSystemPanel) ApplyCurrentExtensionSelection(state bool) {
+	idx := fp.GetCursorIndex()
+	if idx < 0 || idx >= len(fp.entries) {
+		return
+	}
+	current := fp.entries[idx]
+	if current.Name == ".." {
+		return
+	}
+	if current.IsDir {
+		fp.SaveSelection()
+		for i, entry := range fp.entries {
+			if entry.Name != ".." && entry.IsDir {
+				fp.SetItemSelected(i, state)
+			}
+		}
+		vtui.FrameManager.Redraw()
+		return
+	}
+
+	extension := ""
+	if !current.NoExtension {
+		extension = filepath.Ext(current.Name)
+	}
+
+	fp.SaveSelection()
+	for i, entry := range fp.entries {
+		if entry.Name == ".." || entry.IsDir {
+			continue
+		}
+		entryExtension := ""
+		if !entry.NoExtension {
+			entryExtension = filepath.Ext(entry.Name)
+		}
+		if strings.EqualFold(entryExtension, extension) {
+			fp.SetItemSelected(i, state)
+		}
+	}
+	vtui.FrameManager.Redraw()
+}
+
 func (fp *FileSystemPanel) GetSuccessorName() string {
 	if len(fp.entries) <= 1 {
 		return ".."

--- a/file_panel_test.go
+++ b/file_panel_test.go
@@ -60,6 +60,59 @@ func TestFileEntry_GetCellText(t *testing.T) {
 	}
 }
 
+func TestFileSystemPanel_ApplyCurrentExtensionSelection(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	fp := &FileSystemPanel{
+		vfs:            vfs.NewOSVFS(t.TempDir()),
+		table:          vtui.NewTable(0, 0, 40, 10, nil),
+		selectedItems:  make(map[string]bool),
+		selectionEpoch: make(map[string]uint64),
+		entries: []*fileEntry{
+			{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+			{VFSItem: vfs.VFSItem{Name: "one.TXT"}},
+			{VFSItem: vfs.VFSItem{Name: "two.txt"}},
+			{VFSItem: vfs.VFSItem{Name: "archive.tar.gz"}},
+			{VFSItem: vfs.VFSItem{Name: "folder.txt", IsDir: true}},
+			{VFSItem: vfs.VFSItem{Name: "other", IsDir: true}},
+			{VFSItem: vfs.VFSItem{Name: "README"}},
+			{VFSItem: vfs.VFSItem{Name: "virtual.txt", NoExtension: true}},
+		},
+	}
+	fp.SetCursorIndex(1)
+	fp.ApplyCurrentExtensionSelection(true)
+
+	for i, want := range []bool{false, true, true, false, false, false, false, false} {
+		if got := fp.entries[i].Selected; got != want {
+			t.Errorf("entry %q selected = %v, want %v", fp.entries[i].Name, got, want)
+		}
+	}
+
+	fp.ApplyCurrentExtensionSelection(false)
+	if fp.entries[1].Selected || fp.entries[2].Selected {
+		t.Fatal("deselect-current-extension left matching files selected")
+	}
+
+	// Extension-less files form their own group. A VFS row marked NoExtension
+	// belongs to that group even when its display name contains a dot.
+	fp.SetCursorIndex(6)
+	fp.ApplyCurrentExtensionSelection(true)
+	if !fp.entries[6].Selected || !fp.entries[7].Selected {
+		t.Fatal("extension-less selection did not respect NoExtension semantics")
+	}
+
+	// A directory under the cursor selects all directories regardless of dots
+	// in their names, while leaving files and the parent entry unchanged.
+	fp.SetCursorIndex(4)
+	fp.ApplyCurrentExtensionSelection(true)
+	if !fp.entries[4].Selected || !fp.entries[5].Selected || fp.entries[0].Selected {
+		t.Fatal("directory selection did not select all folders or selected parent entry")
+	}
+	fp.ApplyCurrentExtensionSelection(false)
+	if fp.entries[4].Selected || fp.entries[5].Selected {
+		t.Fatal("directory deselection left folders selected")
+	}
+}
+
 func TestFileEntry_HighlightDir(t *testing.T) {
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()

--- a/help_keys_test.go
+++ b/help_keys_test.go
@@ -49,7 +49,7 @@ func TestGenerateKeysHelpTopic_PanelNav(t *testing.T) {
 	joined := strings.Join(topic.Lines, "\n")
 
 	for _, want := range []string{
-		"F3             - Open file in viewer",
+		"F3 / Num5      - Open file in viewer",
 		// Panel.Toggle picked up Del and NumDel as aliases (#351), and
 		// keysFor sorts + joins them alphabetically, so the emitted
 		// prefix is now "Ctrl+O / Del / Esc / NumDel".

--- a/hotkeys.go
+++ b/hotkeys.go
@@ -140,22 +140,41 @@ func (hm *HotkeyManager) GetActiveBindings() map[string]map[string]string {
 
 // GetKeyForAction searches for a key combination bound to the given action in an area.
 func (hm *HotkeyManager) GetKeyForAction(area, actionName string) string {
-	if binds, ok := hm.Bindings[area]; ok {
-		for key, binding := range binds {
-			parts := strings.SplitN(binding, ":", 2)
-			if strings.EqualFold(parts[0], actionName) {
-				return key
-			}
-		}
-	}
+	areas := []string{area}
 	if area != "Common" {
-		if binds, ok := hm.Bindings["Common"]; ok {
-			for key, binding := range binds {
-				parts := strings.SplitN(binding, ":", 2)
-				if strings.EqualFold(parts[0], actionName) {
+		areas = append(areas, "Common")
+	}
+	bindingMatches := func(binding string) bool {
+		name, _, _ := strings.Cut(binding, ":")
+		return strings.EqualFold(name, actionName)
+	}
+
+	// Preserve the action author's ordering for aliases. In particular, F3
+	// must remain the displayed shortcut when Num5 is added as an alternative;
+	// iterating the bindings map directly would choose either at random.
+	if action, ok := GetAction(actionName); ok {
+		for _, keySpec := range action.DefaultKeys {
+			key, _, _ := strings.Cut(keySpec, ":")
+			for _, candidateArea := range areas {
+				if bindingMatches(hm.Bindings[candidateArea][key]) {
 					return key
 				}
 			}
+		}
+	}
+
+	// Custom bindings have no registry ordering, so sort them to keep menus,
+	// help and tests stable across processes.
+	for _, candidateArea := range areas {
+		var keys []string
+		for key, binding := range hm.Bindings[candidateArea] {
+			if bindingMatches(binding) {
+				keys = append(keys, key)
+			}
+		}
+		if len(keys) > 0 {
+			sort.Strings(keys)
+			return keys[0]
 		}
 	}
 	return ""

--- a/hotkeys_test.go
+++ b/hotkeys_test.go
@@ -109,6 +109,25 @@ func TestHotkeyManager_GetKeyForAction(t *testing.T) {
 		t.Errorf("Expected F3, got %q", key)
 	}
 }
+
+func TestHotkeyManager_GetKeyForActionPrefersDeclaredAliasOrder(t *testing.T) {
+	hm := NewHotkeyManager("")
+	hm.initDefaults()
+
+	if key := hm.GetKeyForAction("Shell", "File.View"); key != "F3" {
+		t.Fatalf("primary File.View key = %q, want F3", key)
+	}
+	hm.Bind("Shell", "F3", "None")
+	if key := hm.GetKeyForAction("Shell", "File.View"); key != "Num5" {
+		t.Fatalf("File.View fallback key = %q, want Num5", key)
+	}
+
+	hm.Bind("Shell", "CtrlZ", "Panel.Custom")
+	hm.Bind("Shell", "AltA", "Panel.Custom")
+	if key := hm.GetKeyForAction("Shell", "Panel.Custom"); key != "AltA" {
+		t.Fatalf("custom action key = %q, want deterministic AltA", key)
+	}
+}
 func TestHotkeyManager_ShellDefaults_Issue289(t *testing.T) {
 	hm := NewHotkeyManager("")
 	hm.initDefaults()

--- a/macro.go
+++ b/macro.go
@@ -75,6 +75,7 @@ var farKeyNames = map[uint16]string{
 	vtinput.VK_MULTIPLY: "Multiply",
 	vtinput.VK_ADD:      "Add",
 	vtinput.VK_SUBTRACT: "Subtract",
+	vtinput.VK_NUMPAD5:  "Num5",
 	vtinput.VK_DECIMAL:  "Decimal",
 	vtinput.VK_DIVIDE:   "Divide",
 }

--- a/macro.go
+++ b/macro.go
@@ -94,6 +94,38 @@ func EventToFarString(e *vtinput.InputEvent) string {
 	}
 
 	vk := e.VirtualKeyCode
+	ctrl := mods.Contains(vtinput.LeftCtrlPressed)
+	alt := mods.Contains(vtinput.LeftAltPressed)
+	shift := mods.Contains(vtinput.ShiftPressed)
+	// Normalize keypad 5 with Num Lock off and main-keyboard +/- aliases.
+	// Several backends omit Char for modified OEM keys, but users should see
+	// and configure one stable Far-style name rather than backend-specific VKs.
+	if vk == vtinput.VK_CLEAR && !ctrl && !alt && !shift {
+		sb.WriteString("Num5")
+		return sb.String()
+	}
+	if vk == vtinput.VK_OEM_PLUS && !alt {
+		if ctrl && shift {
+			sb.WriteRune('+')
+			return sb.String()
+		}
+		if ctrl && !shift {
+			sb.WriteRune('=')
+			return sb.String()
+		}
+	}
+	if vk == vtinput.VK_OEM_PLUS && alt && !ctrl && !shift {
+		sb.WriteRune('=')
+		return sb.String()
+	}
+	if vk == vtinput.VK_OEM_MINUS && ctrl && !alt {
+		if shift {
+			sb.WriteRune('_')
+		} else {
+			sb.WriteRune('-')
+		}
+		return sb.String()
+	}
 	// Windows marks the numeric-keypad Enter as enhanced, while the main
 	// keyboard Enter is not enhanced. Delete is the opposite: the navigation
 	// cluster key is enhanced and the keypad decimal/delete key is not.
@@ -217,6 +249,10 @@ func ParseFarKey(s string) *vtinput.InputEvent {
 				e.VirtualKeyCode = vtinput.VK_OEM_MINUS
 			case '=':
 				e.VirtualKeyCode = vtinput.VK_OEM_PLUS
+			case '+':
+				e.VirtualKeyCode = vtinput.VK_OEM_PLUS
+			case '_':
+				e.VirtualKeyCode = vtinput.VK_OEM_MINUS
 			case '/':
 				e.VirtualKeyCode = vtinput.VK_OEM_2
 			case '`', '~':

--- a/macro_test.go
+++ b/macro_test.go
@@ -85,6 +85,47 @@ func TestEnterAndNumEnterUseCorrectFarKeyNames(t *testing.T) {
 	}
 }
 
+func TestNumpadFiveUsesStableFarKeyNames(t *testing.T) {
+	tests := []struct {
+		vk   uint16
+		want string
+	}{
+		{vtinput.VK_NUMPAD5, "Num5"},
+		{vtinput.VK_CLEAR, "VK_C"},
+	}
+	for _, tc := range tests {
+		event := &vtinput.InputEvent{VirtualKeyCode: tc.vk}
+		if got := EventToFarString(event); got != tc.want {
+			t.Errorf("EventToFarString(VK_%X) = %q, want %q", tc.vk, got, tc.want)
+		}
+		if got := ParseFarKey(tc.want).VirtualKeyCode; got != tc.vk {
+			t.Errorf("ParseFarKey(%q) VK = %X, want %X", tc.want, got, tc.vk)
+		}
+	}
+}
+
+func TestMainKeyboardSelectionAliasesUseStableFarKeyNames(t *testing.T) {
+	tests := []struct {
+		name  string
+		event *vtinput.InputEvent
+		want  string
+	}{
+		{"ctrl shift plus", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, Char: '+', ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift+"},
+		{"ctrl shift underscore", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_MINUS, Char: '_', ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift_"},
+		{"alt equals", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, Char: '=', ControlKeyState: vtinput.LeftAltPressed}, "Alt="},
+		{"ctrl shift plus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShiftVK_BB"},
+		{"ctrl shift minus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_MINUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShiftVK_BD"},
+		{"alt equals without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftAltPressed}, "AltVK_BB"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := EventToFarString(tc.event); got != tc.want {
+				t.Errorf("EventToFarString = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 type mockAreaFrame struct {
 	vtui.BaseFrame
 	typ   vtui.FrameType

--- a/macro_test.go
+++ b/macro_test.go
@@ -91,16 +91,16 @@ func TestNumpadFiveUsesStableFarKeyNames(t *testing.T) {
 		want string
 	}{
 		{vtinput.VK_NUMPAD5, "Num5"},
-		{vtinput.VK_CLEAR, "VK_C"},
+		{vtinput.VK_CLEAR, "Num5"},
 	}
 	for _, tc := range tests {
 		event := &vtinput.InputEvent{VirtualKeyCode: tc.vk}
 		if got := EventToFarString(event); got != tc.want {
 			t.Errorf("EventToFarString(VK_%X) = %q, want %q", tc.vk, got, tc.want)
 		}
-		if got := ParseFarKey(tc.want).VirtualKeyCode; got != tc.vk {
-			t.Errorf("ParseFarKey(%q) VK = %X, want %X", tc.want, got, tc.vk)
-		}
+	}
+	if got := ParseFarKey("Num5").VirtualKeyCode; got != vtinput.VK_NUMPAD5 {
+		t.Errorf("ParseFarKey(Num5) VK = %X, want %X", got, vtinput.VK_NUMPAD5)
 	}
 }
 
@@ -113,9 +113,9 @@ func TestMainKeyboardSelectionAliasesUseStableFarKeyNames(t *testing.T) {
 		{"ctrl shift plus", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, Char: '+', ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift+"},
 		{"ctrl shift underscore", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_MINUS, Char: '_', ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift_"},
 		{"alt equals", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, Char: '=', ControlKeyState: vtinput.LeftAltPressed}, "Alt="},
-		{"ctrl shift plus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShiftVK_BB"},
-		{"ctrl shift minus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_MINUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShiftVK_BD"},
-		{"alt equals without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftAltPressed}, "AltVK_BB"},
+		{"ctrl shift plus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift+"},
+		{"ctrl shift minus without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_MINUS, ControlKeyState: vtinput.LeftCtrlPressed | vtinput.ShiftPressed}, "CtrlShift_"},
+		{"alt equals without char", &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_OEM_PLUS, ControlKeyState: vtinput.LeftAltPressed}, "Alt="},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add `Numpad 5` as a panel-view alias for `F3`, with Num Lock on or off
- add current-extension selection and deselection on `Ctrl+Numpad +/-` and main-keyboard `Ctrl+=/-`
- treat directories as one selection group when the cursor is on a folder
- add main-keyboard aliases for mask dialogs (`Ctrl+Shift+=/-`) and selection inversion (`Alt+=`)
- keep the primary declared shortcut stable in menus when an action has aliases

## Tests
- focused panel selection, key normalization, hotkey ordering, mask-dialog and Ctrl+Clear regression tests
- canonical Windows console build completed and launched successfully