### PR TITLE
lang: stop a configured fallback from overriding an English primary

### DIFF
--- a/lang.go
+++ b/lang.go
@@ -121,13 +121,17 @@ func InitLang() {
 		}
 	}
 
-	// 2. Load Fallback language if configured (Tier 2)
-	if fallback != "" && fallback != "en" && fallback != primary {
+	// 2. Load Fallback language if configured (Tier 2). A fallback only
+	// fills keys the primary lacks; with an English primary the embedded
+	// base already covers everything, so loading the fallback would
+	// override the primary instead of backing it up.
+	primaryIsEnglish := primary == "en" || primary == "eng"
+	if fallback != "" && fallback != "en" && fallback != primary && !primaryIsEnglish {
 		loadLang(fallback)
 	}
 
 	// 3. Load Primary language (Tier 3)
-	if primary != "en" && primary != "eng" {
+	if !primaryIsEnglish {
 		loadLang(primary)
 	} else {
 		vtui.DebugLog("LANG: Primary is English, relying on base.")

--- a/lang_fallback_priority_test.go
+++ b/lang_fallback_priority_test.go
@@ -1,0 +1,22 @@
+package main
+
+import "testing"
+
+// A fallback language may only fill keys the primary language lacks — it must
+// never override the primary. With primary English the embedded base already
+// covers every key, so a configured fallback must change nothing.
+func TestInitLang_EnglishPrimaryNotOverriddenByFallback(t *testing.T) {
+	oldLang, oldFallback := AppConfig.Language, AppConfig.FallbackLanguage
+	defer func() {
+		AppConfig.Language, AppConfig.FallbackLanguage = oldLang, oldFallback
+		InitLang()
+	}()
+
+	AppConfig.Language = "en"
+	AppConfig.FallbackLanguage = "ru"
+	InitLang()
+
+	if got := Msg("Menu.Exit"); got != "E&xit" {
+		t.Errorf("primary=en fallback=ru: Msg(Menu.Exit) = %q, want English \"E&xit\"", got)
+	}
+}


### PR DESCRIPTION
## Problem

With `Language = en` and `FallbackLanguage = ru` in settings.ini, the whole UI renders in Russian despite English being selected.

## Cause

InitLang builds the string table in three overriding tiers: embedded English base → fallback language → primary language. When the primary is English, tier 3 is skipped ("the base is already English") — but tier 2 has already painted the fallback over the base, and nothing re-asserts English. A fallback's job is to fill keys the primary lacks; with an English primary the embedded base covers every key, so the fallback must not be loaded at all.

The stray `FallbackLanguage = ru` can be left over from the earlier Language Settings dialog that offered a Fallback dropdown; the current dialog no longer exposes it, so users can't even see why their UI ignores the language choice.

## Fix

Skip tier 2 when the primary is English (`en`/`eng`, matching the existing tier-3 check). Non-English primaries keep the full cascade: English base → fallback → primary.

Adds a regression test: `Language=en, FallbackLanguage=ru` must yield `Msg("Menu.Exit") == "E&xit"` — red before the fix ("В&ыход"), green after. Verified end-to-end with those exact settings: UI comes up in English.

🤖 Generated with [Claude Code](https://claude.com/claude-code)