### PR TITLE
fix: crash opening 0-byte archives via typed nil VFS

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -580,6 +580,28 @@ func sameVFSInstance(a, b vfs.VFS) bool {
 	return a == b
 }
 
+// isNilVFS reports whether v is nil, including a typed nil wrapped inside a
+// non-nil interface (e.g. (*ArchiveVFS)(nil) returned as vfs.VFS). Such a
+// value compares != nil but dereferences to a panic on any method call.
+func isNilVFS(v vfs.VFS) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Func, reflect.Chan:
+		return rv.IsNil()
+	}
+	return false
+}
+
+// isArchiveProvider reports whether p is the archive/zip plugin's provider,
+// so archive open failures get an "Open Error" dialog instead of the
+// network-oriented "Connection Error" used by remote VFS plugins.
+func isArchiveProvider(p vfs.VFSProvider) bool {
+	return p != nil && p.Name() == "zipper/archive"
+}
+
 func (fp *FileSystemPanel) cacheKey(path string) dirCacheKey {
 	return directoryCacheKey(fp.vfs, path)
 }
@@ -1616,8 +1638,14 @@ func (fp *FileSystemPanel) openVFSAsync(
 			err = fmt.Errorf("provider returned no file system")
 		}
 		task.RunOnUI(func() {
+			// A provider may hand back a typed nil wrapped in the interface
+			// (e.g. (*ArchiveVFS)(nil), err): it compares != nil, so Close()
+			// on it would panic. Normalize it to a plain error instead.
+			if err == nil && isNilVFS(newVFS) {
+				err = fmt.Errorf("provider returned no file system")
+			}
 			if fp.providerOpenTask != task {
-				if newVFS != nil {
+				if !isNilVFS(newVFS) {
 					_ = newVFS.Close()
 				}
 				return
@@ -1628,13 +1656,13 @@ func (fp *FileSystemPanel) openVFSAsync(
 			fp.providerOpenTarget = ""
 			fp.providerOpenSourceSelect = ""
 			if !sameVFSInstance(fp.vfs, sourceVFS) || fp.vfs.GetPath() != sourcePath {
-				if newVFS != nil {
+				if !isNilVFS(newVFS) {
 					_ = newVFS.Close()
 				}
 				return
 			}
 			if err != nil {
-				if newVFS != nil {
+				if !isNilVFS(newVFS) {
 					_ = newVFS.Close()
 				}
 				fp.isLoading = false
@@ -2954,7 +2982,11 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 					},
 					func(err error) {
 						fp.pendingSelection = selectedName
-						vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to connect to %s:\n%v", selectedName, err), []string{"&Ok"})
+						if isArchiveProvider(provider) {
+							vtui.ShowMessage(" Open Error ", fmt.Sprintf("Failed to open %s:\n%v", selectedName, err), []string{"&Ok"})
+						} else {
+							vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to connect to %s:\n%v", selectedName, err), []string{"&Ok"})
+						}
 					},
 				)
 			}

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -4376,7 +4376,11 @@ func (pf *PanelsFrame) NavigateToPath(fsp *FileSystemPanel, targetPath string) b
 			},
 			func(newVFS vfs.VFS) { pf.switchToVFS(fsp, newVFS) },
 			func(err error) {
-				vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to open %s:\n%v", targetPath, err), []string{"&Ok"})
+				if isArchiveProvider(provider) {
+					vtui.ShowMessage(" Open Error ", fmt.Sprintf("Failed to open %s:\n%v", targetPath, err), []string{"&Ok"})
+				} else {
+					vtui.ShowMessage(" Connection Error ", fmt.Sprintf("Failed to open %s:\n%v", targetPath, err), []string{"&Ok"})
+				}
 			},
 		)
 	}

--- a/plugins/archive/provider.go
+++ b/plugins/archive/provider.go
@@ -36,5 +36,12 @@ func (p *ArchiveProvider) CanOpen(ctx context.Context, parent vfs.VFS, path stri
 }
 
 func (p *ArchiveProvider) Open(ctx context.Context, parent vfs.VFS, path string) (vfs.VFS, error) {
-	return NewArchiveVFSContext(ctx, parent, path)
+	v, err := NewArchiveVFSContext(ctx, parent, path)
+	if err != nil {
+		// Return an untyped nil so the interface itself is nil: a typed
+		// (*ArchiveVFS)(nil) would still compare != nil to callers, and a
+		// later Close() on it panics (nil dereference in v.mu.Lock()).
+		return nil, err
+	}
+	return v, nil
 }


### PR DESCRIPTION
close: fix all or part https://github.com/unxed/f4/issues/523

## Problem
Entering an empty/0-byte .zip file crashes f4 with
`runtime error: invalid memory address or nil pointer dereference`
in `(*ArchiveVFS).Close` (vfs.go:1266, `v.mu.Lock()`).

## Root cause
`NewArchiveVFSContext` returns `(*ArchiveVFS)(nil), err` on failure
(e.g. `archive.OpenFS` rejects a 0-byte file). `ArchiveProvider.Open`
returned that value directly, so the typed nil got boxed into the
`vfs.VFS` interface as a NON-nil value. The async panel open
(`openVFSAsync`) then ran `if newVFS != nil { _ = newVFS.Close() }`,
and calling a method on the nil pointer panicked.

Any provider can leak a typed nil this way, so the fix is defensive
at the panel layer in addition to the archive source.

## Fix
- `plugins/archive/provider.go`: `Open` returns an untyped `nil`
  interface on error, so `newVFS == nil` is true again.
- `cmd/f4/file_panel.go`: added `isNilVFS` (reflect-based, detects a
  typed nil inside a non-nil interface); `openVFSAsync` uses it for
  every `Close()` guard and normalizes a typed nil into a plain error
  before the success/error branches. This protects all providers.
- Error dialog wording: archive failures now show
  "Open Error / Failed to open ..." instead of the
  network-oriented "Connection Error / Failed to connect ...".
  Only the `zipper/archive` provider is affected; other VFS plugins
  keep the existing wording.

## Testing
Entering a 0-byte `.zip` no longer crashes; the panel shows
"Open Error" and falls back to the previous directory. Regular
archives still open normally.