### PR TITLE
fix: copy multi-click terminal selections

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -324,7 +324,7 @@ type PanelsFrame struct {
 	// Terminal mouse-selection state. Kept in PanelsFrame because
 	// mouse routing lives here; the highlight and text extraction
 	// live on the TerminalView itself.
-	termSelDragging bool      // LMB is down after a drag-initiating click
+	termSelDragging bool      // LMB gesture is waiting for its release
 	termSelClickN   int       // 1 / 2 / 3 for triple-click detection
 	termSelClickAt  time.Time // time of the last click
 	termSelClickX   int
@@ -2508,10 +2508,10 @@ func (pf *PanelsFrame) handleTerminalMouseSelection(e *vtinput.InputEvent) bool 
 			pf.termSelDragging = true
 		case 2:
 			tv.SelectWordAt(mx, my)
-			pf.termSelDragging = false
+			pf.termSelDragging = true
 		default: // 3 or more
 			tv.SelectLineAt(my)
-			pf.termSelDragging = false
+			pf.termSelDragging = true
 			pf.termSelClickN = 0
 		}
 		vtui.FrameManager.Redraw()
@@ -2550,7 +2550,7 @@ func (pf *PanelsFrame) handleTerminalMouseSelection(e *vtinput.InputEvent) bool 
 			if text != "" {
 				// SetClipboard can hang for seconds behind far2l IPC
 				// or xclip/wl-copy — same treatment as the grabber.
-				go vtui.SetClipboard(text)
+				go tv.copySelectionToClipboard(text)
 			}
 		}
 		vtui.FrameManager.Redraw()

--- a/cmd/f4/terminal_selection_test.go
+++ b/cmd/f4/terminal_selection_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
@@ -257,6 +258,87 @@ func TestPanelsFrame_TerminalMouseSelect_Drag(t *testing.T) {
 	}
 	if got := tv.ExtractSelection(); got != "llo w" {
 		t.Errorf("post-release extract: got %q, want %q", got, "llo w")
+	}
+}
+
+func TestPanelsFrame_TerminalMouseSelect_ShiftDoubleClickCopiesWord(t *testing.T) {
+	pf, _ := panelsFrameWithMouseSelect(t)
+	tv := pf.termView
+	seedRow(tv, 0, "foo bar baz")
+
+	// Model the second press of a Shift+double-click. The frame's click
+	// counter has already seen the first press, while the terminal backend
+	// reports the modifier and double-click flag on this press.
+	pf.termSelClickN = 1
+	pf.termSelClickAt = time.Now()
+	pf.termSelClickX, pf.termSelClickY = 5, 0
+	copied := make(chan string, 1)
+	tv.clipboardWriter = func(text string) { copied <- text }
+
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		ControlKeyState: vtinput.ShiftPressed,
+		MouseEventFlags: vtinput.DoubleClick,
+		MouseX:          5, MouseY: 0,
+	})
+	if !pf.termSelDragging {
+		t.Fatal("double-click selection must remain active until button release")
+	}
+
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: false,
+		ButtonState: 0, ControlKeyState: vtinput.ShiftPressed,
+		MouseX: 5, MouseY: 0,
+	})
+
+	select {
+	case got := <-copied:
+		if got != "bar" {
+			t.Fatalf("copied word = %q, want %q", got, "bar")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shift+double-click did not copy the selected word")
+	}
+}
+
+func TestPanelsFrame_TerminalMouseSelect_ShiftTripleClickCopiesLine(t *testing.T) {
+	pf, _ := panelsFrameWithMouseSelect(t)
+	tv := pf.termView
+	seedRow(tv, 0, "foo bar baz")
+
+	// Model the third press of a Shift+triple-click after the first two
+	// presses have established the click sequence.
+	pf.termSelClickN = 2
+	pf.termSelClickAt = time.Now()
+	pf.termSelClickX, pf.termSelClickY = 5, 0
+	copied := make(chan string, 1)
+	tv.clipboardWriter = func(text string) { copied <- text }
+
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		ControlKeyState: vtinput.ShiftPressed,
+		MouseEventFlags: vtui.TripleClick,
+		MouseX:          5, MouseY: 0,
+	})
+	if !pf.termSelDragging {
+		t.Fatal("triple-click selection must remain active until button release")
+	}
+
+	pf.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: false,
+		ButtonState: 0, ControlKeyState: vtinput.ShiftPressed,
+		MouseX: 5, MouseY: 0,
+	})
+
+	select {
+	case got := <-copied:
+		if got != "foo bar baz" {
+			t.Fatalf("copied line = %q, want %q", got, "foo bar baz")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Shift+triple-click did not copy the selected line")
 	}
 }
 

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -125,6 +125,17 @@ func (tv *TerminalView) writeClipboard(text string) {
 	}
 }
 
+// copySelectionToClipboard keeps terminal selection copies on the regular
+// vtui clipboard path while allowing tests to intercept the write without
+// touching the host clipboard.
+func (tv *TerminalView) copySelectionToClipboard(text string) {
+	if tv.clipboardWriter != nil {
+		tv.clipboardWriter(text)
+		return
+	}
+	vtui.SetClipboard(text)
+}
+
 func (tv *TerminalView) CloneStateFrom(other *TerminalView) {
 	other.FlushLog()
 	other.mu.Lock()


### PR DESCRIPTION
Fixes #341

Summary:
- keep terminal text-selection gestures active until the mouse release for word and line selections
- copy Shift+double-click words and Shift+triple-click lines through the normal clipboard path
- preserve the test clipboard hook so selection-copy behavior is covered without touching the host clipboard

Validation:
- go test ./... -count=1
- go vet ./cmd/f4
- native Linux ARM64 build
- Windows amd64 cross-build
- focused tests for Shift+double-click and Shift+triple-click clipboard copies
- real Linux ANSI PTY launch, Ctrl+O terminal view, shell output, and SGR Shift multi-click selection
- git diff --check

— zoin-bot