### PR TITLE
editor: handle Unicode visual clusters

### DIFF
--- a/cmd/f4/editor_grapheme.go
+++ b/cmd/f4/editor_grapheme.go
@@ -1,0 +1,102 @@
+package main
+
+import "github.com/unxed/f4/textlayout"
+
+// editorGrapheme is a byte-addressable grapheme cluster. The editor keeps
+// byte offsets internally, but user-visible cursor operations must stop at
+// these boundaries rather than between the code points that form one glyph.
+type editorGrapheme struct {
+	text       string
+	start, end int
+	width      int
+}
+
+func editorGraphemes(data []byte) []editorGrapheme {
+	visualClusters := textlayout.VisualClusters(string(data))
+	clusters := make([]editorGrapheme, 0, len(visualClusters))
+	for _, cluster := range visualClusters {
+		clusters = append(clusters, editorGrapheme{
+			text:  cluster.Text,
+			start: cluster.Start,
+			end:   cluster.End,
+			width: cluster.Width,
+		})
+	}
+	return clusters
+}
+
+func nextEditorGraphemeBoundary(data []byte, pos int) int {
+	if pos < 0 {
+		pos = 0
+	}
+	if pos >= len(data) {
+		return len(data)
+	}
+	clusters := editorGraphemes(data[pos:])
+	if len(clusters) == 0 {
+		return pos + 1
+	}
+	return pos + clusters[0].end
+}
+
+// nextGraphemeBoundaryInLine reads only a small look-ahead window for the
+// common case. If the window ends exactly at a cluster boundary, it grows
+// until that boundary is proven or the line ends, so long lines do not turn a
+// single right-arrow/Delete into a full-line allocation.
+func (ev *EditorView) nextGraphemeBoundaryInLine(lineStart, lineLen, pos int) int {
+	if pos < 0 {
+		pos = 0
+	}
+	if pos >= lineLen {
+		return lineLen
+	}
+
+	remaining := lineLen - pos
+	take := 64
+	if take > remaining {
+		take = remaining
+	}
+	for {
+		data, err := ev.pt.GetRange(lineStart+pos, take)
+		if err != nil || len(data) == 0 {
+			return pos + 1
+		}
+		next := nextEditorGraphemeBoundary(data, 0)
+		if next < len(data) || take >= remaining {
+			return pos + next
+		}
+		take *= 2
+		if take > remaining {
+			take = remaining
+		}
+	}
+}
+
+func (ev *EditorView) previousGraphemeBoundaryInLine(lineStart, pos int) int {
+	if pos <= 0 {
+		return 0
+	}
+
+	take := 64
+	if take > pos {
+		take = pos
+	}
+	for {
+		start := pos - take
+		data, err := ev.pt.GetRange(lineStart+start, take)
+		if err != nil || len(data) == 0 {
+			return pos - 1
+		}
+		clusters := editorGraphemes(data)
+		if len(clusters) == 0 {
+			return pos - 1
+		}
+		if clusters[0].start > 0 || start == 0 {
+			return start + clusters[len(clusters)-1].start
+		}
+		take *= 2
+		if take > pos {
+			take = pos
+		}
+	}
+}

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/charlievieth/strcase"
 	"github.com/coregx/coregex"
-	"github.com/mattn/go-runewidth"
 	"github.com/unxed/f4/piecetable"
 	"github.com/unxed/f4/textlayout"
 	"github.com/unxed/f4/vfs"
