### PR TITLE
fix: disable editor wrapping for unsafe data

### DIFF
--- a/cmd/f4/action_registry.go
+++ b/cmd/f4/action_registry.go
@@ -2164,6 +2164,14 @@ func init() {
 		MenuPath:    "Options",
 		Checked:     editorState(func(ev *EditorView) bool { return ev.WordWrap }),
 		Handler: withEditor(func(ev *EditorView) {
+			if ev.wordWrapSuppressed {
+				ev.WordWrap = false
+				return
+			}
+			if !ev.WordWrap && ev.currentLineUnsafeForWordWrap() {
+				ev.disableUnsafeWordWrap()
+				return
+			}
 			ev.WordWrap = !ev.WordWrap
 			ev.ScrollLeft = 0
 			ev.clearCaches()

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -65,18 +65,19 @@ type EditorView struct {
 	ScrollTopRow int // Индекс первой видимой ВИЗУАЛЬНОЙ строки
 	ScrollLeft   int // Горизонтальный скролл (когда WordWrap=false)
 
-	WordWrap         bool
-	HexMode          bool
-	DecodeMode       bool
-	HexTopOffset     int
-	HexNibble        int // 0 = high nibble, 1 = low nibble
-	DisasmMode       int // 16, 32, or 64
-	overtype         bool
-	modified         bool
-	closeDlg         *vtui.Window
-	CursorLine       int // Текущая логическая строка (для плагинов)
-	CursorPos        int // Позиция в байтах (для плагинов)
-	DesiredVisualCol int // Колонка, в которую мы хотим попасть при навигации Up/Down
+	WordWrap           bool
+	wordWrapSuppressed bool // Unsafe binary/long-line content forbids re-enabling wrapping.
+	HexMode            bool
+	DecodeMode         bool
+	HexTopOffset       int
+	HexNibble          int // 0 = high nibble, 1 = low nibble
+	DisasmMode         int // 16, 32, or 64
+	overtype           bool
+	modified           bool
+	closeDlg           *vtui.Window
+	CursorLine         int // Текущая логическая строка (для плагинов)
+	CursorPos          int // Позиция в байтах (для плагинов)
+	DesiredVisualCol   int // Колонка, в которую мы хотим попасть при навигации Up/Down
 
 	ShowWhitespaces  bool
 	selActive        bool
@@ -2649,6 +2650,9 @@ func (ev *EditorView) ensureCursorVisible() {
 	if ev.targetLine != -1 {
 		return // Skip clamping and scrolling while waiting for the target line to be indexed
 	}
+	if ev.WordWrap && ev.currentLineUnsafeForWordWrap() {
+		ev.disableUnsafeWordWrap()
+	}
 
 	if ev.HexMode || ev.DecodeMode {
 		height := ev.Y2 - ev.Y1
@@ -3013,20 +3017,23 @@ func (ev *EditorView) StartIndexing() {
 		ev.targetLine = -1
 		return
 	}
-	// A mapped file has no chunk buffer and needs indexing just the same, so
-	// the question is whether there is any text at all, not how it is backed.
-	if ev.asyncBuf == nil && ev.mapped == nil {
-		// Fully read files (non-UTF-8 codepages) have a complete index and no
-		// scan; resolve a pending restore here or Loading waits forever.
-		ev.restoreTargetPos()
-		return
-	}
 	if ev.indexCancel != nil {
 		ev.indexCancel()
 	}
-
 	ev.retireEditSession()
 	sessionID := ev.editSession
+	ev.probeUnsafeWordWrap()
+	// Mapped and fully decoded files already have their line index; they still
+	// need the safety scan before wrapping can be enabled.
+	if ev.asyncBuf == nil {
+		// Fully read files (non-UTF-8 codepages) have a complete index and no
+		// line scan; resolve a pending restore here or Loading waits forever.
+		ev.restoreTargetPos()
+		ctx, cancel := context.WithCancel(context.Background())
+		ev.indexCancel = cancel
+		go ev.scanFullyReadForUnsafeWordWrap(ctx, sessionID)
+		return
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	ev.indexCancel = cancel
@@ -3085,8 +3092,10 @@ func (ev *EditorView) StartIndexing() {
 		if indexer, ok := ev.vfs.(vfs.LineIndexer); ok && ev.Codepage == 65001 {
 			vtui.DebugLog("EDITOR_INDEX: Using remote LineIndexer")
 			var currentLine int64 = int64(li.LineCount() + 1)
+			remoteLineStart := int64(li.GetLineOffset(li.LineCount() - 1))
 			const batchSize = 100000
 			remoteSuccess := true
+			wrapUnsafe := false
 			for {
 				if ctx.Err() != nil || ev.IsDone() {
 					return
@@ -3099,6 +3108,16 @@ func (ev *EditorView) StartIndexing() {
 				}
 
 				if len(res.Offsets) > 0 {
+					for _, off := range res.Offsets {
+						if editorWrapIntervalUnsafe(remoteLineStart, off) {
+							if !wrapUnsafe {
+								ev.postUnsafeWordWrap(sessionID, ctx)
+								wrapUnsafe = true
+							}
+							break
+						}
+						remoteLineStart = off
+					}
 					batchOffsets := make([]int, 0, len(res.Offsets))
 					for _, off := range res.Offsets {
 						batchOffsets = append(batchOffsets, int(off))
@@ -3133,6 +3152,9 @@ func (ev *EditorView) StartIndexing() {
 			}
 
 			if remoteSuccess {
+				if editorWrapIntervalUnsafe(remoteLineStart, int64(maxSize)) && !wrapUnsafe {
+					ev.postUnsafeWordWrap(sessionID, ctx)
+				}
 				scannedTo.Store(int64(maxSize))
 				vtui.FrameManager.PostTask(func() {
 					if ctx.Err() == nil && ev.editSession == sessionID {
@@ -3162,6 +3184,8 @@ func (ev *EditorView) StartIndexing() {
 		chunkSize := 256 * 1024 // 256KB chunks to match AsyncBuffer
 
 		pendingOffsets := make([]int, 0, 10000)
+		lineLen := 0
+		wrapUnsafe := false
 
 		for absPos < maxSize {
 			select {
@@ -3205,6 +3229,12 @@ func (ev *EditorView) StartIndexing() {
 			poll = indexPollMin
 			if err != nil {
 				break
+			}
+			var unsafe bool
+			lineLen, unsafe = scanEditorWrapSafety(data, lineLen)
+			if unsafe && !wrapUnsafe {
+				ev.postUnsafeWordWrap(sessionID, ctx)
+				wrapUnsafe = true
 			}
 
 			// Fast SIMD-accelerated newline scanning using bytes.IndexByte
@@ -3667,9 +3697,6 @@ func (ev *EditorView) scheduleIndexResume() {
 	ev.indexResume = time.AfterFunc(indexResumeDelay, func() {
 		vtui.FrameManager.PostTask(func() {
 			if ev.IsDone() || ev.indexing || ev.indexIsComplete() {
-				return
-			}
-			if ev.asyncBuf == nil && ev.mapped == nil {
 				return
 			}
 			ev.StartIndexing()

--- a/cmd/f4/editor_wrap_safety.go
+++ b/cmd/f4/editor_wrap_safety.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/vtui"
+)
+
+// Word wrapping turns one logical line into many visual fragments. Beyond
+// this size the editor's text layout and highlighter deliberately stop
+// expanding the line, so keeping wrapping enabled would make the view both
+// misleading and unnecessarily expensive.
+const maxWordWrapLineBytes = 64 * 1024
+
+// scanEditorWrapSafety consumes one piece-table chunk. lineLen is the number
+// of bytes already seen on the current logical line; it is returned so a
+// caller can carry the value across chunk boundaries.
+//
+// NUL is included here because it is the editor's binary-data marker for all
+// codepages after decoding. Files with a NUL late in the file can therefore
+// still be protected even when the opening header looked like text.
+func scanEditorWrapSafety(data []byte, lineLen int) (nextLineLen int, unsafe bool) {
+	if bytes.IndexByte(data, 0) >= 0 {
+		return lineLen, true
+	}
+
+	for len(data) > 0 {
+		idx := bytes.IndexByte(data, '\n')
+		if idx < 0 {
+			lineLen += len(data)
+			return lineLen, lineLen > maxWordWrapLineBytes
+		}
+		if lineLen+idx > maxWordWrapLineBytes {
+			return lineLen + idx, true
+		}
+		lineLen = 0
+		data = data[idx+1:]
+	}
+	return lineLen, false
+}
+
+// editorWrapIntervalUnsafe checks a line when a remote VFS has supplied only
+// its line-start offsets. The byte before the next offset is the newline, so
+// it is not part of the logical line length.
+func editorWrapIntervalUnsafe(lineStart, nextLineStart int64) bool {
+	return nextLineStart > lineStart && nextLineStart-lineStart-1 > maxWordWrapLineBytes
+}
+
+func (ev *EditorView) disableUnsafeWordWrap() {
+	if ev.wordWrapSuppressed {
+		return
+	}
+	ev.wordWrapSuppressed = true
+	if ev.WordWrap {
+		ev.WordWrap = false
+		ev.ScrollLeft = 0
+		ev.clearCaches()
+		ev.ensureCursorVisible()
+	}
+	vtui.FrameManager.Redraw()
+}
+
+func (ev *EditorView) postUnsafeWordWrap(sessionID int, ctx context.Context) {
+	vtui.FrameManager.PostTask(func() {
+		if ctx.Err() != nil || ev.editSession != sessionID || ev.IsDone() {
+			return
+		}
+		ev.disableUnsafeWordWrap()
+	})
+}
+
+// probeUnsafeWordWrap avoids painting the first screen with wrapping enabled
+// when the beginning of the file already proves that wrapping is unsafe.
+func (ev *EditorView) probeUnsafeWordWrap() bool {
+	take := min(maxWordWrapLineBytes+1, ev.pt.Size())
+	if take == 0 {
+		return false
+	}
+	data, ok := ev.pt.View(0, take)
+	if !ok {
+		var err error
+		data, err = ev.pt.GetRange(0, take)
+		if err != nil {
+			return false
+		}
+	}
+	_, unsafe := scanEditorWrapSafety(data, 0)
+	if unsafe {
+		ev.disableUnsafeWordWrap()
+	}
+	return unsafe
+}
+
+func (ev *EditorView) currentLineUnsafeForWordWrap() bool {
+	if ev.CursorLine < 0 || ev.CursorLine >= ev.li.LineCount() {
+		return false
+	}
+	// The last line in a lazy buffer may still be an unindexed prefix of the
+	// whole file. Its apparent length is therefore not a real line length yet.
+	if ev.asyncBuf != nil && !ev.indexIsComplete() && ev.CursorLine == ev.li.LineCount()-1 {
+		return false
+	}
+	lineLen := ev.getLineLength(ev.CursorLine)
+	if lineLen > maxWordWrapLineBytes {
+		return true
+	}
+	start := ev.li.GetLineOffset(ev.CursorLine)
+	data, err := ev.pt.GetRange(start, lineLen)
+	return err == nil && bytes.IndexByte(data, 0) >= 0
+}
+
+// scanFullyReadForUnsafeWordWrap covers codepage-decoded files. Those files
+// do not need a line-index scan, but they still need the same safety check as
+// lazily loaded UTF-8 files before the user can enable wrapping.
+func (ev *EditorView) scanFullyReadForUnsafeWordWrap(ctx context.Context, sessionID int) {
+	const chunkSize = 256 * 1024
+	lineLen := 0
+	for pos := 0; pos < ev.pt.Size(); {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		if ev.IsDone() {
+			return
+		}
+
+		take := min(chunkSize, ev.pt.Size()-pos)
+		data, ok := ev.pt.View(pos, take)
+		if !ok {
+			var err error
+			data, err = ev.pt.GetRange(pos, take)
+			if err != nil {
+				if err == piecetable.ErrLoading {
+					continue
+				}
+				return
+			}
+		}
+		var unsafe bool
+		lineLen, unsafe = scanEditorWrapSafety(data, lineLen)
+		if unsafe {
+			ev.postUnsafeWordWrap(sessionID, ctx)
+			return
+		}
+		pos += len(data)
+	}
+}

--- a/cmd/f4/editor_wrap_safety_test.go
+++ b/cmd/f4/editor_wrap_safety_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/unxed/f4/piecetable"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestScanEditorWrapSafety(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		line   int
+		unsafe bool
+	}{
+		{name: "short line", data: []byte("short\ntext"), unsafe: false},
+		{name: "long first line", data: []byte(strings.Repeat("x", maxWordWrapLineBytes+1)), unsafe: true},
+		{name: "long later line", data: []byte("first\n" + strings.Repeat("x", maxWordWrapLineBytes+1)), unsafe: true},
+		{name: "binary marker", data: []byte("text\x00after"), unsafe: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, unsafe := scanEditorWrapSafety(test.data, test.line)
+			if unsafe != test.unsafe {
+				t.Fatalf("unsafe = %v, want %v", unsafe, test.unsafe)
+			}
+		})
+	}
+
+	// A line may cross the 256 KiB indexing chunks or any smaller VFS window.
+	lineLen, unsafe := scanEditorWrapSafety([]byte(strings.Repeat("x", maxWordWrapLineBytes)), 0)
+	if unsafe {
+		t.Fatal("exactly-threshold prefix must still be safe")
+	}
+	_, unsafe = scanEditorWrapSafety([]byte("x\n"), lineLen)
+	if !unsafe {
+		t.Fatal("line crossing a chunk boundary must be detected")
+	}
+
+	if !editorWrapIntervalUnsafe(0, maxWordWrapLineBytes+2) {
+		t.Fatal("remote line offset must detect a line longer than the limit")
+	}
+	if editorWrapIntervalUnsafe(0, maxWordWrapLineBytes+1) {
+		t.Fatal("remote line offset must accept a line exactly at the limit")
+	}
+}
+
+func TestEditorView_UnsafeWordWrapCannotBeReenabled(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	ev := NewEditorView(piecetable.New([]byte("text")), nil, "")
+	defer ev.Close()
+	ev.WordWrap = true
+	ev.ScrollLeft = 7
+
+	ev.disableUnsafeWordWrap()
+	if ev.WordWrap {
+		t.Fatal("unsafe content must turn word wrap off")
+	}
+	if ev.ScrollLeft != 0 {
+		t.Fatalf("horizontal scroll = %d, want 0 after disabling wrap", ev.ScrollLeft)
+	}
+
+	pressKey(ev, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F3,
+	})
+	if ev.WordWrap {
+		t.Fatal("F3 must not re-enable word wrap for unsafe content")
+	}
+}
+
+func TestEditorView_StartIndexingFindsUnsafeLaterLine(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	drainPendingTasks()
+
+	content := "first\n" + strings.Repeat("x", maxWordWrapLineBytes+1)
+	ev := NewEditorView(piecetable.New([]byte(content)), nil, "")
+	defer ev.Close()
+	ev.WordWrap = true
+
+	ev.StartIndexing()
+
+	timeout := time.After(2 * time.Second)
+	for !ev.wordWrapSuppressed {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			t.Fatal("unsafe later line was not detected")
+		}
+	}
+	if ev.WordWrap {
+		t.Fatal("later unsafe line must disable word wrap")
+	}
+}


### PR DESCRIPTION
## Summary
- detect NUL bytes and logical text lines longer than 64 KiB across local, mapped, decoded, and remote-indexed editor buffers
- disable and lock word wrap for unsafe files while preserving horizontal scrolling
- add regression coverage for chunk boundaries, remote offsets, later lines, and F3 re-enable attempts

## Validation
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- native ARM64 build
- real ARM64/KDE Wayland TTY smoke test opening a 65,537-byte line

— zoin-bot