### PR TITLE
test(netfox): pin the typed-nil dial-failure fix behind #423

### DIFF
--- a/plugins/netfox/sftp_dial_test.go
+++ b/plugins/netfox/sftp_dial_test.go
@@ -2,37 +2,56 @@ package netfox
 
 import (
 	"context"
+	"github.com/unxed/f4/internal/netproxy"
+	"github.com/unxed/f4/vfs"
 	"path/filepath"
 	"testing"
 )
 
-// TestSFTPProviderFailedDialReturnsPlainNil covers the stored-site path used
-// by the panel. NewSFTPVFS returns a nil *SFTPVFS when DialSSH fails; the
-// provider must not wrap that pointer in a non-nil vfs.VFS interface, because
-// the asynchronous opener closes every non-nil result while reporting err.
-func TestSFTPProviderFailedDialReturnsPlainNil(t *testing.T) {
-	manager := NewNetFoxVFS(filepath.Join(t.TempDir(), "NetFox.json"))
-	manager.SaveConfig("key-only", NetFoxConfig{
-		Type:    "sftp",
-		Host:    "127.0.0.1",
-		Port:    "1",
-		User:    "nobody",
-		Pass:    "",
-		Timeout: "1",
-	})
-
-	parent := &netFoxVFSWrapper{NetFoxVFS: manager}
-	opened, err := (&sftpProvider{}).Open(context.Background(), parent, "key-only")
-	if err == nil {
-		if opened != nil {
-			_ = opened.Close()
-		}
-		t.Fatal("opening an unreachable SFTP site succeeded")
+// TestNetFoxProvidersFailedDialReturnPlainNil covers the stored-site paths used
+// by the panel for SFTP, FISH+, and FTP. Their constructors return nil concrete
+// VFS pointers when dialing fails; providers must not wrap those pointers in a
+// non-nil vfs.VFS interface, because the asynchronous opener closes every
+// non-nil result while reporting err.
+func TestNetFoxProvidersFailedDialReturnPlainNil(t *testing.T) {
+	tests := []struct {
+		name     string
+		typeName string
+		provider vfs.VFSProvider
+	}{
+		{name: "sftp", typeName: "sftp", provider: &sftpProvider{}},
+		{name: "fish+", typeName: "fish+", provider: &fishProvider{}},
+		{name: "ftp", typeName: "ftp", provider: &ftpProvider{}},
 	}
-	if opened != nil {
-		// This is the cleanup performed by the asynchronous panel opener. A
-		// typed nil reaches this call and panics instead of showing err.
-		_ = opened.Close()
-		t.Fatalf("failed SFTP open returned non-nil file system %T", opened)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := NewNetFoxVFS(filepath.Join(t.TempDir(), "NetFox.json"))
+			manager.SaveConfig("unreachable", NetFoxConfig{
+				Type:      tt.typeName,
+				Host:      "127.0.0.1",
+				Port:      deadTCPPort(t),
+				User:      "nobody",
+				Pass:      "",
+				Timeout:   "1",
+				ProxyMode: netproxy.ModeDirect,
+			})
+
+			parent := &netFoxVFSWrapper{NetFoxVFS: manager}
+			opened, err := tt.provider.Open(context.Background(), parent, "unreachable")
+			if err == nil {
+				t.Errorf("opening an unreachable %s site succeeded", tt.name)
+				if opened != nil {
+					_ = opened.Close()
+				}
+				return
+			}
+			if opened != nil {
+				t.Errorf("failed %s open returned non-nil file system %T", tt.name, opened)
+				// This is the cleanup performed by the asynchronous panel opener. A
+				// typed nil reaches this call while the opener is reporting err.
+				_ = opened.Close()
+			}
+		})
 	}
 }

--- a/plugins/netfox/sftp_dial_test.go
+++ b/plugins/netfox/sftp_dial_test.go
@@ -1,0 +1,38 @@
+package netfox
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+)
+
+// TestSFTPProviderFailedDialReturnsPlainNil covers the stored-site path used
+// by the panel. NewSFTPVFS returns a nil *SFTPVFS when DialSSH fails; the
+// provider must not wrap that pointer in a non-nil vfs.VFS interface, because
+// the asynchronous opener closes every non-nil result while reporting err.
+func TestSFTPProviderFailedDialReturnsPlainNil(t *testing.T) {
+	manager := NewNetFoxVFS(filepath.Join(t.TempDir(), "NetFox.json"))
+	manager.SaveConfig("key-only", NetFoxConfig{
+		Type:    "sftp",
+		Host:    "127.0.0.1",
+		Port:    "1",
+		User:    "nobody",
+		Pass:    "",
+		Timeout: "1",
+	})
+
+	parent := &netFoxVFSWrapper{NetFoxVFS: manager}
+	opened, err := (&sftpProvider{}).Open(context.Background(), parent, "key-only")
+	if err == nil {
+		if opened != nil {
+			_ = opened.Close()
+		}
+		t.Fatal("opening an unreachable SFTP site succeeded")
+	}
+	if opened != nil {
+		// This is the cleanup performed by the asynchronous panel opener. A
+		// typed nil reaches this call and panics instead of showing err.
+		_ = opened.Close()
+		t.Fatalf("failed SFTP open returned non-nil file system %T", opened)
+	}
+}


### PR DESCRIPTION
Regression coverage for #423 — "NetFox роняет весь f4, если не может аутентифицироваться с ключом".

The crash itself is already fixed: 99a5113 stopped the three NetFox providers from returning a typed-nil `vfs.VFS` after a failed dial, which async cleanup then called `Close` on, panicking the whole process instead of showing the dial error. That fix has no test, so this pins it.

The test drives the real provider path — a site config with an empty password (so only agent/key auth is offered, the #423 configuration) pointed at a refused port, then asserts the failed `Open` returns a genuinely nil VFS plus an error, and that closing the result does not panic. It is table-driven over all three providers 99a5113 touched (sftp, fish+, ftp), since a bad key crashes each of them identically.

Hermetic and fast: `ProxyMode: ModeDirect` keeps the deliberately-failing dial from being routed off the machine by `HTTP_PROXY`/`ALL_PROXY` in the environment, and the refused port comes from the package's existing `deadTCPPort` helper. Each case runs in ~0.00s. Verified red against a revert of 99a5113, green on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
