### PR TITLE
fix: path hints respect the CommandLineAutoComplete option

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -2707,6 +2707,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.PanelScrollbarMode = PanelScrollbarMode(comboScrollbars.Menu.SelectPos)
 		AppConfig.SavePanelPaths = chkPaths.State == 1
 		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
+		pf.cmdLine.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
 		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)
 		AppConfig.SearchCommandStayFocused = chkStayFocused.State == 1
 		AppConfig.SyncPanelLoad = chkSync.State == 1

--- a/command_line.go
+++ b/command_line.go
@@ -21,7 +21,7 @@ func NewCommandLine(prompt string) *CommandLine {
 	}
 	cl.Edit.DeduplicateHistory = true
 	cl.Edit.HistoryLimit = 100
-	cl.Edit.PathHintsEnabled = true
+	cl.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
 	cl.Edit.ColorTextIdx = ColCommandLineText
 	cl.Edit.ColorUnchangedIdx = ColCommandLineText
 	cl.Edit.ColorSelectedIdx = ColCommandLineSelectedText

--- a/command_line_test.go
+++ b/command_line_test.go
@@ -154,3 +154,33 @@ func TestCommandLine_AutoCompleteDisabled(t *testing.T) {
 		t.Error("AutoCompleteMenu was shown even though CommandLineAutoComplete is false")
 	}
 }
+
+func TestCommandLine_NoAutoCompleteMenuWhenDisabled(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldCfg := AppConfig
+	AppConfig.CommandLineAutoComplete = false
+	defer func() { AppConfig = oldCfg }()
+
+	cl := NewCommandLine("> ")
+	cl.SetPosition(0, 0, 30, 0)
+	// PathHintsEnabled follows the option (synced like the settings dialog does).
+	cl.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
+	cl.Edit.History = []string{"dir /s", "dir /s d", "dir /s"}
+
+	// Type "dir /s": the separator and the trailing character must not open
+	// the autocomplete menu (neither path hints nor legacy history).
+	for _, r := range "dir /s" {
+		cl.ProcessKey(&vtinput.InputEvent{
+			Type:    vtinput.KeyEventType,
+			KeyDown: true,
+			Char:    r,
+		})
+	}
+
+	top := vtui.FrameManager.GetTopFrame()
+	if _, isAc := top.(*vtui.AutoCompleteMenu); isAc {
+		t.Error("AutoCompleteMenu was shown even though CommandLineAutoComplete is false")
+	}
+}

--- a/path_hints.go
+++ b/path_hints.go
@@ -28,6 +28,10 @@ func applyPathHintSettings() {
 // AppConfig.PathHintSource and returns directory listing items for the
 // autocomplete menu.
 func pathHintProvider(edit *vtui.Edit, word string, from, to int) []vtui.AutoCompleteItem {
+	// Path hints only make sense when command line autocompletion is enabled.
+	if !AppConfig.CommandLineAutoComplete {
+		return nil
+	}
 	if vtui.FrameManager == nil {
 		return nil
 	}

--- a/path_hints_test.go
+++ b/path_hints_test.go
@@ -203,6 +203,7 @@ func TestPathHintProvider_BothPanels(t *testing.T) {
 
 	oldCfg := AppConfig
 	defer func() { AppConfig = oldCfg }()
+	AppConfig.CommandLineAutoComplete = true
 	AppConfig.PathHintSource = PathHintSourceBoth
 	AppConfig.PathHintFullPath = false
 
@@ -233,5 +234,31 @@ func TestPathHintProvider_BothPanels(t *testing.T) {
 	items = pathHintProvider(nil, "sub/", 0, 4)
 	if len(items) != 1 || !strings.HasSuffix(items[0].Display, "active.txt") {
 		t.Fatalf("Active-only source failed: %v", items)
+	}
+}
+
+func TestPathHintProvider_DisabledWhenCommandLineAutoCompleteOff(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	dir := t.TempDir()
+	os.Mkdir(filepath.Join(dir, "sub"), 0755)
+	os.WriteFile(filepath.Join(dir, "sub", "file.txt"), []byte("x"), 0644)
+
+	pf := setupMockPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	pf.panels[1].(*FileSystemPanel).vfs = vfs.NewOSVFS(dir)
+	vtui.FrameManager.Push(pf)
+	defer vtui.FrameManager.Pop()
+
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.CommandLineAutoComplete = false
+	AppConfig.PathHintSource = PathHintSourceBoth
+	AppConfig.PathHintFullPath = false
+
+	if items := pathHintProvider(nil, "sub/", 0, 4); items != nil {
+		t.Fatalf("Path hints should be disabled when command line autocompletion is off, got %d items", len(items))
 	}
 }


### PR DESCRIPTION
## Summary
Path hints (autocompletion from directory contents) were shown on the
command line even when the user disabled "Command line autocomplete" in
the panel settings dialog.

## Changes
- `command_line.go`: `NewCommandLine` no longer hardcodes
  `PathHintsEnabled = true`; it now reads `AppConfig.CommandLineAutoComplete`.
- `actions.go`: the panel settings dialog now live-syncs
  `cmdLine.Edit.PathHintsEnabled` with the checkbox value when settings are saved.
- `path_hints.go`: `pathHintProvider` returns no items when autocompletion
  is disabled.
- Tests: `TestCommandLine_NoAutoCompleteMenuWhenDisabled` and
  `TestPathHintProvider_DisabledWhenCommandLineAutoCompleteOff`, plus the
  existing path-hint test now enables the option explicitly.

## Verification
- `go test ./...` passes.
- Manual: toggling the setting off stops the autocomplete menu from
  appearing while typing on the command line.