### PR TITLE
fix: resolve Windows GUI font family names via registry

### DIFF
--- a/cmd/f4/gui_font.go
+++ b/cmd/f4/gui_font.go
@@ -24,7 +24,11 @@ func resolveGuiFont(goos string, useSystem bool, configured string) string {
 }
 
 func effectiveGuiFont() string {
-	return resolveGuiFont(runtime.GOOS, AppConfig.GuiUseSystemMonospace, AppConfig.GuiFont)
+	font := resolveGuiFont(runtime.GOOS, AppConfig.GuiUseSystemMonospace, AppConfig.GuiFont)
+	if p := windowsFontFile(font); p != "" {
+		return p
+	}
+	return font
 }
 
 func defaultGuiFontSize(goos string) int {

--- a/cmd/f4/gui_font_notwindows.go
+++ b/cmd/f4/gui_font_notwindows.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package main
+
+// windowsFontFile is a no-op outside Windows: font name resolution there is
+// left entirely to vtui.
+func windowsFontFile(fontName string) string {
+	return ""
+}

--- a/cmd/f4/gui_font_windows.go
+++ b/cmd/f4/gui_font_windows.go
@@ -1,0 +1,94 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+type fontEntry struct {
+	base string
+	file string
+}
+
+// windowsFontFile resolves a Windows font family name (as shown in settings)
+// to the actual font file path via the registry. vtui's getFontCandidates only
+// matches file names literally, so "Cascadia Mono" would otherwise miss
+// CascadiaMono.ttf and silently fall back to Consolas. Returns "" if the
+// family is not found; callers then keep the original name.
+func windowsFontFile(fontName string) string {
+	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, registry.QUERY_VALUE)
+	if err != nil {
+		return ""
+	}
+	defer key.Close()
+
+	names, err := key.ReadValueNames(-1)
+	if err != nil {
+		return ""
+	}
+
+	var entries []fontEntry
+	for _, n := range names {
+		file, _, err := key.GetStringValue(n)
+		if err != nil {
+			continue
+		}
+		switch strings.ToLower(filepath.Ext(file)) {
+		case ".ttf", ".ttc", ".otf":
+		default:
+			continue
+		}
+		base := strings.TrimSpace(strings.TrimSuffix(n, " (TrueType)"))
+		base = strings.TrimSpace(strings.TrimSuffix(base, " (OpenType)"))
+		entries = append(entries, fontEntry{base: base, file: file})
+	}
+	return matchWindowsFontFamily(fontName, entries)
+}
+
+func matchWindowsFontFamily(fontName string, entries []fontEntry) string {
+	fontName = strings.TrimSpace(fontName)
+	if fontName == "" {
+		return ""
+	}
+	want := strings.ToLower(fontName)
+
+	for _, e := range entries {
+		if strings.ToLower(e.base) == want {
+			return fontFilePath(e.file)
+		}
+	}
+	// The registry records families with their style, e.g. "Cascadia Mono
+	// Regular", so accept family + " <style>". Prefer the regular weight when
+	// more than one style is installed.
+	var first string
+	for _, e := range entries {
+		got := strings.ToLower(e.base)
+		if !strings.HasPrefix(got, want+" ") {
+			continue
+		}
+		if strings.Contains(got, "regular") {
+			return fontFilePath(e.file)
+		}
+		if first == "" {
+			first = fontFilePath(e.file)
+		}
+	}
+	return first
+}
+
+func fontFilePath(f string) string {
+	if filepath.IsAbs(f) {
+		return f
+	}
+	dir := os.Getenv("WINDIR")
+	if dir == "" {
+		dir = `C:\Windows`
+	}
+	return filepath.Join(dir, "Fonts", f)
+}

--- a/cmd/f4/gui_font_windows_test.go
+++ b/cmd/f4/gui_font_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestMatchWindowsFontFamily(t *testing.T) {
+	entries := []fontEntry{
+		{base: "Consolas", file: "consola.ttf"},
+		{base: "Consolas Bold", file: "consolab.ttf"},
+		{base: "Cascadia Mono Regular", file: "CascadiaMono.ttf"},
+		{base: "FiraCode Nerd Font Mono Reg", file: "FiraCodeNerdFontMono-Regular.ttf"},
+	}
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"Consolas", `C:\Windows\Fonts\consola.ttf`},
+		{"consolas", `C:\Windows\Fonts\consola.ttf`},
+		{"  Consolas  ", `C:\Windows\Fonts\consola.ttf`},
+		{"Cascadia Mono", `C:\Windows\Fonts\CascadiaMono.ttf`},
+		{"FiraCode Nerd Font Mono", `C:\Windows\Fonts\FiraCodeNerdFontMono-Regular.ttf`},
+		{"NoSuchFont", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := matchWindowsFontFamily(c.in, entries); got != c.want {
+			t.Errorf("matchWindowsFontFamily(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Прикольно конечно что никто не жаловался что шрифты в win по имени не грузятся для GUI бэкэндов :)

## Problem
Font-by-name loading is broken on Windows: f4 passes a family name
(e.g. "Consolas", "Cascadia Mono", a Nerd Font) to vtui, whose
getFontCandidates only matches *file names* literally in a few hardcoded
directories. "Cascadia Mono" never finds CascadiaMono.ttf and the app
silently falls back to the default monospace, ignoring the configured
font.

## Fix
Restore the registry-based resolver (previously present, since removed):
- `cmd/f4/gui_font_windows.go` (new): `windowsFontFile()` reads
  `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts` and maps a
  family name to its file. Matching is case/space-insensitive, handles
  the `(TrueType)/(OpenType)` suffixes and `family + <style>` entries
  (preferring the Regular weight), and supports both bare and absolute
  filenames.
- `cmd/f4/gui_font.go`: `effectiveGuiFont()` resolves the name to a path
  and passes the path to vtui; if the family is not installed the
  original name is kept.
- `cmd/f4/gui_font_notwindows.go` (new): no-op stub under `!windows`, so
  Linux/macOS/BSD behavior is unchanged.
- `cmd/f4/gui_font_windows_test.go` (new): coverage for the matcher.

## Testing
`go build ./cmd/f4` passes. Unit test added for `matchWindowsFontFamily`
(exact match, case/whitespace, family+style, unknown family). Test run
(exact match, case/whitespace, family+style, unknown family). Test run
locally on the user's machine; Windows-only path, other OSes unaffected.