### PR TITLE
symlinks: report the link's own attributes and give links a colour of their own

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -4080,7 +4080,7 @@ func actionFileAttributes(pf *PanelsFrame) {
 	fullPath := fsp.vfs.Join(fsp.vfs.GetPath(), name)
 
 	vtui.RunAsync(func(ctx *vtui.TaskContext) {
-		item, err := fsp.vfs.Stat(ctx.Context, fullPath)
+		item, err := vfs.Lstat(ctx.Context, fsp.vfs, fullPath)
 		ctx.RunOnUI(func() {
 			if err != nil {
 				vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -20,6 +22,15 @@ type mockMetadataVFS struct {
 	statErr      error
 	setAttrErr   error
 	statToReturn vfs.VFSItem
+}
+
+type lstatMetadataVFS struct {
+	*mockMetadataVFS
+	item vfs.VFSItem
+}
+
+func (m *lstatMetadataVFS) Lstat(context.Context, string) (vfs.VFSItem, error) {
+	return m.item, nil
 }
 
 func (m *mockMetadataVFS) Stat(ctx context.Context, path string) (vfs.VFSItem, error) {
@@ -79,6 +90,53 @@ Loop:
 
 	if !foundDialog {
 		t.Error("Expected an error dialog when initial Stat fails")
+	}
+}
+
+func TestActionFileAttributes_UsesLstat(t *testing.T) {
+	fm := vtui.FrameManager
+	fm.Init(vtui.NewSilentScreenBuf())
+
+	base := &mockMetadataVFS{
+		VFS:     vfs.NewOSVFS(t.TempDir()),
+		statErr: os.ErrPermission,
+	}
+	mockVFS := &lstatMetadataVFS{
+		mockMetadataVFS: base,
+		item: vfs.VFSItem{
+			Name:     "link.txt",
+			UnixMode: 0o777,
+			MTime:    time.Now(),
+		},
+	}
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 30)
+	fsp := pf.getActivePanel()
+	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "link.txt"}}}
+	fsp.vfs = mockVFS
+
+	actionFileAttributes(pf)
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case task := <-fm.TaskChan:
+			task()
+			top := fm.GetTopFrame()
+			if top != nil && strings.Contains(top.GetTitle(), "Attributes") {
+				top.SetExitCode(-1)
+				fm.Pop()
+				return
+			}
+		case <-deadline:
+			top := fm.GetTopFrame()
+			if top == nil {
+				t.Fatal("attributes dialog was not shown")
+			}
+			t.Fatalf("attributes dialog was not shown; top frame is %q", top.GetTitle())
+		}
 	}
 }
 
@@ -735,38 +793,103 @@ func TestShowAttributesDialog_Dispatch(t *testing.T) {
 		vtui.FrameManager.Pop()
 	}
 }
-func TestAttributesDialog_SymlinkTarget(t *testing.T) {
+func TestAttributesDialog_SymlinkUsesLinkMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink metadata requires privileges on Windows")
+	}
+
 	fm := vtui.FrameManager
 	fm.Init(vtui.NewSilentScreenBuf())
 
 	tmpDir := t.TempDir()
-	targetPath := filepath.Join(tmpDir, "target.txt")
-	os.WriteFile(targetPath, []byte("target"), 0644)
+	targetName := "target-file.txt"
+	targetPath := filepath.Join(tmpDir, targetName)
+	if err := os.WriteFile(targetPath, make([]byte, 4096), 0o600); err != nil {
+		t.Fatalf("create target: %v", err)
+	}
+	targetTime := time.Date(2001, 2, 3, 4, 5, 6, 0, time.Local)
+	if err := os.Chtimes(targetPath, targetTime, targetTime); err != nil {
+		t.Fatalf("set target timestamps: %v", err)
+	}
 	linkPath := filepath.Join(tmpDir, "link.txt")
