### PR TITLE
Avoid persisting terminal geometry as GUI size

### DIFF
--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -773,7 +773,10 @@ func SaveSession() {
 	path := getSessionIniPath()
 	os.MkdirAll(filepath.Dir(path), 0755)
 
-	if vtui.FrameManager != nil {
+	// The terminal frame manager reports the current terminal geometry too.
+	// Persisting that as the GUI geometry makes a later native window inherit
+	// an arbitrary terminal (or test harness) size.
+	if shouldPersistGUIWindowSize(vtui.ActiveBackend()) && vtui.FrameManager != nil {
 		w := vtui.FrameManager.GetScreenSize()
 		h := vtui.FrameManager.GetScreenHeight()
 		if w > 0 && h > 0 {
@@ -842,6 +845,10 @@ func SaveSession() {
 	}
 
 	vtui.DebugLog("SESSION: Saved state to %s", path)
+}
+
+func shouldPersistGUIWindowSize(backend string) bool {
+	return backend != ""
 }
 
 func getFormattedVersionInfo() string {

--- a/cmd/f4/session_test.go
+++ b/cmd/f4/session_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestShouldPersistGUIWindowSize(t *testing.T) {
+	if shouldPersistGUIWindowSize("") {
+		t.Error("terminal mode must not persist its geometry as a GUI window size")
+	}
+	if !shouldPersistGUIWindowSize("wayland") {
+		t.Error("native GUI mode must persist its window size")
+	}
+}


### PR DESCRIPTION
## Problem

`SaveSession` ran for both terminal and native GUI modes. Because the terminal frame manager also reports its current size, closing F4 from a large terminal or an automated harness silently wrote that geometry to `Appearance.GuiCols` and `Appearance.GuiRows`. The next GUI launch then created an unexpectedly huge window.

## Fix

Persist GUI window geometry only after a native VTUI backend has claimed the process. Terminal sessions still save their normal session data, but cannot overwrite GUI geometry.

## Validation

- `go test ./cmd/f4 -run 'TestShouldPersistGUIWindowSize|TestRunGui' -count=1`
- `go vet ./cmd/f4`
