### PR TITLE
bookmarks: expand environment variables and ~ when navigating

### DIFF
--- a/cmd/f4/bookmarks.go
+++ b/cmd/f4/bookmarks.go
@@ -17,7 +17,7 @@ import (
 
 // Bookmark is a single slot of the table.
 type Bookmark struct {
-	Path       string // absolute filesystem path; empty means slot is unset
+	Path       string // filesystem path or expandable path expression; empty means slot is unset
 	Plugin     string // preserved from far2l; f4 does not act on it yet
 	PluginData string
 	PluginFile string

--- a/cmd/f4/bookmarks_dialog.go
+++ b/cmd/f4/bookmarks_dialog.go
@@ -177,11 +177,11 @@ func (d *bookmarksDialog) open(slot int, onClose func()) {
 		if slot < 0 || d.set[slot].IsEmpty() {
 			return
 		}
-		path := d.set[slot].Path
+		bookmark := d.set[slot]
 		pf := d.pf
 		vtui.FrameManager.PostTask(func() {
 			if fsp := pf.getActivePanel(); fsp != nil {
-				pf.NavigateToPath(fsp, path)
+				pf.navigateToBookmark(fsp, bookmark)
 			}
 		})
 	}

--- a/cmd/f4/bookmarks_test.go
+++ b/cmd/f4/bookmarks_test.go
@@ -232,6 +232,67 @@ func TestBookmark_IsEmpty(t *testing.T) {
 	}
 }
 
+func TestExpandPathEnv_BookmarkPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	const undefined = "F4_BOOKMARK_UNDEFINED_412"
+	oldUndefined, hadUndefined := os.LookupEnv(undefined)
+	if err := os.Unsetenv(undefined); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if hadUndefined {
+			_ = os.Setenv(undefined, oldUndefined)
+		} else {
+			_ = os.Unsetenv(undefined)
+		}
+	})
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"dollar variable", filepath.Join("$HOME", "x"), filepath.Join(home, "x")},
+		{"braced dollar variable", filepath.Join("${HOME}", "x"), filepath.Join(home, "x")},
+		{"percent variable", filepath.Join("%USERPROFILE%", "x"), filepath.Join(home, "x")},
+		{"tilde", "~", home},
+		{"tilde subdirectory", filepath.Join("~", "sub"), filepath.Join(home, "sub")},
+		{"literal", filepath.Join(home, "literal"), filepath.Join(home, "literal")},
+		// Unknown variables stay literal. This prevents a typo such as
+		// $HMOE/x from unexpectedly becoming the unrelated rooted path /x.
+		{"undefined dollar variable", filepath.Join("$"+undefined, "x"), filepath.Join("$"+undefined, "x")},
+		{"undefined percent variable", filepath.Join("%"+undefined+"%", "x"), filepath.Join("%"+undefined+"%", "x")},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := expandPathEnv(tc.path); got != tc.want {
+				t.Errorf("expandPathEnv(%q) = %q, want %q", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBookmarks_RoundTripPreservesExpandablePath(t *testing.T) {
+	var in BookmarkSet
+	in[4] = Bookmark{Path: filepath.Join("$HOME", "portable")}
+	p := filepath.Join(t.TempDir(), "bookmarks.ini")
+
+	if err := SaveBookmarks(p, in); err != nil {
+		t.Fatal(err)
+	}
+	out, err := LoadBookmarks(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != in {
+		t.Fatalf("round trip expanded a stored bookmark:\ngot  %#v\nwant %#v", out, in)
+	}
+}
+
 func TestTruncPathLeft(t *testing.T) {
 	const long = "/mnt/d/!!wrkstk/reps/ssh/ski-analyzer"
 	cases := []struct {

--- a/cmd/f4/command_palette_drives.go
+++ b/cmd/f4/command_palette_drives.go
@@ -186,6 +186,6 @@ func executeCommandPaletteBookmark(pf *PanelsFrame, panelIndex, slot int) bool {
 	if err != nil || slot < 0 || slot >= len(bookmarks) || bookmarks[slot].IsEmpty() || strings.TrimSpace(bookmarks[slot].Path) == "" {
 		return false
 	}
-	pf.NavigateToPath(fsp, bookmarks[slot].Path)
+	pf.navigateToBookmark(fsp, bookmarks[slot])
 	return true
 }

--- a/cmd/f4/command_palette_panels.go
+++ b/cmd/f4/command_palette_panels.go
@@ -438,7 +438,7 @@ func runCommandPaletteBookmarkGoto(pf *PanelsFrame, slot int) bool {
 	if err != nil || fsp == nil || strings.TrimSpace(bookmarks[slot].Path) == "" {
 		return false
 	}
-	pf.NavigateToPath(fsp, bookmarks[slot].Path)
+	pf.navigateToBookmark(fsp, bookmarks[slot])
 	return true
 }
 

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1850,7 +1850,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 			} else if !set[slot].IsEmpty() {
 				// An unset slot is a silent no-op, as in far2l.
 				if fsp := pf.getActivePanel(); fsp != nil {
-					pf.NavigateToPath(fsp, set[slot].Path)
+					pf.navigateToBookmark(fsp, set[slot])
 				}
 			}
 			return true
@@ -4128,13 +4128,14 @@ func (pf *PanelsFrame) showDriveMenuAt(panelIdx, selectPos int) {
 				menu.AddSeparator()
 				firstBookmark = false
 			}
-			path := set[i].Path
+			bookmark := set[i]
+			path := bookmark.Path
 			usedHotkeys[rune('0'+i)] = true
 			bookmarkRows[menu.GetItemCount()] = i
 			menu.AddItem(vtui.MenuItem{
 				Text: fmt.Sprintf("&%d  %s", i, escapeAmpersand(truncPathLeft(path, 64))),
 				UserData: func(fsp *FileSystemPanel) {
-					pf.NavigateToPath(fsp, path)
+					pf.navigateToBookmark(fsp, bookmark)
 				},
 			})
 		}
@@ -4322,6 +4323,10 @@ func (pf *PanelsFrame) switchToVFS(fsp *FileSystemPanel, newVFS vfs.VFS) {
 		pf.RefreshAll()
 	}
 }
+func (pf *PanelsFrame) navigateToBookmark(fsp *FileSystemPanel, bookmark Bookmark) bool {
+	return pf.NavigateToPath(fsp, expandPathEnv(bookmark.Path))
+}
+
 func (pf *PanelsFrame) NavigateToPath(fsp *FileSystemPanel, targetPath string) bool {
 	if targetPath == "" {
 		return false
@@ -4651,27 +4656,72 @@ func (pf *PanelsFrame) moveFolderHistory(fsp *FileSystemPanel, direction int) bo
 }
 
 func expandPathEnv(s string) string {
-	if runtime.GOOS == "windows" {
-		var buf strings.Builder
-		for i := 0; i < len(s); i++ {
-			if s[i] == '%' {
-				end := strings.IndexByte(s[i+1:], '%')
-				if end <= 0 {
-					buf.WriteByte(s[i])
+	s = expandEnvironmentVariables(s)
+	if s != "~" && !(len(s) > 1 && s[0] == '~' && (s[1] == '/' || s[1] == '\\')) {
+		return s
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return s
+	}
+	if s == "~" {
+		return home
+	}
+	return filepath.Join(home, s[2:])
+}
+
+func expandEnvironmentVariables(s string) string {
+	var buf strings.Builder
+	for i := 0; i < len(s); {
+		switch s[i] {
+		case '$':
+			start, end := i+1, i+1
+			if start < len(s) && s[start] == '{' {
+				start++
+				if close := strings.IndexByte(s[start:], '}'); close >= 0 {
+					end = start + close
+					if end > start {
+						if value, ok := os.LookupEnv(s[start:end]); ok {
+							buf.WriteString(value)
+						} else {
+							buf.WriteString(s[i : end+1])
+						}
+						i = end + 1
+						continue
+					}
+				}
+			} else {
+				for end < len(s) && isEnvironmentVariableChar(s[end]) {
+					end++
+				}
+				if end > start {
+					if value, ok := os.LookupEnv(s[start:end]); ok {
+						buf.WriteString(value)
+					} else {
+						buf.WriteString(s[i:end])
+					}
+					i = end
 					continue
 				}
-				name := s[i+1 : i+1+end]
-				if v := os.Getenv(name); v != "" {
-					buf.WriteString(v)
+			}
+		case '%':
+			if close := strings.IndexByte(s[i+1:], '%'); close > 0 {
+				end := i + close + 1
+				if value, ok := os.LookupEnv(s[i+1 : end]); ok {
+					buf.WriteString(value)
 				} else {
-					buf.WriteString(s[i : i+end+2])
+					buf.WriteString(s[i : end+1])
 				}
-				i += end + 1
-			} else {
-				buf.WriteByte(s[i])
+				i = end + 1
+				continue
 			}
 		}
-		return buf.String()
+		buf.WriteByte(s[i])
+		i++
 	}
-	return os.ExpandEnv(s)
+	return buf.String()
+}
+
+func isEnvironmentVariableChar(c byte) bool {
+	return c == '_' || c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9'
 }

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -479,6 +479,74 @@ func TestPanelsFrame_DriveMenuListsAssignedBookmarks(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
+	cfg := t.TempDir()
+	oldUserConfigDir := userConfigDir
+	userConfigDir = func() (string, error) { return cfg, nil }
+	t.Cleanup(func() { userConfigDir = oldUserConfigDir })
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	for _, dir := range []string{
+		filepath.Join(home, "x"),
+		filepath.Join(home, "sub"),
+		filepath.Join(home, "literal"),
+	} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"dollar variable", filepath.Join("$HOME", "x"), filepath.Join(home, "x")},
+		{"percent variable", filepath.Join("%USERPROFILE%", "x"), filepath.Join(home, "x")},
+		{"tilde", "~", home},
+		{"tilde subdirectory", filepath.Join("~", "sub"), filepath.Join(home, "sub")},
+		{"literal", filepath.Join(home, "literal"), filepath.Join(home, "literal")},
+	}
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+	fsp := pf.panels[1].(*FileSystemPanel)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := os.WriteFile(BookmarksFilePath(),
+				[]byte("[6]\nPath="+tc.path+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := fsp.vfs.SetPath(t.TempDir()); err != nil {
+				t.Fatal(err)
+			}
+			pf.showDriveMenu(1)
+			menu, ok := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
+			if !ok {
+				t.Fatalf("drive menu not shown, top frame is %T", vtui.FrameManager.GetTopFrame())
+			}
+			menu.ProcessKey(&vtinput.InputEvent{
+				Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_6, Char: '6',
+			})
+
+			if got := fsp.vfs.GetPath(); got != tc.want {
+				t.Errorf("bookmark %q navigated to %q, want %q", tc.path, got, tc.want)
+			}
+			vtui.FrameManager.RemoveFrame(menu)
+		})
+	}
+}
+
 // settleFrames does what the render loop does between keystrokes: run the
 // tasks frames posted, then drop the ones that closed themselves.
 func settleFrames(t *testing.T) {


### PR DESCRIPTION
Fixes #412.

A bookmark pointing at `$HOME`, `%USERPROFILE%` or `~` was handed to the panel verbatim, so the jump simply failed.

Every bookmark route — Ctrl+digit, the drive menu, the bookmarks dialog and both command palette entries — now goes through one `navigateToBookmark`, which expands the stored path *on use*. The bookmark itself stays literal on disk, so it keeps working across machines and stays compatible with far2l's `bookmarks.ini`.

The expansion happens in `expandPathEnv`, which the command line's `cd` already shared and which had grown lopsided: `%VAR%` was understood only on Windows, `$VAR` only elsewhere, and `~` nowhere. It now handles `$VAR`, `${VAR}` and `%VAR%` on every platform, resolves `~` and `~/…` against the home directory, and leaves an undefined variable in place instead of collapsing it to an empty string — which used to turn a typo into a jump to the filesystem root. `cd` in the command line benefits from the same.

Covered by tests for each form, for a path with no variables, for an undefined variable, for the drive menu's bookmark entries, and for the round trip that keeps the stored path unexpanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
