### PR TITLE
Protect the only panels workspace from Ctrl+W

### DIFF
--- a/cmd/f4/framework_actions.go
+++ b/cmd/f4/framework_actions.go
@@ -217,6 +217,31 @@ func queueFrameInWorkspace(screen *vtui.AppScreen) *QueueFrame {
 	return nil
 }
 
+func workspaceHasOpenPanels(screen *vtui.AppScreen) bool {
+	if screen == nil {
+		return false
+	}
+	for index := len(screen.Frames) - 1; index >= 0; index-- {
+		if panels, ok := screen.Frames[index].(*PanelsFrame); ok && !panels.closed {
+			return true
+		}
+	}
+	return false
+}
+
+func isOnlyPanelsWorkspace(screen *vtui.AppScreen) bool {
+	if !workspaceHasOpenPanels(screen) || vtui.FrameManager == nil || len(vtui.FrameManager.Screens) <= 1 {
+		return false
+	}
+	panelsWorkspaces := 0
+	for _, candidate := range vtui.FrameManager.Screens {
+		if workspaceHasOpenPanels(candidate) {
+			panelsWorkspaces++
+		}
+	}
+	return panelsWorkspaces == 1
+}
+
 // actionWorkspaceCloseNumber resolves the stable workspace number at
 // execution time. Queue may be underneath contextual Help, or the target may
 // be a background workspace selected by a dynamic palette entry; both cases
@@ -225,6 +250,13 @@ func actionWorkspaceCloseNumber(number int) bool {
 	screen := workspaceByNumber(number)
 	if screen == nil {
 		return false
+	}
+	// Keep f4 alive while the only workspace containing file panels exists.
+	// Closing it while editor/viewer workspaces remain leaves the next last
+	// workspace without PanelsFrame, so its final Ctrl+W emits CmQuit directly
+	// and bypasses PanelsFrame's exit-confirmation policy (issue #531).
+	if isOnlyPanelsWorkspace(screen) {
+		return true
 	}
 	if queue := queueFrameInWorkspace(screen); queue != nil && queue.vetoCloseWhileActive() {
 		return true

--- a/cmd/f4/framework_actions_test.go
+++ b/cmd/f4/framework_actions_test.go
@@ -466,6 +466,43 @@ func TestWorkspaceClosePreservesQueueVetoBelowHelpAndForBackgroundTarget(t *test
 	}
 }
 
+func TestWorkspaceCloseKeepsTheOnlyPanelsWorkspace(t *testing.T) {
+	initFrameworkActionTestScreen(t)
+	panels := setupMockPanelsFrame()
+	vtui.FrameManager.Push(panels)
+	viewer := &frameworkActionTestFrame{title: "Viewer"}
+	vtui.FrameManager.AddScreen(viewer)
+
+	panelsScreen := vtui.FrameManager.Screens[0]
+	if !actionWorkspaceCloseNumber(panelsScreen.Number) {
+		t.Fatal("closing the only panels workspace was not handled")
+	}
+	if len(vtui.FrameManager.Screens) != 2 || panels.IsDone() {
+		t.Fatalf("only panels workspace was closed: screens=%d panelsDone=%v", len(vtui.FrameManager.Screens), panels.IsDone())
+	}
+
+	viewerScreen := vtui.FrameManager.Screens[1]
+	if !actionWorkspaceCloseNumber(viewerScreen.Number) {
+		t.Fatal("viewer workspace did not close while panels workspace remained")
+	}
+	if len(vtui.FrameManager.Screens) != 1 || vtui.FrameManager.Screens[0] != panelsScreen || panels.IsDone() {
+		t.Fatalf("closing viewer changed the wrong workspace: screens=%d panelsDone=%v", len(vtui.FrameManager.Screens), panels.IsDone())
+	}
+}
+
+func TestPanelsFrameCloseVetoProtectsTheOnlyPanelsWorkspace(t *testing.T) {
+	initFrameworkActionTestScreen(t)
+	panels := setupMockPanelsFrame()
+	vtui.FrameManager.Push(panels)
+	vtui.FrameManager.AddScreen(&frameworkActionTestFrame{title: "Editor"})
+	vtui.FrameManager.SwitchScreen(0)
+
+	vtui.FrameManager.CloseActiveScreen()
+	if len(vtui.FrameManager.Screens) != 2 || panels.IsDone() {
+		t.Fatalf("native close path removed the only panels workspace: screens=%d panelsDone=%v", len(vtui.FrameManager.Screens), panels.IsDone())
+	}
+}
+
 func TestWorkspaceNewFindsPanelsBehindFullScreenWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
 	source := setupMockPanelsFrame()

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1040,6 +1040,35 @@ func (pf *PanelsFrame) reportLocalPTYFailure() {
 	})
 }
 
+// ConfirmClose prevents the last workspace containing file panels from being
+// removed while editor/viewer workspaces remain. FrameManager asks this vetoer
+// before every close path, including its native Ctrl+W fallback; without it,
+// the final panel-less workspace could emit CmQuit without PanelsFrame's exit
+// confirmation policy (issue #531).
+func (pf *PanelsFrame) ConfirmClose() bool {
+	if pf == nil || pf.closed || vtui.FrameManager == nil {
+		return true
+	}
+	for _, screen := range vtui.FrameManager.Screens {
+		if workspaceHasOpenPanels(screen) && workspaceContainsPanelsFrame(screen, pf) {
+			return !isOnlyPanelsWorkspace(screen)
+		}
+	}
+	return true
+}
+
+func workspaceContainsPanelsFrame(screen *vtui.AppScreen, target *PanelsFrame) bool {
+	if screen == nil || target == nil {
+		return false
+	}
+	for _, frame := range screen.Frames {
+		if frame == target {
+			return true
+		}
+	}
+	return false
+}
+
 func (pf *PanelsFrame) Close() {
 	if pf.shellMode == ShellModeHost && pf.isHostConsoleActive() {
 		pf.leaveHostConsole()


### PR DESCRIPTION
## Summary
- prevent closing the last workspace that contains an open `PanelsFrame` while editor/viewer workspaces still exist
- apply the protection through `PanelsFrame.ConfirmClose`, covering native Ctrl+W, semantic workspace close, and tab close paths
- keep the final single-panels-workspace Ctrl+W exit path available so f4 can apply its normal exit confirmation policy
- add regression coverage for both the action path and FrameManager's native close path

Fixes #531.

## Verification by zoin-bot
- `go test ./cmd/f4`
- built and launched the Win32 GUI on Windows 10 x64
- exercised workspace creation and Ctrl+W input against the native build; the process remained alive after the protected close path