### PR TITLE
test: settle panel load in seedPanelForRestore so async tasks don't leak

### DIFF
--- a/action_restore_selection_test.go
+++ b/action_restore_selection_test.go
@@ -20,6 +20,11 @@ func seedPanelForRestore(t *testing.T, names []string) *PanelsFrame {
 
 	fsp := pf.getActivePanel()
 	fsp.vfs = vfs.NewOSVFS(".")
+	// NewFileSystemPanel starts an asynchronous directory read. Let it finish
+	// before returning, otherwise its completion task leaks into the shared
+	// FrameManager queue and corrupts the next test that drains it (and, if
+	// this test swaps the VFS, the late callback panics against the new VFS).
+	waitForLoad(t, fsp)
 
 	entries := []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
 	for _, n := range names {


### PR DESCRIPTION
## What

`seedPanelForRestore` builds a panel via `NewFileSystemPanel`, which starts an **asynchronous** directory read whose completion task is posted to the shared `vtui.FrameManager.TaskChan`. The helper returned without draining it, so:

- the completion task leaked into whichever test next drained the queue — the `TestEditorFindAll_*` helpers, which all failed when run after it in `go test ./...` but passed in isolation;
- a test that swaps the panel's VFS (e.g. `TestApplyCompletionDoesNotTouchClosedWorkspace`) could trip the late callback against the new VFS, panicking nondeterministically with `panic: closed workspace VFS was touched`.

## Fix

One line using the existing `waitForLoad` helper:

```go
fsp := pf.getActivePanel()
fsp.vfs = vfs.NewOSVFS(".")
waitForLoad(t, fsp)   // drain NewFileSystemPanel's async directory read
```

## Verification

- `TestApplyCompletionDoesNotTouchClosedWorkspace` — 5/5 pass on native Windows (previously flaky, panicking ~1/3 of runs)
- `TestEditorFindAll` — green in isolation and when run after the full set of preceding tests
- All other `seedPanelForRestore` users (apply-command / restore-selection suites) — green
- `go build ./...` clean