### PR TITLE
Guard GUI backend initialization panics

### DIFF
--- a/cmd/f4/gui_unix.go
+++ b/cmd/f4/gui_unix.go
@@ -3,18 +3,42 @@
 package main
 
 import (
+	"fmt"
 	"strings"
+	"sync/atomic"
 
 	"github.com/unxed/vtui"
 )
+
+func runGuiWithStartupRecovery(backend string, startupComplete *atomic.Bool, run func() error) (err error) {
+	// A display backend is an optional integration and may panic while
+	// initializing (for example, while loading a Wayland cursor theme). Treat
+	// that as a backend failure so automatic GUI selection can try another
+	// available backend. Panics after SetupUI completes are application faults
+	// and must retain the normal crash-reporting path.
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			if startupComplete.Load() {
+				panic(recovered)
+			}
+			err = fmt.Errorf("%s GUI backend panicked during startup: %v", backend, recovered)
+		}
+	}()
+	return run()
+}
 
 func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
 	}
-	applyDarwinDockIcon(backend)
-	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {
-		SetupUI()
-		openDashEFileIfRequested()
+
+	var startupComplete atomic.Bool
+	return runGuiWithStartupRecovery(backend, &startupComplete, func() error {
+		applyDarwinDockIcon(backend)
+		return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {
+			SetupUI()
+			openDashEFileIfRequested()
+			startupComplete.Store(true)
+		})
 	})
 }

--- a/cmd/f4/gui_unix_test.go
+++ b/cmd/f4/gui_unix_test.go
@@ -1,0 +1,36 @@
+//go:build linux || darwin || openbsd || netbsd || dragonfly || freebsd || illumos || solaris
+
+package main
+
+import (
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestRunGuiConvertsStartupPanicToError(t *testing.T) {
+	var startupComplete atomic.Bool
+	err := runGuiWithStartupRecovery("wayland", &startupComplete, func() error {
+		panic("cursor initialization failed")
+	})
+
+	if err == nil || !strings.Contains(err.Error(), "wayland GUI backend panicked") {
+		t.Fatalf("panic was not converted to a useful backend error: %v", err)
+	}
+}
+
+func TestRunGuiPreservesPanicAfterStartup(t *testing.T) {
+	var startupComplete atomic.Bool
+	startupComplete.Store(true)
+
+	defer func() {
+		if recovered := recover(); recovered != "render failed" {
+			t.Fatalf("recovered panic = %v, want %q", recovered, "render failed")
+		}
+	}()
+
+	_ = runGuiWithStartupRecovery("wayland", &startupComplete, func() error {
+		panic("render failed")
+	})
+	t.Fatal("runtime panic was unexpectedly suppressed")
+}


### PR DESCRIPTION
## Problem

F4's automatic GUI selection already treats a backend error as recoverable and tries the next available backend. A panic during backend initialization bypasses that mechanism and terminates the process before fallback can happen.

We observed this on Linux/ARM64 with the Wayland backend. The cursor decoder in `github.com/neurlang/wayland` panicked inside `window.DisplayCreate`, before F4's UI setup callback ran, so launching `f4 --gui` appeared to do nothing except create a crash report.

The underlying ARM64 swizzle issue is addressed separately in [neurlang/wayland#28](https://github.com/neurlang/wayland/pull/28).

## Fix

Convert a panic into a backend startup error only while the native backend is initializing. This lets `tryRunDefaultGui` record the Wayland failure and continue to another available backend.

The recovery boundary is deliberately narrow:

- startup is marked complete only after `SetupUI` and `openDashEFileIfRequested` return;
- a panic after that point is re-thrown, preserving F4's normal crash reporting for runtime/application faults;
- external `qt` and `ext:` backends keep their existing execution path and are not wrapped;
- successful GUI startup and normal backend errors are unchanged.

An atomic startup flag avoids assumptions about which goroutine invokes the backend setup callback.

## Tests

Added focused tests proving that:

- a pre-setup backend panic becomes a descriptive error containing the backend name;
- a post-setup panic is not suppressed.

Validated with:

```text
go test -run '^TestRunGui(ConvertsStartupPanicToError|PreservesPanicAfterStartup)$' ./cmd/f4
go build ./cmd/f4
```

For integration validation, this branch was built in a Go workspace with the Wayland fix from `neurlang/wayland#28` on Linux/ARM64. Running the resulting binary with `--gui=wayland` initialized `BACKEND: active rendering backend is "wayland"` and remained running without a crash.

This PR intentionally contains no dependency replacement or reference to a personal fork.
