### PR TITLE
pty sync: replace POSIX '# f4_sync' comment with '&& true f4_sync'

### DIFF
--- a/ansi_parser.go
+++ b/ansi_parser.go
@@ -79,9 +79,9 @@ func (p *AnsiParser) Process(data []byte) {
 		if startIdx == -1 {
 			break
 		}
-		endIdx := bytes.Index(data[startIdx:], []byte("' # f4_sync"))
+		endIdx := bytes.Index(data[startIdx:], []byte("' && true f4_sync"))
 		if endIdx != -1 {
-			actualEnd := startIdx + endIdx + len("' # f4_sync")
+			actualEnd := startIdx + endIdx + len("' && true f4_sync")
 			if actualEnd < len(data) && data[actualEnd] == '\r' {
 				actualEnd++
 			}

--- a/ansi_parser_test.go
+++ b/ansi_parser_test.go
@@ -723,7 +723,7 @@ func TestAnsiParser_ExcisionExtra(t *testing.T) {
 		},
 		{
 			name:     "Unix background sync excision",
-			input:    "user@host:~$ cd '/new/path' # f4_sync\r\n",
+			input:    "user@host:~$ cd '/new/path' && true f4_sync\r\n",
 			expected: "",
 		},
 		{
@@ -745,6 +745,12 @@ func TestAnsiParser_ExcisionExtra(t *testing.T) {
 
 			if !strings.Contains(logStr, tt.expected) {
 				t.Errorf("Expected log to contain %q, but got %q", tt.expected, logStr)
+			}
+
+			// expected "" makes the check above vacuous; the real assertion
+			// is that the sync marker never leaks into the visible log.
+			if strings.Contains(logStr, "f4_sync") {
+				t.Errorf("Sync marker leaked into log: %q", logStr)
 			}
 		})
 	}

--- a/panels_frame.go
+++ b/panels_frame.go
@@ -3528,7 +3528,11 @@ func (pf *PanelsFrame) syncPTYDirectory(path string, v vfs.VFS) bool {
 		pf.writePTY(activePty, []byte(fmt.Sprintf("cd /d \"%s\" & rem f4_sync\r", path)))
 	} else {
 		sqPath := strings.ReplaceAll(path, "'", "'\\''")
-		pf.writePTY(activePty, []byte(fmt.Sprintf(" cd '%s' # f4_sync\r", sqPath)))
+		// "&& true f4_sync" instead of "# f4_sync": stock zsh ships with
+		// interactive_comments off, so a trailing comment becomes extra cd
+		// arguments ("cd: too many arguments"). true ignores its arguments
+		// in every POSIX-ish shell including fish.
+		pf.writePTY(activePty, []byte(fmt.Sprintf(" cd '%s' && true f4_sync\r", sqPath)))
 	}
 	return true
 }

--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -948,7 +948,9 @@ func (v *FishVFS) FindFiles(ctx context.Context, dir string, q vfs.FindQuery) ([
 // wants (C:\Users\foo for cmd, /c/Users/foo unchanged for POSIX).
 //
 // f4_sync is a stray marker helper.sh's own log filter can strip: cmd
-// keeps it as a rem comment, POSIX keeps it as a shell comment.
+// keeps it as a rem comment, POSIX carries it as "&& true f4_sync" —
+// not a "#" comment, because stock zsh ships with interactive_comments
+// off and would feed the tail to cd as extra arguments.
 func (v *FishVFS) PtyChangeDirCommand(dir string) []byte {
 	if v.peerIsWindows() {
 		winDir := fishplus.WirePathToWindows(dir)
@@ -958,7 +960,7 @@ func (v *FishVFS) PtyChangeDirCommand(dir string) []byte {
 		return []byte(fmt.Sprintf("cd /d \"%s\" & rem f4_sync\r", winDir))
 	}
 	sq := strings.ReplaceAll(dir, "'", "'\\''")
-	return []byte(fmt.Sprintf(" cd '%s' # f4_sync\r", sq))
+	return []byte(fmt.Sprintf(" cd '%s' && true f4_sync\r", sq))
 }
 
 // PtyRunCommand implements vfs.PtyShellIntegration. Same shell-flavor


### PR DESCRIPTION
## Problem

Navigating panels with a background PTY open spams the terminal on stock zsh:

```
hrt@localhost ~ %  cd '/Users/hrt' # f4_sync
cd: too many arguments
```

The cwd sync line ` cd '<path>' # f4_sync` relies on `#` starting a comment, but stock zsh ships with `interactive_comments` off (oh-my-zsh enables it, plain macOS zsh does not). zsh passes `#` and `f4_sync` to `cd` as extra arguments, so every panel navigation prints `cd: too many arguments` and the shell cwd never follows the panel. The error line also defeats the ANSI parser's excision, leaving junk in the scrollback.

## Fix

Send the marker as an executable no-op instead of a comment:

```
 cd '<path>' && true f4_sync
```

`true` ignores its arguments in every POSIX-ish shell including fish, so the line works regardless of `interactive_comments`. Changed in both generators (`panels_frame.go`, `plugins/netfox/fish_vfs.go`) and in the parser's excision needle (`ansi_parser.go`). The Windows `& rem f4_sync` variant is untouched.

Also made the Unix excision test meaningful: it asserted `strings.Contains(log, "")` which is vacuously true; it now asserts the marker never leaks into the visible log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)