-	if err := os.Symlink(targetPath, linkPath); err != nil {
+	if err := os.Symlink(targetName, linkPath); err != nil {
 		t.Skipf("Symlink creation not supported: %v", err)
 	}
 
 	v := vfs.NewOSVFS(tmpDir)
-	litem, err := v.Lstat(context.Background(), "link.txt")
+	targetItem, err := v.Stat(context.Background(), linkPath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	linkInfo, err := os.Lstat(linkPath)
 	if err != nil {
 		t.Fatalf("Lstat failed: %v", err)
 	}
+	if targetItem.Size == linkInfo.Size() || targetItem.UnixMode == uint32(linkInfo.Mode().Perm()) || targetItem.MTime.Equal(linkInfo.ModTime()) {
+		t.Fatalf("test setup did not distinguish target and link metadata: target=%+v link=%+v", targetItem, linkInfo)
+	}
 
-	showAttributesUnix(nil, v, "link.txt", litem)
+	ShowAttributesDialog(nil, v, linkPath, targetItem)
 	dlg := fm.GetTopFrame().(vtui.Container)
 
-	var editTarget *vtui.Edit
+	wantMode := fmt.Sprintf("%04o", linkInfo.Mode().Perm())
+	wantMTime := linkInfo.ModTime().Format("02.01.2006 15:04:05")
+	found := map[string]bool{}
 	walkUI(dlg.(vtui.UIElement), func(el vtui.UIElement) bool {
-		if e, ok := el.(*vtui.Edit); ok && strings.Contains(e.GetText(), "target.txt") {
-			editTarget = e
-			return false
+		if control, ok := el.(*vtui.Edit); ok {
+			found[control.GetText()] = true
 		}
 		return true
 	})
 
-	if editTarget == nil {
-		t.Error("Symlink target edit box not found in Unix attributes dialog")
+	for _, want := range []string{targetName, wantMode, wantMTime} {
+		if !found[want] {
+			t.Errorf("link property %q not found in attributes dialog", want)
+		}
+	}
+	fm.GetTopFrame().SetExitCode(-1)
+	fm.Pop()
+}
+
+func TestAttributesDialog_SymlinkToDirectoryIsIdentifiedAsLink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink metadata requires privileges on Windows")
+	}
+
+	fm := vtui.FrameManager
+	fm.Init(vtui.NewSilentScreenBuf())
+
+	tmpDir := t.TempDir()
+	targetName := "target-dir"
+	if err := os.Mkdir(filepath.Join(tmpDir, targetName), 0o755); err != nil {
+		t.Fatalf("create target directory: %v", err)
+	}
+	linkPath := filepath.Join(tmpDir, "link-dir")
+	if err := os.Symlink(targetName, linkPath); err != nil {
+		t.Skipf("Symlink creation not supported: %v", err)
+	}
+
+	v := vfs.NewOSVFS(tmpDir)
+	targetItem, err := v.Stat(context.Background(), linkPath)
+	if err != nil {
+		t.Fatalf("Stat failed: %v", err)
+	}
+	if !targetItem.IsDir {
+		t.Fatal("test setup: symlink target is not reported as a directory")
+	}
+
+	ShowAttributesDialog(nil, v, linkPath, targetItem)
+	dlg := fm.GetTopFrame().(vtui.Container)
+	foundTarget := false
+	walkUI(dlg.(vtui.UIElement), func(el vtui.UIElement) bool {
+		if control, ok := el.(*vtui.Edit); ok {
+			foundTarget = foundTarget || control.GetText() == targetName
+		}
+		return true
+	})
+
+	if !foundTarget {
+		t.Error("symlink-to-directory Target edit is not present with the link target")
 	}
 	fm.GetTopFrame().SetExitCode(-1)
 	fm.Pop()

--- a/cmd/f4/highlight_files_test.go
+++ b/cmd/f4/highlight_files_test.go
@@ -90,6 +90,34 @@ func TestHighlightRule_MatchSymlinkAttribute(t *testing.T) {
 	}
 }
 
+func TestBuiltInStylesHighlightSymlinks(t *testing.T) {
+	styles := loadStylesFromFS(builtInStyles, "styles/*.ini")
+	if len(styles) == 0 {
+		t.Fatal("no built-in styles loaded")
+	}
+
+	linkDir := vfs.VFSItem{Name: "link-dir", IsDir: true, IsSymlink: true}
+	plainDir := vfs.VFSItem{Name: "plain-dir", IsDir: true}
+	for _, style := range styles {
+		found := false
+		for _, rule := range parseHighlightRules(style.ini) {
+			if !rule.Match(&linkDir) {
+				continue
+			}
+			if rule.AttrSet&AttrSymlink != 0 && !rule.Match(&plainDir) && rule.NormalStr != "" {
+				found = true
+				if rule.Mark != "" {
+					t.Errorf("built-in style %q symlink rule marker = %q, want empty so the panel arrow fallback stays authoritative", style.Name, rule.Mark)
+				}
+			}
+			break
+		}
+		if !found {
+			t.Errorf("built-in style %q has no visible symlink highlight rule", style.Name)
+		}
+	}
+}
+
 func TestFileHighlighter_GetColor(t *testing.T) {
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()

--- a/cmd/f4/styles/classic.ini
+++ b/cmd/f4/styles/classic.ini
@@ -25,40 +25,45 @@ Panel.Tabs.Accent = foreground:#FFFF00 | background:#0000A0
 Panel.Tabs.Attention = foreground:#FF8700 | background:#0000A0
 Editor.Status = foreground:#000000 | background:#00FFFF
 [Highlight_0]
+Name = Symbolic Links
+IncludeAttributes = Symlink
+NormalColor = foreground:#34E2E2
+
+[Highlight_1]
 Name = Hidden Files
 IncludeAttributes = Hidden
 NormalColor = foreground:#06989A
 
-[Highlight_1]
+[Highlight_2]
 Name = System Files
 IncludeAttributes = System
 NormalColor = foreground:#06989A
 
-[Highlight_2]
+[Highlight_3]
 Name = Directories
 IncludeAttributes = Directory
 NormalColor = foreground:#EEEEEC
 
-[Highlight_3]
+[Highlight_4]
 Name = Scripts
 Mask = *.sh, *.bash, *.py, *.pl, *.cmd, *.exe, *.bat, *.com
 ExcludeAttributes = Directory
 Mark = *
 NormalColor = foreground:#8AE234
 
-[Highlight_4]
+[Highlight_5]
 Name = Archives
 Mask = *.zip, *.rar, *.tar, *.gz, *.7z, *.tgz, *.bz2, *.xz, *.zst, *.jar, *.cab, *.lzh, *.cpio, *.rpm
 ExcludeAttributes = Directory
 NormalColor = foreground:#AD7FA8
 
-[Highlight_5]
+[Highlight_6]
 Name = Temporary Files
 Mask = *.bak, *.tmp
 ExcludeAttributes = Directory
 NormalColor = foreground:#C4A000
 
-[Highlight_6]
+[Highlight_7]
 Name = Executables
 IncludeAttributes = Executable
 ExcludeAttributes = Directory

--- a/cmd/f4/styles/default_dark.ini
+++ b/cmd/f4/styles/default_dark.ini
@@ -128,40 +128,45 @@ Help.Text.Highlight = foreground:#eeeeec | background:#06989a
 Help.Topic = foreground:#fce94f | background:#06989a
 Help.Topic.Selected = foreground:#eeeeec | background:#555753
 [Highlight_0]
+Name = Symbolic Links
+IncludeAttributes = Symlink
+NormalColor = foreground:#34E2E2
+
+[Highlight_1]
 Name = Hidden Files
 IncludeAttributes = Hidden
 NormalColor = foreground:#06989A
 
-[Highlight_1]
+[Highlight_2]
 Name = System Files
 IncludeAttributes = System
 NormalColor = foreground:#06989A
 
-[Highlight_2]
+[Highlight_3]
 Name = Directories
 IncludeAttributes = Directory
 NormalColor = foreground:#EEEEEC
 
-[Highlight_3]
+[Highlight_4]
 Name = Scripts
 Mask = *.sh, *.bash, *.py, *.pl, *.cmd, *.exe, *.bat, *.com
 ExcludeAttributes = Directory
 Mark = *
 NormalColor = foreground:#8AE234
 
-[Highlight_4]
+[Highlight_5]
 Name = Archives
 Mask = *.zip, *.rar, *.tar, *.gz, *.7z, *.tgz, *.bz2, *.xz, *.zst, *.jar, *.cab, *.lzh, *.cpio, *.rpm
 ExcludeAttributes = Directory
 NormalColor = foreground:#AD7FA8
 
-[Highlight_5]
+[Highlight_6]
 Name = Temporary Files
 Mask = *.bak, *.tmp
 ExcludeAttributes = Directory
 NormalColor = foreground:#C4A000
 
-[Highlight_6]
+[Highlight_7]
 Name = Executables
 IncludeAttributes = Executable
 ExcludeAttributes = Directory

--- a/cmd/f4/styles/modern.ini
+++ b/cmd/f4/styles/modern.ini
@@ -105,40 +105,45 @@ Help.Link = foreground:#6CA6CD | background:#2A2A2C
 Help.SelectedLink = foreground:#FFFFFF | background:#3B6290
 Help.Box = foreground:#5A5A5A | background:#2A2A2C
 [Highlight_0]
+Name = Symbolic Links
+IncludeAttributes = Symlink
+NormalColor = foreground:#66D9EF
+
+[Highlight_1]
 Name = Hidden Files
 IncludeAttributes = Hidden
 NormalColor = foreground:#06989A
 
-[Highlight_1]
+[Highlight_2]
 Name = System Files
 IncludeAttributes = System
 NormalColor = foreground:#06989A
 
-[Highlight_2]
+[Highlight_3]
 Name = Directories
 IncludeAttributes = Directory
 NormalColor = foreground:#EEEEEC
 
-[Highlight_3]
+[Highlight_4]
 Name = Scripts
 Mask = *.sh, *.bash, *.py, *.pl, *.cmd, *.exe, *.bat, *.com
 ExcludeAttributes = Directory
 Mark = *
 NormalColor = foreground:#8AE234
 
-[Highlight_4]
+[Highlight_5]
 Name = Archives
 Mask = *.zip, *.rar, *.tar, *.gz, *.7z, *.tgz, *.bz2, *.xz, *.zst, *.jar, *.cab, *.lzh, *.cpio, *.rpm
 ExcludeAttributes = Directory
 NormalColor = foreground:#AD7FA8
 
-[Highlight_5]
+[Highlight_6]
 Name = Temporary Files
 Mask = *.bak, *.tmp
 ExcludeAttributes = Directory
 NormalColor = foreground:#C4A000
 
-[Highlight_6]
+[Highlight_7]
 Name = Executables
 IncludeAttributes = Executable
 ExcludeAttributes = Directory

--- a/cmd/f4/styles/radiola.ini
+++ b/cmd/f4/styles/radiola.ini
@@ -113,24 +113,30 @@ Help.Text = foreground:#1e1a16 | background:#e6b450
 Help.Text.Highlight = foreground:#a04020 | background:#e6b450
 Help.Topic = foreground:#a04020 | background:#e6b450
 [Highlight_0]
+Name = Symbolic Links
+IncludeAttributes = Symlink
+NormalColor = foreground:#66D9EF
+SelectedColor = foreground:#ec6a2c
+
+[Highlight_1]
 Name = Hidden Files
 IncludeAttributes = Hidden
 NormalColor = foreground:#6a6458
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_1]
+[Highlight_2]
 Name = System Files
 IncludeAttributes = System
 NormalColor = foreground:#6a6458
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_2]
+[Highlight_3]
 Name = Directories
 IncludeAttributes = Directory
 NormalColor = foreground:#eeeeec
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_3]
+[Highlight_4]
 Name = Scripts
 Mask = *.sh, *.bash, *.py, *.pl, *.cmd, *.exe, *.bat, *.com
 ExcludeAttributes = Directory
