### PR TITLE
fix: keep settings dialogs accessible in short windows

### DIFF
--- a/cmd/f4/issue561_test.go
+++ b/cmd/f4/issue561_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+type issue561ViewportRenderer struct {
+}
+
+func (*issue561ViewportRenderer) Render([]vtui.CharInfo, []vtui.CharInfo, int, int, bool) {}
+func (*issue561ViewportRenderer) SetCursor(int, int, bool, vtui.CursorShape)              {}
+func (*issue561ViewportRenderer) SetPalette(*[256]uint32)                                 {}
+func (*issue561ViewportRenderer) SetWindowTitle(string)                                   {}
+func (*issue561ViewportRenderer) Flush()                                                  {}
+
+func TestIssue561PanelSettingsRequestsViewportLargeEnoughForDialog(t *testing.T) {
+	oldConfig := AppConfig
+	defer func() { AppConfig = oldConfig }()
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(100, 30)
+	renderer := &issue561ViewportRenderer{}
+	scr.Renderer = renderer
+	vtui.FrameManager.Init(scr)
+
+	pf := NewPanelsFrame()
+	vtui.FrameManager.Push(pf)
+	actionPanelSettings(pf)
+
+	top, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+	if !ok {
+		t.Fatalf("top frame = %T, want *vtui.Window", vtui.FrameManager.GetTopFrame())
+	}
+	_, y1, _, y2 := top.GetPosition()
+	if y1 < 0 || y2 >= 30 {
+		t.Fatalf("Panel Settings viewport = (%d,%d), want it fully within 30 rows", y1, y2)
+	}
+	top.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_NEXT})
+	focused := top.GetFocusedItem()
+	if focused == nil {
+		t.Fatal("Panel Settings has no focused control after Page Down")
+	}
+	button, ok := focused.(*vtui.Button)
+	if !ok || !button.IsDefault {
+		t.Fatalf("Page Down focused %T, want the default action button", focused)
+	}
+	_, _, _, focusedY := focused.GetPosition()
+	if focusedY >= 29 {
+		t.Fatalf("default button remained below viewport at row %d", focusedY)
+	}
+}

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -3347,11 +3347,14 @@ func TestLayout_F4ActionDialogs_Validity(t *testing.T) {
 	vtui.SetDefaultPalette()
 	pf := NewPanelsFrame()
 	defer pf.Close()
-	pf.ResizeConsole(80, 25)
+	// Validate the intended, full dialog layout. Short screens are exercised
+	// separately by the viewport regression test; settings dialogs can now
+	// intentionally extend beyond a small viewport and scroll their contents.
+	pf.ResizeConsole(80, 60)
 	fm := vtui.FrameManager
 
 	scr := vtui.NewSilentScreenBuf()
-	scr.AllocBuf(80, 25)
+	scr.AllocBuf(80, 60)
 	fm.Init(scr)
 
 	// Helper to setup active panel with some files

--- a/docs/issue-561-solutions.md
+++ b/docs/issue-561-solutions.md
@@ -1,0 +1,21 @@
+# Issue #561: settings dialogs in a short GUI window
+
+## Candidate 1: change every settings dialog
+
+Give each settings dialog its own compact layout or scrolling container. This
+would duplicate viewport handling across roughly thirty dialogs, risks
+inconsistent keyboard navigation, and would still leave plugins affected.
+
+## Candidate 2: impose a global minimum window height
+
+Reject resizes below the tallest dialog. It avoids clipping, but it makes the
+application impossible to use in a small window even when no dialog is open
+and does not satisfy the request for accessible dialog content.
+
+## Candidate 3: make modal dialogs viewport-aware
+
+Have the shared `vtui` window implementation resize a modal dialog to the
+available viewport and provide a scrollable content area. This covers f4 and
+plugin dialogs consistently, preserves normal layouts at usable sizes, and
+keeps every action reachable. It is the preferred design, but must be
+implemented and released in `vtui`, then consumed by f4.


### PR DESCRIPTION
## Summary
- add a regression test for Panel Settings in a short 100×30 viewport
- keep full-layout validation separate from short-viewport scrolling behavior
- document the three considered solutions for issue #561

The implementation is included in `github.com/unxed/vtui v0.1.255`, which is now consumed by the current f4 `main`. This PR adds the f4-level regression coverage and documentation on top of that released fix.

## Verification
- Native Windows 11 / Win32 GUI: opened Panel Settings in a 30-row viewport, navigated to `OK`/`Cancel` with Page Down, scrolled via the wheel while pointer was over a child control, and ran repeated window-resize cycles without redraw artifacts.
- `go test ./cmd/f4 -count=1`
- `go build -o build\\f4-issue561-rebased-gui.exe ./cmd/f4`