### PR TITLE
fix: show trash setting in Panel settings (#631)

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -2860,7 +2860,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	// display options live in actionPanelAdditionalSettings below. Keeping both
 	// pages as ordinary dialogs means they remain usable on a 25-row terminal
 	// without introducing a second scrolling container for interactive items.
-	dlg := vtui.NewCenteredDialog(60, 23, Msg("PanelSettings.Title"))
+	dlg := vtui.NewCenteredDialog(60, 24, Msg("PanelSettings.Title"))
 	dlg.ShowClose = true
 
 	chkHidden := vtui.NewCheckbox(0, 0, Msg("PanelSettings.ShowHidden"), false)
@@ -2912,6 +2912,10 @@ func actionPanelSettings(pf *PanelsFrame) {
 		chkAutoSave.State = 1
 	}
 
+	chkUseTrash := vtui.NewCheckbox(0, 0, Msg("PanelSettings.UseTrash"), false)
+	if AppConfig.UseTrash {
+		chkUseTrash.State = 1
+	}
 	chkCmdAc := vtui.NewCheckbox(0, 0, Msg("PanelSettings.CommandLineAutoComplete"), false)
 	chkCmdAc.State = 0
 	if AppConfig.CommandLineAutoComplete {
@@ -2953,6 +2957,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(comboScrollbars)
 	dlg.AddItem(chkPaths)
 	dlg.AddItem(chkAutoSave)
+	dlg.AddItem(chkUseTrash)
 	dlg.AddItem(chkCmdAc)
 	dlg.AddItem(lblNavigation)
 	dlg.AddItem(navigation)
@@ -2961,7 +2966,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
 
-	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 19)
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 20)
 	// First checkbox cluster — stack tight, no blank rows between.
 	vbox.Add(chkHidden, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkDirPrefix, vtui.Margins{}, vtui.AlignLeft)
