### PR TITLE
fix: report stalled update downloads (#635)

### DIFF
--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -43,6 +43,10 @@ var (
 	currentOS    = runtime.GOOS
 	currentArch  = runtime.GOARCH
 
+	// zoin-bot: fail a stalled release download instead of leaving the
+	// progress screen without an answer after the network disappears.
+	updateDownloadIdleTimeout = 30 * time.Second
+
 	// sessionDismissedUpdateKey remembers which update the user
 	// declined during the current f4 session, so an interval-driven
 	// auto-check does not re-prompt for the same version this run.
@@ -50,6 +54,37 @@ var (
 	// see #374 — and a manual "Check for updates" always ignores it.
 	sessionDismissedUpdateKey string
 )
+
+type updateReadResult struct {
+	n   int
+	err error
+}
+
+// readUpdateChunk bounds the time spent waiting for the next download chunk.
+// Closing the response body in the caller releases a reader that is still
+// blocked when the timeout or task cancellation wins the select.
+func readUpdateChunk(ctx context.Context, r io.Reader, buf []byte) (int, error) {
+	if updateDownloadIdleTimeout <= 0 {
+		return r.Read(buf)
+	}
+
+	result := make(chan updateReadResult, 1)
+	go func() {
+		n, err := r.Read(buf)
+		result <- updateReadResult{n: n, err: err}
+	}()
+
+	timer := time.NewTimer(updateDownloadIdleTimeout)
+	defer timer.Stop()
+	select {
+	case res := <-result:
+		return res.n, res.err
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-timer.C:
+		return 0, fmt.Errorf("update download stalled for %s", updateDownloadIdleTimeout)
+	}
+}
 
 func getCurrentVersion() string {
 	api := &coreAPI{}
@@ -317,7 +352,7 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			if ctx.Err() != nil {
 				return ctx.Err()
 			}
-			n, readErr := resp.Body.Read(buf)
+			n, readErr := readUpdateChunk(ctx, resp.Body, buf)
 			if n > 0 {
 				archiveData.Write(buf[:n])
 				downloaded += int64(n)

--- a/cmd/f4/updater_issue635_test.go
+++ b/cmd/f4/updater_issue635_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/unxed/vtui"
+)
+
+func TestIssue635NetworkDropWhileProgressScreenIsBackground(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	oldTimeout := updateDownloadIdleTimeout
+	updateDownloadIdleTimeout = 50 * time.Millisecond
+	defer func() { updateDownloadIdleTimeout = oldTimeout }()
+	tmpDir := t.TempDir()
+	exePath := filepath.Join(tmpDir, "f4")
+	if err := os.WriteFile(exePath, []byte("old"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldExe := osExecutable
+	osExecutable = func() (string, error) { return exePath, nil }
+	defer func() { osExecutable = oldExe }()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "100")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	performUpdate(pf, ts.URL, "zip", "v9.9.9", "2026-08-22")
+
+	backgrounded := false
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			if !backgrounded && len(vtui.FrameManager.Screens) > 1 {
+				vtui.FrameManager.SwitchScreen(0)
+				backgrounded = true
+			}
+			top := vtui.FrameManager.GetTopFrame()
+			if backgrounded && top != nil && top.GetTitle() == " Update Failed " {
+				return
+			}
+		case <-deadline:
+			t.Fatalf("update failure message was not shown after backgrounding progress screen; backgrounded=%v active=%d screens=%d", backgrounded, vtui.FrameManager.ActiveIdx, len(vtui.FrameManager.Screens))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a 30-second idle timeout while reading release archive data
- surface stalled downloads through the existing Update Failed dialog instead of leaving a background progress screen unresolved
- add a regression test for a network drop after Ctrl+Tab moves the update progress screen to the background

## Validation
- `go test ./...`
- targeted updater and regression tests
- native Windows 10 x64 build and `--version` smoke

Fixes #635