### PR TITLE
language dialog: list the translations embedded in the binary

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -4100,10 +4100,37 @@ type langInfo struct {
 
 func listAvailableUILanguages() []langInfo {
 	langs := []langInfo{{"en", "English"}}
+	seen := map[string]bool{"en": true}
+
+	// Every .lng shipped with f4 is embedded in the binary (langPackFS), and
+	// InitLang loads the configured language from there even when no lang/
+	// directory exists on disk. The dialog has to enumerate the same set:
+	// built from disk alone it offered English only, silently misrepresenting
+	// a configured non-English language as "English" (selection fell back to
+	// item 0) with no way to see or change the real setting.
+	if entries, err := langPackFS.ReadDir("lang"); err == nil {
+		for _, e := range entries {
+			if e.IsDir() || !strings.HasSuffix(e.Name(), ".lng") {
+				continue
+			}
+			code := strings.TrimSuffix(e.Name(), ".lng")
+			if seen[code] {
+				continue
+			}
+			data, err := langPackFS.ReadFile("lang/" + e.Name())
+			if err != nil {
+				continue
+			}
+			ini := ParseIni(strings.NewReader(string(data)))
+			langs = append(langs, langInfo{code: code, name: ini.GetString("Language", "Name", code)})
+			seen[code] = true
+		}
+	}
+
+	// Packs on disk extend the embedded set (user-supplied translations).
 	exeDir := filepath.Dir(os.Args[0])
 	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 	dirs := []string{filepath.Join(exeDir, "lang"), userDir, "lang"}
-	seen := map[string]bool{"en": true}
 
 	for _, d := range dirs {
 		entries, err := os.ReadDir(d)

--- a/cmd/f4/language_list_test.go
+++ b/cmd/f4/language_list_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+// The language dialog must offer every translation embedded in the binary,
+// not only what a lang/ directory on disk happens to hold: a bare binary
+// otherwise lists English alone while a configured non-English language
+// keeps working invisibly, with no way to see or change it from the UI.
+func TestListAvailableUILanguages_IncludesEmbedded(t *testing.T) {
+	langs := listAvailableUILanguages()
+
+	if len(langs) == 0 || langs[0].code != "en" {
+		t.Fatalf("English must stay the first entry, got %+v", langs)
+	}
+
+	byCode := make(map[string]string, len(langs))
+	for _, l := range langs {
+		if _, dup := byCode[l.code]; dup {
+			t.Errorf("duplicate language code %q", l.code)
+		}
+		byCode[l.code] = l.name
+	}
+
+	for code, name := range map[string]string{"ru": "Русский", "ka": "ქართული"} {
+		if got, ok := byCode[code]; !ok {
+			t.Errorf("embedded language %q missing from the dialog list", code)
+		} else if got != name {
+			t.Errorf("language %q listed as %q, want %q", code, got, name)
+		}
+	}
+}


### PR DESCRIPTION
The language settings dialog built its list of UI languages by scanning `lang/` directories on disk, while `InitLang` happily loads the configured language from the packs embedded in the binary. On any install without such a directory — a bare binary is the normal case since the packs went embedded — the dialog offered English alone, the combo silently fell back to item 0 and displayed "English" whatever the real setting was, and the actual UI language could be neither seen nor changed from the UI.

That is exactly how it bites in practice: with `Language = ka` in settings.ini the whole UI runs Georgian while the dialog insists both dropdowns say "English" (screenshot-reproducible on a dev build).

The dialog now enumerates the embedded packs first (code + `[Language] Name`), with disk directories only extending the set with user-supplied translations. The help-language list is untouched on purpose: only `en.hlf` is embedded, other help languages genuinely require files on disk.

Covered by `TestListAvailableUILanguages_IncludesEmbedded`.

Related: unxed/vtui#51 fixes the companion bug that lets a cancelled dropdown silently *write* such a language into the config in the first place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
