### PR TITLE
input: update vtui for enhanced navigation keys

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -178,4 +178,4 @@ replace github.com/ebitengine/hideconsole => ./internal/hideconsole
 // replace github.com/unxed/vtui => ../../../dev/vtui
 // Use the immutable vtui revision that preserves EnhancedKey for X11 and
 // Wayland navigation keys while unxed/vtui#62 and unxed/keytrans#4 are reviewed.
-replace github.com/unxed/vtui => github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e
+replace github.com/unxed/vtui => github.com/Zoinen/vtui v0.1.238-0.20260822042247-3e65ee53bfbc

--- a/go.mod
+++ b/go.mod
@@ -176,3 +176,6 @@ replace github.com/ebitengine/hideconsole => ./internal/hideconsole
 // replace github.com/unxed/colorer4go => ../../../dev/colorer4go
 
 // replace github.com/unxed/vtui => ../../../dev/vtui
+// Use the immutable vtui revision that preserves EnhancedKey for X11 and
+// Wayland navigation keys while unxed/vtui#62 and unxed/keytrans#4 are reviewed.
+replace github.com/unxed/vtui => github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
-github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e h1:fw0FmSoxSWn7GtgYYLOI9EQ1Uad9wdlUSHRPN2dwhIQ=
-github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e/go.mod h1:wlKhDK+7X8w8HjSoumJAshi4YFdBUE2z6vUp7NBNTcU=
+github.com/Zoinen/vtui v0.1.238-0.20260822042247-3e65ee53bfbc h1:8ad7x8CvsdkeRwogv7mikBhO5L5zJ3rM6nAd44cIMcY=
+github.com/Zoinen/vtui v0.1.238-0.20260822042247-3e65ee53bfbc/go.mod h1:wlKhDK+7X8w8HjSoumJAshi4YFdBUE2z6vUp7NBNTcU=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/akalin/gopar v0.0.0-20210524065929-a776223763d3 h1:riZbpH66GmEJzxox72D09gKw8YQ0DE5+GAYEtnGP1PM=

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e h1:fw0FmSoxSWn7GtgYYLOI9EQ1Uad9wdlUSHRPN2dwhIQ=
+github.com/Zoinen/vtui v0.1.238-0.20260822041328-6ba17e5f799e/go.mod h1:wlKhDK+7X8w8HjSoumJAshi4YFdBUE2z6vUp7NBNTcU=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/akalin/gopar v0.0.0-20210524065929-a776223763d3 h1:riZbpH66GmEJzxox72D09gKw8YQ0DE5+GAYEtnGP1PM=
@@ -268,8 +270,6 @@ github.com/unxed/tar v0.1.126 h1:RleuQKR5lCz+5ESFmED4RS6IizeEVjZ/pn3UER9jTBI=
 github.com/unxed/tar v0.1.126/go.mod h1:PVC2kDNoHYKzggPKeyE+xAr5fn8cBHuU0Y+hHCsleSI=
 github.com/unxed/vtinput v0.1.4 h1:yiYD83SwunjdoKTi6IllVAvKSE+av46DKSHyVhuezHQ=
 github.com/unxed/vtinput v0.1.4/go.mod h1:ZOqbBmEzYb33FrwsJf0y1QSJLo378ciXEgZWD4cTqGU=
-github.com/unxed/vtui v0.1.256 h1:JWVO7w4vKXvuPncJ4MzJP/vLW7MwCDV+aYM8gAkJpLg=
-github.com/unxed/vtui v0.1.256/go.mod h1:0VXhD7WOMjQ70XQJaYGitMJsf8kDKtYKN0CXA+5Un3E=
 github.com/unxed/winkeys v0.1.1 h1:CeRhzQLrZtO2aVq8C8gPX1ySdbbvPombbUZ15cRjFTI=
 github.com/unxed/winkeys v0.1.1/go.mod h1:eCDbEJFdYcii0Fd4O9u+CAqjJ4SkkhWDkhikNFwBCd4=
 github.com/unxed/xkb-go v0.1.8 h1:hqPI2wJw2LQ7YOqghNYat/TJF3pFamCCPjhxI5I3lhU=


### PR DESCRIPTION
## Summary

- update the `vtui` dependency to the reviewed immutable revision that preserves `EnhancedKey` for X11 and Wayland navigation keys
- keep the integration pinned while the upstream dependency PRs are reviewed

This is the `f4` integration part of #464. The behavior changes are in:

- keytrans PR: https://github.com/unxed/keytrans/pull/4
- vtui PR: https://github.com/unxed/vtui/pull/62

## Validation

- `go test ./cmd/f4 -run 'TestConfig_ConsoleMode|TestHostConsole|TestHotkeyDelAliases' -count=1`
- `go test ./cmd/f4 -run '^$'`
- Windows native build: `go build -o C:/Temp/f4-464-validation.exe ./cmd/f4`
- Linux/amd64 cross-compile: `go test -c -o C:/Temp/f4-464-linux.test ./cmd/f4`

The current validation host is Windows 10 x64, so X11/Wayland runtime behavior is covered by the focused vtui/keytrans tests and Linux cross-compilation; no X11/Wayland device is available for native GUI execution here.
