### PR TITLE
pty/darwin: set master non-blocking before os.NewFile, restoring the console reader on macOS

### DIFF
--- a/pty_darwin.go
+++ b/pty_darwin.go
@@ -38,17 +38,19 @@ func NewPTY() (*PTY, error) {
 	if err != nil {
 		return nil, err
 	}
-	master := os.NewFile(uintptr(masterFd), "/dev/ptmx")
-	// Put the master fd in non-blocking mode before wrapping it in
-	// os.NewFile; see pty_unix.go for why Close() cannot otherwise
-	// interrupt a Master.Read() blocked in another goroutine. This must
-	// happen right after the fd is wrapped here (rather than before, as
-	// on the other platforms) because the TIOCPTY* ioctls below take the
-	// wrapped *os.File's Fd() as their argument.
+	// Put the master fd in non-blocking mode *before* wrapping it in
+	// os.NewFile, same as every other platform; see pty_unix.go. Go only
+	// registers a descriptor with the runtime poller when it is already
+	// non-blocking at NewFile time. Setting it afterwards leaves os.File
+	// in raw-syscall mode reading a non-blocking fd: every Read returns
+	// EAGAIN immediately, and the terminal read loop treats that as fatal,
+	// so the console goes permanently dark. The TIOCPTY* ioctls below take
+	// the raw masterFd, so the ordering does not affect them.
 	if err := unix.SetNonblock(masterFd, true); err != nil {
-		master.Close()
+		unix.Close(masterFd)
 		return nil, err
 	}
+	master := os.NewFile(uintptr(masterFd), "/dev/ptmx")
 
 	if _, _, e := syscall.Syscall(syscall.SYS_IOCTL, uintptr(masterFd), unix.TIOCPTYGRANT, 0); e != 0 {
 		master.Close()

--- a/pty_pollable_test.go
+++ b/pty_pollable_test.go
@@ -1,0 +1,38 @@
+//go:build darwin || linux || freebsd || dragonfly || netbsd || openbsd
+
+package main
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// TestPTYMasterPollable locks in the invariant the reader goroutine depends
+// on: the master must be registered with Go's runtime poller. That only
+// happens when the fd is already non-blocking at os.NewFile time. If it is
+// wrapped first and flipped to non-blocking afterwards, os.File stays in
+// raw-syscall mode and every Read returns EAGAIN immediately, which
+// panels_frame's read loop treats as fatal — a permanently black console.
+func TestPTYMasterPollable(t *testing.T) {
+	p, err := NewPTY()
+	if err != nil {
+		t.Fatalf("NewPTY: %v", err)
+	}
+	defer p.Close()
+
+	// SetReadDeadline only works on poller-registered files.
+	if err := p.Master.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err != nil {
+		t.Fatalf("master is not registered with the runtime poller: %v", err)
+	}
+
+	// With no child attached nothing is writable, so a pollable master must
+	// block until the deadline — not return EAGAIN instantly.
+	buf := make([]byte, 1)
+	_, err = p.Master.Read(buf)
+	if !errors.Is(err, os.ErrDeadlineExceeded) {
+		t.Fatalf("expected deadline-exceeded from pollable read, got: %v", err)
+	}
+	_ = p.Master.SetReadDeadline(time.Time{})
+}


### PR DESCRIPTION
## Problem

Since 6dd5934 ("Fix a real PTY reader-goroutine leak..."), the Ctrl+O console view is permanently black on macOS: no prompt, typed commands are echoed on f4's command line but never execute. Bisected to that commit with an automated pty harness (spawn `f4 --tty`, press Ctrl+O, run a marker command, assert its output appears).

## Cause

On darwin the leak fix calls `unix.SetNonblock(masterFd, true)` **after** `os.NewFile` — unlike every other platform it touched. Go registers a descriptor with the runtime poller only when it is already non-blocking at `NewFile` time. So the darwin master stays in raw-syscall mode while the underlying fd silently becomes non-blocking: the first `Master.Read()` returns `EAGAIN`, and the terminal read loop in `panels_frame.go` treats any read error as fatal and exits. The reader dies before the shell prints its first prompt.

The comment justifying the late call says the `TIOCPTY*` ioctls need the wrapped file's `Fd()` — they actually take the raw `masterFd`, so the ordering never mattered to them.

## Fix

Move `SetNonblock` before `os.NewFile`, exactly as `pty_unix.go` / `pty_bsd.go` / `pty_ptm*.go` already do. This also preserves the leak fix's intent: the master is poller-registered, so `Close()` can interrupt a blocked `Read()`.

Adds `TestPTYMasterPollable` (tagged for the six platforms the leak fix touched): asserts `SetReadDeadline` works on the master and an idle `Read` returns deadline-exceeded instead of instant `EAGAIN`. Red before the fix on darwin, green after; verified end-to-end with the pty harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)