### PR TITLE
file ops: show the overwrite confirmation on the warning palette

### DIFF
--- a/cmd/f4/file_ops.go
+++ b/cmd/f4/file_ops.go
@@ -1593,6 +1593,7 @@ func AskOverwrite(ctx context.Context, destPath string, srcStat, dstStat vfs.VFS
 		width := 76
 		height := 13
 		dlg = vtui.NewCenteredDialog(width, height, Msg("Warning.Title"))
+		dlg.IsWarning = true
 
 		lbl1 := vtui.NewLabel(0, 0, Msg("FileOp.FileAlreadyExists"), nil)
 		truncPath := vtui.TruncateMiddle(destPath, width-6)

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 	"io"
 	"os"
@@ -1153,6 +1154,47 @@ func TestRecursiveCopy_ByteProgress(t *testing.T) {
 }
 
 // --- UI Integration Tests for Conflict Resolution ---
+
+func TestAskOverwriteUsesWarningPalette(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan int, 1)
+	go func() {
+		choice, _ := AskOverwrite(ctx, "/destination/existing.txt", vfs.VFSItem{}, vfs.VFSItem{}, nil)
+		result <- choice
+	}()
+
+	container := waitForDialog(t, Msg("Warning.Title"))
+	dlg, ok := container.(*vtui.Window)
+	if !ok {
+		t.Fatalf("overwrite dialog is not a *vtui.Window, got %T", container)
+	}
+	if !dlg.IsWarning {
+		t.Error("overwrite confirmation must render on the WarnDialog palette (see #494)")
+	}
+
+	if !pressKey(dlg, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_ESCAPE,
+	}) {
+		t.Error("Escape was not handled by the overwrite dialog")
+	}
+
+	select {
+	case choice := <-result:
+		if choice != 6 {
+			t.Errorf("Escape returned overwrite choice %d, want cancel (6)", choice)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("AskOverwrite did not return after Escape")
+	}
+	if dlg.IsDone() {
+		vtui.FrameManager.Pop()
+	}
+}
 
 // Helper to pump UI tasks until a dialog with the given title appears
 func waitForDialog(t *testing.T, title string) vtui.Container {


### PR DESCRIPTION
Fixes #494.

Overwriting a file during copy/move is destructive, and the confirmation asking about it rendered in the neutral dialog palette — the same blue as any informational prompt. The dialog's content was already right (title, path, size and date of both the new and the existing file, "remember choice" checkbox, far2l button order with Overwrite as default); it simply did not *look* like a warning.

One line enables the warning palette that eight other f4 dialogs already use (`dlg.IsWarning = true`), so the frame, labels and buttons all switch to the warn colors. Button order, the default button and every behavior stay exactly as they were.

Covered by `TestAskOverwriteUsesWarningPalette`, which fails without the change.

Noticed while in there, left alone as out of scope: the "New"/"Existing" row labels in this dialog are hardcoded English with no `Msg()` keys, so they stay English in localized builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
