### PR TITLE
fix: wrap generated help descriptions

### DIFF
--- a/cmd/f4/help.go
+++ b/cmd/f4/help.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/mattn/go-runewidth"
 	embedded "github.com/unxed/f4"
 	"github.com/unxed/vtui"
 )
@@ -63,7 +64,7 @@ func parseMarkdownToHelpTopic(name string, mdContent string) *vtui.HelpTopic {
 			continue
 		}
 
-		wrapped := vtui.WrapText(line, 70)
+		wrapped := vtui.WrapText(line, generatedHelpLineWidth)
 		for _, wLine := range wrapped {
 			wLine = convertMarkdownLinks(wLine)
 			topic.Lines = append(topic.Lines, wLine)
@@ -76,6 +77,28 @@ func parseMarkdownToHelpTopic(name string, mdContent string) *vtui.HelpTopic {
 // language. Generated key topics use it so their language matches the
 // static .hlf content even when it differs from the UI language.
 var helpActionStrings map[string]string
+
+const generatedHelpLineWidth = 70
+
+func appendGeneratedHelpAction(topic *vtui.HelpTopic, keys, desc string) {
+	prefix := fmt.Sprintf("  %-14s - ", keys)
+	prefixWidth := runewidth.StringWidth(prefix)
+	if prefixWidth >= generatedHelpLineWidth {
+		for _, line := range vtui.WrapText(prefix+desc, generatedHelpLineWidth) {
+			topic.Lines = append(topic.Lines, line)
+		}
+		return
+	}
+
+	continuation := strings.Repeat(" ", prefixWidth)
+	for i, line := range vtui.WrapText(desc, generatedHelpLineWidth-prefixWidth) {
+		if i == 0 {
+			topic.Lines = append(topic.Lines, prefix+line)
+		} else {
+			topic.Lines = append(topic.Lines, continuation+line)
+		}
+	}
+}
 
 // helpMsg resolves an i18n key preferring the help language strings,
 // falling back to the UI language.
@@ -218,7 +241,7 @@ func generateKeysHelpTopic(name, title string, areas []string, navTarget string)
 					desc = s
 				}
 			}
-			topic.Lines = append(topic.Lines, fmt.Sprintf("  %-14s - %s", keys, desc))
+			appendGeneratedHelpAction(topic, keys, desc)
 		}
 		topic.Lines = append(topic.Lines, "")
 	}

--- a/cmd/f4/help_keys_ru_test.go
+++ b/cmd/f4/help_keys_ru_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"github.com/mattn/go-runewidth"
 )
 
 func TestGenerateKeysHelpTopic_Russian(t *testing.T) {
@@ -27,6 +29,35 @@ func TestGenerateKeysHelpTopic_Russian(t *testing.T) {
 	topic2 := generateKeysHelpTopic("ViewerEditor", "t", []string{"Editor"}, "")
 	if !strings.Contains(strings.Join(topic2.Lines, "\n"), "Сохранить файл") {
 		t.Errorf("Expected Russian editor description in generated topic")
+	}
+}
+
+func TestGenerateKeysHelpTopicsFitHelpWidth(t *testing.T) {
+	old := GlobalHotkeysMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	t.Cleanup(func() { GlobalHotkeysMgr = old })
+
+	oldLang := AppConfig.Language
+	t.Cleanup(func() {
+		AppConfig.Language = oldLang
+		InitLang()
+	})
+	AppConfig.Language = "ru"
+	InitLang()
+
+	for _, tc := range []struct {
+		name  string
+		areas []string
+	}{
+		{name: "PanelNav", areas: []string{"Shell", "Terminal", "Common"}},
+		{name: "ViewerEditor", areas: []string{"Editor", "Viewer", "Common"}},
+	} {
+		topic := generateKeysHelpTopic(tc.name, "t", tc.areas, "")
+		for lineNo, line := range topic.Lines {
+			if width := runewidth.StringWidth(line); width > generatedHelpLineWidth {
+				t.Errorf("%s line %d is %d columns wide, want <= %d: %q", tc.name, lineNo, width, generatedHelpLineWidth, line)
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #451

Summary:
- wrap generated help action descriptions to the shared 70-column help width
- align continuation lines so long localized entries stay inside the help frame
- add regression coverage for Russian PanelNav and ViewerEditor topics

Validation:
- go test ./... -count=1
- go vet ./cmd/f4
- native Linux ARM64 build
- Windows amd64 cross-build
- real Linux ANSI PTY startup with F1 Help
- git diff --check

— zoin-bot