@@ -2977,6 +2982,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 	// Second checkbox cluster.
 	vbox.Add(chkPaths, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(chkAutoSave, vtui.Margins{}, vtui.AlignLeft)
+	vbox.Add(chkUseTrash, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkCmdAc, vtui.Margins{}, vtui.AlignLeft)
 	// Navigation radio group — its own visual island.
 	vbox.Add(lblNavigation, vtui.Margins{Top: 1}, vtui.AlignLeft)
@@ -3002,6 +3008,7 @@ func actionPanelSettings(pf *PanelsFrame) {
 		AppConfig.PanelScrollbarMode = PanelScrollbarMode(comboScrollbars.Menu.SelectPos)
 		AppConfig.SavePanelPaths = chkPaths.State == 1
 		AppConfig.AutoSaveSettings = chkAutoSave.State == 1
+		AppConfig.UseTrash = chkUseTrash.State == 1
 		AppConfig.CommandLineAutoComplete = chkCmdAc.State == 1
 		pf.cmdLine.Edit.PathHintsEnabled = AppConfig.CommandLineAutoComplete
 		AppConfig.NavigationMode = PanelNavigationMode(navigation.Selected)
@@ -3203,11 +3210,6 @@ func actionConfirmationsSettings(pf *PanelsFrame) {
 		chkDelete.State = 1
 	}
 
-	chkUseTrash := vtui.NewCheckbox(0, 0, Msg("ConfirmationsSettings.UseTrash"), false)
-	if AppConfig.UseTrash {
-		chkUseTrash.State = 1
-	}
-
 	chkExit := vtui.NewCheckbox(0, 0, Msg("ConfirmationsSettings.Exit"), false)
 	chkExit.State = 0
 	if AppConfig.ConfirmExit {
@@ -3227,7 +3229,6 @@ func actionConfirmationsSettings(pf *PanelsFrame) {
 	dlg.AddItem(chkCopy)
 	dlg.AddItem(chkMove)
 	dlg.AddItem(chkDelete)
-	dlg.AddItem(chkUseTrash)
 	dlg.AddItem(chkExit)
 	dlg.AddItem(chkDelFocus)
 	dlg.AddItem(btnOk)
@@ -3237,7 +3238,6 @@ func actionConfirmationsSettings(pf *PanelsFrame) {
 	vbox.Add(chkCopy, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkMove, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkDelete, vtui.Margins{}, vtui.AlignLeft)
-	vbox.Add(chkUseTrash, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkExit, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(chkDelFocus, vtui.Margins{}, vtui.AlignLeft)
 
@@ -3255,7 +3255,6 @@ func actionConfirmationsSettings(pf *PanelsFrame) {
 		AppConfig.ConfirmCopy = chkCopy.State == 1
 		AppConfig.ConfirmMove = chkMove.State == 1
 		AppConfig.ConfirmDelete = chkDelete.State == 1
-		AppConfig.UseTrash = chkUseTrash.State == 1
 		AppConfig.ConfirmExit = chkExit.State == 1
 		AppConfig.DeleteCancelFocused = chkDelFocus.State == 1
 		SaveConfig()

--- a/cmd/f4/issue631_test.go
+++ b/cmd/f4/issue631_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestIssue631TrashSettingIsInPanelSettings(t *testing.T) {
+	oldConfig := AppConfig
+	defer func() { AppConfig = oldConfig }()
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	AppConfig.UseTrash = true
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	actionPanelSettings(pf)
+	panelFrame := vtui.FrameManager.GetTopFrame()
+	panelDialog := panelFrame.(vtui.Container)
+	wantText := getCleanText(vtui.NewCheckbox(0, 0, Msg("PanelSettings.UseTrash"), false))
+
+	var trashCheckbox *vtui.Checkbox
+	for _, child := range panelDialog.GetChildren() {
+		if checkbox, ok := child.(*vtui.Checkbox); ok && getCleanText(checkbox) == wantText {
+			trashCheckbox = checkbox
+			break
+		}
+	}
+	if trashCheckbox == nil {
+		t.Fatalf("trash setting %q is missing from Panel Settings", wantText)
+	}
+	if trashCheckbox.State != 1 {
+		t.Fatalf("trash setting state = %d, want enabled state from AppConfig", trashCheckbox.State)
+	}
+
+	panelFrame.SetExitCode(-1)
+	vtui.FrameManager.Pop()
+	actionConfirmationsSettings(pf)
+	confirmationsFrame := vtui.FrameManager.GetTopFrame()
+	confirmationsDialog := confirmationsFrame.(vtui.Container)
+	for _, child := range confirmationsDialog.GetChildren() {
+		if checkbox, ok := child.(*vtui.Checkbox); ok && getCleanText(checkbox) == wantText {
+			t.Fatalf("trash setting %q is duplicated in Confirmations Settings", wantText)
+		}
+	}
+	confirmationsFrame.SetExitCode(-1)
+	vtui.FrameManager.Pop()
+}

--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -561,6 +561,7 @@ PanelSettings.ScrollbarsMinimal=Minimal
 PanelSettings.ScrollbarsFull=Full
 PanelSettings.SavePaths=Save panel &paths on exit
 PanelSettings.AutoSave=Automatically save settings
+PanelSettings.UseTrash=Use the &trash for F8 deletion
 PanelSettings.KeepCursor=Don't touch terminal &cursor style
 PanelSettings.Navigation=&Navigation:
 PanelSettings.NavigationClassic=&Classic
@@ -759,7 +760,6 @@ ConfirmationsSettings.Title= Confirmations
 ConfirmationsSettings.Copy=Confirm on &copy
 ConfirmationsSettings.Move=Confirm on &move
 ConfirmationsSettings.Delete=Confirm on &delete
-ConfirmationsSettings.UseTrash=Use the &trash for F8 deletion
 ConfirmationsSettings.DeleteCancelFocused=Focus '&Cancel' in delete confirmations
 ConfirmationsSettings.Exit=Confirm on e&xit
 

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -553,6 +553,7 @@ PanelSettings.ScrollbarsMinimal=Минимальные
 PanelSettings.ScrollbarsFull=Полные
 PanelSettings.SavePaths=Сохранять &пути панелей при выходе
 PanelSettings.AutoSave=Автоматически сохранять настройки
+PanelSettings.UseTrash=Использовать &корзину при удалении по F8
 PanelSettings.KeepCursor=Не трогать стиль &курсора терминала
 PanelSettings.Navigation=&Навигация:
 PanelSettings.NavigationClassic=&Классическая
@@ -748,7 +749,6 @@ ConfirmationsSettings.Title= Подтверждения
 ConfirmationsSettings.Copy=Подтверждать &копирование
 ConfirmationsSettings.Move=Подтверждать &перенос
 ConfirmationsSettings.Delete=Подтверждать &удаление
-ConfirmationsSettings.UseTrash=Использовать &корзину при удалении по F8
 ConfirmationsSettings.DeleteCancelFocused=Фокусировать «&Отмена» в подтверждении удаления
 ConfirmationsSettings.Exit=Подтверждать в&ыход
 


### PR DESCRIPTION
## Summary
- move the persistent UseTrash option from Confirmations Settings into Panel Settings
- keep the existing config and delete behavior unchanged
- add English/Russian labels and a regression test covering placement and state
- increase the settings dialog height by one row so every shipped locale remains inside the frame

## Validation
- go test ./...
- native Windows 10 x64 build and --version smoke
- native Win32 UI: opened Panel settings through the command palette and verified the trash checkbox is visible

Fixes #631