### PR TITLE
test: cover file operations and OSVFS contracts

### DIFF
--- a/cmd/f4/file_ops_coverage_test.go
+++ b/cmd/f4/file_ops_coverage_test.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+type coverageTaskReporter struct {
+	scans      int
+	cancelled  bool
+	lastAction string
+	lastName   string
+	lastPct    int
+	totalText  string
+	totalPct   int
+	speedText  string
+}
+
+func (r *coverageTaskReporter) UpdateScan(_ string, _, _ int64) { r.scans++ }
+func (r *coverageTaskReporter) IsCancelled() bool               { return r.cancelled }
+func (r *coverageTaskReporter) UpdateTransfer(action, name string, pct int, total string, totalPct int, speed string) {
+	r.lastAction = action
+	r.lastName = name
+	r.lastPct = pct
+	r.totalText = total
+	r.totalPct = totalPct
+	r.speedText = speed
+}
+
+func TestGlobalAwareReporterCoversDelegationAndCommitPhases(t *testing.T) {
+	original := &coverageTaskReporter{}
+	tracker := NewFileOpTracker(vfs.OpStats{Files: 1, Bytes: 1000})
+	accounted := 0
+	reporter := &globalAwareReporter{
+		original: original,
+		tracker:  tracker,
+		getGlobal: func(string) (string, int, string) {
+			return "Total: 1 KB / 1 KB", 50, "global speed"
+		},
+		onBytes: func(n int) { accounted += n },
+	}
+
+	reporter.StartFileKnown("cross-cloud.bin", 0, false, 2, 1)
+	reporter.SetCurrentSize(1000)
+	reporter.SetCurrentSize(0)
+	reporter.UpdateBytes(-1)
+	reporter.UpdateBytes(100)
+	reporter.UpdateTransfer("Uploading", "cross-cloud.bin", 40, "commit", 40, "local speed")
+
+	if original.lastAction != "Uploading" || original.lastName != "cross-cloud.bin (commit)" {
+		t.Fatalf("delegated transfer = %#v", original)
+	}
+	if original.totalPct != 50 || original.totalText != "Total: 1 KB / 1 KB" || original.speedText != "global speed" {
+		t.Fatalf("global progress was not preserved: %#v", original)
+	}
+	if accounted != 500 {
+		t.Fatalf("accounted phase bytes = %d, want 500", accounted)
+	}
+
+	reporter.UpdateScan("/tmp", 2, 1)
+	if original.scans != 1 || reporter.IsCancelled() {
+		t.Fatalf("delegation state = scans %d cancelled %v", original.scans, reporter.IsCancelled())
+	}
+	reporter.FileSkipped()
+	reporter.DirDone()
+	processed, _ := tracker.GetStats()
+	if processed.Files != 1 || processed.Dirs != 1 {
+		t.Fatalf("processed stats = %#v", processed)
+	}
+
+	reporter.StartFile("download.bin", 1000)
+	reporter.UpdateTransfer("Downloading", "download.bin", 25, "", 25, "")
+	before := accounted
+	reporter.UpdateBytes(100)
+	if accounted != before {
+		t.Fatal("provider-owned download bytes were counted a second time")
+	}
+	original.cancelled = true
+	if !reporter.IsCancelled() {
+		t.Fatal("cancellation was not delegated")
+	}
+}
+
+func TestFileOperationPureSafetyHelpers(t *testing.T) {
+	closeCalls := 0
+	closeErr := errors.New("close failed")
+	close := closeOnce(testCloserFunc(func() error {
+		closeCalls++
+		return closeErr
+	}))
+	if err := close(); !errors.Is(err, closeErr) {
+		t.Fatalf("first close error = %v", err)
+	}
+	if err := close(); err != nil || closeCalls != 1 {
+		t.Fatalf("second close = %v, calls = %d", err, closeCalls)
+	}
+
+	partial := &vfs.PartialOperationError{}
+	unknown := &vfs.UnknownOperationStateError{}
+	for _, test := range []struct {
+		name    string
+		err     error
+		display bool
+	}{
+		{name: "partial", err: partial, display: true},
+		{name: "unknown", err: unknown, display: true},
+		{name: "cancel", err: context.Canceled, display: false},
+		{name: "deadline", err: context.DeadlineExceeded, display: true},
+	} {
+		if !operationMustNotRetry(test.err) || shouldDisplayFileOpError(test.err) != test.display {
+			t.Fatalf("safety helpers disagreed for %s", test.name)
+		}
+	}
+	if shouldDisplayFileOpError(nil) || shouldDisplayFileOpError(context.Canceled) {
+		t.Fatal("cancellation or nil should not display an operation error")
+	}
+	if !shouldDisplayFileOpError(errors.New("ordinary failure")) {
+		t.Fatal("ordinary operation failure was hidden")
+	}
+
+	dir := t.TempDir()
+	linkTarget := filepath.Join(dir, "target")
+	link := filepath.Join(dir, "link")
+	if err := os.Mkdir(linkTarget, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(linkTarget, link); err != nil {
+		t.Skip("symlinks unavailable")
+	}
+	resolved := resolveSymlinksForCompare(filepath.Join(link, "new", "file.txt"))
+	want := filepath.Join(linkTarget, "new", "file.txt")
+	if resolved != want {
+		t.Fatalf("resolved comparison path = %q, want %q", resolved, want)
+	}
+}
+
+func TestTryOptimizedRenameUsesAtomicNoReplace(t *testing.T) {
+	dir := t.TempDir()
+	filesystem := vfs.NewOSVFS(dir)
+	source := filepath.Join(dir, "source.txt")
+	destination := filepath.Join(dir, "destination.txt")
+	if err := os.WriteFile(source, []byte("source"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ok, err := tryOptimizedRename(context.Background(), filesystem, filesystem, source, destination)
+	if err != nil || !ok {
+		t.Fatalf("empty-destination rename = %v, %v", ok, err)
+	}
+
+	source = filepath.Join(dir, "source-2.txt")
+	if err := os.WriteFile(source, []byte("source-2"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("keep"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ok, err = tryOptimizedRename(context.Background(), filesystem, filesystem, source, destination)
+	if err != nil || ok {
+		t.Fatalf("occupied-destination rename = %v, %v", ok, err)
+	}
+	if data, err := os.ReadFile(destination); err != nil || string(data) != "keep" {
+		t.Fatalf("destination changed to %q, %v", data, err)
+	}
+}
+
+type testCloserFunc func() error
+
+func (f testCloserFunc) Close() error { return f() }

--- a/cmd/f4/file_ops_coverage_test.go
+++ b/cmd/f4/file_ops_coverage_test.go
@@ -133,7 +133,7 @@ func TestFileOperationPureSafetyHelpers(t *testing.T) {
 		t.Skip("symlinks unavailable")
 	}
 	resolved := resolveSymlinksForCompare(filepath.Join(link, "new", "file.txt"))
-	want := filepath.Join(linkTarget, "new", "file.txt")
+	want := filepath.Join(resolveSymlinksForCompare(linkTarget), "new", "file.txt")
 	if resolved != want {
 		t.Fatalf("resolved comparison path = %q, want %q", resolved, want)
 	}

--- a/vfs/os_vfs_contract_coverage_test.go
+++ b/vfs/os_vfs_contract_coverage_test.go
@@ -139,7 +139,8 @@ func TestOSVFSLinksAndDirectoryChunkDelivery(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if chunks != 2 || items != 1002 || !executable || !hidden {
+	wantExecutable := runtime.GOOS != "windows"
+	if chunks != 2 || items != 1002 || executable != wantExecutable || !hidden {
 		t.Fatalf("directory delivery = chunks %d items %d executable %v hidden %v", chunks, items, executable, hidden)
 	}
 

--- a/vfs/os_vfs_contract_coverage_test.go
+++ b/vfs/os_vfs_contract_coverage_test.go
@@ -1,0 +1,219 @@
+package vfs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOSVFSContractCoversLocalOperations(t *testing.T) {
+	root := t.TempDir()
+	filesystem := NewOSVFS(root)
+	if filesystem.GetPath() != root || !filesystem.IsAbs(root) || filesystem.IsAtRoot() {
+		t.Fatalf("initial path state = %q/%v/%v", filesystem.GetPath(), filesystem.IsAbs(root), filesystem.IsAtRoot())
+	}
+	if filesystem.Base(filepath.Join(root, "nested", "file.txt")) != "file.txt" || filesystem.Dir(filepath.Join(root, "nested", "file.txt")) != filepath.Join(root, "nested") {
+		t.Fatal("path helper methods returned wrong values")
+	}
+	if filesystem.ParentVFS() != nil || filesystem.Close() != nil {
+		t.Fatal("OSVFS root lifecycle contract changed")
+	}
+	clone := filesystem.Clone()
+	if clone.GetPath() != filesystem.GetPath() || clone == filesystem {
+		t.Fatal("Clone did not create an equivalent independent VFS")
+	}
+	caps := filesystem.GetCapabilities()
+	if !caps.HasWrite || !caps.HasRandomAccess || !caps.HasAtomicNoReplaceRename || caps.HasSearch {
+		t.Fatalf("local capabilities = %#v", caps)
+	}
+	if result, err := filesystem.Search(context.Background(), root, "*"); err != nil || result != nil {
+		t.Fatalf("local search stub = %v, %v", result, err)
+	}
+
+	nested := filepath.Join(root, "nested", "dir")
+	if err := filesystem.MkDir(context.Background(), nested); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(nested, "file.txt")
+	writer, err := filesystem.Create(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte("hello local vfs")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := filesystem.Open(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reader.Size() != int64(len("hello local vfs")) {
+		t.Fatalf("Open size = %d", reader.Size())
+	}
+	buf := make([]byte, 5)
+	if n, err := reader.ReadAt(context.Background(), buf, 6); err != nil || string(buf[:n]) != "local" {
+		t.Fatalf("ReadAt = %q, %v", buf[:n], err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAt, err := filesystem.OpenWriteAt(context.Background(), file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writeAt.WriteAt([]byte("LOCAL"), 6); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAt.Truncate(15); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeAt.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(file); err != nil || string(data) != "hello LOCAL vfs" {
+		t.Fatalf("OpenWriteAt result = %q, %v", data, err)
+	}
+
+	if runtime.GOOS != "windows" {
+		item, err := filesystem.Stat(context.Background(), file)
+		if err != nil {
+			t.Fatal(err)
+		}
+		item.UnixMode = 0600
+		item.Uid = -1
+		item.Gid = -1
+		if err := filesystem.SetAttributes(context.Background(), file, item); err != nil {
+			t.Fatal(err)
+		}
+		if info, err := os.Stat(file); err != nil || info.Mode().Perm() != 0600 {
+			t.Fatalf("SetAttributes mode = %v, %v", info.Mode().Perm(), err)
+		}
+	}
+
+	rename := filepath.Join(nested, "renamed.txt")
+	if err := filesystem.Rename(context.Background(), file, rename); err != nil {
+		t.Fatal(err)
+	}
+	if err := filesystem.Remove(context.Background(), filepath.Join(root, "nested")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(rename); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("Remove left renamed file: %v", err)
+	}
+}
+
+func TestOSVFSLinksAndDirectoryChunkDelivery(t *testing.T) {
+	root := t.TempDir()
+	filesystem := NewOSVFS(root)
+	for i := 0; i < 1001; i++ {
+		name := filepath.Join(root, fmt.Sprintf("file-%04d", i))
+		if err := os.WriteFile(name, []byte("x"), 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".hidden"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(root, "file-0000"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	chunks := 0
+	items := 0
+	var executable, hidden bool
+	if err := filesystem.ReadDir(context.Background(), root, func(batch []VFSItem) {
+		chunks++
+		items += len(batch)
+		for _, item := range batch {
+			executable = executable || item.Name == "file-0000" && item.IsExecutable
+			hidden = hidden || item.Name == ".hidden" && item.IsHidden
+		}
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if chunks != 2 || items != 1002 || !executable || !hidden {
+		t.Fatalf("directory delivery = chunks %d items %d executable %v hidden %v", chunks, items, executable, hidden)
+	}
+
+	target := filepath.Join(root, "target.txt")
+	link := filepath.Join(root, "link.txt")
+	if err := os.WriteFile(target, []byte("target"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := filesystem.Symlink(context.Background(), target, link); err != nil {
+		t.Skip("symlinks unavailable")
+	}
+	if got, err := filesystem.Readlink(context.Background(), link); err != nil || got != target {
+		t.Fatalf("Readlink = %q, %v", got, err)
+	}
+	if item, err := filesystem.Lstat(context.Background(), link); err != nil || !item.IsSymlink {
+		t.Fatalf("Lstat symlink = %#v, %v", item, err)
+	}
+	hard := filepath.Join(root, "hard.txt")
+	if err := filesystem.Hardlink(context.Background(), target, hard); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(hard); err != nil || string(data) != "target" {
+		t.Fatalf("hardlink contents = %q, %v", data, err)
+	}
+	junction := filepath.Join(root, "junction.txt")
+	if err := filesystem.Junction(context.Background(), target, junction); err != nil {
+		t.Skip("junction/symlink unavailable")
+	}
+}
+
+func TestOSVFSContextCancellationCoversMutations(t *testing.T) {
+	root := t.TempDir()
+	filesystem := NewOSVFS(root)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	want := context.Canceled
+
+	if err := filesystem.MkDir(ctx, filepath.Join(root, "mkdir")); !errors.Is(err, want) {
+		t.Errorf("MkDir error = %v", err)
+	}
+	if err := filesystem.Remove(ctx, filepath.Join(root, "remove")); !errors.Is(err, want) {
+		t.Errorf("Remove error = %v", err)
+	}
+	if err := filesystem.Rename(ctx, "old", "new"); !errors.Is(err, want) {
+		t.Errorf("Rename error = %v", err)
+	}
+	if err := filesystem.RenameNoReplace(ctx, "old", "new"); !errors.Is(err, want) {
+		t.Errorf("RenameNoReplace error = %v", err)
+	}
+	if _, err := filesystem.Stat(ctx, root); !errors.Is(err, want) {
+		t.Errorf("Stat error = %v", err)
+	}
+	if _, err := filesystem.Lstat(ctx, root); !errors.Is(err, want) {
+		t.Errorf("Lstat error = %v", err)
+	}
+	if _, err := filesystem.Open(ctx, root); !errors.Is(err, want) {
+		t.Errorf("Open error = %v", err)
+	}
+	if _, err := filesystem.Create(ctx, filepath.Join(root, "create")); !errors.Is(err, want) {
+		t.Errorf("Create error = %v", err)
+	}
+	if _, err := filesystem.OpenWriteAt(ctx, filepath.Join(root, "write")); !errors.Is(err, want) {
+		t.Errorf("OpenWriteAt error = %v", err)
+	}
+	if _, err := filesystem.Readlink(ctx, root); !errors.Is(err, want) {
+		t.Errorf("Readlink error = %v", err)
+	}
+	if err := filesystem.Symlink(ctx, "target", filepath.Join(root, "link")); !errors.Is(err, want) {
+		t.Errorf("Symlink error = %v", err)
+	}
+	if err := filesystem.Hardlink(ctx, "target", filepath.Join(root, "hard")); !errors.Is(err, want) {
+		t.Errorf("Hardlink error = %v", err)
+	}
+	if err := filesystem.Junction(ctx, "target", filepath.Join(root, "junction")); !errors.Is(err, want) {
+		t.Errorf("Junction error = %v", err)
+	}
+}


### PR DESCRIPTION
I, zoin-bot, am starting with the f4 portion of issue #629. This PR adds behavior-focused coverage for:

- global-aware file-operation progress accounting and delegation
- cancellation, retry, close-once, symlink comparison, and atomic no-replace rename helpers
- OSVFS local file operations, metadata, links, directory chunk delivery, lifecycle, and cancellation contracts

Scope is intentionally limited to f4 and its local vfs package; dependency coverage is a separate follow-up from the issue. Tests skip platform-specific junction behavior when the host cannot provide it.

Validation on Linux ARM64 (Fedora Asahi Remix 44, KDE Wayland):
- `GOTMPDIR=... go test ./... -count=1` passed
- focused new tests passed under `go test -race`
- `go vet ./...` passed
- native ARM64 build passed
- full local race run still reports pre-existing races in unrelated existing tests/async code; no race was reported in the added tests

— zoin-bot