@@ -138,21 +144,21 @@ Mark = *
 NormalColor = foreground:#a6e22e
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_4]
+[Highlight_5]
 Name = Archives
 Mask = *.zip, *.rar, *.tar, *.gz, *.7z, *.tgz, *.bz2, *.xz, *.zst, *.jar, *.cab, *.lzh, *.cpio, *.rpm
 ExcludeAttributes = Directory
 NormalColor = foreground:#e6b450
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_5]
+[Highlight_6]
 Name = Temporary Files
 Mask = *.bak, *.tmp
 ExcludeAttributes = Directory
 NormalColor = foreground:#6a6458
 SelectedColor = foreground:#ec6a2c
 
-[Highlight_6]
+[Highlight_7]
 Name = Executables
 IncludeAttributes = Executable
 ExcludeAttributes = Directory


### PR DESCRIPTION
Addresses what is left of #420.

The first half of that issue — nothing telling you an entry is a symlink — is already fixed: the panel falls back to a `→` marker for links, and the reporter confirmed it. Two things were left open.

## Ctrl+A still describes the target, not the link

`actionFileAttributes` stats through the link, so the attributes dialog showed the target's size, permissions and timestamps while the panel's highlighting matched on the link itself — the two disagreed about what the cursor was on, which is the second bullet of the issue.

