### PR TITLE
Respect configurable Right Ctrl hotkeys for the AI panel

### DIFF
--- a/cmd/f4/macro.go
+++ b/cmd/f4/macro.go
@@ -128,6 +128,30 @@ func EventToFarString(e *vtinput.InputEvent) string {
 	return sb.String()
 }
 
+// EventToHotkeyString preserves an otherwise normalized Right Ctrl modifier
+// for configurable hotkeys. Macros intentionally keep treating Left Ctrl and
+// Right Ctrl as the same key, while actions such as AI.TogglePanel may be
+// rebound or explicitly unbound on the RCtrl spelling.
+func EventToHotkeyString(e *vtinput.InputEvent) string {
+	key := EventToFarString(e)
+	mods := e.ControlKeyState
+	if mods.Contains(vtinput.RightCtrlPressed) && !mods.Contains(vtinput.LeftCtrlPressed) && strings.HasPrefix(key, "Ctrl") {
+		return "RCtrl" + key[len("Ctrl"):]
+	}
+	return key
+}
+
+// configuredHotkeyAction gives an explicit RCtrl binding precedence while
+// preserving the historical behavior that a plain Ctrl binding also responds
+// to the physical Right Ctrl key when no RCtrl-specific binding exists.
+func configuredHotkeyAction(hm *HotkeyManager, area, key string) string {
+	action := hm.GetAction(area, key)
+	if action == "" && strings.HasPrefix(key, "RCtrl") {
+		return hm.GetAction(area, "Ctrl"+strings.TrimPrefix(key, "RCtrl"))
+	}
+	return action
+}
+
 func ParseFarKey(s string) *vtinput.InputEvent {
 	e := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true}
 	orig := s
