### PR TITLE
fix: avoid duplicate keybar in console overlay

### DIFF
--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -220,6 +220,9 @@ func (pf *PanelsFrame) drawConsoleOverlay() {
 	if pf.overlayLines() == 0 || !pf.consoleViewActive() {
 		return
 	}
+	// zoin-bot: the console overlay owns the physical bottom rows; leaving the
+	// frame-manager keybar registered would repaint a second copy afterwards.
+	pf.suppressFrameManagerKeyBar()
 	ov := pf.buildConsoleOverlayContent()
 	// The single most useful line in a Wine bug report: which emitter ran and
 	// what geometry it believed in. "Overlay drew at the top of the window"
@@ -234,6 +237,15 @@ func (pf *PanelsFrame) drawConsoleOverlay() {
 		return
 	}
 	pf.emitAnsiConsoleOverlay(ov)
+}
+
+// zoin-bot: suppressFrameManagerKeyBar prevents the normal ScreenBuf renderer from
+// drawing a second keybar while the console overlay paints directly to the
+// host terminal. The next panel redraw registers it again when appropriate.
+func (pf *PanelsFrame) suppressFrameManagerKeyBar() {
+	if vtui.FrameManager != nil && vtui.FrameManager.KeyBar == pf.keyBar {
+		vtui.FrameManager.KeyBar = nil
+	}
 }
 
 // clearConsoleOverlay takes the overlay off the screen and gives the cursor back
@@ -343,6 +355,7 @@ func (pf *PanelsFrame) enterHostConsole() {
 	pf.syncAutoCompleteSuppression()
 
 	pf.SetBusy(true)
+	pf.suppressFrameManagerKeyBar()
 	vtui.SetAltScreen(false)
 
 	n := pf.overlayLines()

--- a/cmd/f4/console_passthrough_test.go
+++ b/cmd/f4/console_passthrough_test.go
@@ -66,6 +66,32 @@ func TestHostConsole_Transitions(t *testing.T) {
 	}
 }
 
+func TestHostConsole_OverlaySuppressesRegisteredKeyBar(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ConsoleMode = "host"
+	AppConfig.ConsoleOverlayUI = true
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+	defer func() { vtui.FrameManager.KeyBar = nil }()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.shellMode = ShellModeHost
+	pf.showPanels = false
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.KeyBar = pf.keyBar
+
+	pf.enterHostConsole()
+	if vtui.FrameManager.KeyBar != nil {
+		t.Fatal("host console overlay must unregister the ScreenBuf keybar")
+	}
+
+	pf.leaveHostConsole()
+}
+
 func TestChildEnv_HostModeLeavesTERMUntouched(t *testing.T) {
 	oldProbeGUI := probeGUIBackend
 	oldProbeTTY := probeHostTTY


### PR DESCRIPTION
zoin-bot: Fixes #483.\n\nThe host-console overlay paints its command line and keybar directly onto the physical terminal, while FrameManager could still have the normal ScreenBuf keybar registered from the previous panel render. On the next repaint that produced two adjacent keybar rows.\n\nThis change unregisters the frame-manager keybar when the overlay is entered and before each direct overlay repaint; normal panel redraws register it again after leaving. Added a host-console regression test.\n\nValidation:\n- go test ./cmd/f4 -count=1\n- Native Windows 10 x64 winapi TTY build at 80x24, host overlay enabled; toggled Ctrl+O into the overlay twice and back, with one overlay bar per repaint and no duplicate row.