### PR TITLE
ci: move actions to Node 24 majors, silencing the deprecation warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive # Автоматически подтягивает vtui и vtinput
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: '1.26.x'
         cache-dependency-path: go.sum
@@ -151,7 +151,7 @@ jobs:
         fi
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: f4-${{ matrix.goos }}-${{ matrix.goarch }}
         path: f4-${{ matrix.goos }}-${{ matrix.goarch }}.*
@@ -183,7 +183,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
@@ -322,7 +322,7 @@ jobs:
       run: (cd build && zip -r ../f4-windows7-amd64.zip .)
 
     - name: Upload Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: f4-windows7-amd64
         path: f4-windows7-amd64.zip
@@ -341,12 +341,12 @@ jobs:
       CGO_ENABLED: 0
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: recursive
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         go-version: '1.26.x'
         cache-dependency-path: go.sum
@@ -383,12 +383,12 @@ jobs:
       contents: write
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
         merge-multiple: true
     - name: Publish Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         files: artifacts/*
         generate_release_notes: true
@@ -486,7 +486,7 @@ jobs:
       contents: write
     steps:
     - name: Checkout code (to get git info)
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
 
     - name: Set Release Metadata
       run: |
@@ -494,13 +494,13 @@ jobs:
         echo "BUILD_TIME=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
 
     - name: Download all artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: artifacts
         merge-multiple: true
 
     - name: Update Nightly Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: nightly
         name: "Continuous Build (Nightly)"


### PR DESCRIPTION
Every CI job currently prints "Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24". The pinned action majors (`checkout@v4`, `setup-go@v5`, `upload-artifact@v4`, `download-artifact@v4`, `action-gh-release@v2`) all declare a `node20` runtime; since GitHub's autumn 2025 deprecation the runners force them onto Node 24 and warn on every run. GitHub has removed old runtimes outright before (Node 12, Node 16), so at some point this stops being cosmetic.

One commit bumping each action to its current major — all of them declare `node24` (verified against each repo's `action.yml`):

| action | from | to |
|---|---|---|
| actions/checkout | v4 | v7 |
| actions/setup-go | v5 | v7 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |
| softprops/action-gh-release | v2 | v3 |

No input/behavior changes needed anywhere — the `with:` blocks are untouched.

Verified on a fork run: all build and test jobs green, and the run log contains **zero** "Node.js 20 is deprecated" warnings. Caveat: `download-artifact` and `action-gh-release` only execute in the release/nightly jobs (tag or main push), which a fork dispatch doesn't trigger — those two bumps are validated by review only, though neither major changed the inputs this workflow uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
