### PR TITLE
editor: confirm unsaved changes before a workspace close destroys them

### DIFF
--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -74,6 +74,7 @@ type EditorView struct {
 	DisasmMode       int // 16, 32, or 64
 	overtype         bool
 	modified         bool
+	closeDlg         *vtui.Window
 	CursorLine       int // Текущая логическая строка (для плагинов)
 	CursorPos        int // Позиция в байтах (для плагинов)
 	DesiredVisualCol int // Колонка, в которую мы хотим попасть при навигации Up/Down
@@ -261,6 +262,14 @@ type editorState struct {
 	table piecetable.TableState
 	line  int
 	pos   int
+}
+
+func (ev *EditorView) ConfirmClose() bool {
+	if !ev.modified {
+		return true
+	}
+	ev.closeDlg = ev.tryClose()
+	return false
 }
 
 func (ev *EditorView) Close() {
@@ -1768,23 +1777,11 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 			return true
 		}
 		// Prevent fallthrough to text editing keys
-		switch e.VirtualKeyCode {
-		case vtinput.VK_F1, vtinput.VK_F2, vtinput.VK_F3, vtinput.VK_F4, vtinput.VK_F5, vtinput.VK_F6, vtinput.VK_F7, vtinput.VK_F8, vtinput.VK_F9, vtinput.VK_F10, vtinput.VK_F11, vtinput.VK_F12:
-			return false // Let global hotkeys handle it
-		}
-		if MacroMgr.LookupHotkey(e) {
-			return true
-		}
-		return true // Consume all other keys in Hex mode so they don't insert text
-	}
-
-	if ev.HexMode {
-		if ev.processKeyHex(e) {
-			return true
-		}
-		// Prevent fallthrough to text editing keys
-		switch e.VirtualKeyCode {
-		case vtinput.VK_F1, vtinput.VK_F2, vtinput.VK_F3, vtinput.VK_F4, vtinput.VK_F5, vtinput.VK_F6, vtinput.VK_F7, vtinput.VK_F8, vtinput.VK_F9, vtinput.VK_F10, vtinput.VK_F11, vtinput.VK_F12:
+		switch {
+		case e.VirtualKeyCode == vtinput.VK_W &&
+			e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0:
+			return false // Let the framework handle Ctrl+W
+		case e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12:
 			return false // Let global hotkeys handle it
 		}
 		if MacroMgr.LookupHotkey(e) {
@@ -3175,7 +3172,7 @@ func (ev *EditorView) StartIndexing() {
 
 func (ev *EditorView) HandleCommand(cmd int, args any) bool {
 	if cmd == vtui.CmClose {
-		ev.tryClose()
+		ev.closeDlg = ev.tryClose()
 		return true
 	}
 	if cmd == CmSwitchToViewer {
@@ -3196,14 +3193,17 @@ func (ev *EditorView) HandleCommand(cmd int, args any) bool {
 	return ev.BaseFrame.HandleCommand(cmd, args)
 }
 
-func (ev *EditorView) tryClose() {
+func (ev *EditorView) tryClose() *vtui.Window {
+	if ev.closeDlg != nil && !ev.closeDlg.IsDone() {
+		return ev.closeDlg
+	}
 	if !ev.modified {
 		ev.Close()
-		return
+		return nil
 	}
 
 	msg := "The file has been modified.\nDo you want to save it?"
-	dlg := vtui.ShowMessage(" Confirm ", msg, []string{"&Save", "&Don't Save", "Cancel"})
+	dlg := vtui.ShowMessageOn(ev, " Confirm ", msg, []string{"&Save", "&Don't Save", "Cancel"})
 	dlg.OnResult = func(code int) {
 		switch code {
 		case 0: // Save
@@ -3214,6 +3214,7 @@ func (ev *EditorView) tryClose() {
 			ev.Close()
 		}
 	}
+	return dlg
 }
 
 func (ev *EditorView) GetKeyLabels() *vtui.KeySet {

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -1228,6 +1228,219 @@ func TestEditorView_HandleClose(t *testing.T) {
 		t.Error("EditorView failed to set IsDone after receiving CmClose")
 	}
 }
+
+func pressCtrlWForWorkspaceClose(frame vtui.Frame) {
+	handled := pressKey(frame, &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true,
+		VirtualKeyCode: vtinput.VK_W, ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if !handled {
+		// pressKey covers the frame and hotkey portions of vtui's production
+		// dispatch. Reproduce its final framework fallback for Ctrl+W.
+		vtui.FrameManager.CloseActiveScreen()
+	}
+	vtui.FrameManager.Step(0)
+}
+
+func unsavedChangesConfirms(screen *vtui.AppScreen) []vtui.Frame {
+	var confirms []vtui.Frame
+	for _, frame := range screen.Frames {
+		if frame.GetType() == vtui.TypeDialog && frame.GetTitle() == " Confirm " {
+			confirms = append(confirms, frame)
+		}
+	}
+	return confirms
+}
+
+func requireUnsavedChangesConfirm(t *testing.T) vtui.Frame {
+	t.Helper()
+	if vtui.FrameManager.ActiveIdx < 0 || vtui.FrameManager.ActiveIdx >= len(vtui.FrameManager.Screens) {
+		t.Fatalf("active workspace index = %d, want an existing workspace", vtui.FrameManager.ActiveIdx)
+	}
+	confirms := unsavedChangesConfirms(vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx])
+	if len(confirms) != 1 {
+		t.Fatalf("active workspace has %d unsaved-changes confirmations, want exactly one", len(confirms))
+	}
+	top := vtui.FrameManager.GetTopFrame()
+	if top == nil {
+		t.Fatal("top frame is nil, want unsaved-changes confirmation")
+	}
+	if top != confirms[0] {
+		t.Fatalf("top frame = %T %q, want unsaved-changes confirmation", top, top.GetTitle())
+	}
+	return top
+}
+
+func TestEditorView_CtrlWConfirmsUnsavedChanges(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+
+	pressKey(ev, &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, Char: '!',
+	})
+	if !ev.modified {
+		t.Fatal("editor should be modified before Ctrl+W")
+	}
+
+	pressCtrlWForWorkspaceClose(ev)
+
+	if ev.IsDone() {
+		t.Fatal("Ctrl+W closed an editor with unsaved changes")
+	}
+	if len(vtui.FrameManager.Screens) != 2 {
+		t.Fatalf("Ctrl+W left %d workspaces, want the editor workspace preserved", len(vtui.FrameManager.Screens))
+	}
+	requireUnsavedChangesConfirm(t)
+}
+
+func TestEditorView_CtrlWClosesCleanEditor(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+
+	pressCtrlWForWorkspaceClose(ev)
+
+	if !ev.IsDone() {
+		t.Fatal("Ctrl+W did not close an unmodified editor")
+	}
+	if len(vtui.FrameManager.Screens) != 1 {
+		t.Fatalf("Ctrl+W left %d workspaces, want the clean editor workspace closed", len(vtui.FrameManager.Screens))
+	}
+}
+
+func TestEditorView_CloseEntryPointsSharePendingConfirm(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+	pressKey(ev, &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, Char: '!',
+	})
+
+	pressCtrlWForWorkspaceClose(ev)
+	requireUnsavedChangesConfirm(t)
+	ev.HandleCommand(vtui.CmClose, nil)
+
+	if ev.IsDone() {
+		t.Fatal("a second close entry point closed an editor with unsaved changes")
+	}
+	if len(vtui.FrameManager.Screens) != 2 {
+		t.Fatalf("a second close entry point left %d workspaces, want the editor workspace preserved", len(vtui.FrameManager.Screens))
+	}
+	requireUnsavedChangesConfirm(t)
+}
+
+func TestEditorView_WorkspaceCloseActionConfirmsUnsavedChanges(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+	pressKey(ev, &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, Char: '!',
+	})
+
+	if !actionWorkspaceClose() {
+		t.Fatal("Workspace.Close action was not handled")
+	}
+	vtui.FrameManager.Step(0)
+
+	if ev.IsDone() {
+		t.Fatal("Workspace.Close action closed an editor with unsaved changes")
+	}
+	if len(vtui.FrameManager.Screens) != 2 {
+		t.Fatalf("Workspace.Close action left %d workspaces, want the editor workspace preserved", len(vtui.FrameManager.Screens))
+	}
+	requireUnsavedChangesConfirm(t)
+}
+
+func TestEditorView_BackgroundWorkspaceCloseAnchorsUnsavedChangesConfirm(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+	previouslyActive := vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx]
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+	editorScreen := vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx]
+	pressKey(ev, &vtinput.InputEvent{
+		Type: vtinput.KeyEventType, KeyDown: true, Char: '!',
+	})
+	vtui.FrameManager.SwitchScreen(0)
+
+	if !actionWorkspaceCloseNumber(editorScreen.Number) {
+		t.Fatal("background Workspace.Close action was not handled")
+	}
+	vtui.FrameManager.Step(0)
+
+	if ev.IsDone() {
+		t.Fatal("background Workspace.Close action closed an editor with unsaved changes")
+	}
+	if vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx] != editorScreen {
+		t.Fatal("unsaved-changes confirmation did not focus the editor's workspace")
+	}
+	if confirms := unsavedChangesConfirms(previouslyActive); len(confirms) != 0 {
+		t.Fatalf("previously active workspace has %d unsaved-changes confirmations, want none", len(confirms))
+	}
+	requireUnsavedChangesConfirm(t)
+}
+
+func TestEditorView_HexModeCtrlWConfirmsUnsavedChanges(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+	ev.HexMode = true
+	ev.modified = true
+
+	pressCtrlWForWorkspaceClose(ev)
+
+	if ev.IsDone() {
+		t.Fatal("Ctrl+W closed a hex-mode editor with unsaved changes")
+	}
+	requireUnsavedChangesConfirm(t)
+}
+
+func TestEditorView_WorkspaceCloseActionClosesCleanEditor(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	ev := NewEditorView(piecetable.New([]byte("test")), nil, "file.txt")
+	defer ev.Close()
+	vtui.FrameManager.AddScreen(ev)
+
+	if !actionWorkspaceClose() {
+		t.Fatal("Workspace.Close action was not handled")
+	}
+	vtui.FrameManager.Step(0)
+
+	if !ev.IsDone() {
+		t.Fatal("Workspace.Close action did not close an unmodified editor")
+	}
+	if len(vtui.FrameManager.Screens) != 1 {
+		t.Fatalf("Workspace.Close action left %d workspaces, want the clean editor workspace closed", len(vtui.FrameManager.Screens))
+	}
+}
+
 func TestEditorView_GetTitle(t *testing.T) {
 	pt := piecetable.New([]byte(""))
 


### PR DESCRIPTION
Fixes #527.

The editor asks "save / don't save / cancel" when you close it — but not when you close its *workspace*. Ctrl+W, the Close Workspace menu item, the command palette, the `Workspace.Close` macro, a middle click on the tab and the `workspace.close` semantic action all tore the editor down silently and lost the buffer.

## Why not just intercept Ctrl+W

That was the first attempt, and it does not hold up: it fixes exactly one of those six routes, and even there a second Ctrl+W — pressed while the confirmation dialog is up, which is what someone in the habit of closing tabs with Ctrl+W will do — still closed the workspace, because the dialog on top does not consume the key either. Verified empirically before rewriting it.

The framework now has the right choke point: `vtui.CloseVetoer` (unxed/vtui#52, released in v0.1.245, which this repo's `go.mod` already requires) is consulted for every frame before a workspace closes, on every route. `EditorView` implements it: clean editors close exactly as before, modified ones raise the usual confirmation and veto.

## Also fixed along the way

- **One confirmation, not a stack.** `tryClose` now returns its dialog and reuses a pending one, so repeated Ctrl+W yields a single prompt. Previously each press pushed another, and resolving one of the stacked dialogs left a zombie workspace holding a stale confirm window bound to a closed editor.
- **Anchored to the right workspace.** The prompt goes up with `ShowMessageOn(ev, …)`, so closing a dirty editor that sits on a *background* workspace surfaces the question there (switching to it) instead of over whatever the user is currently looking at.
- **Hex/decode mode.** Its key sink consumed every key including Ctrl+W, leaving the shortcut inert there; it now releases the chord to the framework the same way it already released the F-keys.

## Tests

`cmd/f4` suite green, including new cases: dirty editor + Ctrl+W confirms and survives; clean editor closes; a second Ctrl+W yields exactly one dialog; a background-workspace close anchors the dialog to the editor's workspace; hex mode confirms. Each was verified to fail without the corresponding part of the change. Layout validation green.

Out of scope but worth noting: `CmQuit` (Alt+F4, menu Exit) still discards unsaved editors — same class of bug, different path. And `QueueFrame` can now retire its bespoke Ctrl+W swallow plus close-action pre-check in favor of the same hook, which would also cover the tab-click route it currently misses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
