### PR TITLE
fix: apply rename masks to path selections

### DIFF
--- a/cmd/f4/file_ops.go
+++ b/cmd/f4/file_ops.go
@@ -306,6 +306,27 @@ func transferItemName(srcVFS vfs.VFS, srcPath string, dstVFS vfs.VFS, fallback s
 	return name
 }
 
+// transferItemNameForMask applies a rename mask to the name that far2l would
+// feed to ConvertWildcards. A selected item can be represented by a path (for
+// example in a search or temporary panel), but the mask is applied to its
+// final component, not to a sanitized representation of that path. Providers
+// still get to supply their exported name, which may differ from the panel
+// label (for example document.gdoc -> document.docx).
+func transferItemNameForMask(srcVFS vfs.VFS, srcPath string, dstVFS vfs.VFS, fallback, mask string) string {
+	if provider, ok := srcVFS.(vfs.TransferNameProvider); ok {
+		if name := provider.TransferName(srcPath, dstVFS); name != "" && isSafeTransferItemName(dstVFS, name) {
+			return applyFileMask(name, mask)
+		}
+	}
+
+	// Do not call transferItemName here: when fallback contains a path it
+	// deliberately adds a hash after sanitizing the whole label to prevent
+	// collisions, while far2l discards that path before applying the mask.
+	base := srcVFS.Base(fallback)
+	base = safeTransferItemName(dstVFS, base)
+	return applyFileMask(base, mask)
+}
+
 func isSafeTransferItemName(dstVFS vfs.VFS, name string) bool {
 	if name == "" || name == "." || name == ".." || strings.ContainsRune(name, '\x00') || strings.ContainsAny(name, `/\\`) {
 		return false
@@ -646,9 +667,11 @@ func ExecuteFileOpAt(pf *PanelsFrame, srcVfs, dstVfs vfs.VFS, srcBasePath string
 			srcPath := srcVfs.Join(srcBasePath, name)
 			targetItemPath := destPath
 			if isTargetDir {
-				targetName := transferItemName(srcVfs, srcPath, dstVfs, name)
-				if mask != "" {
-					targetName = applyFileMask(targetName, mask)
+				var targetName string
+				if mask == "" {
+					targetName = transferItemName(srcVfs, srcPath, dstVfs, name)
+				} else {
+					targetName = transferItemNameForMask(srcVfs, srcPath, dstVfs, name, mask)
 				}
 				targetItemPath = dstVfs.Join(destPath, targetName)
 			}

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -515,6 +515,66 @@ func TestFileOp_PathLogic(t *testing.T) {
 		}
 	})
 }
+
+func TestExecuteFileOp_RenameMaskUsesBasenameForPathSelection(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	srcRoot := t.TempDir()
+	dstRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(srcRoot, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcRoot, "nested", "source.txt"), []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	srcVfs := vfs.NewOSVFS(srcRoot)
+	dstVfs := vfs.NewOSVFS(dstRoot)
+	ExecuteFileOpAt(nil, srcVfs, dstVfs, srcRoot, []string{"nested" + string(filepath.Separator) + "source.txt"}, filepath.Join(dstRoot, "masked", "*.bak"), false, 2, nil)
+
+	want := filepath.Join(dstRoot, "masked", "source.bak")
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(want); err == nil {
+			break
+		}
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if _, err := os.Stat(want); err != nil {
+		t.Fatalf("masked path selection was not copied to %q: %v", want, err)
+	}
+
+	entries, err := os.ReadDir(filepath.Join(dstRoot, "masked"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name() != "source.bak" {
+		t.Fatalf("masked destination entries = %#v, want only source.bak", entries)
+	}
+
+	ExecuteFileOpAt(nil, srcVfs, dstVfs, srcRoot, []string{"nested"}, filepath.Join(dstRoot, "tree", "*.bak"), false, 2, nil)
+	wantTreeFile := filepath.Join(dstRoot, "tree", "nested.bak", "source.txt")
+	deadline = time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(wantTreeFile); err == nil {
+			break
+		}
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if _, err := os.Stat(wantTreeFile); err != nil {
+		t.Fatalf("masked directory tree was not copied to %q: %v", wantTreeFile, err)
+	}
+}
+
 func TestExecuteFileOp_RemotePathResolution_Issue74(t *testing.T) {
 	// This test reproduces the bug where a Unix-style absolute path was treated
 	// as relative when running on a Windows host.

--- a/cmd/f4/file_ops_transfer_name_test.go
+++ b/cmd/f4/file_ops_transfer_name_test.go
@@ -71,6 +71,37 @@ func TestTransferItemNameSanitizesPortableInvalidNames(t *testing.T) {
 	}
 }
 
+func TestTransferItemNameForMaskUsesBasenameOfPathSelection(t *testing.T) {
+	source := vfs.NewOSVFS(t.TempDir())
+	destination := vfs.NewOSVFS(t.TempDir())
+
+	got := transferItemNameForMask(source, source.Join(source.GetPath(), "nested", "file.txt"), destination, "nested/file.txt", "*.bak")
+	if got != "file.bak" {
+		t.Fatalf("masked path selection = %q, want %q", got, "file.bak")
+	}
+}
+
+func TestTransferItemNameForMaskKeepsProviderExportName(t *testing.T) {
+	source := &transferNameOSVFS{OSVFS: vfs.NewOSVFS(t.TempDir())}
+	destination := vfs.NewOSVFS(t.TempDir())
+
+	got := transferItemNameForMask(source, source.Join(source.GetPath(), "document.gdoc [a1b2]"), destination, "document.gdoc [a1b2]", "*.bak")
+	if got != "document.bak" {
+		t.Fatalf("masked provider name = %q, want %q", got, "document.bak")
+	}
+}
+
+func TestTransferItemNameForMaskCanExposeFar2lNameCollision(t *testing.T) {
+	source := vfs.NewOSVFS(t.TempDir())
+	destination := vfs.NewOSVFS(t.TempDir())
+
+	first := transferItemNameForMask(source, "ab.txt", destination, "ab.txt", "?.bak")
+	second := transferItemNameForMask(source, "ac.txt", destination, "ac.txt", "?.bak")
+	if first != "a.bak" || second != first {
+		t.Fatalf("mask collision = %q and %q, want both %q", first, second, "a.bak")
+	}
+}
+
 func TestBulkCopyRequiresIdentityAfterNameSanitization(t *testing.T) {
 	source := vfs.NewOSVFS(t.TempDir())
 	destination := vfs.NewOSVFS(t.TempDir())


### PR DESCRIPTION
## Summary

- apply copy/move rename masks to the basename when a selected item includes a path;
- preserve VFS provider export names for masked transfers;
- cover path selections, masked directory trees, provider names, trailing-slash directory behavior, and far2l-style mask collisions with regression tests.

## Validation

- `go test ./...`
- native Windows `go build -o C:\Temp\f4-457.exe ./cmd/f4`
- native Windows masked file and directory-tree copy test
- `GOOS=linux GOARCH=amd64 go test -c ./cmd/f4`
- launched the built Windows ANSI binary in attached mode and opened a real file successfully

Far2l's behavior was checked for the two remaining edge cases: a trailing destination slash selects directory semantics, and mask collisions remain ordinary overwrite conflicts rather than being silently renamed.

— zoin-bot
