### PR TITLE
editor: open binary files in hex without a full scan

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -2085,6 +2085,10 @@ func init() {
 				ev.HexNibble = 0
 			} else {
 				ev.DecodeMode = false
+				// A binary file opened straight into hex never ran the indexer.
+				if !ev.indexing && !ev.indexIsComplete() {
+					ev.StartIndexing()
+				}
 			}
 			ev.ensureCursorVisible()
 			vtui.FrameManager.Redraw()

--- a/actions.go
+++ b/actions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/hex"
@@ -21,6 +22,16 @@ import (
 )
 
 const openingProgressDelay = 250 * time.Millisecond
+
+// editorHeaderIsBinary: NUL in the header means binary — text in any codepage
+// (cp1251 included, which the viewer's utf8 check would call binary) has none.
+func editorHeaderIsBinary(header []byte, cpID int) bool {
+	// DecodeBytes is a no-op for 65001 and leaves the data alone on error.
+	if decoded, err := vfs.DecodeBytes(header, cpID); err == nil {
+		header = decoded
+	}
+	return bytes.IndexByte(header, 0) >= 0
+}
 
 var (
 	LastFindFileMask = "*"
@@ -685,6 +696,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 	var buf *AsyncBuffer
 	var mapped *MappedFile
 	cpID := AppConfig.EditorDefaultCodePage
+	binary := false
 
 	if f != nil {
 		size := f.Size()
@@ -693,9 +705,19 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 			detectLen = int(size)
 		}
 		header := make([]byte, detectLen)
-		_, _ = f.ReadAt(context.Background(), header, 0)
+		n, _ := f.ReadAt(context.Background(), header, 0)
+		// Unread bytes stay zero and would look like NULs, so only inspect
+		// what was actually read.
+		header = header[:n]
 
 		cpID = vfs.DetectEncoding(header, AppConfig.EditorAutodetectCodePage, AppConfig.EditorDefaultCodePage)
+
+		// Binary files open straight into hex; 65001 keeps them on the lazy
+		// chunked path instead of a full read, like the viewer.
+		binary = editorHeaderIsBinary(header, cpID)
+		if binary {
+			cpID = 65001
+		}
 
 		if cpID == 65001 {
 			// A local file is mapped rather than read: the mapping is one
@@ -733,10 +755,12 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 
 	editor := NewEditorView(pt, v, path)
 	editor.Codepage = cpID
-	if _, isDisks := v.(*vfs.DisksVFS); isDisks {
+	// StartIndexing skips hex, so binary files open without a line scan.
+	if _, isDisks := v.(*vfs.DisksVFS); isDisks || binary {
 		editor.HexMode = true
 	}
-	if GlobalFileState != nil && path != "" {
+	// A saved position is a line number, meaningless for a hex view.
+	if GlobalFileState != nil && path != "" && !binary {
 		if state := GlobalFileState.GetState(FileStateKey(v, path)); state != nil {
 			editor.WordWrap = state.EditorWrap
 			editor.targetLine = state.EditorLine

--- a/editor_binary_open_test.go
+++ b/editor_binary_open_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// NUL headers are binary; cp1251 text (invalid UTF-8 but NUL-free) and
+// UTF-16 text (NULs decoded away) are not.
+func TestEditorHeaderIsBinary(t *testing.T) {
+	if !editorHeaderIsBinary([]byte{0, 0, 0, 0x20, 'f', 't'}, 65001) {
+		t.Error("NUL header must be binary")
+	}
+	cp1251 := []byte{0xCF, 0xF0, 0xE8, 0xE2, 0xE5, 0xF2} // "Привет"
+	for _, cp := range []int{65001, 1251} {
+		if editorHeaderIsBinary(cp1251, cp) {
+			t.Errorf("cp1251 text must not be binary (cp=%d)", cp)
+		}
+	}
+	if editorHeaderIsBinary([]byte{0xFF, 0xFE, 'h', 0, 'i', 0}, 1200) {
+		t.Error("UTF-16 text must not be binary")
+	}
+}
+
+// Hex/decode render by byte offset: no line scan may run, and a pending
+// line-based restore is meaningless there.
+func TestStartIndexingSkipsHexAndDecodeModes(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	pt := piecetable.New([]byte("line one\nline two\n"))
+	for _, tc := range []struct {
+		mode string
+		hex  bool
+		deco bool
+	}{{"hex", true, false}, {"decode", false, true}} {
+		ev := newEditorView(pt, nil, "", false)
+		ev.HexMode, ev.DecodeMode = tc.hex, tc.deco
+		ev.targetLine = 1
+		ev.StartIndexing()
+		if ev.targetLine != -1 {
+			t.Errorf("%s mode must clear a pending target line, got %d", tc.mode, ev.targetLine)
+		}
+		if ev.indexing || ev.indexIsComplete() {
+			t.Errorf("%s mode must not run the line-index scan", tc.mode)
+		}
+	}
+}
+
+// A binary file opened for editing goes straight into hex on the lazy chunked
+// path (codepage 65001) without a background scan.
+func TestShowEditorBinaryOpensInHex(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sample.bin")
+	if err := os.WriteFile(path, []byte{0, 0, 0, 0x20, 'f', 't', 'y', 'p', 0x0A, 'x'}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	localVFS := vfs.NewOSVFS(dir)
+	_ = localVFS.SetPath(dir)
+	pf := NewPanelsFrame()
+	pf.panels[0] = NewFileSystemPanel(0, 0, 40, 20, localVFS)
+	pf.panels[1] = NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+	pf.ResizeConsole(120, 60)
+	vtui.FrameManager.Push(pf)
+
+	f, err := localVFS.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	showEditor(pf, localVFS, path, f)
+
+	ev, _ := findOpenedEditor(localVFS, path)
+	if ev == nil {
+		t.Fatal("editor was not opened")
+	}
+	defer ev.Close()
+	if !ev.HexMode || ev.Codepage != 65001 {
+		t.Errorf("binary file must open in hex with codepage 65001, got hex=%v cp=%d", ev.HexMode, ev.Codepage)
+	}
+	if ev.indexing || ev.indexIsComplete() {
+		t.Error("binary file in hex mode must not run the line-index scan")
+	}
+}

--- a/editor_view.go
+++ b/editor_view.go
@@ -2891,6 +2891,12 @@ func nextIndexPoll(cur time.Duration) time.Duration {
 }
 
 func (ev *EditorView) StartIndexing() {
+	// Hex/decode render by byte offset: the index is only needed if the user
+	// switches back to text, and scanning a big binary is a full read.
+	if ev.HexMode || ev.DecodeMode {
+		ev.targetLine = -1
+		return
+	}
 	// A mapped file has no chunk buffer and needs indexing just the same, so
 	// the question is whether there is any text at all, not how it is backed.
 	if ev.asyncBuf == nil && ev.mapped == nil {


### PR DESCRIPTION
Opening a large binary file for editing previously triggered a
full-file **line-index scan** in the background: the indexer read the *entire* file
through 32 KB chunks to find newlines that are never shown in a binary view. 

Now binary files open in the editor **directly in hex mode** on the lazy chunked
path, exactly like the viewer: the open is instant and no full-file read happens
unless the user explicitly switches back to text view.