@@ -2087,13 +2086,7 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		} else {
 			if ev.CursorPos > 0 {
 				lineStart := ev.li.GetLineOffset(ev.CursorLine)
-				data, _ := ev.pt.GetRange(lineStart, ev.CursorPos)
-				if data != nil && len(data) > 0 {
-					_, size := utf8.DecodeLastRune(data)
-					ev.CursorPos -= size
-				} else {
-					ev.CursorPos--
-				}
+				ev.CursorPos = ev.previousGraphemeBoundaryInLine(lineStart, ev.CursorPos)
 			} else if ev.CursorLine > 0 {
 				ev.CursorLine--
 				ev.CursorPos = ev.getLineLength(ev.CursorLine)
@@ -2178,17 +2171,7 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		} else {
 			if ev.CursorPos < lineLen {
 				lineStart := ev.li.GetLineOffset(ev.CursorLine)
-				peekLen := 4
-				if lineLen-ev.CursorPos < 4 {
-					peekLen = lineLen - ev.CursorPos
-				}
-				data, _ := ev.pt.GetRange(lineStart+ev.CursorPos, peekLen)
-				if data != nil && len(data) > 0 {
-					_, size := utf8.DecodeRune(data)
-					ev.CursorPos += size
-				} else {
-					ev.CursorPos++
-				}
+				ev.CursorPos = ev.nextGraphemeBoundaryInLine(lineStart, lineLen, ev.CursorPos)
 			} else if ev.CursorLine < ev.li.LineCount()-1 {
 				if ev.CursorBeyondEOL {
 					ev.CursorVirtualSpaces++
@@ -2258,14 +2241,16 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 					ev.CursorLine--
 					ev.CursorPos = prevLen
 				} else {
-					// Remove the UTF-8 character before the cursor
+					// Backspace follows the terminal/editor convention used by the
+					// reference text fields: remove one UTF-8 code point. Delete
+					// below is the operation that removes a visual cluster.
 					lineStart := ev.li.GetLineOffset(ev.CursorLine)
 					lineData, _ := ev.pt.GetRange(lineStart, ev.CursorPos)
 					size := 1
-					if lineData != nil {
-						r, rsize := utf8.DecodeLastRune(lineData)
-						if r != utf8.RuneError {
-							size = rsize
+					if lineData != nil && len(lineData) > 0 {
+						_, runeSize := utf8.DecodeLastRune(lineData)
+						if runeSize > 0 {
+							size = runeSize
 						}
 					}
 
@@ -2313,18 +2298,14 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.noteBufferEdit()
 				ev.saveUndo(opOther)
 				ev.modified = true
-				// Remove the UTF-8 character under the cursor
-				peekLen := 4
-				if ev.pt.Size()-offset < 4 {
-					peekLen = ev.pt.Size() - offset
-				}
-				data, _ := ev.pt.GetRange(offset, peekLen)
+				// Remove the grapheme cluster under the cursor, not just its
+				// first UTF-8 code point.
+				lineStart := ev.li.GetLineOffset(ev.CursorLine)
+				lineLen := ev.getLineLength(ev.CursorLine)
 				size := 1
-				if data != nil {
-					r, rsize := utf8.DecodeRune(data)
-					if r != utf8.RuneError {
-						size = rsize
-					}
+				if ev.CursorPos < lineLen {
+					next := ev.nextGraphemeBoundaryInLine(lineStart, lineLen, ev.CursorPos)
+					size = next - ev.CursorPos
 				}
 
 				ev.pt.Delete(offset, size)
@@ -2455,16 +2436,12 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 		if ev.overtype {
 			lineLen := ev.getLineLength(ev.CursorLine)
 			if ev.CursorPos < lineLen {
-				peekLen := 4
-				if lineLen-ev.CursorPos < 4 {
-					peekLen = lineLen - ev.CursorPos
-				}
-				oldData, _ := ev.pt.GetRange(offset, peekLen)
 				size := 1
-				if oldData != nil && len(oldData) > 0 {
-					_, rsize := utf8.DecodeRune(oldData)
-					if rsize > 0 {
-						size = rsize
+				lineStart := ev.li.GetLineOffset(ev.CursorLine)
+				if ev.CursorPos < lineLen {
+					next := ev.nextGraphemeBoundaryInLine(lineStart, lineLen, ev.CursorPos)
+					if next > ev.CursorPos {
+						size = next - ev.CursorPos
 					}
 				}
 				ev.pt.Delete(offset, size)
@@ -2500,39 +2477,39 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr, selAttr uint64, offset int, selActive bool, selMin, selMax int, syntax []uint64, startVisualCol int, isCrossRow bool, crossVCol int, horzCrossAttr, vertCrossAttr uint64, visualRow int) []vtui.CharInfo {
 	target = target[:0]
 	currByte := 0
-	charIdx := 0
+	runeIdx := 0
 	visualCol := startVisualCol
 	tabSize := ev.TabSize
 	if tabSize <= 0 {
 		tabSize = 8
 	}
 
-	for len(data) > 0 {
-		r, size := utf8.DecodeRune(data)
-		data = data[size:]
+	for _, visualCluster := range textlayout.VisualClusters(string(data)) {
+		cluster := visualCluster.Text
+		w := visualCluster.Width
+		size := visualCluster.End - visualCluster.Start
+		r, _ := utf8.DecodeRuneInString(cluster)
 
-		displayRune, w := vtui.SanitizeRune(r)
+		displayCluster, sanitizedWidth := vtui.SanitizeCluster(cluster)
+		if sanitizedWidth == 0 {
+			runeIdx += utf8.RuneCountInString(cluster)
+			currByte += size
+			continue
+		}
+		w = sanitizedWidth
 		if r == '\t' {
 			w = tabSize - (visualCol % tabSize)
-			displayRune = ' '
+			displayCluster = " "
 			if ev.ShowWhitespaces {
-				displayRune = '→'
+				displayCluster = "→"
 			}
 		} else if r == ' ' && ev.ShowWhitespaces {
-			displayRune = '·'
-		} else if r < 0x20 || r == 0x7F {
-			w = 1
-			if !ev.ShowWhitespaces {
-				displayRune = ' '
-			}
-		}
-		if w <= 0 {
-			w = 1
+			displayCluster = "·"
 		}
 
 		attr := defaultAttr
-		if charIdx < len(syntax) {
-			attr = syntax[charIdx]
+		if runeIdx < len(syntax) {
+			attr = syntax[runeIdx]
 		}
 
 		// Horizontal crosshair line applies to the entire character in the active row
@@ -2558,15 +2535,15 @@ func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr
 			}
 		} else if selActive {
 			absPos := offset + currByte
-			if absPos >= selMin && absPos < selMax {
+			if absPos < selMax && absPos+size > selMin {
 				attr = selAttr
 			}
 		}
-		charIdx++
+		runeIdx += utf8.RuneCountInString(cluster)
 		currByte += size
 
 		if w > 0 {
-			charVal := uint64(displayRune)
+			charVal := vtui.RegisterCluster(displayCluster)
 			for j := 0; j < w; j++ {
 				cellAttr := attr
 				// Vertical crosshair line: apply ONLY to the specific cell index
@@ -2578,7 +2555,7 @@ func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr
 					}
 				}
 				target = append(target, vtui.CharInfo{Char: charVal, Attributes: cellAttr})
-				charVal = uint64(vtui.WideCharFiller)
+				charVal = vtui.WideCharFiller
 				if r == '\t' {
 					charVal = ' '
 				}
@@ -4654,25 +4631,20 @@ func (ev *EditorView) CopySelection() {
 
 			var piece []rune
 			visualCol := 0
-			runes := []rune(string(lineData))
+			clusters := editorGraphemes(lineData)
 			tabSize := ev.TabSize
 			if tabSize <= 0 {
 				tabSize = 8
 			}
 
-			for _, r := range runes {
-				rw := 1
-				if r == '\t' {
+			for _, cluster := range clusters {
+				rw := cluster.width
+				if cluster.text == "\t" {
 					rw = tabSize - (visualCol % tabSize)
-				} else {
-					rw = runewidth.RuneWidth(r)
-					if rw <= 0 {
-						rw = 1
-					}
 				}
 
 				if visualCol >= minX && visualCol < maxX {
-					piece = append(piece, r)
+					piece = append(piece, []rune(cluster.text)...)
 				} else if visualCol < minX && visualCol+rw > minX {
 					piece = append(piece, ' ')
 				}
@@ -4749,7 +4721,7 @@ func (ev *EditorView) PasteRectangular(text string, targetCol int) {
 		lineData, _ := ev.pt.GetRange(lineStart, lineLen)
 
 		visualCol := 0
-		runes := []rune(string(lineData))
+		clusters := editorGraphemes(lineData)
 		tabSize := ev.TabSize
 		if tabSize <= 0 {
 			tabSize = 8
@@ -4758,15 +4730,10 @@ func (ev *EditorView) PasteRectangular(text string, targetCol int) {
 		insertByteOff := -1
 		byteAcc := 0
 
-		for _, r := range runes {
-			rw := 1
-			if r == '\t' {
+		for _, cluster := range clusters {
+			rw := cluster.width
+			if cluster.text == "\t" {
 				rw = tabSize - (visualCol % tabSize)
-			} else {
-				rw = runewidth.RuneWidth(r)
-				if rw <= 0 {
-					rw = 1
-				}
 			}
 
 			if visualCol >= targetCol && insertByteOff == -1 {
@@ -4775,7 +4742,7 @@ func (ev *EditorView) PasteRectangular(text string, targetCol int) {
 			}
 
 			visualCol += rw
-			byteAcc += utf8.RuneLen(r)
+			byteAcc = cluster.end
 		}
 
 		if insertByteOff == -1 {
@@ -4847,7 +4814,6 @@ func (ev *EditorView) DeleteSelection() {
 			lineData, _ := ev.pt.GetRange(lineStart, lineLen)
 
 			visualCol := 0
-			runes := []rune(string(lineData))
 			tabSize := ev.TabSize
 			if tabSize <= 0 {
 				tabSize = 8
@@ -4857,15 +4823,10 @@ func (ev *EditorView) DeleteSelection() {
 			endByte := -1
 			byteAcc := 0
 
-			for _, r := range runes {
-				rw := 1
-				if r == '\t' {
+			for _, cluster := range editorGraphemes(lineData) {
+				rw := cluster.width
+				if cluster.text == "\t" {
 					rw = tabSize - (visualCol % tabSize)
-				} else {
-					rw = runewidth.RuneWidth(r)
-					if rw <= 0 {
-						rw = 1
-					}
 				}
 
 				if visualCol >= minX && startByte == -1 {
@@ -4876,7 +4837,7 @@ func (ev *EditorView) DeleteSelection() {
 				}
 
 				visualCol += rw
-				byteAcc += utf8.RuneLen(r)
+				byteAcc = cluster.end
 			}
 
 			if startByte != -1 {

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -792,6 +792,82 @@ func TestEditorView_WideCharBackspace(t *testing.T) {
 	}
 }
 
+func TestEditorView_GraphemeNavigationAndDeletion(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		del  []string
+		back []string
+	}{
+		{
+			name: "Sanskrit",
+			text: "संस्कृतम्",
+			del:  []string{"स्कृतम्", "तम्", "म्", ""},
+			back: []string{"संस्कृतम", "संस्कृत", "संस्कृ", "संस्क", "संस्", "संस", "सं", "स", ""},
+		},
+		{
+			name: "Divehi",
+			text: "ދިވެހިބަސް",
+			del:  []string{"ވެހިބަސް", "ހިބަސް", "ބަސް", "ސް", ""},
+			back: []string{"ދިވެހިބަސ", "ދިވެހިބަ", "ދިވެހިބ", "ދިވެހި", "ދިވެހ", "ދިވެ", "ދިވ", "ދި", "ދ", ""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+" Delete", func(t *testing.T) {
+			pt := piecetable.New([]byte(test.text))
+			ev := NewEditorView(pt, nil, "")
+			defer ev.Close()
+			ev.SetPosition(0, 0, 79, 24)
+			ev.CursorPos = 0
+
+			for i, want := range test.del {
+				ev.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_DELETE})
+				if got := pt.String(); got != want {
+					t.Fatalf("delete %d: got %q, want %q", i, got, want)
+				}
+				if ev.CursorPos != 0 {
+					t.Fatalf("delete %d moved cursor to byte offset %d", i, ev.CursorPos)
+				}
+			}
+		})
+
+		t.Run(test.name+" Backspace", func(t *testing.T) {
+			pt := piecetable.New([]byte(test.text))
+			ev := NewEditorView(pt, nil, "")
+			defer ev.Close()
+			ev.SetPosition(0, 0, 79, 24)
+			ev.CursorPos = len([]byte(test.text))
+
+			for i, want := range test.back {
+				ev.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_BACK})
+				if got := pt.String(); got != want {
+					t.Fatalf("backspace %d: got %q, want %q", i, got, want)
+				}
+				if ev.CursorPos != len([]byte(want)) {
+					t.Fatalf("backspace %d: cursor byte offset %d, want %d", i, ev.CursorPos, len([]byte(want)))
+				}
+			}
+		})
+
+		t.Run(test.name+" Movement", func(t *testing.T) {
+			pt := piecetable.New([]byte(test.text))
+			ev := NewEditorView(pt, nil, "")
+			defer ev.Close()
+			ev.SetPosition(0, 0, 79, 24)
+			ev.CursorPos = 0
+
+			clusters := editorGraphemes([]byte(test.text))
+			for i, cluster := range clusters {
+				ev.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RIGHT})
+				if ev.CursorPos != cluster.end {
+					t.Fatalf("right %d: cursor byte offset %d, want cluster end %d", i, ev.CursorPos, cluster.end)
+				}
+			}
+		})
+	}
+}
+
 func TestEditorView_BracketedPaste(t *testing.T) {
 	pt := piecetable.New([]byte("Start-"))
 	ev := NewEditorView(pt, nil, "")
@@ -4645,34 +4721,34 @@ func TestEditorView_ZeroAndDoubleWidthConsistency(t *testing.T) {
 
 	cells := ev.fillCells(nil, text, 0, 0, 0, false, 0, 0, nil, 0, false, -1, 0, 0, 0)
 
-	if colA != 1 {
-		t.Errorf("Expected column after 'a' to be 1, got %d", colA)
+	if colA != 0 {
+		t.Errorf("Expected an offset inside the a-plus-acute grapheme to map to column 0, got %d", colA)
 	}
-	if colCombining != 2 {
-		t.Errorf("Expected column after combining char to be 2, got %d", colCombining)
+	if colCombining != 1 {
+		t.Errorf("Expected column after the a-plus-acute grapheme to be 1, got %d", colCombining)
 	}
-	if colCJK != 4 {
-		t.Errorf("Expected column after CJK char to be 4, got %d", colCJK)
+	if colCJK != 3 {
+		t.Errorf("Expected column after CJK char to be 3, got %d", colCJK)
 	}
-	if colB != 5 {
-		t.Errorf("Expected column after 'b' to be 5, got %d", colB)
-	}
-
-	if len(cells) != 5 {
-		t.Errorf("Expected exactly 5 cells rendered (1 for 'a', 1 for combining, 2 for CJK, 1 for 'b'), got %d", len(cells))
+	if colB != 4 {
+		t.Errorf("Expected column after 'b' to be 4, got %d", colB)
 	}
 
-	if cells[0].Char != 'a' {
-		t.Errorf("Expected cells[0] to be 'a', got %c", rune(cells[0].Char))
+	if len(cells) != 4 {
+		t.Errorf("Expected exactly 4 cells rendered (1 for a-plus-acute, 2 for CJK, 1 for b), got %d", len(cells))
 	}
-	if cells[2].Char != '世' {
-		t.Errorf("Expected cells[2] to be '世', got %c", rune(cells[2].Char))
+
+	if vtui.CellString(cells[0].Char) != "a\u0301" {
+		t.Errorf("Expected cells[0] to carry the a-plus-acute grapheme, got %q", vtui.CellString(cells[0].Char))
 	}
-	if cells[3].Char != uint64(vtui.WideCharFiller) {
-		t.Errorf("Expected cells[3] to be WideCharFiller, got %d", cells[3].Char)
+	if vtui.CellString(cells[1].Char) != "世" {
+		t.Errorf("Expected cells[1] to be '世', got %q", vtui.CellString(cells[1].Char))
 	}
-	if cells[4].Char != 'b' {
-		t.Errorf("Expected cells[4] to be 'b', got %c", rune(cells[4].Char))
+	if cells[2].Char != uint64(vtui.WideCharFiller) {
+		t.Errorf("Expected cells[2] to be WideCharFiller, got %d", cells[2].Char)
+	}
+	if vtui.CellString(cells[3].Char) != "b" {
+		t.Errorf("Expected cells[3] to be 'b', got %q", vtui.CellString(cells[3].Char))
 	}
 }
 

--- a/textlayout/cluster.go
+++ b/textlayout/cluster.go
@@ -1,0 +1,104 @@
+package textlayout
+
+import (
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/unxed/vtui"
+)
+
+// VisualCluster is a terminal-facing grapheme cluster with byte boundaries in
+// the original string.
+type VisualCluster struct {
+	Text       string
+	Width      int
+	Start, End int
+}
+
+// VisualClusters segments a string once and returns its visual clusters. It
+// deliberately uses vtui's callback API rather than calling NextCluster for
+// every suffix: the latter would rescan the remaining string for every ASCII
+// character and turn long-line layout into quadratic work.
+func VisualClusters(s string) []VisualCluster {
+	clusters := make([]VisualCluster, 0, len(s))
+	previousStart, previousWidth := 0, 0
+	havePrevious := false
+
+	emit := func(start, end, width int) {
+		if start >= end {
+			return
+		}
+		raw := s[start:end]
+		if len(clusters) > 0 && endsInIndicVirama(clusters[len(clusters)-1].Text) && startsWithLetter(raw) {
+			last := &clusters[len(clusters)-1]
+			last.Text = s[last.Start:end]
+			last.End = end
+			last.Width = vtui.ClusterWidth(last.Text)
+			return
+		}
+		clusters = append(clusters, VisualCluster{Text: raw, Width: width, Start: start, End: end})
+	}
+
+	vtui.ForEachClusterAt(s, func(_ string, width, offset, _ int) {
+		if havePrevious {
+			emit(previousStart, offset, previousWidth)
+		}
+		previousStart, previousWidth = offset, width
+		havePrevious = true
+	})
+	if havePrevious {
+		emit(previousStart, len(s), previousWidth)
+	}
+	return clusters
+}
+
+// NextVisualCluster returns the next cluster as it is treated by a terminal
+// text editor. UAX #29 (which vtui implements) handles combining marks, emoji,
+// and bidi marks, while the extra virama join handles Indic conjuncts that
+// older versions of the Unicode grapheme tables split between the virama and
+// the following consonant. Keeping this rule here makes wrapping, cursor
+// movement, and deletion agree on the same byte boundaries.
+func NextVisualCluster(s string) (cluster string, width int, size int) {
+	clusters := VisualClusters(s)
+	if len(clusters) == 0 {
+		return "", 0, 0
+	}
+	first := clusters[0]
+	return first.Text, first.Width, first.End
+}
+
+func startsWithLetter(s string) bool {
+	r, _ := utf8.DecodeRuneInString(s)
+	return unicode.IsLetter(r)
+}
+
+func endsInIndicVirama(s string) bool {
+	r, _ := utf8.DecodeLastRuneInString(s)
+	switch r {
+	case
+		'\u094D',                     // Devanagari
+		'\u09CD',                     // Bengali
+		'\u0A4D',                     // Gurmukhi
+		'\u0ACD',                     // Gujarati
+		'\u0B4D',                     // Oriya
+		'\u0BCD',                     // Tamil
+		'\u0C4D',                     // Telugu
+		'\u0CCD',                     // Kannada
+		'\u0D3B', '\u0D3C', '\u0D4D', // Malayalam
+		'\u0DCA', // Sinhala
+		'\u1039', // Myanmar
+		'\u1714', // Tagalog
+		'\u17D2', // Khmer
+		'\u1A60', // Tai Tham
+		'\u1BAA', // Sundanese
+		'\uA806', // Syloti Nagri
+		'\uA8C4', // Saurashtra
+		'\uA953', // Rejang
+		'\uA9C0', // Javanese
+		'\uAAF6', // Meetei Mayek
+		'\uABED': // Meetei Mayek
+		return true
+	default:
+		return false
+	}
+}

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -2,12 +2,9 @@ package textlayout
 
 import (
 	"sort"
-	"unicode/utf8"
 
 	"github.com/unxed/f4/piecetable"
 	"github.com/unxed/vtui"
-
-	"github.com/mattn/go-runewidth"
 )
 
 // LineFragment описывает один визуальный кусок логической строки после свертки.
@@ -168,25 +165,15 @@ func (we *WrapEngine) GetFragments(logLineIdx int) []LineFragment {
 
 	if !we.wordWrap || we.wrapWidth <= 0 {
 		width := 0
-		tmpData := lineData
-		for len(tmpData) > 0 {
-			b := tmpData[0]
-			if b < 0x80 {
-				if b == '\t' {
-					width += we.tabSize - (width % we.tabSize)
-				} else {
-					width++
-				}
-				tmpData = tmpData[1:]
-				continue
+		for _, cluster := range VisualClusters(string(lineData)) {
+			rw := cluster.Width
+			if cluster.Text == "\t" {
+				rw = we.tabSize - (width % we.tabSize)
 			}
-			r, size := utf8.DecodeRune(tmpData)
-			rw := runewidth.RuneWidth(r)
-			if rw < 0 {
+			if rw <= 0 {
 				rw = 1
 			}
 			width += rw
-			tmpData = tmpData[size:]
 		}
 
 		frag := LineFragment{
@@ -205,57 +192,56 @@ func (we *WrapEngine) GetFragments(logLineIdx int) []LineFragment {
 	var fragments []LineFragment
 	bytePos := 0
 	dataLen := len(lineData)
+	clusters := VisualClusters(string(lineData))
+	clusterPos := 0
 
 	cumulativeVisualWidth := 0
-	for bytePos < dataLen {
+	for bytePos < dataLen && clusterPos < len(clusters) {
 		visualWidth := 0
 		fragStartByte := bytePos
 		lastSpaceEnd := -1
 		lastSpaceWidth := 0
+		lastSpaceClusterPos := -1
 
 		scanPos := bytePos
-		for scanPos < dataLen {
-			b := lineData[scanPos]
-			var r rune
-			var size, w int
-			if b < 0x80 {
-				r = rune(b)
-				size = 1
-				if b == '\t' {
-					w = we.tabSize - ((cumulativeVisualWidth + visualWidth) % we.tabSize)
-				} else {
-					w = 1
-				}
-			} else {
-				r, size = utf8.DecodeRune(lineData[scanPos:])
-				w = runewidth.RuneWidth(r)
-				if w <= 0 {
-					w = 1
-				}
+		scanClusterPos := clusterPos
+		for scanClusterPos < len(clusters) {
+			cluster := clusters[scanClusterPos]
+			w := cluster.Width
+			if cluster.Text == "\t" {
+				w = we.tabSize - ((cumulativeVisualWidth + visualWidth) % we.tabSize)
+			}
+			if w <= 0 {
+				w = 1
 			}
 
 			if visualWidth+w > we.wrapWidth {
-				if r == ' ' {
+				if cluster.Text == " " {
 					// Пробел не влезает, но мы его забираем в конец этой строки
-					scanPos += size
+					scanPos = cluster.End
+					scanClusterPos++
 					visualWidth += w
 				} else if lastSpaceEnd != -1 {
 					// Word Wrap: откатываемся к последнему пробелу
 					scanPos = lastSpaceEnd
+					scanClusterPos = lastSpaceClusterPos
 					visualWidth = lastSpaceWidth
 				} else if scanPos == fragStartByte {
 					// Даже один символ не влез (CJK в узком окне) - поглощаем его
-					scanPos += size
+					scanPos = cluster.End
+					scanClusterPos++
 					visualWidth = w
 				}
 				break
 			}
 
 			visualWidth += w
-			scanPos += size
-			if r == ' ' {
-				lastSpaceEnd = scanPos
+			scanPos = cluster.End
+			scanClusterPos++
+			if cluster.Text == " " {
+				lastSpaceEnd = cluster.End
 				lastSpaceWidth = visualWidth
+				lastSpaceClusterPos = scanClusterPos
 			}
 		}
 
@@ -267,6 +253,7 @@ func (we *WrapEngine) GetFragments(logLineIdx int) []LineFragment {
 		})
 		cumulativeVisualWidth += visualWidth
 		bytePos = scanPos
+		clusterPos = scanClusterPos
 	}
 
 	if len(fragments) == 0 {
@@ -438,21 +425,19 @@ func (we *WrapEngine) LogicalToVisual(byteOffset int) (visualRow, visualCol int)
 			width := 0
 			if byteOffset > frag.ByteOffsetStart {
 				we.tmpBuf = we.tmpBuf[:0]
-				we.tmpBuf, _ = we.pt.AppendRange(we.tmpBuf, frag.ByteOffsetStart, byteOffset-frag.ByteOffsetStart)
-				data := we.tmpBuf
-				for len(data) > 0 {
-					r, size := utf8.DecodeRune(data)
-					rw := 1
-					if r == '\t' {
+				we.tmpBuf, _ = we.pt.AppendRange(we.tmpBuf, frag.ByteOffsetStart, frag.ByteOffsetEnd-frag.ByteOffsetStart)
+				for _, cluster := range VisualClusters(string(we.tmpBuf)) {
+					if frag.ByteOffsetStart+cluster.End > byteOffset {
+						break
+					}
+					rw := cluster.Width
+					if cluster.Text == "\t" {
 						rw = we.tabSize - (width % we.tabSize)
-					} else if r >= 0x7F {
-						rw = runewidth.RuneWidth(r)
 					}
 					if rw <= 0 {
 						rw = 1
 					}
 					width += rw
-					data = data[size:]
 				}
 			}
 			return totalRow + i, width
@@ -494,13 +479,10 @@ func (we *WrapEngine) VisualToLogical(visualRow, visualCol int) int {
 	offset := frag.ByteOffsetStart
 	currentCol := 0
 
-	for len(lineData) > 0 {
-		r, size := utf8.DecodeRune(lineData)
-		rw := 1
-		if r == '\t' {
+	for _, cluster := range VisualClusters(string(lineData)) {
+		rw := cluster.Width
+		if cluster.Text == "\t" {
 			rw = we.tabSize - (currentCol % we.tabSize)
-		} else if r >= 0x7F {
-			rw = runewidth.RuneWidth(r)
 		}
 		if rw <= 0 {
 			rw = 1
@@ -509,8 +491,7 @@ func (we *WrapEngine) VisualToLogical(visualRow, visualCol int) int {
 			return offset
 		}
 		currentCol += rw
-		offset += size
-		lineData = lineData[size:]
+		offset = frag.ByteOffsetStart + cluster.End
 	}
 	return offset
 }

--- a/textlayout/wrap_test.go
+++ b/textlayout/wrap_test.go
@@ -488,6 +488,47 @@ func TestWrapEngine_CacheResilience(t *testing.T) {
 		t.Errorf("Engine did not reset total rows after index change, got %d", total)
 	}
 }
+
+func TestWrapEngine_IndicVisualClusters(t *testing.T) {
+	text := "संस्कृतम्"
+	pt := piecetable.New([]byte(text))
+	li := piecetable.NewLineIndex()
+	li.Rebuild(pt)
+
+	we := NewWrapEngine(pt, li)
+	we.ToggleWrap(false)
+
+	var offsets []int
+	var columns []int
+	offset, column := 0, 0
+	for rest := text; len(rest) > 0; {
+		cluster, width, size := NextVisualCluster(rest)
+		if cluster == "" || size <= 0 {
+			t.Fatalf("invalid cluster result for %q", rest)
+		}
+		offsets = append(offsets, offset)
+		columns = append(columns, column)
+		offset += size
+		column += width
+		rest = rest[size:]
+	}
+	offsets = append(offsets, offset)
+	columns = append(columns, column)
+
+	if got := len(offsets); got != 5 {
+		t.Fatalf("expected four visual clusters plus EOF, got %d", got-1)
+	}
+	for i := range offsets {
+		row, col := we.LogicalToVisual(offsets[i])
+		if row != 0 || col != columns[i] {
+			t.Errorf("logical offset %d: got visual (%d,%d), want (0,%d)", offsets[i], row, col, columns[i])
+		}
+		if got := we.VisualToLogical(0, columns[i]); got != offsets[i] {
+			t.Errorf("visual column %d: got logical offset %d, want %d", columns[i], got, offsets[i])
+		}
+	}
+}
+
 func TestWrapEngine_BoundarySafety(t *testing.T) {
 	pt := piecetable.New([]byte("line1\nline2"))
 	li := piecetable.NewLineIndex()


### PR DESCRIPTION
## Summary

- make editor layout and navigation use shared visual grapheme-cluster byte boundaries
- make Delete, overtype, rectangular selection, and wrapping cluster-aware while preserving the reference code-point Backspace behavior
- cover the Sanskrit and Divehi sequences from issue #546 and prevent long-line layout from regressing to quadratic work

## Verification

- `go test ./...`
- `go vet ./cmd/f4 ./textlayout`
- `go build -o /tmp/f4-546-bin ./cmd/f4`
- targeted Wayland editor smoke on Linux ARM64 with the issue's sample file passed on the pre-existing f4 base

The current upstream base has an unrelated Wayland GUI startup nil-pointer panic in this environment before editor initialization; the changed editor code is covered by the full test suite and the same fix was exercised in the running editor on the previous base.

— zoin-bot
