### PR TITLE
viewer: stop copying vtui.Window mutex by value

### DIFF
--- a/find_file.go
+++ b/find_file.go
@@ -324,7 +324,7 @@ func (r foundFileRow) GetCellText(col int) string {
 }
 
 type SearchResultsWindow struct {
-	vtui.Window
+	*vtui.Window
 	table *vtui.Table
 	found []FoundFile
 	vfs   vfs.VFS
@@ -375,7 +375,7 @@ func ShowSearchResults(pf *PanelsFrame, v vfs.VFS, found []FoundFile) {
 	baseDlg := vtui.NewCenteredDialog(dlgW, dlgH, Msg("FindFile.SearchResultsTitle"))
 
 	srw := &SearchResultsWindow{
-		Window: *baseDlg,
+		Window: baseDlg,
 		found:  found,
 		vfs:    v,
 		pf:     pf,

--- a/hotkeys_ui.go
+++ b/hotkeys_ui.go
@@ -247,7 +247,7 @@ func showAreaSelectDialog(actionName, defaultArea, defaultCond string, onComplet
 }
 
 type HotkeyAssignFrame struct {
-	vtui.Window
+	*vtui.Window
 	actionName string
 	area       string
 	onComplete func()
@@ -257,7 +257,7 @@ func NewHotkeyAssignFrame(actionName, area string, onComplete func()) *HotkeyAss
 	width, height := 42, 9
 	base := vtui.NewCenteredDialog(width, height, Msg("Hotkeys.AssignTitle"))
 	f := &HotkeyAssignFrame{
-		Window:     *base,
+		Window:     base,
 		actionName: actionName,
 		area:       area,
 		onComplete: onComplete,

--- a/macro.go
+++ b/macro.go
@@ -594,7 +594,7 @@ func (m *MacroManager) Save() {
 
 // MacroAssignFrame is a modal frame that captures a key combination to assign a macro.
 type MacroAssignFrame struct {
-	vtui.Window
+	*vtui.Window
 	mgr *MacroManager
 }
 
@@ -602,7 +602,7 @@ func NewMacroAssignFrame(m *MacroManager) *MacroAssignFrame {
 	width, height := 42, 7
 	base := vtui.NewCenteredDialog(width, height, Msg("Macro.AssignTitle"))
 	f := &MacroAssignFrame{
-		Window: *base,
+		Window: base,
 		mgr:    m,
 	}
 


### PR DESCRIPTION
## What

`SearchResultsWindow`, `HotkeyAssignFrame` and `MacroAssignFrame` embed `vtui.Window` **by value** and initialise it with `*vtui.NewCenteredDialog(...)`, which copies the embedded `sync.Mutex`. `go vet` flags all three (`copies lock value`).

Each struct now embeds `*vtui.Window` and keeps the dialog pointer, matching the pointer form already used elsewhere in f4 (`apply_command_output.go`, `command_palette_ui.go`, `file_op_dialog.go`, …). All existing field accesses work unchanged via Go's automatic pointer dereference.

## Verification

- `go build ./...` clean
- `go vet .` — the three `copies lock value` warnings are gone
- `go test -run 'FindFile|SearchResults|Hotkey|Macro'` green

*(Local note: `TestCommandPaletteProductionCommandSurfaceInventory` fails in a Freebuff worktree because it scans `.freebuff/worktrees/*` copies; it is unaffected by this change and passes in a clean CI checkout.)*