### PR TITLE
Editor: fix "Loading..." stuck on non-UTF-8 files, and Colorer: make downloaded themes appear in the picker

### DIFF
--- a/colorer_downloader.go
+++ b/colorer_downloader.go
@@ -125,6 +125,8 @@ func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 			vtui.ShowMessage(" Error ", fmt.Sprintf("Failed to download Colorer schemas:\n%v\n\nFalling back to Chroma.", err), []string{"&Ok"})
 			onComplete(false)
 		} else {
+			// The cached scheme list predates the download — invalidate it.
+			ResetColorerSchemesCache()
 			vtui.ShowMessage(" Success ", "Colorer schemas downloaded and installed successfully!", []string{"&Ok"})
 			onComplete(true)
 		}

--- a/editor_index_status_test.go
+++ b/editor_index_status_test.go
@@ -26,6 +26,29 @@ func pumpUntil(t *testing.T, what string, cond func() bool) {
 	}
 }
 
+// A fully read file (non-UTF-8) has no scan at all — the restore must still
+// resolve, or Loading stays on screen until a key press aborts it.
+func TestIndexRestore_ResolvesForFullyReadFile(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	pt := piecetable.New([]byte("line one\nline two\nline three\nline four\nline five\n"))
+	ev := newEditorView(pt, nil, "", false)
+	ev.targetLine = 3
+	ev.targetPos = 2
+	ev.targetTopRow = 3
+	ev.targetLeft = 0
+
+	ev.StartIndexing()
+
+	if ev.targetLine != -1 {
+		t.Fatalf("StartIndexing on a fully read file must resolve the restore, targetLine = %d", ev.targetLine)
+	}
+	if ev.CursorLine != 3 || ev.CursorPos != 2 || ev.ScrollTopRow != 3 {
+		t.Errorf("restore = line %d pos %d top %d, want 3, 2, 3", ev.CursorLine, ev.CursorPos, ev.ScrollTopRow)
+	}
+}
+
 // TestIndexStatus_ReachesCompleteAndNotifies covers the state machine end to
 // end: a scan announces itself, reports progress, and settles on complete,
 // telling subscribers about every phase it passes through.

--- a/editor_view.go
+++ b/editor_view.go
@@ -2634,6 +2634,26 @@ func (ev *EditorView) scrollViewBy(delta int) {
 	vtui.FrameManager.Redraw()
 }
 
