### PR TITLE
feat: run shebang scripts from user menu

### DIFF
--- a/cmd/f4/user_menu_script.go
+++ b/cmd/f4/user_menu_script.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/unxed/f4/vfs"
+)
+
+// userMenuInterpreter recognizes a standard shebang on the first command line.
+// A menu item can therefore carry a complete script while each
+// item remains free to choose its own interpreter:
+//
+//	#!/usr/bin/env bash
+//	printf '%s\\n' "hello"
+//
+// The shebang is metadata for f4 and is not sent to the interpreter as part of
+// the script body.
+func userMenuInterpreter(commands []string) (interpreter string, scriptStart bool) {
+	if len(commands) == 0 {
+		return "", false
+	}
+	line := strings.TrimSpace(commands[0])
+	if !strings.HasPrefix(line, "#!") {
+		return "", false
+	}
+	interpreter = strings.TrimSpace(strings.TrimPrefix(line, "#!"))
+	return interpreter, interpreter != ""
+}
+
+// userMenuCommandDialect selects the shell syntax used by the command window.
+// Remote command runners can advertise their dialect; ordinary local panels
+// use the native shell. The POSIX path deliberately does not create a local
+// temporary file, so the same menu item also works through a remote POSIX PTY.
+func userMenuCommandDialect(pf *PanelsFrame) vfs.CommandDialect {
+	if pf != nil {
+		if fsp := pf.getActivePanel(); fsp != nil {
+			if provider, ok := fsp.vfs.(vfs.CommandRunnerInfoProvider); ok {
+				if dialect := provider.CommandRunnerInfo().Dialect; dialect != vfs.CommandDialectUnknown {
+					return dialect
+				}
+			}
+		}
+	}
+	if runtime.GOOS == "windows" {
+		return vfs.CommandDialectCmd
+	}
+	return vfs.CommandDialectPOSIX
+}
+
+// buildUserMenuScriptCommand turns a shebang-selected script into one command
+// line suitable for the existing command-window path. POSIX interpreters read
+// the decoded script from stdin; this avoids assuming that /tmp is visible to
+// a remote PTY. Windows uses a temporary script file because cmd.exe has no
+// portable equivalent of a binary-safe stdin pipeline for arbitrary scripts.
+func buildUserMenuScriptCommand(interpreter, script string, dialect vfs.CommandDialect) (string, error) {
+	interpreter = strings.TrimSpace(interpreter)
+	if interpreter == "" {
+		return "", errors.New("script interpreter is empty")
+	}
+	if strings.IndexByte(script, 0) >= 0 {
+		return "", errors.New("script contains NUL")
+	}
+
+	switch dialect {
+	case vfs.CommandDialectPOSIX:
+		quoted, err := QuoteCommandArgument(vfs.CommandDialectPOSIX, script)
+		if err != nil {
+			return "", err
+		}
+		// `-` is the conventional stdin script operand for sh, bash, python,
+		// perl, ruby and node. The interpreter itself is user-authored, so
+		// flags may be placed before the final stdin operand in the shebang.
+		return fmt.Sprintf("printf '%%s' %s | %s -", quoted, interpreter), nil
+	case vfs.CommandDialectCmd:
+		file, err := os.CreateTemp("", "f4-usermenu-*.script")
+		if err != nil {
+			return "", fmt.Errorf("create temporary script: %w", err)
+		}
+		path := file.Name()
+		cleanup := func() {
+			_ = file.Close()
+			_ = os.Remove(path)
+		}
+		if _, err := file.WriteString(strings.ReplaceAll(script, "\n", "\r\n")); err != nil {
+			cleanup()
+			return "", fmt.Errorf("write temporary script: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			_ = os.Remove(path)
+			return "", fmt.Errorf("close temporary script: %w", err)
+		}
+		quoted, err := QuoteCommandPath(vfs.CommandDialectCmd, path)
+		if err != nil {
+			_ = os.Remove(path)
+			return "", err
+		}
+		// cmd.exe's '&' is sequential, so the temporary file is removed after
+		// the interpreter returns, including when the script exits non-zero.
+		return fmt.Sprintf("%s %s & del /Q %s", interpreter, quoted, quoted), nil
+	default:
+		return "", fmt.Errorf("unsupported command dialect %d", dialect)
+	}
+}

--- a/cmd/f4/user_menu_ui.go
+++ b/cmd/f4/user_menu_ui.go
@@ -1074,29 +1074,45 @@ func executeMenuCommandsWithResult(pf *PanelsFrame, commands []string) bool {
 	ctx := &SubstContext{Active: active, Passive: passive}
 
 	var lines []string
-	for _, raw := range commands {
-		t := strings.TrimSpace(raw)
-		if t == "" {
+	interpreter, scriptStart := userMenuInterpreter(commands)
+	for i, raw := range commands {
+		if scriptStart && i == 0 {
 			continue
 		}
-		// Skip REM-style comments (case-insensitive, with separator) and ::.
-		if isMenuComment(t) {
-			continue
-		}
-		// "@" silent prefix isn't supported yet (would need to suppress
-		// panel show/hide). Strip it so the command at least runs.
-		t = strings.TrimPrefix(t, "@")
 
-		res := SubstFileName(t, ctx)
+		if !scriptStart {
+			t := strings.TrimSpace(raw)
+			if t == "" {
+				continue
+			}
+			// Skip REM-style comments (case-insensitive, with separator) and ::.
+			if isMenuComment(t) {
+				continue
+			}
+			// "@" silent prefix isn't supported yet (would need to suppress
+			// panel show/hide). Strip it so the command at least runs.
+			raw = strings.TrimPrefix(t, "@")
+		}
+
+		res := SubstFileName(raw, ctx)
 		if res.Cancelled {
 			return false
 		}
-		if res.Command != "" {
+		if scriptStart || res.Command != "" {
 			lines = append(lines, res.Command)
 		}
 	}
 	if len(lines) == 0 {
 		return false
+	}
+
+	if scriptStart {
+		command, err := buildUserMenuScriptCommand(interpreter, strings.Join(lines, "\n"), userMenuCommandDialect(pf))
+		if err != nil {
+			vtui.ShowMessage(" User menu ", fmt.Sprintf("Cannot run script:\n%v", err), []string{"&Ok"})
+			return false
+		}
+		lines = []string{command}
 	}
 
 	// Join so multiple commands run sequentially in one shell.

--- a/cmd/f4/user_menu_ui_test.go
+++ b/cmd/f4/user_menu_ui_test.go
@@ -283,6 +283,35 @@ func TestUserMenu_ExecuteMultipleCommands(t *testing.T) {
 	}
 }
 
+func TestUserMenu_InterpreterDirectiveUsesScriptMode(t *testing.T) {
+	interpreter, ok := userMenuInterpreter([]string{
+		"#!/usr/bin/env python3",
+		"print('hello')",
+	})
+	if !ok || interpreter != "/usr/bin/env python3" {
+		t.Fatalf("userMenuInterpreter() = %q, %v", interpreter, ok)
+	}
+
+	if _, ok := userMenuInterpreter([]string{"echo plain", "#!/bin/sh", "echo script"}); ok {
+		t.Fatal("a shebang below the first command must not switch a legacy menu item to script mode")
+	}
+}
+
+func TestUserMenu_ScriptCommandUsesInterpreterAndQuotedBody(t *testing.T) {
+	body := "printf '%s\\n' hello\nprintf \"quoted\\\" world\\n\""
+	command, err := buildUserMenuScriptCommand("/usr/bin/env bash", body, vfs.CommandDialectPOSIX)
+	if err != nil {
+		t.Fatal(err)
+	}
+	quotedBody, err := QuoteCommandArgument(vfs.CommandDialectPOSIX, body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(command, "printf '%s' "+quotedBody+" | /usr/bin/env bash -") {
+		t.Fatalf("script command = %q", command)
+	}
+}
+
 func TestUserMenu_InteractiveEdit(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()

--- a/docs/USER_MENU.md
+++ b/docs/USER_MENU.md
@@ -1,0 +1,22 @@
+# User menu scripts
+
+F2 user-menu entries can contain a complete script instead of a list of
+one-line commands. Put a standard shebang on the first line of the command
+field; f4 removes that line, feeds the remaining script to the selected
+interpreter through the normal command window, and keeps all existing panel
+substitutions such as `!.!`:
+
+```text
+#!/usr/bin/env bash
+printf 'current file: %s\\n' !.!
+```
+
+Every menu item may select a different interpreter. Examples include
+`#!/usr/bin/env bash`, `#!/usr/bin/python3 -u`, `#!/usr/bin/perl -w`, and
+`#!/usr/bin/env node`. On POSIX command windows the script is shell-quoted and
+sent through stdin, so it also works when the active panel is a remote POSIX
+PTY. On Windows f4 creates a temporary script file, runs the selected
+interpreter, and removes the file afterward.
+
+Items without a shebang retain the existing FarMenu-compatible behavior: each
+non-comment command line is sent to the command window in sequence.


### PR DESCRIPTION
## Summary

- Allow a user-menu item to contain a complete script beginning with a standard shebang.
- Send POSIX scripts through the existing command window via shell-quoted stdin, including remote POSIX PTYs.
- Run Windows scripts from a temporary file and remove it after the interpreter returns.
- Keep existing one-line FarMenu behavior unchanged and document per-item custom interpreters.
- Add regression tests for interpreter detection and command construction.

## Verification

- `go test ./...`
- `go vet ./cmd/f4 ./vfs`
- `go build -o /tmp/f4-522-bin ./cmd/f4`
- `GOOS=windows GOARCH=amd64 go build -o /tmp/f4-522-windows.exe ./cmd/f4`
- Real Linux ARM64 ANSI TTY run: F2 opened a FarMenu item with `#!/usr/bin/env bash`, the command window executed the generated stdin command, a marker file was created, and f4 exited without a crash log.

Closes #522

— zoin-bot