It now resolves through `vfs.Lstat`, the helper that already exists for exactly this and falls back to `Stat` for backends with no notion of links, so the dialog describes the entry under the cursor and keeps its Target row for where it points. The dialog's own `IsSymlink` check was already using `Lstat`; only the item handed to it was wrong.

## "А у них есть какие-то настройки? Типа символ/цвет"

The reporter's follow-up question, unanswered so far: yes, through the normal highlight rules — but no shipped style defined one, so links had no colour of their own. All four styles gain a `Symbolic Links` rule, placed first so a link to a directory reads as a link rather than a plain folder. It deliberately carries no `Mark`: the panel's arrow already marks links whether or not `ShowHighlightMarks` is on, and a rule marker would only have applied in one of those two modes. A user who wants a different colour or their own symbol can now see the rule in the style file and override it in `highlight.ini`.

## Tests

`TestActionFileAttributes_UsesLstat` drives the action against a VFS whose `Stat` fails and whose `Lstat` succeeds — it only passes if the action takes the `Lstat` path. `TestAttributesDialog_SymlinkUsesLinkMetadata` asserts the dialog shows the link's own mode, mtime and target, and guards its own setup by first checking that link and target metadata actually differ. `TestBuiltInStylesHighlightSymlinks` checks every shipped style has a symlink rule that a plain directory does not match, and that it defines no marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
