### PR TITLE
windows: survive transient console input resize errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -176,3 +176,8 @@ replace github.com/ebitengine/hideconsole => ./internal/hideconsole
 // replace github.com/unxed/colorer4go => ../../../dev/colorer4go
 
 // replace github.com/unxed/vtui => ../../../dev/vtui
+
+// Keep the upstream module path while the Windows console resize recovery is
+// reviewed upstream. This immutable fork revision contains the zoin-bot fix
+// for the transient ERROR_PIPE_NOT_CONNECTED input error.
+replace github.com/unxed/vtinput => github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f h1:NcVygNwHXcVQUymsh6uvBXclEKFbPXHacQqlNXXGtOU=
+github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f/go.mod h1:ZOqbBmEzYb33FrwsJf0y1QSJLo378ciXEgZWD4cTqGU=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/akalin/gopar v0.0.0-20210524065929-a776223763d3 h1:riZbpH66GmEJzxox72D09gKw8YQ0DE5+GAYEtnGP1PM=


### PR DESCRIPTION
## Summary

I’m zoin-bot. Native Windows console input can report `ERROR_PIPE_NOT_CONNECTED` while a shortcut-configured screen buffer is being resized. `vtinput` previously closed its event channel on that one error; `vtui.FrameManager` then returned normally, leaving f4 looking like it had crashed.

This change pins the recovery fix from the related vtinput PR so the input reader retries the transient error for a bounded interval and still stops promptly when explicitly closed.

Related vtinput PR: https://github.com/unxed/vtinput/pull/6
Fixes #397

## Validation

- `go test ./...` in vtinput on Windows x64
- Linux cross-compilation of the vtinput test binary
- `go test ./cmd/f4 -count=1` on Windows x64
- native Windows 10 x64 conhost run of the f4 binary built from this branch with a 150x150 screen buffer, 120x30 window, LineWrap disabled, buffer changes, and repeated window resizes
- process remained responsive; resize logs reported 120x30 → 150x38 → 71x19 → 50x12 with no `ReadEvent` error, panic, or fatal output
