### PR TITLE
Split Panel settings into compact dialogs

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -2749,18 +2749,12 @@ func actionFindFile(pf *PanelsFrame) {
 	vtui.FrameManager.Push(dlg)
 }
 func actionPanelSettings(pf *PanelsFrame) {
-	// Height sized so consecutive checkbox rows stack tightly without
-	// blank lines between them (see #298). Blank rows are kept only at
-	// transitions between widget kinds (checkbox↔combo↔radio↔button)
-	// so groups still read as groups. One extra row is reserved when the
-	// console-mode "unavailable" notice needs its own line — see the
-	// consoleModeUnavailable comment below.
-	consoleModeUnavailable := probeGUIBackend() != "" || !probeHostTTY()
-	dialogHeight := 43
-	if consoleModeUnavailable {
-		dialogHeight++
-	}
-	dlg := vtui.NewCenteredDialog(60, dialogHeight, Msg("PanelSettings.Title"))
+	// Keep the frequently used panel and navigation options in a compact
+	// dialog. The less frequently changed performance, console, and operation
+	// display options live in actionPanelAdditionalSettings below. Keeping both
+	// pages as ordinary dialogs means they remain usable on a 25-row terminal
+	// without introducing a second scrolling container for interactive items.
+	dlg := vtui.NewCenteredDialog(60, 22, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
 	chkHidden := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowHidden"), false)
@@ -2834,8 +2828,90 @@ func actionPanelSettings(pf *PanelsFrame) {
 		chkStayFocused.SetDisabled(PanelNavigationMode(selected) != NavigationSearchFirst)
 	}
 
+	btnAdditional := vtui.NewButton(0, 0, Msg("PanelSettings.Additional"))
+	btnOk := vtui.NewButton(0, 0, Msg("vtui.Ok"))
+	btnOk.IsDefault = true
+	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
+
+	dlg.AddItem(chkHidden)
+	dlg.AddItem(chkDirPrefix)
+	dlg.AddItem(chkHighlightMarks)
+	dlg.AddItem(chkSeparateExtensions)
+	dlg.AddItem(chkFileInfo)
+	dlg.AddItem(lblScrollbars)
+	dlg.AddItem(comboScrollbars)
+	dlg.AddItem(chkPaths)
+	dlg.AddItem(chkCmdAc)
+	dlg.AddItem(lblNavigation)
+	dlg.AddItem(navigation)
+	dlg.AddItem(chkStayFocused)
+	dlg.AddItem(btnAdditional)
+	dlg.AddItem(btnOk)
+	dlg.AddItem(btnCancel)
+
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 18)
+	// First checkbox cluster — stack tight, no blank rows between.
+	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkDirPrefix, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkHighlightMarks, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkSeparateExtensions, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkFileInfo, vtui.Margins{}, vtui.AlignLeft)
+	// Blank row before the scrollbar combo — transition to a different
+	// widget kind, worth the visual separator.
+	rowScrollbars := vtui.NewHBoxLayout(0, 0, 56, 1)
+	rowScrollbars.Add(lblScrollbars, vtui.Margins{Right: 1}, vtui.AlignLeft)
+	rowScrollbars.Add(comboScrollbars, vtui.Margins{}, vtui.AlignFill)
+	vbox.Add(rowScrollbars, vtui.Margins{Top: 1}, vtui.AlignFill)
+	// Second checkbox cluster.
+	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkCmdAc, vtui.Margins{}, vtui.AlignLeft)
+	// Navigation radio group — its own visual island.
+	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(navigation, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkStayFocused, vtui.Margins{Left: 2}, vtui.AlignLeft)
+	hbox := vtui.NewHBoxLayout(0, 0, 56, 1)
+	hbox.HorizontalAlign = vtui.AlignCenter
+	hbox.Spacing = 1
+	hbox.Add(btnAdditional, vtui.Margins{}, vtui.AlignTop)
+	hbox.Add(btnOk, vtui.Margins{}, vtui.AlignTop)
+	hbox.Add(btnCancel, vtui.Margins{}, vtui.AlignTop)
+
+	vbox.Add(hbox, vtui.Margins{Top: 1}, vtui.AlignFill)
+	vbox.Apply()
+
+	btnCancel.OnClick = func() { dlg.Close() }
+	btnOk.OnClick = func() {
+		AppConfig.ShowHiddenFiles = chkHidden.State == 1
+		AppConfig.ShowDirPrefix = chkDirPrefix.State == 1
+		AppConfig.ShowHighlightMarks = chkHighlightMarks.State == 1
+		AppConfig.SeparateFileExtensions = chkSeparateExtensions.State == 1
+		AppConfig.ShowPanelFileInfo = chkFileInfo.State == 1
+		AppConfig.PanelScrollbarMode = PanelScrollbarMode(comboScrollbars.Menu.SelectPos)
+		AppConfig.SavePanelPaths = chkPaths.State == 1
+		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
+		pf.cmdLine.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
+		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)
+		AppConfig.SearchCommandStayFocused = chkStayFocused.State == 1
+		pf.applyNavigationMode()
+		SaveConfig()
+		dlg.Close()
+		pf.ResizeConsole(pf.lastW, pf.lastH)
+		pf.RefreshAll()
+	}
+	btnAdditional.OnClick = func() { actionPanelAdditionalSettings(pf) }
+
+	vtui.FrameManager.Push(dlg)
+}
+
+func actionPanelAdditionalSettings(pf *PanelsFrame) {
+	// This page contains the options that are changed less often than the
+	// panel/navigation controls. Keep it below 25 rows even when the host
+	// console notice needs a separate line.
+	consoleModeUnavailable := probeGUIBackend() != "" || !probeHostTTY()
+	dlg := vtui.NewCenteredDialog(60, 23, Msg("PanelSettings.AdvancedTitle"))
+	dlg.ShowClose = true
+
 	chkSync := vtui.NewCheckbox(0, 0, Msg("PanelSettings.SyncPanelLoad"), false)
-	chkSync.State = 0
 	if AppConfig.SyncPanelLoad {
 		chkSync.State = 1
 	}
@@ -2843,38 +2919,29 @@ func actionPanelSettings(pf *PanelsFrame) {
 	lblApplyWorkers := vtui.NewLabel(0, 0, Msg("PanelSettings.ApplyWorkers"), editApplyWorkers)
 
 	chkAlwaysMenu := vtui.NewCheckbox(0, 0, Msg("PanelSettings.AlwaysShowMenuBar"), false)
-	chkAlwaysMenu.State = 0
 	if AppConfig.AlwaysShowMenuBar {
 		chkAlwaysMenu.State = 1
 	}
-
 	chkCPUGPU := vtui.NewCheckbox(0, 0, Msg("PanelSettings.InfoPanelCPUGPU"), false)
-	chkCPUGPU.State = 0
 	if AppConfig.InfoPanelCPUGPU {
 		chkCPUGPU.State = 1
 	}
-
 	chkEscToggle := vtui.NewCheckbox(0, 0, Msg("PanelSettings.EscTogglePanels"), false)
-	chkEscToggle.State = 0
 	if AppConfig.EscTogglePanels {
 		chkEscToggle.State = 1
 	}
-
 	chkTerminalCtrlN := vtui.NewCheckbox(0, 0, Msg("PanelSettings.TerminalCtrlNWorkspace"), false)
 	if AppConfig.TerminalCtrlNWorkspace {
 		chkTerminalCtrlN.State = 1
 	}
 
 	lblConsoleMode := vtui.NewText(0, 0, Msg("PanelSettings.ConsoleMode"), 0)
-	consoleModes := []string{
+	radioConsoleMode := vtui.NewRadioGroup(0, 0, 1, []string{
 		Msg("PanelSettings.ConsoleModeOwn"),
 		Msg("PanelSettings.ConsoleModeHost"),
-	}
-	radioConsoleMode := vtui.NewRadioGroup(0, 0, 1, consoleModes)
+	})
 	if strings.EqualFold(AppConfig.ConsoleMode, "host") {
 		radioConsoleMode.Selected = 1
-	} else {
-		radioConsoleMode.Selected = 0
 	}
 	for i := 0; i < radioConsoleMode.Selected; i++ {
 		radioConsoleMode.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DOWN})
@@ -2884,18 +2951,11 @@ func actionPanelSettings(pf *PanelsFrame) {
 		chkOverlay.State = 1
 	}
 	chkOverlay.SetDisabled(radioConsoleMode.Selected != 1)
-
-	noteText := Msg("PanelSettings.ConsoleModeNote")
-	// "(unavailable in current environment) (applies to new sessions)" does
-	// not fit the dialog's 56-column content width on one line (auto-sized
-	// Text widgets never wrap), so give the unavailability notice its own
-	// row instead of concatenating it into noteText.
 	var lblConsoleUnavailable *vtui.Text
 	if consoleModeUnavailable {
 		lblConsoleUnavailable = vtui.NewText(0, 0, Msg("PanelSettings.ConsoleModeUnavailable"), 0)
 	}
-	lblConsoleNote := vtui.NewText(0, 0, noteText, 0)
-
+	lblConsoleNote := vtui.NewText(0, 0, Msg("PanelSettings.ConsoleModeNote"), 0)
 	radioConsoleMode.OnChange = func(selected int) {
 		chkOverlay.SetDisabled(selected != 1)
 	}
@@ -2925,72 +2985,28 @@ func actionPanelSettings(pf *PanelsFrame) {
 	btnOk.IsDefault = true
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
 
-	dlg.AddItem(chkHidden)
-	dlg.AddItem(chkDirPrefix)
-	dlg.AddItem(chkHighlightMarks)
-	dlg.AddItem(chkSeparateExtensions)
-	dlg.AddItem(chkFileInfo)
-	dlg.AddItem(lblScrollbars)
-	dlg.AddItem(comboScrollbars)
-	dlg.AddItem(chkPaths)
-	dlg.AddItem(chkCmdAc)
-	dlg.AddItem(lblNavigation)
-	dlg.AddItem(navigation)
-	dlg.AddItem(chkStayFocused)
-	dlg.AddItem(chkSync)
-	dlg.AddItem(lblApplyWorkers)
-	dlg.AddItem(editApplyWorkers)
-	dlg.AddItem(chkAlwaysMenu)
-	dlg.AddItem(chkCPUGPU)
-	dlg.AddItem(chkEscToggle)
-	dlg.AddItem(chkTerminalCtrlN)
-	dlg.AddItem(lblConsoleMode)
-	dlg.AddItem(radioConsoleMode)
-	dlg.AddItem(chkOverlay)
+	for _, item := range []vtui.UIElement{
+		chkSync, lblApplyWorkers, editApplyWorkers, chkAlwaysMenu, chkCPUGPU,
+		chkEscToggle, chkTerminalCtrlN, lblConsoleMode, radioConsoleMode,
+		chkOverlay, lblConsoleNote, lblMode, comboMode, lblPath, comboPath,
+		lblMacro, comboMacro, btnOk, btnCancel,
+	} {
+		dlg.AddItem(item)
+	}
 	if lblConsoleUnavailable != nil {
 		dlg.AddItem(lblConsoleUnavailable)
 	}
-	dlg.AddItem(lblConsoleNote)
-	dlg.AddItem(lblMode)
-	dlg.AddItem(comboMode)
-	dlg.AddItem(lblPath)
-	dlg.AddItem(comboPath)
-	dlg.AddItem(lblMacro)
-	dlg.AddItem(comboMacro)
-	dlg.AddItem(btnOk)
-	dlg.AddItem(btnCancel)
 
-	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, dialogHeight-4)
-	// First checkbox cluster — stack tight, no blank rows between.
-	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkDirPrefix, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkHighlightMarks, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkSeparateExtensions, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkFileInfo, vtui.Margins{}, vtui.AlignLeft)
-	// Blank row before the scrollbar combo — transition to a different
-	// widget kind, worth the visual separator.
-	rowScrollbars := vtui.NewHBoxLayout(0, 0, 56, 1)
-	rowScrollbars.Add(lblScrollbars, vtui.Margins{Right: 1}, vtui.AlignLeft)
-	rowScrollbars.Add(comboScrollbars, vtui.Margins{}, vtui.AlignFill)
-	vbox.Add(rowScrollbars, vtui.Margins{Top: 1}, vtui.AlignFill)
-	// Second checkbox cluster.
-	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(chkCmdAc, vtui.Margins{}, vtui.AlignLeft)
-	// Navigation radio group — its own visual island.
-	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(navigation, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkStayFocused, vtui.Margins{Left: 2}, vtui.AlignLeft)
-	// Third checkbox cluster.
-	vbox.Add(chkSync, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 19)
+	vbox.Add(chkSync, vtui.Margins{}, vtui.AlignLeft)
 	rowApplyWorkers := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowApplyWorkers.Add(lblApplyWorkers, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowApplyWorkers.Add(editApplyWorkers, vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(rowApplyWorkers, vtui.Margins{Top: 1}, vtui.AlignFill)
-	vbox.Add(chkAlwaysMenu, vtui.Margins{Top: 1}, vtui.AlignLeft)
+	vbox.Add(chkAlwaysMenu, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkCPUGPU, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkEscToggle, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkTerminalCtrlN, vtui.Margins{}, vtui.AlignLeft)
-
 	vbox.Add(lblConsoleMode, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(radioConsoleMode, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkOverlay, vtui.Margins{Left: 2}, vtui.AlignLeft)
@@ -3002,24 +3018,20 @@ func actionPanelSettings(pf *PanelsFrame) {
 	rowMode := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowMode.Add(lblMode, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowMode.Add(comboMode, vtui.Margins{}, vtui.AlignFill)
-	vbox.Add(rowMode, vtui.Margins{Top: 1}, vtui.AlignFill)
-
+	vbox.Add(rowMode, vtui.Margins{}, vtui.AlignFill)
 	rowPath := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowPath.Add(lblPath, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowPath.Add(comboPath, vtui.Margins{}, vtui.AlignFill)
-	vbox.Add(rowPath, vtui.Margins{Top: 1}, vtui.AlignFill)
-
+	vbox.Add(rowPath, vtui.Margins{}, vtui.AlignFill)
 	rowMacro := vtui.NewHBoxLayout(0, 0, 56, 1)
 	rowMacro.Add(lblMacro, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowMacro.Add(comboMacro, vtui.Margins{}, vtui.AlignFill)
-	vbox.Add(rowMacro, vtui.Margins{Top: 1}, vtui.AlignFill)
-
+	vbox.Add(rowMacro, vtui.Margins{}, vtui.AlignFill)
 	hbox := vtui.NewHBoxLayout(0, 0, 56, 1)
 	hbox.HorizontalAlign = vtui.AlignCenter
 	hbox.Spacing = 2
 	hbox.Add(btnOk, vtui.Margins{}, vtui.AlignTop)
 	hbox.Add(btnCancel, vtui.Margins{}, vtui.AlignTop)
-
 	vbox.Add(hbox, vtui.Margins{Top: 1}, vtui.AlignFill)
 	vbox.Apply()
 
@@ -3030,17 +3042,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 			vtui.ShowMessageOn(dlg, Msg("ApplyCommand.InvalidWorkersTitle"), Msg("ApplyCommand.InvalidWorkers"), []string{Msg("vtui.Ok")})
 			return
 		}
-		AppConfig.ShowHiddenFiles = chkHidden.State == 1
-		AppConfig.ShowDirPrefix = chkDirPrefix.State == 1
-		AppConfig.ShowHighlightMarks = chkHighlightMarks.State == 1
-		AppConfig.SeparateFileExtensions = chkSeparateExtensions.State == 1
-		AppConfig.ShowPanelFileInfo = chkFileInfo.State == 1
-		AppConfig.PanelScrollbarMode = PanelScrollbarMode(comboScrollbars.Menu.SelectPos)
-		AppConfig.SavePanelPaths = chkPaths.State == 1
-		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
-		pf.cmdLine.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
-		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)
-		AppConfig.SearchCommandStayFocused = chkStayFocused.State == 1
 		AppConfig.SyncPanelLoad = chkSync.State == 1
 		AppConfig.ApplyCommandParallelism = applyWorkers
 		AppConfig.AlwaysShowMenuBar = chkAlwaysMenu.State == 1
@@ -3056,7 +3057,6 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.DefaultFileOpMode = comboMode.Menu.SelectPos
 		AppConfig.FileOpPathDisplay = comboPath.Menu.SelectPos
 		AppConfig.MacroRecordFormat = comboMacro.Menu.SelectPos
-		pf.applyNavigationMode()
 		SaveConfig()
 		dlg.Close()
 		pf.ResizeConsole(pf.lastW, pf.lastH)

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -1205,6 +1205,37 @@ func TestActionPanelSettings_Flow(t *testing.T) {
 	top.SetExitCode(-1)
 	vtui.FrameManager.Pop()
 }
+
+func TestActionPanelSettings_FitsSmallTerminal(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	actionPanelSettings(pf)
+	mainDlg := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+	_, y1, _, y2 := mainDlg.GetPosition()
+	if got := y2 - y1 + 1; got > 25 {
+		t.Fatalf("Panel settings dialog is %d rows tall; want at most 25", got)
+	}
+	vtui.AssertLayout(t, mainDlg)
+
+	clickDialogButton(t, mainDlg, "Additional settings")
+	additionalDlg := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+	_, y1, _, y2 = additionalDlg.GetPosition()
+	if got := y2 - y1 + 1; got > 25 {
+		t.Fatalf("Additional panel settings dialog is %d rows tall; want at most 25", got)
+	}
+	vtui.AssertLayout(t, additionalDlg)
+
+	additionalDlg.SetExitCode(-1)
+	vtui.FrameManager.Pop()
+	mainDlg.SetExitCode(-1)
+	vtui.FrameManager.Pop()
+}
+
 func TestActionPanelSettings_ConsoleModes(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
@@ -1224,6 +1255,12 @@ func TestActionPanelSettings_ConsoleModes(t *testing.T) {
 		t.Fatal("Panel settings dialog not shown")
 	}
 	dlg := top.(vtui.Container)
+	clickDialogButton(t, dlg, "Additional settings")
+	top = vtui.FrameManager.GetTopFrame()
+	if top == nil {
+		t.Fatal("Additional panel settings dialog not shown")
+	}
+	dlg = top.(vtui.Container)
 
 	var radioConsole *vtui.RadioGroup
 	var chkOverlay *vtui.Checkbox
@@ -1267,6 +1304,10 @@ func TestActionPanelSettings_ConsoleModes(t *testing.T) {
 	}
 	if !AppConfig.ConsoleOverlayUI {
 		t.Error("AppConfig.ConsoleOverlayUI = false, want true")
+	}
+	if top = vtui.FrameManager.GetTopFrame(); top != nil {
+		top.SetExitCode(-1)
+		vtui.FrameManager.Pop()
 	}
 }
 func TestActionLanguage_Flow(t *testing.T) {

--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -606,6 +606,8 @@ PanelSettings.ConsoleModeHost=Host &console
 PanelSettings.ConsoleOverlayUI=Show command line &over host console
 PanelSettings.ConsoleModeNote=(applies to new sessions)
 PanelSettings.ConsoleModeUnavailable=(unavailable in current environment)
+PanelSettings.Additional=Additional &settings
+PanelSettings.AdvancedTitle= Additional panel settings
 
 AppearanceSettings.Title= Appearance settings
 AppearanceSettings.Style=Application &style:

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -604,6 +604,8 @@ PanelSettings.ConsoleModeHost=Консоль &хоста
 PanelSettings.ConsoleOverlayUI=Показывать командную строку поверх &консоли
 PanelSettings.ConsoleModeNote=(применится к новым сессиям)
 PanelSettings.ConsoleModeUnavailable=(недоступно в текущем окружении)
+PanelSettings.Additional=Дополнительные &настройки
+PanelSettings.AdvancedTitle= Дополнительные настройки панелей
 
 AppearanceSettings.Title= Внешний вид
 AppearanceSettings.Style=Стиль &оформления:


### PR DESCRIPTION
Fixes #569

Panel Settings previously used a 43-row dialog, so it was clipped on 25-row terminals. This change keeps frequently used panel/navigation options in the main dialog and moves performance, console, and operation-display options to an additional dialog. Both dialogs fit small terminals and retain all existing settings.

Validation:
- go test ./...
- go vet ./cmd/f4
- go build -o /tmp/f4-569-bin ./cmd/f4
- real ARM64 Wayland smoke run: backend selected wayland, screen 80x25 rendered without crashes
- new layout test covers both dialogs at 80x25