### PR TITLE
highlight: the Executable rule attribute must not match directories

### DIFF
--- a/cmd/f4/highlight_files.go
+++ b/cmd/f4/highlight_files.go
@@ -258,7 +258,11 @@ func (r *HighlightRule) Match(item *vfs.VFSItem) bool {
 		case AttrHidden:
 			return item.IsHidden == set
 		case AttrExecutable:
-			return item.IsExecutable == set
+			// On Unix every directory carries the x bit (it means "may be
+			// entered", not "may be run"), so a bare IsExecutable check would
+			// light up all folders (#419). The rule attribute means
+			// "executable program", which a directory never is.
+			return (item.IsExecutable && !item.IsDir) == set
 		case AttrReadOnly:
 			return isReadOnly == set
 		case AttrSystem:

--- a/cmd/f4/highlight_files_test.go
+++ b/cmd/f4/highlight_files_test.go
@@ -39,6 +39,9 @@ func TestHighlightRule_MatchAttributes(t *testing.T) {
 	ruleExec := HighlightRule{
 		AttrSet: AttrExecutable,
 	}
+	ruleNotExec := HighlightRule{
+		AttrClear: AttrExecutable,
+	}
 
 	tests := []struct {
 		item vfs.VFSItem
@@ -48,6 +51,11 @@ func TestHighlightRule_MatchAttributes(t *testing.T) {
 		{vfs.VFSItem{Name: "dir", IsDir: true}, ruleDir, true},
 		{vfs.VFSItem{Name: "file", IsDir: false}, ruleDir, false},
 		{vfs.VFSItem{Name: "run.sh", IsExecutable: true}, ruleExec, true},
+		// On Unix directories carry the x bit, but the Executable rule
+		// attribute means "executable program" and must skip them (#419).
+		{vfs.VFSItem{Name: "dir", IsDir: true, IsExecutable: true}, ruleExec, false},
+		{vfs.VFSItem{Name: "dir", IsDir: true, IsExecutable: true}, ruleNotExec, true},
+		{vfs.VFSItem{Name: "run.sh", IsExecutable: true}, ruleNotExec, false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #419.

On Unix every directory carries the x bit — it grants traversal, not execution — so a highlight rule with the Executable attribute lit up every folder, unless a Directory rule happened to sort before it (the workaround #419 mentions; the default themes dodge the same trap with an explicit `ExcludeAttributes = Directory` on their script rules).

The fix interprets the rule attribute as what it names — an executable *program* — at the one place all VFS backends route through: `HighlightRule.Match` now treats a directory as not-executable regardless of its mode bits. The complement becomes consistent too: an `ExcludeAttributes = Executable` rule now matches directories instead of skipping them.

`VFSItem.IsExecutable` itself intentionally keeps the raw bit: its other consumers (fusefs mode synthesis, terminal runnability) already branch on `IsDir` first and want the honest value.

Covered by new table cases in `TestHighlightRule_MatchAttributes` (fail without the fix); verified manually on macOS with an `IncludeAttributes = Executable` rule — folders stay uncolored, `+x` files light up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
