### PR TITLE
Fix regression nightly update prompt showing UTC instead of local time

### DIFF
--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -170,6 +170,14 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		// post-update version line agree. See #343.
 		if commit, builtOn := commitInfoFromReleaseBody(release.Body); commit != "" {
 			if builtOn != "" {
+				// The nightly workflow records BUILD_TIME with `date` on
+				// a UTC GitHub runner and without a zone suffix, so it is
+				// UTC. Treat it as such and show the user's local time so
+				// the prompt agrees with the asset-timestamp path above
+				// and never regresses to UTC. See f4 issue #343.
+				if t, err := time.ParseInLocation("2006-01-02 15:04:05", builtOn, time.UTC); err == nil {
+					builtOn = t.Local().Format("2006-01-02 15:04")
+				}
 				displayVersion = "Nightly (" + commit + " [" + builtOn + "])"
 			} else {
 				displayVersion = "Nightly (" + commit + ")"


### PR DESCRIPTION
The regression was caused by commit: 2e466adf3e78ddc3cf8276ab5717d56fbcbd0ac2 
 
Author: Ivan Sorokin unxed@mail.ru Date: 2026-08-18 09:13:09 +0200 Subject: updater: show the nightly's commit and 
build time, not the asset upload time 
 
Why it is at fault: This commit added, in cmd/f4/updater.go (the UpdateChannel == 1 block), preference for the **Built 
on:** field from the release body (via commitInfoFromReleaseBody), and the string is now shown "as-is". It is produced 
by the workflow at .github/workflows/build.yml:502: 
 
echo "BUILD_TIME=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV 
On GitHub runners date returns time in UTC (and without a zone indicator). Previously the prompt showed assetUpdated via t.Local() (commit 92a84461, Zeroes1, 2026-08-04) — i.e. the user's local time. The new code overrides it with builtOn, which is UTC and is never converted → "reverted to UTC again".

## Summary
- Fixes the nightly update prompt displaying build time in UTC instead of the user's local time (regression from `2e466adf`, see #343).
- `builtOn` (the `**Built on:**` field from the release body) is now parsed as UTC and rendered via `.Local().Format("2006-01-02 15:04")`, matching how `assetUpdated` was already shown.

## Changes
- `cmd/f4/updater.go`: in the `UpdateChannel == 1` branch, localize `builtOn` before embedding it into `displayVersion`.

## Notes
- Display-only change; update detection (`updateKey`, `LastUpdateVersion`) still uses `assetUpdated`/`publishedAt`, so behavior is unaffected.
- If the workflow format ever changes and parsing fails, the raw string is kept (no crash).
