### PR TITLE
Command Palette in Commands menu

### DIFF
--- a/action_registry.go
+++ b/action_registry.go
@@ -293,14 +293,16 @@ func init() {
 		Handler:     actionScreenGrab,
 	})
 	RegisterAction(Action{
-		Name:        commandPaletteActionName,
-		Area:        "Common",
-		Label:       "Command Palette",
-		LabelKey:    "Action.App.CommandPalette",
-		Description: "Search and run available commands",
-		DescKey:     "Action.App.CommandPalette.Desc",
-		DefaultKeys: []string{"CtrlShiftP"},
-		Handler:     ShowCommandPalette,
+		Name:                commandPaletteActionName,
+		Area:                "Common",
+		Label:               "Command Palette",
+		LabelKey:            "Action.App.CommandPalette",
+		Description:         "Search and run available commands",
+		DescKey:             "Action.App.CommandPalette.Desc",
+		DefaultKeys:         []string{"CtrlShiftP"},
+		MenuPath:            "Commands",
+		MenuSeparatorBefore: true,
+		Handler:             ShowCommandPalette,
 	})
 	RegisterAction(Action{
 		Name:        "App.Help",


### PR DESCRIPTION
Добавил Command Palette в меню Commands с разделителем перед.

Хотелось бы, чтобы оно всегда было последним пунктом меню, но не разобрался как такое указать.

Сам пункт в меню появился, но действие из него не срабатывает. Поправьте кто понимает.