### PR TITLE
fix: keep panel path header color neutral

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -2256,9 +2256,6 @@ func (fp *FileSystemPanel) cursorSizeOnBottomBorder() string {
 func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 	fp.frame.Show(scr)
 	titleAttr := vtui.Palette[ColPanelTitle]
-	if fp.IsFocused() || fp.showInactiveCursor {
-		titleAttr = vtui.Palette[ColPanelSelectedTitle]
-	}
 	if fp.currentTitle != "" {
 		availW := (fp.X2 - fp.X1) - 6
 		if availW < 5 {

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -3047,7 +3047,7 @@ func TestFileSystemPanel_TitleDoesNotContainSortIndicator(t *testing.T) {
 	}
 }
 
-func TestFileSystemPanel_CurrentTitleUsesSelectedColor(t *testing.T) {
+func TestFileSystemPanel_CurrentTitleKeepsTheSameColorWhenFocused(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 24, v)
@@ -3072,8 +3072,8 @@ func TestFileSystemPanel_CurrentTitleUsesSelectedColor(t *testing.T) {
 
 	fp.SetFocus(true)
 	fp.Show(scr)
-	if got := scr.GetCell(3, 0).Attributes; got != vtui.Palette[ColPanelSelectedTitle] {
-		t.Fatalf("active title attributes = %#x; want %#x", got, vtui.Palette[ColPanelSelectedTitle])
+	if got := scr.GetCell(3, 0).Attributes; got != vtui.Palette[ColPanelTitle] {
+		t.Fatalf("active title attributes = %#x; want %#x", got, vtui.Palette[ColPanelTitle])
 	}
 
 	// Search-first keeps the current panel visually active while the command
@@ -3081,8 +3081,8 @@ func TestFileSystemPanel_CurrentTitleUsesSelectedColor(t *testing.T) {
 	fp.SetFocus(false)
 	fp.showInactiveCursor = true
 	fp.Show(scr)
-	if got := scr.GetCell(3, 0).Attributes; got != vtui.Palette[ColPanelSelectedTitle] {
-		t.Fatalf("current title with command-line focus attributes = %#x; want %#x", got, vtui.Palette[ColPanelSelectedTitle])
+	if got := scr.GetCell(3, 0).Attributes; got != vtui.Palette[ColPanelTitle] {
+		t.Fatalf("current title with command-line focus attributes = %#x; want %#x", got, vtui.Palette[ColPanelTitle])
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep the current panel path in the neutral panel-title color even when the panel is focused
- preserve active cursor, borders, tabs, and selected colors for other panel elements
- update the ScreenBuf regression test for focused and command-line-search states

## Validation

- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- native ARM64 build
- Windows amd64 CGO=0 build
- real ANSI PTY launch at 120x30 and clean F10+Enter exit

— zoin-bot