### PR TITLE
ci: test natively on 6 os/arch cells; make the timing-sensitive tests deterministic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -330,13 +330,21 @@ jobs:
 
   # Эта джоба создает постоянные релизы при пуше тэгов v*.*.*
   test:
-    name: Test (${{ matrix.os }})
+    name: Test (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # One hosted runner per native os/arch cell, labeled to match the
+        # build matrix.
+        include:
+          - { os: ubuntu-latest,    target: linux/amd64 }
+          - { os: ubuntu-24.04-arm, target: linux/arm64 }
+          - { os: macos-latest,     target: darwin/arm64 }
+          - { os: macos-15-intel,   target: darwin/amd64 }
+          - { os: windows-latest,   target: windows/amd64 }
+          - { os: windows-11-arm,   target: windows/arm64 }
     env:
       CGO_ENABLED: 0
     steps:

--- a/cmd/f4/editor_highlight_budget_test.go
+++ b/cmd/f4/editor_highlight_budget_test.go
@@ -10,18 +10,48 @@ import (
 	"github.com/unxed/vtui"
 )
 
-// mockSlowHighlighter spends a fixed amount of time per line, standing in for
-// a parser whose per-line cost is high enough that a fixed batch size turns
-// into a visible freeze (Colorer through wasm, in practice).
+// fakeHLClock replaces the slice budget clock, so a "slow" highlighter costs
+// exact fake time instead of real sleeps. Budget tests then assert equalities
+// instead of wall-clock bounds that a descheduled CI runner blows through.
+type fakeHLClock struct{ now time.Time }
+
+func (c *fakeHLClock) get() time.Time { return c.now }
+
+func installFakeHLClock(t *testing.T) *fakeHLClock {
+	t.Helper()
+	c := &fakeHLClock{now: time.Unix(0, 0)}
+	prev := hlNow
+	hlNow = c.get
+	t.Cleanup(func() { hlNow = prev })
+	return c
+}
+
+// hlSliceLines is how many lines one slice processes before the budget stops
+// it, for a highlighter costing perLine of fake time: the first clock-stride
+// multiple at which the elapsed fake time reaches the budget.
+func hlSliceLines(perLine time.Duration) int {
+	lines := 0
+	for {
+		lines += hlClockStride
+		if time.Duration(lines)*perLine >= hlSliceBudget {
+			return lines
+		}
+	}
+}
+
+// mockSlowHighlighter charges a fixed amount of fake time per line, standing
+// in for a parser whose per-line cost is high enough that a fixed batch size
+// turns into a visible freeze (Colorer through wasm, in practice).
 type mockSlowHighlighter struct {
 	perLine time.Duration
+	clock   *fakeHLClock
 	calls   int
 }
 
 func (m *mockSlowHighlighter) Highlight(line string, prev any, base uint64) ([]uint64, any) {
 	m.calls++
-	if m.perLine > 0 {
-		time.Sleep(m.perLine)
+	if m.clock != nil {
+		m.clock.now = m.clock.now.Add(m.perLine)
 	}
 	depth := 0
 	if prev != nil {
@@ -103,25 +133,25 @@ func TestNextIndexPoll(t *testing.T) {
 // multi-second freeze with a parser this slow.
 func TestEditor_HighlightSlice_StopsOnBudget(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	clock := installFakeHLClock(t)
+
+	const perLine = time.Millisecond
 
 	ev := NewEditorView(buildLinesPT(5000), nil, "test.txt")
 	defer ev.Close()
 	ev.SetPosition(0, 0, 80, 10)
-	ev.highlighter = &mockSlowHighlighter{perLine: time.Millisecond}
+	ev.highlighter = &mockSlowHighlighter{perLine: perLine, clock: clock}
 
 	plan := ev.highlightSlice(0)
 
-	if plan.lines == 0 {
-		t.Fatal("slice highlighted nothing")
-	}
 	if plan.done {
 		t.Error("a budgeted slice cannot have finished 5000 slow lines")
 	}
-	if plan.lines > 8*hlClockStride {
-		t.Errorf("slice ran for %d lines, budget should have stopped it near %d", plan.lines, hlClockStride)
+	if want := hlSliceLines(perLine); plan.lines != want {
+		t.Errorf("slice ran for %d lines, budget stops it at exactly %d", plan.lines, want)
 	}
-	if plan.work > 20*hlSliceBudget {
-		t.Errorf("slice occupied the UI thread for %v, budget is %v", plan.work, hlSliceBudget)
+	if want := time.Duration(plan.lines) * perLine; plan.work != want {
+		t.Errorf("slice reported %v of work, %d lines cost exactly %v", plan.work, plan.lines, want)
 	}
 	if len(ev.lineStates) != plan.lines {
 		t.Errorf("state chain grew by %d, slice reported %d", len(ev.lineStates), plan.lines)
@@ -132,11 +162,12 @@ func TestEditor_HighlightSlice_StopsOnBudget(t *testing.T) {
 // way, because the index is what the scroll bar and every jump wait for.
 func TestEditor_HighlightSlice_YieldsWhileIndexing(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	clock := installFakeHLClock(t)
 
 	ev := NewEditorView(buildLinesPT(5000), nil, "test.txt")
 	defer ev.Close()
 	ev.SetPosition(0, 0, 80, 10)
-	ev.highlighter = &mockSlowHighlighter{perLine: 200 * time.Microsecond}
+	ev.highlighter = &mockSlowHighlighter{perLine: 200 * time.Microsecond, clock: clock}
 
 	ev.indexing = false
 	normal := ev.highlightSlice(0)
@@ -144,8 +175,6 @@ func TestEditor_HighlightSlice_YieldsWhileIndexing(t *testing.T) {
 	ev.indexing = true
 	throttled := ev.highlightSlice(0)
 
-	// Compared against the plan's own measured work, so the assertion holds
-	// on a loaded CI box as well as on a fast desktop.
 	if want := highlightIdleGap(normal.work, hlDutyAhead); normal.idle != want {
 		t.Errorf("idle gap outside indexing is %v, want %v", normal.idle, want)
 	}
@@ -153,7 +182,8 @@ func TestEditor_HighlightSlice_YieldsWhileIndexing(t *testing.T) {
 		t.Errorf("idle gap while indexing is %v, want %v", throttled.idle, want)
 	}
 	if normal.idle >= hlIdleMax || throttled.idle >= hlIdleMax {
-		return // both clamped, the ratio below would prove nothing
+		t.Fatalf("fake-clock slices must not clamp at hlIdleMax (normal %v, throttled %v)",
+			normal.idle, throttled.idle)
 	}
 	if throttled.idle <= normal.idle {
 		t.Errorf("walker must back off harder while indexing: idle %v is not above %v",
@@ -162,17 +192,22 @@ func TestEditor_HighlightSlice_YieldsWhileIndexing(t *testing.T) {
 }
 
 // End to end through the task queue: the chain still gets built, and no single
-// task blocks the UI thread for long enough to be felt.
+// task consumes more than one slice budget's worth of highlighting. The stall
+// is asserted in the fake clock's currency — lines processed per task — not in
+// real elapsed time, which on a shared CI runner measures the machine's load,
+// not this code.
 func TestEditor_BackgroundWalker_NoLongUIStalls(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	clock := installFakeHLClock(t)
 
 	const total = 3000
-	const maxStall = 150 * time.Millisecond
+	const perLine = 50 * time.Microsecond
+	maxLines := hlSliceLines(perLine)
 
 	ev := NewEditorView(buildLinesPT(total), nil, "test.txt")
 	defer ev.Close()
 	ev.SetPosition(0, 0, 80, 10)
-	ev.highlighter = &mockSlowHighlighter{perLine: 50 * time.Microsecond}
+	ev.highlighter = &mockSlowHighlighter{perLine: perLine, clock: clock}
 
 	ev.startHighlighting()
 
@@ -180,10 +215,10 @@ func TestEditor_BackgroundWalker_NoLongUIStalls(t *testing.T) {
 	for len(ev.lineStates) < total {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
-			began := time.Now()
+			before := len(ev.lineStates)
 			task()
-			if stall := time.Since(began); stall > maxStall {
-				t.Fatalf("a single UI task ran for %v, slice budget is %v", stall, hlSliceBudget)
+			if grew := len(ev.lineStates) - before; grew > maxLines {
+				t.Fatalf("a single UI task highlighted %d lines, the budget stops a slice at %d", grew, maxLines)
 			}
 		case <-timeout:
 			t.Fatalf("walker stalled at %d of %d lines", len(ev.lineStates), total)

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -665,6 +665,11 @@ const (
 	hlMaxStallSlices = 100
 )
 
+// hlNow feeds the slice budget clock. Tests swap it for a fake advanced by
+// the highlighter itself, so budget behavior is asserted deterministically
+// instead of against the wall clock of a loaded CI machine.
+var hlNow = time.Now
+
 // highlightSlicePlan is what one slice did and when the next one may start.
 // It crosses from the UI thread back to the walker goroutine, which is why
 // every view field the decision depends on is read inside the slice itself.
@@ -759,7 +764,7 @@ func (ev *EditorView) highlightSlice(bgAttr uint64) highlightSlicePlan {
 	startLogLine, _ := ev.engine.GetLogLineAtVisualRow(ev.ScrollTopRow)
 	behind := cIdx < startLogLine
 
-	start := time.Now()
+	start := hlNow()
 	for cIdx < lineCount {
 		lStart := ev.li.GetLineOffset(cIdx)
 		lineLen := ev.getLineLength(cIdx)
@@ -782,11 +787,11 @@ func (ev *EditorView) highlightSlice(bgAttr uint64) highlightSlicePlan {
 		cIdx++
 		plan.lines++
 
-		if plan.lines%hlClockStride == 0 && time.Since(start) >= hlSliceBudget {
+		if plan.lines%hlClockStride == 0 && hlNow().Sub(start) >= hlSliceBudget {
 			break
 		}
 	}
-	plan.work = time.Since(start)
+	plan.work = hlNow().Sub(start)
 	plan.done = cIdx >= ev.li.LineCount() && !ev.indexing
 
 	if plan.lines == 0 {

--- a/cmd/f4/terminal_view_test.go
+++ b/cmd/f4/terminal_view_test.go
@@ -945,6 +945,12 @@ func TestTerminalView_ProcessFar2lInteract_ConcurrentRace(t *testing.T) {
 	pty := &mockPtyForTerminal{}
 	tv.pty = pty
 
+	// This test exists to hammer the real OS clipboard concurrently — it is
+	// the reproducer for the Win32 thread-ownership race — so it opts back
+	// out of the suite-wide in-process clipboard.
+	vtui.SkipOSClipboard(false)
+	defer vtui.SkipOSClipboard(true)
+
 	vtui.GlobalClipboardAccessManager = &mockClipAuthManager{authorized: true}
 	defer func() { vtui.GlobalClipboardAccessManager = nil }()
 

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -52,6 +52,15 @@ func TestMain(m *testing.M) {
 	// tests that exercise the PTY path construct one explicitly.
 	spawnLocalShellPTY = false
 
+	// The machine's clipboard is global, slow to reach (pbcopy/xclip) and
+	// shared with whatever else the CI runner is doing; tests keep clipboard
+	// traffic in vtui's process-local buffer instead, and skip the OSC 52
+	// stdout fallback that used to spray base64 into the test logs. A test
+	// that genuinely targets the OS clipboard switches the knob back off
+	// for its own scope.
+	vtui.SkipOSClipboard(true)
+	vtui.DisableTerminalClipboard()
+
 	tmpDir, err := os.MkdirTemp("", "f4-test-config-*")
 	if err == nil {
 		// XDG_CONFIG_HOME/APPDATA cover Linux and Windows; os.UserConfigDir

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -339,7 +339,9 @@ func TestArchiveVFS_OpenCloseNonBlocking(t *testing.T) {
 	select {
 	case <-closeDone:
 		// Success
-	case <-time.After(500 * time.Millisecond):
+	case <-time.After(10 * time.Second):
+		// Generous: on the happy path Close returns immediately, and a bound
+		// this loose still catches the regression — Close blocking forever.
 		t.Fatal("BUG REPRODUCED: ArchiveVFS.Close() blocked because v.Open() holds the mutex during extraction/seeking!")
 	}
 
@@ -349,7 +351,10 @@ func TestArchiveVFS_OpenCloseNonBlocking(t *testing.T) {
 	_ = openErr
 }
 
+// mockSeekingReporter is written from the progress ticker goroutine and read
+// from the test goroutine, so its fields live behind a mutex.
 type mockSeekingReporter struct {
+	mu            sync.Mutex
 	lastAction    string
 	lastFilename  string
 	lastTotalText string
@@ -358,12 +363,36 @@ type mockSeekingReporter struct {
 
 func (r *mockSeekingReporter) UpdateScan(currentPath string, files, dirs int64) {}
 func (r *mockSeekingReporter) UpdateTransfer(action, filename string, currentPct int, totalText string, totalPct int, speedText string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.lastAction = action
 	r.lastFilename = filename
 	r.lastTotalText = totalText
 	r.lastSpeedText = speedText
 }
 func (r *mockSeekingReporter) IsCancelled() bool { return false }
+
+// waitForStatus waits until the reporter shows a status with the given prefix
+// alongside an elapsed-time field. The progress ticker fires every 250ms for
+// as long as the phase lasts, so on any machine the status arrives eventually;
+// sleeping a fixed interval and asserting — what this test used to do — is a
+// bet on the scheduler that a loaded CI runner loses.
+func (r *mockSeekingReporter) waitForStatus(t *testing.T, prefix string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		r.mu.Lock()
+		total, speed := r.lastTotalText, r.lastSpeedText
+		r.mu.Unlock()
+		if strings.HasPrefix(total, prefix) && strings.Contains(speed, "Time:") {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	t.Fatalf("no %q status with elapsed time; last total %q, speed %q", prefix, r.lastTotalText, r.lastSpeedText)
+}
 
 func TestArchiveVFS_Open_SeekingProgress(t *testing.T) {
 	openBlock := make(chan struct{})
@@ -383,24 +412,13 @@ func TestArchiveVFS_Open_SeekingProgress(t *testing.T) {
 		close(openDone)
 	}()
 
-	// 1. Verify "Locating file..." status and elapsed time presence
-	time.Sleep(400 * time.Millisecond)
-	if !strings.HasPrefix(reporter.lastTotalText, "Locating file") {
-		t.Errorf("Expected 'Locating file...' status while Open is blocked, got %q", reporter.lastTotalText)
-	}
-	if !strings.Contains(reporter.lastSpeedText, "Time:") {
-		t.Errorf("Expected elapsed time in 'Locating' phase, got %q", reporter.lastSpeedText)
-	}
+	// 1. While Open is blocked the ticker must report "Locating file..."
+	// with an elapsed-time field.
+	reporter.waitForStatus(t, "Locating file")
 	close(openBlock)
 
-	// 2. Verify "Seeking/Decompressing..." status and elapsed time presence
-	time.Sleep(400 * time.Millisecond)
-	if !strings.HasPrefix(reporter.lastTotalText, "Seeking/Decompressing") {
-		t.Errorf("Expected 'Seeking/Decompressing...' status while Read is blocked, got %q", reporter.lastTotalText)
-	}
-	if !strings.Contains(reporter.lastSpeedText, "Time:") {
-		t.Errorf("Expected elapsed time in 'Seeking' phase, got %q", reporter.lastSpeedText)
-	}
+	// 2. While Read is blocked it must report "Seeking/Decompressing...".
+	reporter.waitForStatus(t, "Seeking/Decompressing")
 
 	close(readBlock)
 	<-openDone


### PR DESCRIPTION
Follow-up to #545, three commits. Depends on nothing: unxed/vtui#44 is already merged and this branch requires the tag that carries it (`vtui v0.1.234`).

## 1. Test matrix: 3 → 6 native cells

`ubuntu-24.04-arm`, `windows-11-arm` and `macos-15-intel` join the test matrix, adding native linux/arm64, windows/arm64 and darwin/amd64 coverage. All three are free hosted runners at native speed — linux/arm64 is actually the fastest cell of the six (~2 min). No BSD/Solaris cells: GitHub has no such runners, and QEMU-based VMs would be slow and flaky enough to hurt more than help.

## 2. Highlight budget tests: deterministic instead of wall-clock

`TestEditor_HighlightSlice_StopsOnBudget` and `TestEditor_BackgroundWalker_NoLongUIStalls` measured real elapsed time and asserted bounds on it — so any stall of a shared runner (GC, antivirus, noisy neighbor) failed them. `StopsOnBudget` failed exactly that way on this repo's own CI ("slice occupied the UI thread for 101.948ms, budget is 4ms" — that's the machine, not the code), and the walker test did the same on windows-11-arm.

The slice budget clock now sits behind a seam (`hlNow`), and the tests install a fake clock advanced by the mock highlighter's per-line cost. Every bound became an exact equality: a slice stops at exactly the first clock-stride multiple that exhausts the budget, and one walker task may grow the chain by exactly that many lines. Verified with `-race -count=10`.

## 3. Deflake: archive progress and clipboard

**plugins/archive**: the seeking-progress test slept a fixed 400ms and asserted that a 250ms ticker had already fired — a bet the scheduler loses on a loaded runner (flaked on ubuntu-latest). It now waits for the status to arrive, and the mock reporter gets the mutex its cross-goroutine use always needed. The Close-deadlock reproducer's verdict window widens 500ms → 10s (happy path returns instantly; the guarded regression — Close blocking forever — is still caught).

**cmd/f4**: clipboard tests ran against the machine's real clipboard — on macOS that's up to ~400 pbpaste spawns inside one test's 2s deadline (`TestAction_PanelCopySelectedNames` flaked on macos-latest), and locally it clobbers the developer's actual clipboard. `TestMain` now keeps clipboard traffic in vtui's process-local buffer via `vtui.SkipOSClipboard` (unxed/vtui#44, in v0.1.234) plus `DisableTerminalClipboard()` — which also stops the OSC 52 fallback from spraying base64 over the test logs. `TestTerminalView_ProcessFar2lInteract_ConcurrentRace` opts back out for its own scope: hammering the real OS clipboard is the point of that reproducer.

## Verification

Fork CI on this exact head: all 6 test cells green, all build cells green (including windows7 legacy). The previously-flaky tests were additionally hammered locally with `-race -count=10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
