### PR TITLE
fix: complete hotkey configurator inventory

### DIFF
--- a/cmd/f4/action_registry.go
+++ b/cmd/f4/action_registry.go
@@ -707,6 +707,36 @@ func init() {
 			}
 		}),
 	})
+	RegisterAction(Action{
+		Name:        "Panel.SelectNavigation",
+		Area:        "Shell",
+		Label:       "Select While Navigating",
+		Description: "Select or deselect files with Insert and Shift-navigation",
+		NativeKeys: []string{
+			"Ins", "ShiftUp", "ShiftDown", "ShiftLeft", "ShiftRight",
+			"ShiftPgUp", "ShiftPgDn", "ShiftHome", "ShiftEnd",
+		},
+		Handler: withPF(func(pf *PanelsFrame) {
+			if fsp := pf.getActivePanel(); fsp != nil {
+				fsp.ProcessKey(ParseFarKey("Ins"))
+			}
+		}),
+	})
+	RegisterAction(Action{
+		Name:        "Panel.ToggleCommandLineFocus",
+		Area:        "Shell",
+		Label:       "Toggle Command Line Focus",
+		Description: "Toggle command-line focus in Search by default navigation mode",
+		NativeKeys:  []string{"VK_C0:SearchFirst", "`:SearchFirst", "ё:SearchFirst"},
+		Handler: func() bool {
+			pf := findPanelsFrameAnyScreen()
+			if pf == nil || !pf.searchFirstMode() || !pf.showPanels {
+				return false
+			}
+			pf.setCommandLineFocus(!pf.commandLineFocused)
+			return true
+		},
+	})
 
 	RegisterAction(Action{
 		Name:         "Panel.UserMenu",

--- a/cmd/f4/hotkeys.go
+++ b/cmd/f4/hotkeys.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/unxed/vtui"
@@ -18,6 +19,9 @@ type HotkeyManager struct {
 }
 
 var conditionRegistry = map[string]func() bool{
+	"searchfirst": func() bool {
+		return AppConfig.NavigationMode == NavigationSearchFirst
+	},
 	"emptycommandline": func() bool {
 		if pf := findPanelsFrameAnyScreen(); pf != nil {
 			return pf.cmdLine.IsEmpty()
@@ -120,7 +124,7 @@ var conditionRegistry = map[string]func() bool{
 
 // GetConditions returns the user-friendly names of all registered conditions.
 func GetConditions() []string {
-	return []string{"None", "EmptyCommandLine", "CommandLineNotEmpty", "EscToggle", "TerminalQuiet", "AltPanelVisible", "NoAltScreenApp", "NoTerminalApp"}
+	return []string{"None", "SearchFirst", "EmptyCommandLine", "CommandLineNotEmpty", "EscToggle", "TerminalQuiet", "AltPanelVisible", "NoAltScreenApp", "NoTerminalApp"}
 }
 
 // RegisterCondition adds a dynamic boolean check accessible by hotkey bindings.
@@ -188,6 +192,45 @@ func (hm *HotkeyManager) GetKeyForAction(area, actionName string) string {
 	return ""
 }
 
+var keyTokenDisplayNames = map[string]string{
+	"VK_BA": ";",
+	"VK_BB": "=",
+	"VK_BC": ",",
+	"VK_BD": "-",
+	"VK_BE": ".",
+	"VK_BF": "/",
+	"VK_C0": "`",
+	"VK_DB": "[",
+	"VK_DC": "\\",
+	"VK_DD": "]",
+	"VK_DE": "'",
+	"VK_E2": "\\",
+}
+
+func formatKeyTokenForUI(key string) string {
+	if name, ok := keyTokenDisplayNames[strings.ToUpper(key)]; ok {
+		return name
+	}
+	if strings.HasPrefix(strings.ToUpper(key), "VK_") {
+		if len(key) == len("VK_")+1 {
+			last := key[len(key)-1]
+			if (last >= 'A' && last <= 'Z') || (last >= 'a' && last <= 'z') || (last >= '0' && last <= '9') {
+				return strings.ToUpper(string(last))
+			}
+		}
+		value, err := strconv.ParseUint(key[3:], 16, 8)
+		if err == nil {
+			switch {
+			case value >= 'A' && value <= 'Z':
+				return string(rune(value))
+			case value >= '0' && value <= '9':
+				return string(rune(value))
+			}
+		}
+	}
+	return key
+}
+
 // FormatKeyForUI converts a raw key string (like CtrlShiftF5) into a pretty UI string (Ctrl+Shift+F5).
 func FormatKeyForUI(key string) string {
 	if key == "" {
@@ -207,7 +250,7 @@ func FormatKeyForUI(key string) string {
 		key = key[5:]
 	}
 	if key != "" {
-		parts = append(parts, key)
+		parts = append(parts, formatKeyTokenForUI(key))
 	}
 	return strings.Join(parts, "+")
 }

--- a/cmd/f4/hotkeys_test.go
+++ b/cmd/f4/hotkeys_test.go
@@ -89,6 +89,9 @@ func TestFormatKeyForUI(t *testing.T) {
 		{"ShiftF4", "Shift+F4"},
 		{"CtrlShiftF5", "Ctrl+Shift+F5"},
 		{"AltF12", "Alt+F12"},
+		{"CtrlVK_C", "Ctrl+C"},
+		{"CtrlVK_DB", "Ctrl+["},
+		{"VK_C0", "`"},
 		{"", ""},
 	}
 	for _, tc := range tests {

--- a/cmd/f4/hotkeys_ui.go
+++ b/cmd/f4/hotkeys_ui.go
@@ -13,6 +13,8 @@ type hotkeyRow struct {
 	Label     string
 	Area      string
 	Key       string
+	RawKey    string
+	Editable  bool
 	Condition string
 	Desc      string
 }
@@ -34,14 +36,96 @@ func (r hotkeyRow) GetCellText(col int) string {
 }
 
 func (r hotkeyRow) GetCellAttr(col int, def uint64) uint64 {
-	if r.Key == "" {
+	if r.Key == "" || !r.Editable {
 		return vtui.DimColor(def)
 	}
 	return def
 }
 
+func hotkeyDialogSizeForScreen(screenWidth, screenHeight int) (int, int) {
+	if screenWidth <= 0 {
+		screenWidth = 120
+	}
+	if screenHeight <= 0 {
+		screenHeight = 48
+	}
+	width := screenWidth - 4
+	if width < 40 {
+		width = 40
+	}
+	height := screenHeight - 2
+	if height < 10 {
+		height = 10
+	}
+	if height > 48 {
+		height = 48
+	}
+	return width, height
+}
+
+func sumInts(values []int) int {
+	total := 0
+	for _, value := range values {
+		total += value
+	}
+	return total
+}
+
+func fitHotkeyColumnWidths(widths []int, budget int) []int {
+	if budget < 0 {
+		budget = 0
+	}
+	for sumInts(widths) > budget {
+		changed := false
+		for i := range widths {
+			if widths[i] <= 1 {
+				continue
+			}
+			widths[i]--
+			changed = true
+			if sumInts(widths) <= budget {
+				break
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+	return widths
+}
+
+func hotkeyTableColumns(rows []hotkeyRow, dialogWidth int) []vtui.TableColumn {
+	titles := []string{"Command", "Key", "Area", "When", "Description"}
+	widths := make([]int, len(titles))
+	for i, title := range titles {
+		widths[i] = vtui.StringWidth(title)
+	}
+	for _, row := range rows {
+		for col := range widths {
+			if cellWidth := vtui.StringWidth(row.GetCellText(col)); cellWidth > widths[col] {
+				widths[col] = cellWidth
+			}
+		}
+	}
+
+	// The description column remains elastic. Reserve its header, the four
+	// column separators, and the table's side padding before fitting the other
+	// columns to the actual dialog width.
+	fixedBudget := dialogWidth - 4 - (len(widths) - 1) - vtui.StringWidth(titles[len(titles)-1])
+	fixed := fitHotkeyColumnWidths(append([]int(nil), widths[:len(widths)-1]...), fixedBudget)
+	columns := make([]vtui.TableColumn, 0, len(widths))
+	for i, width := range fixed {
+		columns = append(columns, vtui.TableColumn{Title: titles[i], Width: width})
+	}
+	columns = append(columns, vtui.TableColumn{Title: titles[len(titles)-1], Width: 0})
+	return columns
+}
+
 func actionHotkeyConfig(pf *PanelsFrame) {
 	w, h := 120, 48
+	if vtui.FrameManager != nil {
+		w, h = hotkeyDialogSizeForScreen(vtui.FrameManager.GetScreenSize(), vtui.FrameManager.GetScreenHeight())
+	}
 
 	btnAssign := vtui.NewButton(0, 0, Msg("Hotkeys.BtnAssign"))
 	btnUnbind := vtui.NewButton(0, 0, Msg("Hotkeys.BtnUnbind"))
@@ -86,7 +170,40 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 					Action:    act.Name,
 					Label:     plainLabel(act.DisplayLabel()),
 					Area:      area,
-					Key:       key,
+					Key:       FormatKeyForUI(key),
+					RawKey:    key,
+					Editable:  true,
+					Condition: cond,
+					Desc:      act.DisplayDescription(),
+				})
+				assignedActions[strings.ToLower(act.Name)] = true
+			}
+		}
+
+		// Native shortcuts are handled by the focused frame rather than the
+		// configurable hotkey manager. They still belong in this inventory so
+		// the dialog describes every shortcut the user can press. Keep these
+		// rows read-only: assigning them would create a misleading binding that
+		// cannot replace the frame-owned behavior.
+		for _, act := range actions {
+			seenNative := make(map[string]bool)
+			for _, spec := range act.NativeKeys {
+				key, cond, _ := strings.Cut(spec, ":")
+				key = strings.TrimSpace(key)
+				displayKey := FormatKeyForUI(key)
+				if key == "" || seenNative[displayKey] {
+					continue
+				}
+				if GlobalHotkeysMgr != nil && GlobalHotkeysMgr.GetAction(act.Area, key) != "" {
+					continue
+				}
+				seenNative[displayKey] = true
+				hkRows = append(hkRows, hotkeyRow{
+					Action:    act.Name,
+					Label:     plainLabel(act.DisplayLabel()),
+					Area:      act.Area,
+					Key:       displayKey,
+					RawKey:    key,
 					Condition: cond,
 					Desc:      act.DisplayDescription(),
 				})
@@ -101,6 +218,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 					Label:     plainLabel(act.DisplayLabel()),
 					Area:      act.Area, // unassigned, shown under the action's native area
 					Key:       "",
+					Editable:  true,
 					Condition: "",
 					Desc:      act.DisplayDescription(),
 				})
@@ -124,13 +242,14 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		for _, r := range hkRows {
 			rows = append(rows, r)
 		}
+		table.Columns = hotkeyTableColumns(hkRows, w)
 		table.SetRows(rows)
 		vtui.FrameManager.Redraw()
 	}
 
 	btnAssign.OnClick = func() {
 		idx := table.SelectPos
-		if idx >= 0 && idx < len(hkRows) {
+		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
 			row := hkRows[idx]
 			showAreaSelectDialog(row.Action, row.Area, row.Condition, refresh)
 		}
@@ -138,10 +257,10 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 
 	btnUnbind.OnClick = func() {
 		idx := table.SelectPos
-		if idx >= 0 && idx < len(hkRows) {
+		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
 			row := hkRows[idx]
-			if row.Key != "" && row.Area != "" {
-				GlobalHotkeysMgr.Bind(row.Area, row.Key, "None")
+			if row.RawKey != "" && row.Area != "" {
+				GlobalHotkeysMgr.Bind(row.Area, row.RawKey, "None")
 				GlobalHotkeysMgr.Save()
 				refresh()
 			}

--- a/cmd/f4/hotkeys_ui_test.go
+++ b/cmd/f4/hotkeys_ui_test.go
@@ -46,3 +46,106 @@ func TestHotkeyRow(t *testing.T) {
 		t.Errorf("Expected Description")
 	}
 }
+
+func TestHotkeyDialogSizeForScreen(t *testing.T) {
+	if gotW, gotH := hotkeyDialogSizeForScreen(200, 60); gotW != 196 || gotH != 48 {
+		t.Fatalf("large screen size = %dx%d, want 196x48", gotW, gotH)
+	}
+	if gotW, gotH := hotkeyDialogSizeForScreen(80, 25); gotW != 76 || gotH != 23 {
+		t.Fatalf("small screen size = %dx%d, want 76x23", gotW, gotH)
+	}
+}
+
+func TestHotkeyTableColumnsFitContentWhenSpaceAllows(t *testing.T) {
+	rows := []hotkeyRow{{
+		Label:     "A long localized command label",
+		Key:       "Ctrl+Shift+PgDn",
+		Area:      "Terminal",
+		Condition: "CommandLineNotEmpty",
+		Desc:      "A long localized description that remains in the flexible column",
+	}}
+	columns := hotkeyTableColumns(rows, 160)
+	for col := 0; col < 4; col++ {
+		if got, want := columns[col].Width, vtui.StringWidth(rows[0].GetCellText(col)); got < want {
+			t.Errorf("column %d width = %d, want at least %d", col, got, want)
+		}
+	}
+}
+
+func TestNativeHotkeyInventory(t *testing.T) {
+	selectAction, ok := GetAction("Panel.SelectNavigation")
+	if !ok {
+		t.Fatal("Panel.SelectNavigation is not registered")
+	}
+	for _, key := range []string{"Ins", "ShiftUp", "ShiftDown", "ShiftLeft", "ShiftRight"} {
+		found := false
+		for _, native := range selectAction.NativeKeys {
+			if native == key {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Panel.SelectNavigation is missing native key %q", key)
+		}
+	}
+
+	focusAction, ok := GetAction("Panel.ToggleCommandLineFocus")
+	if !ok {
+		t.Fatal("Panel.ToggleCommandLineFocus is not registered")
+	}
+	if len(focusAction.NativeKeys) == 0 || focusAction.NativeKeys[0] != "VK_C0:SearchFirst" {
+		t.Errorf("command-line focus native keys = %v", focusAction.NativeKeys)
+	}
+}
+
+func TestActionHotkeyConfigBuildsNativeRowsAndFitsScreen(t *testing.T) {
+	previous := GlobalHotkeysMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	t.Cleanup(func() { GlobalHotkeysMgr = previous })
+
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(160, 40)
+	vtui.FrameManager.Init(screen)
+	actionHotkeyConfig(nil)
+
+	dlg, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+	if !ok {
+		t.Fatalf("top frame = %T, want hotkey dialog", vtui.FrameManager.GetTopFrame())
+	}
+	defer dlg.Close()
+
+	var table *vtui.Table
+	for _, child := range dlg.GetChildren() {
+		if candidate, ok := child.(*vtui.Table); ok {
+			table = candidate
+			break
+		}
+	}
+	if table == nil {
+		t.Fatal("hotkey dialog has no table")
+	}
+
+	selectInsert := false
+	toggleFocus := false
+	for _, row := range table.Rows {
+		hotkey, ok := row.(hotkeyRow)
+		if !ok {
+			continue
+		}
+		if hotkey.Action == "Panel.SelectNavigation" && hotkey.Key == "Ins" && !hotkey.Editable {
+			selectInsert = true
+		}
+		if hotkey.Action == "Panel.ToggleCommandLineFocus" && hotkey.Key == "`" && hotkey.Condition == "SearchFirst" && !hotkey.Editable {
+			toggleFocus = true
+		}
+	}
+	if !selectInsert || !toggleFocus {
+		t.Fatalf("native rows missing: select=%v toggle-focus=%v", selectInsert, toggleFocus)
+	}
+
+	x1, _, x2, _ := dlg.GetPosition()
+	if got, want := x2-x1+1, 156; got != want {
+		t.Errorf("dialog width = %d, want %d", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #416

Summary:
- list frame-owned Insert and Shift-navigation selection shortcuts in the hotkey configurator
- list the Search-first command-line focus toggle
- render raw VK_* bindings as readable key labels while preserving raw values for edits
- size the dialog and columns from the current terminal and available content

Frame-owned shortcuts are shown read-only because their direction/focus behavior belongs to the active frame.

Validation:
- go test ./... -count=1
- go vet ./cmd/f4
- native Linux ARM64 build
- Windows amd64 cross-build
- real Linux ANSI PTY launch and hotkey-dialog navigation on a 160x40 terminal
- git diff --check

Local validation used the open unxed/vtui#61 branch because current f4 main already references its window-position API while the dependency replace is temporarily absent.

— zoin-bot