+// restoreTargetPos applies the saved position once the line it targets is
+// indexed; the indexer's batches call it, and so does StartIndexing's early
+// return for fully read files where no scan will ever run.
+func (ev *EditorView) restoreTargetPos() bool {
+	if ev.targetLine == -1 {
+		return false
+	}
+	ev.CursorLine = max(min(ev.targetLine, ev.li.LineCount()-1), 0)
+	if ev.asyncBuf != nil && ev.targetPos >= 0 {
+		_, _ = ev.asyncBuf.Read(ev.li.GetLineOffset(ev.CursorLine)+ev.targetPos, 4096)
+	}
+	ev.CursorPos = ev.targetPos
+	ev.ScrollTopRow = ev.targetTopRow
+	ev.ScrollLeft = max(ev.targetLeft, 0)
+	ev.targetLine = -1
+	ev.ensureCursorVisible()
+	ev.updateDesiredVisualCol()
+	return true
+}
+
 func (ev *EditorView) ensureCursorVisible() {
 	if ev.targetLine != -1 {
 		return // Skip clamping and scrolling while waiting for the target line to be indexed
@@ -2894,6 +2914,9 @@ func (ev *EditorView) StartIndexing() {
 	// A mapped file has no chunk buffer and needs indexing just the same, so
 	// the question is whether there is any text at all, not how it is backed.
 	if ev.asyncBuf == nil && ev.mapped == nil {
+		// Fully read files (non-UTF-8 codepages) have a complete index and no
+		// scan; resolve a pending restore here or Loading waits forever.
+		ev.restoreTargetPos()
 		return
 	}
 	if ev.indexCancel != nil {
@@ -2987,28 +3010,7 @@ func (ev *EditorView) StartIndexing() {
 						li.AppendOffsets(batchOffsets, maxSize)
 
 						if ev.targetLine != -1 && (li.LineCount() > ev.targetLine || len(res.Offsets) < batchSize) {
-							ev.CursorLine = ev.targetLine
-							if ev.CursorLine >= li.LineCount() {
-								ev.CursorLine = li.LineCount() - 1
-							}
-							if ev.CursorLine < 0 {
-								ev.CursorLine = 0
-							}
-
-							targetOff := li.GetLineOffset(ev.CursorLine) + ev.targetPos
-							if targetOff >= 0 && ev.asyncBuf != nil {
-								_, _ = ev.asyncBuf.Read(targetOff, 4096)
-							}
-
-							ev.CursorPos = ev.targetPos
-							ev.ScrollTopRow = ev.targetTopRow
-							ev.ScrollLeft = ev.targetLeft
-							if ev.ScrollLeft < 0 {
-								ev.ScrollLeft = 0
-							}
-							ev.targetLine = -1
-							ev.ensureCursorVisible()
-							ev.updateDesiredVisualCol()
+							ev.restoreTargetPos()
 						}
 
 						ev.engine.InvalidateFrom(lastLineBefore)
@@ -3032,27 +3034,7 @@ func (ev *EditorView) StartIndexing() {
 				scannedTo.Store(int64(maxSize))
 				vtui.FrameManager.PostTask(func() {
 					if ctx.Err() == nil && ev.editSession == sessionID {
-						if ev.targetLine != -1 {
-							ev.CursorLine = ev.targetLine
-							if ev.CursorLine >= li.LineCount() {
-								ev.CursorLine = li.LineCount() - 1
-							}
-							if ev.CursorLine < 0 {
-								ev.CursorLine = 0
-							}
-							targetOff := li.GetLineOffset(ev.CursorLine) + ev.targetPos
-							if targetOff >= 0 && ev.asyncBuf != nil {
-								_, _ = ev.asyncBuf.Read(targetOff, 4096)
-							}
-							ev.CursorPos = ev.targetPos
-							ev.ScrollTopRow = ev.targetTopRow
-							ev.ScrollLeft = ev.targetLeft
-							if ev.ScrollLeft < 0 {
-								ev.ScrollLeft = 0
-							}
-							ev.targetLine = -1
-							ev.ensureCursorVisible()
-							ev.updateDesiredVisualCol()
+						if ev.restoreTargetPos() {
 							vtui.FrameManager.Redraw()
 						}
 						if ev.highlighter != nil && !ev.highlighting && len(ev.lineStates) < li.LineCount() {
@@ -3155,22 +3137,7 @@ func (ev *EditorView) StartIndexing() {
 					li.AppendOffsets(currentBatch, maxSize)
 
 					if ev.targetLine != -1 && (li.LineCount() > ev.targetLine || batchEnd >= maxSize) {
-						ev.CursorLine = ev.targetLine
-						if ev.CursorLine >= li.LineCount() {
-							ev.CursorLine = li.LineCount() - 1
-						}
-						if ev.CursorLine < 0 {
-							ev.CursorLine = 0
-						}
-						ev.CursorPos = ev.targetPos
-						ev.ScrollTopRow = ev.targetTopRow
-						ev.ScrollLeft = ev.targetLeft
-						if ev.ScrollLeft < 0 {
-							ev.ScrollLeft = 0
-						}
-						ev.targetLine = -1
-						ev.ensureCursorVisible()
-						ev.updateDesiredVisualCol()
+						ev.restoreTargetPos()
 					}
 
 					ev.engine.InvalidateFrom(lastLineBefore)
@@ -3184,23 +3151,7 @@ func (ev *EditorView) StartIndexing() {
 
 		vtui.FrameManager.PostTask(func() {
 			if ctx.Err() == nil && ev.editSession == sessionID {
-				if ev.targetLine != -1 {
-					ev.CursorLine = ev.targetLine
-					if ev.CursorLine >= li.LineCount() {
-						ev.CursorLine = li.LineCount() - 1
-					}
-					if ev.CursorLine < 0 {
-						ev.CursorLine = 0
-					}
-					ev.CursorPos = ev.targetPos
-					ev.ScrollTopRow = ev.targetTopRow
-					ev.ScrollLeft = ev.targetLeft
-					if ev.ScrollLeft < 0 {
-						ev.ScrollLeft = 0
-					}
-					ev.targetLine = -1
-					ev.ensureCursorVisible()
-					ev.updateDesiredVisualCol()
+				if ev.restoreTargetPos() {
 					vtui.FrameManager.Redraw()
 				}
 				if ev.highlighter != nil && !ev.highlighting && len(ev.lineStates) < li.LineCount() {


### PR DESCRIPTION
**1. `editor: resolve saved-position restore for fully read files`**

The early return in `StartIndexing()` now resolves a pending saved-position restore immediately. The restore logic (cursor/scroll clamping, scroll into view) was extracted into a single `restoreTargetPos()` helper and is now shared by all four indexer batch sites, removing the duplicated block.

**2. `colorer: invalidate scheme list cache after download`**

`ResetColorerSchemesCache()` is now called at the single success point of the download flow, so both entry points (the wizard on first open and the button in settings) see the freshly installed themes immediately.
