### PR TITLE
Reject unmatched shell quotes before execution

### DIFF
--- a/cmd/f4/command_quotes.go
+++ b/cmd/f4/command_quotes.go
@@ -1,0 +1,35 @@
+package main
+
+// commandHasUnmatchedQuote reports whether command leaves a shell quote open.
+// The command line is a single-shot input field, so it cannot provide the
+// continuation prompt that an interactive shell would normally use; sending
+// such input would make f4 appear to hang while the child shell waits for the
+// closing quote.
+func commandHasUnmatchedQuote(command string, windowsShell bool) bool {
+	var quote rune
+	escaped := false
+	for _, ch := range command {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '^' && windowsShell && quote != '\'' {
+			escaped = true
+			continue
+		}
+		if ch == '\\' && !windowsShell && quote != '\'' {
+			escaped = true
+			continue
+		}
+		if quote == 0 {
+			if ch == '"' || (!windowsShell && ch == '\'') {
+				quote = ch
+			}
+			continue
+		}
+		if ch == quote {
+			quote = 0
+		}
+	}
+	return quote != 0
+}

--- a/cmd/f4/command_quotes_test.go
+++ b/cmd/f4/command_quotes_test.go
@@ -1,0 +1,28 @@
+package main
+
+import "testing"
+
+func TestCommandHasUnmatchedQuote(t *testing.T) {
+	tests := []struct {
+		name         string
+		command      string
+		windowsShell bool
+		want         bool
+	}{
+		{name: "posix single quote", command: "echo 'ok'", want: false},
+		{name: "posix open single quote", command: "echo 'broken", want: true},
+		{name: "posix open double quote", command: `echo "broken`, want: true},
+		{name: "posix escaped quote", command: `echo can\'t`, want: false},
+		{name: "windows open double quote", command: `echo "broken`, windowsShell: true, want: true},
+		{name: "windows single quote is literal", command: "echo 'literal", windowsShell: true, want: false},
+		{name: "windows caret escaped quote", command: `echo ^"literal`, windowsShell: true, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := commandHasUnmatchedQuote(test.command, test.windowsShell); got != test.want {
+				t.Fatalf("commandHasUnmatchedQuote(%q, windows=%v) = %v, want %v", test.command, test.windowsShell, got, test.want)
+			}
+		})
+	}
+}

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1990,6 +1990,10 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		commandInputActive := !pf.searchFirstMode() || pf.commandLineFocused || !pf.showPanels
 		if commandInputActive && !pf.cmdLine.IsEmpty() {
 			cmd := pf.cmdLine.Edit.GetText()
+			if commandHasUnmatchedQuote(cmd, runtime.GOOS == "windows") {
+				vtui.ShowMessage(" Error ", "Unmatched quote in command. Close the quote and press Enter again.", []string{"&Ok"})
+				return true
+			}
 			pf.addCommandHistory(cmd)
 			pf.cmdLine.Edit.HistoryPos = -1
 

--- a/cmd/f4/resolve_command_windows.go
+++ b/cmd/f4/resolve_command_windows.go
@@ -58,7 +58,7 @@ func findCmdToken(cmd string) (start, end int, name string, ok bool) {
 		return -1, -1, "", false
 	}
 
-	if cmd[start] == '"' || cmd[start] == '\'' {
+	if cmd[start] == '"' {
 		quote := cmd[start]
 		close := -1
 		for i := start + 1; i < len(cmd); i++ {
@@ -68,7 +68,7 @@ func findCmdToken(cmd string) (start, end int, name string, ok bool) {
 			}
 		}
 		if close < 0 {
-			close = len(cmd) - 1
+			return -1, -1, "", false
 		}
 		return start, close + 1, cmd[start+1 : close], true
 	}

--- a/cmd/f4/resolve_command_windows_test.go
+++ b/cmd/f4/resolve_command_windows_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package main
+
+import "testing"
+
+func TestFindCmdTokenRejectsUnmatchedQuote(t *testing.T) {
+	for _, command := range []string{`"`, `"program`} {
+		if _, _, _, ok := findCmdToken(command); ok {
+			t.Fatalf("findCmdToken(%q) accepted an unmatched quote", command)
+		}
+	}
+	if _, _, name, ok := findCmdToken(`'`); !ok || name != `'` {
+		t.Fatalf("findCmdToken did not treat a Windows single quote as a literal token: name=%q ok=%v", name, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- reject commands with an unmatched shell quote before sending them to the PTY
- keep the command line available and show an error instead of entering a shell continuation state that looks like a frozen f4
- make Windows command-token parsing safely reject an unmatched double quote instead of panicking, while treating a single quote as a literal cmd token
- add regression tests for POSIX/Windows quote handling and the Windows token parser

Fixes #526.

## Verification by zoin-bot
- `go test ./cmd/f4`
- Windows 10 x64 native Win32 build: entering a single quote no longer panics; entering an unmatched double quote keeps f4 alive, shows the Error dialog, and does not write that command to the PTY.