### PR TITLE
fix: restore main menu with hidden panels

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -617,12 +617,37 @@ func (pf *PanelsFrame) rightMenu() vtui.MenuBarItem {
 	}}
 }
 
+// appendTerminalMenuItems keeps terminal-specific log commands reachable from
+// the ordinary Files menu while panels are hidden. The terminal actions use
+// their Terminal-area shortcuts, so this changes only menu presentation.
+func appendTerminalMenuItems(items []vtui.MenuBarItem) []vtui.MenuBarItem {
+	terminalItems := BuildMenuBarItems("Terminal")
+	if len(terminalItems) == 0 || len(terminalItems[0].SubItems) == 0 {
+		return items
+	}
+
+	filesLabel := Msg("Menu.Shell.Files")
+	for i := range items {
+		if items[i].Label != filesLabel {
+			continue
+		}
+		if len(items[i].SubItems) > 0 {
+			items[i].SubItems = append(items[i].SubItems, vtui.MenuItem{Separator: true})
+		}
+		items[i].SubItems = append(items[i].SubItems, terminalItems[0].SubItems...)
+		break
+	}
+	return items
+}
+
 // buildMenuItems assembles the main menu: the custom Left/Right panel
 // menus around the Files/Commands/Options menus generated from the
-// action registry. With panels hidden, the Terminal-area menu is shown.
+// action registry. With panels hidden, the ordinary Shell menu remains
+// available so Options and panel actions do not disappear behind the
+// terminal-log menu.
 func (pf *PanelsFrame) buildMenuItems() []vtui.MenuBarItem {
 	if !pf.showPanels {
-		return BuildMenuBarItems("Terminal")
+		return appendTerminalMenuItems(BuildMenuBarItems("Shell"))
 	}
 	items := []vtui.MenuBarItem{pf.leftMenu()}
 	items = append(items, BuildMenuBarItems("Shell")...)

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -3295,6 +3295,54 @@ func TestPanelsFrame_F9Context(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_F9HiddenPanels_UsesShellMenuAndKeepsTerminalLog(t *testing.T) {
+	old := GlobalHotkeysMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	defer func() { GlobalHotkeysMgr = old }()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.showPanels = false
+
+	items := pf.GetMenuBar().Items
+	wantLabels := []string{Msg("Menu.Shell.Files"), Msg("Menu.Shell.Commands"), Msg("Menu.Shell.Options")}
+	if len(items) != len(wantLabels) {
+		t.Fatalf("hidden-panels F9 menu has %d top-level items, want %d: %+v", len(items), len(wantLabels), items)
+	}
+	for i, want := range wantLabels {
+		if items[i].Label != want {
+			t.Errorf("hidden-panels F9 menu %d = %q, want %q", i, items[i].Label, want)
+		}
+	}
+
+	wantTerminalItems := map[string]bool{
+		Msg("Action.Terminal.ViewLog"): false,
+		Msg("Action.Terminal.EditLog"): false,
+	}
+	for _, item := range items[0].SubItems {
+		if _, ok := wantTerminalItems[item.Text]; ok {
+			wantTerminalItems[item.Text] = true
+		}
+	}
+	for label, found := range wantTerminalItems {
+		if !found {
+			t.Errorf("hidden-panels Files menu is missing terminal action %q", label)
+		}
+	}
+
+	pressKey(pf, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F9,
+	})
+	if !pf.menuBar.Active {
+		t.Error("F9 with hidden panels did not activate the main menu")
+	}
+	if pf.menuBar.SelectPos != 0 {
+		t.Errorf("F9 with hidden panels selected menu %d, want Files menu 0", pf.menuBar.SelectPos)
+	}
+}
+
 func TestLayout_F4InternalDialogs_Validity(t *testing.T) {
 	vtui.SetDefaultPalette()
 	pf := NewPanelsFrame()


### PR DESCRIPTION
Fixes #402.

When panels were hidden, F9 rebuilt only the Terminal-area log menu, so the normal Files, Commands, and Options menus disappeared. This change keeps the Shell menu available in terminal mode and appends the terminal View/Edit Log actions to the Files menu, preserving their Terminal-area shortcuts.

Added regression coverage for the hidden-panels F9 path, menu groups, terminal log actions, and menu activation.

Validation on Linux ARM64 (Fedora Asahi Remix 44, KDE Wayland):
- go test ./cmd/f4 -run 'TestPanelsFrame_(F9Context|F9HiddenPanels_UsesShellMenuAndKeepsTerminalLog)' -count=1
- go test ./... -count=1
- go vet ./cmd/f4
- native Linux ARM64 build
- Windows amd64 cross-build
- real ANSI PTY: Ctrl+O to hide panels, F9 opened Files/Commands/Options, arrow navigation opened Options and showed Panel settings, then F10 exited cleanly
- git diff --check

— zoin-bot
