### PR TITLE
fix: preserve pending workspace paths on exit

### DIFF
--- a/cmd/f4/workspace_session.go
+++ b/cmd/f4/workspace_session.go
@@ -91,7 +91,7 @@ func captureWorkspaceSession(pf *PanelsFrame) workspaceSessionState {
 		}
 	}
 	if left, ok := pf.panels[0].(*FileSystemPanel); ok {
-		path := left.vfs.GetPath()
+		path := left.persistentPath()
 		cursor := left.GetSelectedName()
 		if isAIPanel(left) {
 			path = aiPrevPath[0]
@@ -106,7 +106,7 @@ func captureWorkspaceSession(pf *PanelsFrame) workspaceSessionState {
 		}
 	}
 	if right, ok := pf.panels[1].(*FileSystemPanel); ok {
-		path := right.vfs.GetPath()
+		path := right.persistentPath()
 		cursor := right.GetSelectedName()
 		if isAIPanel(right) {
 			path = aiPrevPath[1]

--- a/cmd/f4/workspace_session_test.go
+++ b/cmd/f4/workspace_session_test.go
@@ -70,6 +70,26 @@ func TestCaptureWorkspaceSessionsUsesTabOrderAndActiveIndex(t *testing.T) {
 	}
 }
 
+func TestCaptureWorkspaceSessionPreservesPendingProviderPath(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })
+
+	pf := &PanelsFrame{
+		panels: [2]Panel{
+			&FileSystemPanel{vfs: vfs.NewOSVFS(t.TempDir())},
+			&FileSystemPanel{vfs: vfs.NewOSVFS(t.TempDir())},
+		},
+	}
+	left := pf.panels[0].(*FileSystemPanel)
+	left.providerOpenTarget = "cloud://account/photos"
+	left.providerOpenTask = &vtui.TaskContext{}
+
+	state := captureWorkspaceSession(pf)
+	if state.Left.Path != left.providerOpenTarget {
+		t.Fatalf("saved pending path = %q, want %q", state.Left.Path, left.providerOpenTarget)
+	}
+}
+
 func TestApplyWorkspaceSessionInitializesFreshPanelsFrame(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	t.Cleanup(func() { vtui.FrameManager.Init(vtui.NewSilentScreenBuf()) })


### PR DESCRIPTION
## Summary
- save workspace panels through the panel's persistent path when provider navigation is still pending
- add a regression test for pending provider targets

## Validation
- go test ./...
- native Win32 build and restart validation on Windows 10 x64 confirmed a changed panel path is saved and restored after exit/restart