@@ -334,9 +358,9 @@ func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 	// neither captured in the macro buffer nor shadowed by macro playback.
 	if e.KeyDown {
 		currentArea := m.GetCurrentArea()
-		keyStr := EventToFarString(e)
+		hotkeyStr := EventToHotkeyString(e)
 		if hm := GlobalHotkeysMgr; hm != nil {
-			if actionName := hm.GetAction(currentArea, keyStr); strings.EqualFold(actionName, commandPaletteActionName) {
+			if actionName := configuredHotkeyAction(hm, currentArea, hotkeyStr); strings.EqualFold(actionName, commandPaletteActionName) {
 				RunAction(actionName)
 				return true
 			}
@@ -432,7 +456,8 @@ func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 
 	// Hotkey Manager evaluation (System actions)
 	if hm := GlobalHotkeysMgr; hm != nil {
-		if actionName := hm.GetAction(currentArea, keyStr); actionName != "" {
+		keyStr := EventToHotkeyString(e)
+		if actionName := configuredHotkeyAction(hm, currentArea, keyStr); actionName != "" {
 			if strings.EqualFold(actionName, "none") {
 				return true // Intercept and silence (explicitly unbound)
 			}
@@ -480,12 +505,12 @@ func (m *MacroManager) LookupHotkey(e *vtinput.InputEvent) bool {
 	if hm == nil {
 		return false
 	}
-	keyStr := EventToFarString(e)
+	keyStr := EventToHotkeyString(e)
 	if keyStr == "" {
 		return false
 	}
 	area := m.GetCurrentArea()
-	actionName := hm.GetAction(area, keyStr)
+	actionName := configuredHotkeyAction(hm, area, keyStr)
 	if actionName == "" {
 		return false
 	}

--- a/cmd/f4/macro_test.go
+++ b/cmd/f4/macro_test.go
@@ -213,6 +213,35 @@ func TestKeyNormalization(t *testing.T) {
 	}
 }
 
+func TestEventToHotkeyStringPreservesRightCtrl(t *testing.T) {
+	left := &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_A, ControlKeyState: vtinput.LeftCtrlPressed}
+	right := &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_A, ControlKeyState: vtinput.RightCtrlPressed}
+	rightAlt := &vtinput.InputEvent{VirtualKeyCode: vtinput.VK_A, ControlKeyState: vtinput.RightCtrlPressed | vtinput.LeftAltPressed}
+
+	if got := EventToHotkeyString(left); got != "CtrlA" {
+		t.Fatalf("left Ctrl hotkey = %q, want CtrlA", got)
+	}
+	if got := EventToHotkeyString(right); got != "RCtrlA" {
+		t.Fatalf("right Ctrl hotkey = %q, want RCtrlA", got)
+	}
+	if got := EventToHotkeyString(rightAlt); got != "RCtrlAltA" {
+		t.Fatalf("right Ctrl+Alt hotkey = %q, want RCtrlAltA", got)
+	}
+}
+
+func TestConfiguredHotkeyActionRightCtrlFallback(t *testing.T) {
+	hm := NewHotkeyManager("")
+
+	if got := configuredHotkeyAction(hm, "Shell", "RCtrlF3"); got != "Panel.SortByName" {
+		t.Fatalf("right Ctrl should fall back to Ctrl binding: got %q, want Panel.SortByName", got)
+	}
+
+	hm.Bind("Shell", "RCtrlF3", "None")
+	if got := configuredHotkeyAction(hm, "Shell", "RCtrlF3"); got != "None" {
+		t.Fatalf("explicit RCtrl unbind should win over fallback: got %q, want None", got)
+	}
+}
+
 func TestPanelBookmarkHotkeysKeepRightCtrlDistinct(t *testing.T) {
 	tests := []struct {
 		name string

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1464,15 +1464,8 @@ func (pf *PanelsFrame) InterceptPluginKey(e *vtinput.InputEvent) bool {
 		return false
 	}
 	ctrl := (e.ControlKeyState & (vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed)) != 0
-	rctrl := (e.ControlKeyState & vtinput.RightCtrlPressed) != 0
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
 	shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
-
-	// RCtrl+A: Toggle AI Panel
-	if e.VirtualKeyCode == 'A' && rctrl && !alt && !shift {
-		aiTogglePanel(pf)
-		return true
-	}
 
 	// Arkanoid easter egg: Ctrl+Alt+A
 	if e.VirtualKeyCode == 'A' && alt && ctrl {

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -1525,6 +1525,50 @@ func TestCtrlBracketsIgnoreDialogsWithoutFocusedEdit(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_AIHotkeyCanBeUnbound(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldHotkeys := GlobalHotkeysMgr
+	oldGlobalHotkeys := GlobalHotkeys
+	oldMacroMgr := MacroMgr
+	t.Cleanup(func() {
+		GlobalHotkeysMgr = oldHotkeys
+		GlobalHotkeys = oldGlobalHotkeys
+		MacroMgr = oldMacroMgr
+	})
+	GlobalHotkeys = nil
+	hm := NewHotkeyManager("")
+	hm.Bind("Shell", "RCtrlA", "None")
+	GlobalHotkeysMgr = hm
+	MacroMgr = NewMacroManager("")
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	pf.showPanels = true
+	vtui.FrameManager.Push(pf)
+
+	if _, ok := pf.panels[1].(*FileSystemPanel).vfs.(*aiVFSWrapper); ok {
+		t.Fatal("test setup unexpectedly started with an AI panel")
+	}
+	e := &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  'A',
+		ControlKeyState: vtinput.RightCtrlPressed,
+	}
+	if pf.InterceptPluginKey(e) {
+		t.Fatal("unbound RCtrl+A was intercepted before the hotkey manager")
+	}
+	if !MacroMgr.Filter(e) {
+		t.Fatal("unbound RCtrl+A was not consumed by the hotkey manager")
+	}
+	if _, ok := pf.panels[1].(*FileSystemPanel).vfs.(*aiVFSWrapper); ok {
+		t.Fatal("unbound RCtrl+A toggled the AI panel")
+	}
+}
+
 func TestPanelsFrame_CtrlArrows_CommandLineNavigation(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()


### PR DESCRIPTION
## Summary

- remove the hardcoded RCtrl+A AI-panel interception from PanelsFrame
- preserve Right Ctrl in configurable hotkey matching so explicit remaps and unbinds work
- fall back to the existing Ctrl binding when no RCtrl-specific binding is configured
- add regression coverage for conversion, fallback, and an explicit AI-panel unbind

## Validation

- `go test ./...`
- native Win32 build and validation: `RCtrlA=Settings.Hotkeys` opened Hotkey Configurator; `RCtrlA=None` left the normal panels unchanged for extended Right Ctrl+A