### PR TITLE
feat: highlight and open URLs from text views

### DIFF
--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -84,6 +84,8 @@ type EditorView struct {
 	rectSelActive    bool
 	rectSelStartLine int
 	rectSelStartCol  int
+	hoverURL         string
+	hoverURLStart    int
 	editSession      int // Unique ID to fence background tasks
 
 	pasting     bool
@@ -1459,6 +1461,7 @@ func (ev *EditorView) DisplayObject(scr *vtui.ScreenBuf) {
 		} else {
 			lineLen = ev.pt.Size() - lineStart
 		}
+		lineLinks := ev.urlLinksForLine(lineStart, lineStart+lineLen)
 
 		// Stateful Highlighting
 		var lineSyntax []uint64
@@ -1580,7 +1583,7 @@ func (ev *EditorView) DisplayObject(scr *vtui.ScreenBuf) {
 
 			_, startVCol := ev.engine.LogicalToVisual(frag.ByteOffsetStart)
 			isCrossRow := (absVRow == crossVRow)
-			ev.renderCells = ev.fillCells(ev.renderCells, ev.renderBytes, bgAttr, selAttr, frag.ByteOffsetStart, ev.selActive, selMin, selMax, ev.fadeSyntax(fragSyntax, bgAttr), startVCol, isCrossRow, crossVCol, horzCrossAttr, vertCrossAttr, absVRow)
+			ev.renderCells = ev.fillCellsWithLinks(ev.renderCells, ev.renderBytes, bgAttr, selAttr, frag.ByteOffsetStart, ev.selActive, selMin, selMax, ev.fadeSyntax(fragSyntax, bgAttr), lineLinks, startVCol, isCrossRow, crossVCol, horzCrossAttr, vertCrossAttr, absVRow)
 
 			scr.Write(ev.X1-ev.ScrollLeft, currY, ev.renderCells)
 
@@ -2475,6 +2478,10 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 }
 
 func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr, selAttr uint64, offset int, selActive bool, selMin, selMax int, syntax []uint64, startVisualCol int, isCrossRow bool, crossVCol int, horzCrossAttr, vertCrossAttr uint64, visualRow int) []vtui.CharInfo {
+	return ev.fillCellsWithLinks(target, data, defaultAttr, selAttr, offset, selActive, selMin, selMax, syntax, nil, startVisualCol, isCrossRow, crossVCol, horzCrossAttr, vertCrossAttr, visualRow)
+}
+
+func (ev *EditorView) fillCellsWithLinks(target []vtui.CharInfo, data []byte, defaultAttr, selAttr uint64, offset int, selActive bool, selMin, selMax int, syntax []uint64, links []urlLink, startVisualCol int, isCrossRow bool, crossVCol int, horzCrossAttr, vertCrossAttr uint64, visualRow int) []vtui.CharInfo {
 	target = target[:0]
 	currByte := 0
 	runeIdx := 0
@@ -2510,6 +2517,11 @@ func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr
 		attr := defaultAttr
 		if runeIdx < len(syntax) {
 			attr = syntax[runeIdx]
+		}
+		if ev.hoverURL != "" {
+			if link, ok := urlLinkAt(links, offset+currByte); ok && link.URL == ev.hoverURL {
+				attr |= vtui.CommonLvbUnderscore
+			}
 		}
 
 		// Horizontal crosshair line applies to the entire character in the active row
@@ -2747,6 +2759,18 @@ func (ev *EditorView) ProcessMouse(e *vtinput.InputEvent) bool {
 		ev.ensureCursorVisible()
 	}
 
+	if e.WheelDirection == 0 {
+		if changed := ev.updateURLHover(int(e.MouseX), int(e.MouseY)); changed {
+			vtui.FrameManager.Redraw()
+		}
+		if ctrlMouseClick(e) {
+			if link, ok := ev.urlLinkAtMouse(int(e.MouseX), int(e.MouseY)); ok {
+				openExternalURLAsync(link.URL)
+				return true
+			}
+		}
+	}
+
 	if ev.scrollBar != nil && ev.scrollBar.ProcessMouse(e) {
 		return true
 	}
@@ -2837,6 +2861,99 @@ func (ev *EditorView) ProcessMouse(e *vtinput.InputEvent) bool {
 	}
 
 	return false
+}
+
+func (ev *EditorView) urlLinkAtMouse(mx, my int) (urlLink, bool) {
+	link, _, ok := ev.urlLinkLocationAtMouse(mx, my)
+	return link, ok
+}
+
+func (ev *EditorView) urlLinkLocationAtMouse(mx, my int) (urlLink, int, bool) {
+	if ev.HexMode || ev.DecodeMode || mx < ev.X1 || mx > ev.X2 || my < ev.Y1+1 || my > ev.Y2 {
+		return urlLink{}, 0, false
+	}
+	width := ev.X2 - ev.X1 + 1
+	if ev.scrollBar != nil {
+		width--
+	}
+	if mx >= ev.X1+width {
+		return urlLink{}, 0, false
+	}
+	visualCol := mx - ev.X1 + ev.ScrollLeft
+	visualRow := my - (ev.Y1 + 1) + ev.ScrollTopRow
+	offset := ev.engine.VisualToLogical(visualRow, visualCol)
+	line := ev.li.GetLineAtOffset(offset)
+	lineStart := ev.li.GetLineOffset(line)
+	lineEnd := ev.pt.Size()
+	if line+1 < ev.li.LineCount() {
+		lineEnd = ev.li.GetLineOffset(line + 1)
+	}
+	rel := offset - lineStart
+	links := ev.urlLinksNearOffset(lineStart, lineEnd, rel)
+	if link, ok := urlLinkAt(links, rel); ok {
+		return link, lineStart + link.Start, true
+	}
+	if rel > 0 {
+		if link, ok := urlLinkAt(links, rel-1); ok {
+			return link, lineStart + link.Start, true
+		}
+	}
+	return urlLink{}, 0, false
+}
+
+func (ev *EditorView) updateURLHover(mx, my int) bool {
+	var next string
+	start := -1
+	if link, linkStart, ok := ev.urlLinkLocationAtMouse(mx, my); ok {
+		next = link.URL
+		start = linkStart
+	}
+	if next == ev.hoverURL && start == ev.hoverURLStart {
+		ev.hoverURLStart = start
+		return false
+	}
+	ev.hoverURL = next
+	ev.hoverURLStart = start
+	return true
+}
+
+func (ev *EditorView) urlLinksNearOffset(lineStart, lineEnd, rel int) []urlLink {
+	if lineEnd <= lineStart {
+		return nil
+	}
+	readStart, readEnd := lineStart, lineEnd
+	if readEnd-readStart > maxURLScanBytes {
+		readStart = lineStart + rel - 4096
+		if readStart < lineStart {
+			readStart = lineStart
+		}
+		readEnd = readStart + maxURLScanBytes
+		if readEnd > lineEnd {
+			readEnd = lineEnd
+			readStart = readEnd - maxURLScanBytes
+			if readStart < lineStart {
+				readStart = lineStart
+			}
+		}
+	}
+	data, err := ev.pt.GetRange(readStart, readEnd-readStart)
+	if err != nil {
+		return nil
+	}
+	links := findURLLinks(string(data))
+	base := readStart - lineStart
+	for i := range links {
+		links[i].Start += base
+		links[i].End += base
+	}
+	return links
+}
+
+func (ev *EditorView) urlLinksForLine(lineStart, lineEnd int) []urlLink {
+	if ev.hoverURL == "" || ev.hoverURLStart < lineStart || ev.hoverURLStart >= lineEnd {
+		return nil
+	}
+	return ev.urlLinksNearOffset(lineStart, lineEnd, ev.hoverURLStart-lineStart)
 }
 
 func (ev *EditorView) SetPosition(x1, y1, x2, y2 int) {

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -2588,6 +2588,18 @@ func (pf *PanelsFrame) processMiddleMouseGesture(e *vtinput.InputEvent) (handled
 func (pf *PanelsFrame) ProcessMouse(e *vtinput.InputEvent) bool {
 	// If panels are hidden, route relevant mouse events to PTY immediately
 	if !pf.showPanels {
+		mx, my := int(e.MouseX), int(e.MouseY)
+		if pf.termView != nil && e.WheelDirection == 0 {
+			if changed := pf.termView.UpdateURLHover(mx, my); changed {
+				vtui.FrameManager.Redraw()
+			}
+			if ctrlMouseClick(e) {
+				if rawURL, ok := pf.termView.URLAt(mx, my); ok {
+					openExternalURLAsync(rawURL)
+					return true
+				}
+			}
+		}
 		active := pf.getActivePTY()
 		if active != nil && (pf.termView.MouseTrackingMode != 0 || pf.termView.MouseSGRMode) {
 			seq := TranslateMouseInput(e)

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -95,6 +95,7 @@ type TerminalView struct {
 	selEndY    int
 	selBlock   bool
 	showOffset int // last vertical "visual gravity" offset applied in Show
+	hoverURL   string
 }
 
 func NewTerminalView(w, h int) *TerminalView {
@@ -915,7 +916,9 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 		}
 		// Проверка выхода за пределы экрана
 		if drawY >= tv.Y1 && drawY <= tv.Y1+tv.Height-1 {
-			scr.Write(tv.X1, drawY, line)
+			drawLine := append([]vtui.CharInfo(nil), line...)
+			applyURLHoverAttr(drawLine, urlCellRangesFromCells(line), tv.hoverURL)
+			scr.Write(tv.X1, drawY, drawLine)
 		}
 	}
 
@@ -1235,6 +1238,56 @@ func (tv *TerminalView) SelectLineAt(y int) {
 // terminal's visible viewport.
 func (tv *TerminalView) InTerminalArea(x, y int) bool {
 	return x >= tv.X1 && x <= tv.X1+tv.Width-1 && y >= tv.Y1 && y <= tv.Y1+tv.Height-1
+}
+
+func (tv *TerminalView) urlAtScreenCell(x, y int) (urlCellRange, bool) {
+	if !tv.InTerminalArea(x, y) {
+		return urlCellRange{}, false
+	}
+	row := tv.gridRowForScreenY(y)
+	if row < 0 {
+		return urlCellRange{}, false
+	}
+	buf := tv.Lines
+	if tv.UseAltScreen {
+		buf = tv.AltLines
+	}
+	if row >= len(buf) {
+		return urlCellRange{}, false
+	}
+	col := x - tv.X1
+	for _, link := range urlCellRangesFromCells(buf[row]) {
+		if col >= link.Start && col < link.End {
+			return link, true
+		}
+	}
+	return urlCellRange{}, false
+}
+
+// UpdateURLHover tracks the URL under the pointer without changing terminal
+// selection state. It returns true when a repaint is needed.
+func (tv *TerminalView) UpdateURLHover(x, y int) bool {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	var next string
+	if link, ok := tv.urlAtScreenCell(x, y); ok {
+		next = link.URL
+	}
+	if next == tv.hoverURL {
+		return false
+	}
+	tv.hoverURL = next
+	return true
+}
+
+func (tv *TerminalView) URLAt(x, y int) (string, bool) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	link, ok := tv.urlAtScreenCell(x, y)
+	if !ok {
+		return "", false
+	}
+	return link.URL, true
 }
 
 func (tv *TerminalView) Resize(w, h int) {

--- a/cmd/f4/url_links.go
+++ b/cmd/f4/url_links.go
@@ -1,0 +1,188 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// urlLink is a byte range in the text that contains one externally
+// launchable URL. End is exclusive.
+type urlLink struct {
+	Start int
+	End   int
+	URL   string
+}
+
+const maxURLScanBytes = 64 * 1024
+
+// URL-looking text is deliberately limited to web links. Terminal output is
+// untrusted input, so accepting arbitrary schemes here would make a click a
+// way to invoke custom URI handlers unexpectedly.
+var urlLinkPattern = regexp.MustCompile(`(?i)(?:https?://|www\.)[^\s<>"']+`)
+
+func findURLLinks(text string) []urlLink {
+	matches := urlLinkPattern.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	links := make([]urlLink, 0, len(matches))
+	for _, match := range matches {
+		start, end := match[0], match[1]
+		candidate := strings.TrimRight(text[start:end], ".,;:!?)]}")
+		if candidate == "" {
+			continue
+		}
+		if len(candidate) < end-start {
+			end = start + len(candidate)
+		}
+		launchURL := candidate
+		if strings.HasPrefix(strings.ToLower(launchURL), "www.") {
+			launchURL = "https://" + launchURL
+		}
+		if !validExternalURL(launchURL) {
+			continue
+		}
+		links = append(links, urlLink{Start: start, End: end, URL: launchURL})
+	}
+	return links
+}
+
+func validExternalURL(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
+func urlLinkAt(links []urlLink, byteOffset int) (urlLink, bool) {
+	for _, link := range links {
+		if byteOffset >= link.Start && byteOffset < link.End {
+			return link, true
+		}
+	}
+	return urlLink{}, false
+}
+
+// urlCellRange maps a byte-range link to the cells that display it. The
+// offsets slice has one entry per cell and points at that cell's byte offset
+// in text. It also works for tabs and wide-character filler cells.
+type urlCellRange struct {
+	Start int
+	End   int
+	URL   string
+}
+
+func urlCellRanges(text string, cellByteOffsets []int) []urlCellRange {
+	links := findURLLinks(text)
+	if len(links) == 0 || len(cellByteOffsets) == 0 {
+		return nil
+	}
+	ranges := make([]urlCellRange, 0, len(links))
+	for _, link := range links {
+		first, last := -1, -1
+		for i, offset := range cellByteOffsets {
+			if offset >= link.Start && offset < link.End {
+				if first == -1 {
+					first = i
+				}
+				last = i + 1
+			}
+		}
+		if first >= 0 {
+			ranges = append(ranges, urlCellRange{Start: first, End: last, URL: link.URL})
+		}
+	}
+	return ranges
+}
+
+func urlCellRangesFromCells(cells []vtui.CharInfo) []urlCellRange {
+	var text strings.Builder
+	offsets := make([]int, 0, len(cells))
+	for _, cell := range cells {
+		offsets = append(offsets, text.Len())
+		if cell.Char == vtui.WideCharFiller {
+			continue
+		}
+		ch := rune(cell.Char)
+		if ch == 0 {
+			ch = ' '
+		}
+		text.WriteRune(ch)
+	}
+	return urlCellRanges(text.String(), offsets)
+}
+
+func applyURLHoverAttr(cells []vtui.CharInfo, ranges []urlCellRange, hoveredURL string) {
+	if hoveredURL == "" {
+		return
+	}
+	for _, link := range ranges {
+		if link.URL != hoveredURL {
+			continue
+		}
+		start, end := link.Start, link.End
+		if start < 0 {
+			start = 0
+		}
+		if end > len(cells) {
+			end = len(cells)
+		}
+		for i := start; i < end; i++ {
+			cells[i].Attributes |= vtui.CommonLvbUnderscore
+		}
+	}
+}
+
+func ctrlMouseClick(e *vtinput.InputEvent) bool {
+	return e != nil && e.Type == vtinput.MouseEventType &&
+		e.ButtonState&vtinput.FromLeft1stButtonPressed != 0 && e.KeyDown &&
+		e.MouseEventFlags&vtinput.MouseMoved == 0 &&
+		e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0
+}
+
+// launchExternalURL is a variable so UI tests can verify the full click path
+// without starting a real browser.
+var launchExternalURL = launchExternalURLDefault
+
+func openExternalURL(raw string) error {
+	if !validExternalURL(raw) {
+		return fmt.Errorf("unsupported URL")
+	}
+	return launchExternalURL(raw)
+}
+
+func launchExternalURLDefault(raw string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "windows":
+		cmd = exec.Command("rundll32.exe", "url.dll,FileProtocolHandler", raw)
+	case "darwin":
+		cmd = exec.Command("open", raw)
+	default:
+		cmd = exec.Command("xdg-open", raw)
+	}
+	return cmd.Start()
+}
+
+func openExternalURLAsync(raw string) {
+	go func() {
+		if err := openExternalURL(raw); err != nil {
+			vtui.ShowToast(fmt.Sprintf("Cannot open URL: %v", err), 3*time.Second)
+		}
+	}()
+}

--- a/cmd/f4/url_links_test.go
+++ b/cmd/f4/url_links_test.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestFindURLLinks_TrimsPunctuationAndRejectsOtherSchemes(t *testing.T) {
+	links := findURLLinks(`see https://example.com/path?q=1. www.example.org, ftp://example.org`)
+	if len(links) != 2 {
+		t.Fatalf("got %d links, want 2: %#v", len(links), links)
+	}
+	if links[0].URL != "https://example.com/path?q=1" {
+		t.Errorf("first URL = %q", links[0].URL)
+	}
+	if links[1].URL != "https://www.example.org" {
+		t.Errorf("www URL = %q", links[1].URL)
+	}
+}
+
+func TestOpenExternalURL_OnlyAllowsWebURLs(t *testing.T) {
+	old := launchExternalURL
+	defer func() { launchExternalURL = old }()
+	var got string
+	launchExternalURL = func(raw string) error {
+		got = raw
+		return nil
+	}
+	if err := openExternalURL("https://example.org/a"); err != nil {
+		t.Fatalf("openExternalURL returned error: %v", err)
+	}
+	if got != "https://example.org/a" {
+		t.Fatalf("launcher received %q", got)
+	}
+	if err := openExternalURL("file:///etc/passwd"); err == nil {
+		t.Fatal("file URL was accepted")
+	}
+}
+
+func TestCtrlMouseClickRequiresLeftButtonAndCtrl(t *testing.T) {
+	base := &vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true}
+	if ctrlMouseClick(base) {
+		t.Fatal("plain mouse event was treated as Ctrl+click")
+	}
+	e := *base
+	e.ButtonState = vtinput.FromLeft1stButtonPressed
+	e.ControlKeyState = vtinput.LeftCtrlPressed
+	if !ctrlMouseClick(&e) {
+		t.Fatal("Ctrl+left click was not recognized")
+	}
+	e.MouseEventFlags = vtinput.MouseMoved
+	if ctrlMouseClick(&e) {
+		t.Fatal("drag event was treated as a click")
+	}
+}
+
+func TestEditorURLHoverAddsUnderlineOnlyToHoveredLink(t *testing.T) {
+	const text = "https://example.org"
+	links := findURLLinks(text)
+	ev := &EditorView{hoverURL: links[0].URL, TabSize: 8}
+	cells := ev.fillCellsWithLinks(nil, []byte(text), DefaultTermAttr, DefaultTermAttr, 0, false, 0, 0, nil, links, 0, false, -1, 0, 0, 0)
+	if len(cells) != len(text) {
+		t.Fatalf("rendered %d cells, want %d", len(cells), len(text))
+	}
+	for i, cell := range cells {
+		if cell.Attributes&vtui.CommonLvbUnderscore == 0 {
+			t.Errorf("cell %d was not underlined", i)
+		}
+	}
+	ev.hoverURL = "https://other.example"
+	cells = ev.fillCellsWithLinks(nil, []byte(text), DefaultTermAttr, DefaultTermAttr, 0, false, 0, 0, nil, links, 0, false, -1, 0, 0, 0)
+	for i, cell := range cells {
+		if cell.Attributes&vtui.CommonLvbUnderscore != 0 {
+			t.Errorf("cell %d was underlined for a different URL", i)
+		}
+	}
+}
+
+func TestTerminalURLHoverUnderlinesVisibleLink(t *testing.T) {
+	tv := NewTerminalView(40, 3)
+	defer tv.Close()
+	tv.SetPosition(0, 0, 39, 2)
+	tv.SetVisible(true)
+	for i, r := range "https://example.org" {
+		tv.Lines[0][i] = vtui.CharInfo{Char: uint64(r), Attributes: DefaultTermAttr}
+	}
+	if !tv.UpdateURLHover(4, 0) {
+		t.Fatal("hover state did not change")
+	}
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(40, 3)
+	SetDefaultF4Palette()
+	tv.Show(scr)
+	if scr.GetCell(4, 0).Attributes&vtui.CommonLvbUnderscore == 0 {
+		t.Fatal("hovered terminal URL was not underlined")
+	}
+	if tv.UpdateURLHover(30, 0) != true {
+		t.Fatal("moving off the URL did not clear hover state")
+	}
+}
+
+func TestViewerURLHoverMapsScreenCellToLink(t *testing.T) {
+	data := []byte("https://example.org\n")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	backend := &ViewerBackend{
+		file:      &vfs.MemoryReadAtCloser{Data: data},
+		size:      int64(len(data)),
+		cacheData: data,
+		ctx:       ctx,
+		cancelCtx: cancel,
+	}
+	vv := &ViewerView{backend: backend}
+	vv.SetPosition(0, 0, 39, 2)
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(40, 3)
+	vv.renderText(scr, 40, 2)
+
+	link, ok := vv.urlLinkAtMouse(4, 1)
+	if !ok || link.URL != "https://example.org" {
+		t.Fatalf("screen cell did not resolve URL: %#v, %v", link, ok)
+	}
+	if !vv.updateURLHover(4, 1) {
+		t.Fatal("viewer hover did not change")
+	}
+	vv.renderText(scr, 40, 2)
+	if scr.GetCell(4, 1).Attributes&vtui.CommonLvbUnderscore == 0 {
+		t.Fatal("hovered viewer URL was not underlined")
+	}
+}

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -36,6 +36,8 @@ type ViewerView struct {
 	// For Text mode: offsets of lines currently on screen
 	lineOffsets         []int64
 	rowCells            []vtui.CharInfo
+	visibleURLRows      [][]urlCellRange
+	hoverURL            string
 	eofVisible          bool
 	lastKnownSize       int64
 	lastSearch          string
@@ -406,11 +408,13 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 	attr := vtui.Palette[ColViewerText]
 	currOffset := vv.TopOffset
 	vv.lineOffsets = vv.lineOffsets[:0]
+	vv.visibleURLRows = vv.visibleURLRows[:0]
 	//lastRowWasEOF := false
 
 	for y := 0; y < contentHeight; y++ {
 		vv.lineOffsets = append(vv.lineOffsets, currOffset)
 		if currOffset >= vv.backend.Size() {
+			vv.visibleURLRows = append(vv.visibleURLRows, nil)
 			//lastRowWasEOF = true
 			break
 		}
@@ -418,14 +422,17 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 		// Read a generous chunk to handle wrapping
 		data, err := vv.backend.ReadAt(currOffset, width*4)
 		if err == piecetable.ErrLoading {
+			vv.visibleURLRows = append(vv.visibleURLRows, nil)
 			scr.Write(vv.X1, vv.Y1+1+y, vtui.StringToCharInfo(" [ Loading... ] ", attr))
 			break
 		}
 		if err != nil {
+			vv.visibleURLRows = append(vv.visibleURLRows, nil)
 			scr.Write(vv.X1, vv.Y1+1+y, vtui.StringToCharInfo(fmt.Sprintf(" [ Error: %v ] ", err), attr))
 			break
 		}
 		if len(data) == 0 {
+			vv.visibleURLRows = append(vv.visibleURLRows, nil)
 			break
 		}
 
@@ -470,8 +477,10 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 
 		// Build []vtui.CharInfo for the line
 		vv.rowCells = vv.rowCells[:0]
+		cellByteOffsets := make([]int, 0, textLen)
 		lineBytes := data[:textLen]
 		visualCol := 0
+		lineByteOffset := 0
 
 		for len(lineBytes) > 0 {
 			r, size := utf8.DecodeRune(lineBytes)
@@ -481,6 +490,7 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 				w := tabSize - (visualCol % tabSize)
 				for i := 0; i < w; i++ {
 					vv.rowCells = append(vv.rowCells, vtui.CharInfo{Char: ' ', Attributes: attr})
+					cellByteOffsets = append(cellByteOffsets, lineByteOffset)
 				}
 				visualCol += w
 			} else {
@@ -492,13 +502,18 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 					charVal := uint64(displayRune)
 					for i := 0; i < w; i++ {
 						vv.rowCells = append(vv.rowCells, vtui.CharInfo{Char: charVal, Attributes: attr})
+						cellByteOffsets = append(cellByteOffsets, lineByteOffset)
 						charVal = uint64(vtui.WideCharFiller)
 					}
 					visualCol += w
 				}
 			}
+			lineByteOffset += size
 		}
 
+		rowLinks := urlCellRanges(string(data[:textLen]), cellByteOffsets)
+		applyURLHoverAttr(vv.rowCells, rowLinks, vv.hoverURL)
+		vv.visibleURLRows = append(vv.visibleURLRows, rowLinks)
 		scr.Write(vv.X1, vv.Y1+1+y, vv.rowCells)
 		currOffset += int64(lineLen)
 
@@ -987,10 +1002,22 @@ func (vv *ViewerView) ProcessMouse(e *vtinput.InputEvent) bool {
 	if e.Type != vtinput.MouseEventType {
 		return false
 	}
+	if e.WheelDirection == 0 {
+		if changed := vv.updateURLHover(int(e.MouseX), int(e.MouseY)); changed {
+			vtui.FrameManager.Redraw()
+		}
+		if ctrlMouseClick(e) {
+			if link, ok := vv.urlLinkAtMouse(int(e.MouseX), int(e.MouseY)); ok {
+				openExternalURLAsync(link.URL)
+				return true
+			}
+		}
+	}
 	if vv.scrollBar != nil && vv.scrollBar.ProcessMouse(e) {
 		return true
 	}
 	if e.WheelDirection != 0 {
+		vv.hoverURL = ""
 		speed := AppConfig.WheelViewerDown
 		vk := uint16(vtinput.VK_DOWN)
 		if e.WheelDirection > 0 {
@@ -1003,6 +1030,35 @@ func (vv *ViewerView) ProcessMouse(e *vtinput.InputEvent) bool {
 		return true
 	}
 	return false
+}
+
+func (vv *ViewerView) urlLinkAtMouse(mx, my int) (urlCellRange, bool) {
+	if vv.HexMode || vv.DecodeMode || mx < vv.X1 || mx > vv.X2 || my < vv.Y1+1 || my > vv.Y2 {
+		return urlCellRange{}, false
+	}
+	row := my - (vv.Y1 + 1)
+	if row < 0 || row >= len(vv.visibleURLRows) {
+		return urlCellRange{}, false
+	}
+	col := mx - vv.X1
+	for _, link := range vv.visibleURLRows[row] {
+		if col >= link.Start && col < link.End {
+			return link, true
+		}
+	}
+	return urlCellRange{}, false
+}
+
+func (vv *ViewerView) updateURLHover(mx, my int) bool {
+	var next string
+	if link, ok := vv.urlLinkAtMouse(mx, my); ok {
+		next = link.URL
+	}
+	if next == vv.hoverURL {
+		return false
+	}
+	vv.hoverURL = next
+	return true
 }
 func (vv *ViewerView) ResizeConsole(w, h int) {
 	vv.SetPosition(0, vtui.FrameManager.WorkspaceTopInset(), w-1, h-2)


### PR DESCRIPTION
## Summary

- detect safe http/https and www URLs in the editor, viewer, and hidden-panels terminal
- underline the URL under the mouse and open it on Ctrl+left-click
- preserve normal clicks, scrolling, and terminal selection; use platform launchers without shell interpolation
- add parser, rendering, hover, click, and safety regression tests

## Validation

- `go test ./...`
- `go build -o C:\\Temp\\f4-459.exe ./cmd/f4`
- `GOOS=linux GOARCH=amd64 go test -c ./cmd/f4`
- native Windows 10 x64 attached ANSI run: opened a real file, moved the mouse over the URL, observed ANSI underline (`ESC[4m`), and sent Ctrl+left-click through the live PTY

zoin-bot
