### PR TITLE
Follow up #644: preserve Indic input boundaries and performance

### DIFF
--- a/cmd/f4/editor_grapheme.go
+++ b/cmd/f4/editor_grapheme.go
@@ -1,6 +1,9 @@
 package main
 
-import "github.com/unxed/f4/textlayout"
+import (
+	"github.com/unxed/f4/textlayout"
+	"github.com/unxed/vtui"
+)
 
 // editorGrapheme is a byte-addressable grapheme cluster. The editor keeps
 // byte offsets internally, but user-visible cursor operations must stop at
@@ -23,6 +26,22 @@ func editorGraphemes(data []byte) []editorGrapheme {
 		})
 	}
 	return clusters
+}
+
+// lineUsesVisualBidi limits the full visual engine to lines that actually
+// contain RTL text. zoin-bot keeps the common long LTR path bounded by the
+// existing small-window grapheme helpers.
+func (ev *EditorView) lineUsesVisualBidi() bool {
+	if vtui.DefaultBidiMode != vtui.BidiFull {
+		return false
+	}
+	lineLen := ev.getLineLength(ev.CursorLine)
+	if lineLen <= 0 {
+		return false
+	}
+	lineStart := ev.li.GetLineOffset(ev.CursorLine)
+	data, err := ev.pt.GetRange(lineStart, lineLen)
+	return err == nil && vtui.HasRTL(string(data))
 }
 
 func nextEditorGraphemeBoundary(data []byte, pos int) int {
@@ -92,7 +111,11 @@ func (ev *EditorView) previousGraphemeBoundaryInLine(lineStart, pos int) int {
 			return pos - 1
 		}
 		if clusters[0].start > 0 || start == 0 {
-			return start + clusters[len(clusters)-1].start
+			last := clusters[len(clusters)-1]
+			if split := textlayout.TrailingModifierStart(last.text); split >= 0 {
+				return start + last.start + split
+			}
+			return start + last.start
 		}
 		take *= 2
 		if take > pos {

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -2086,12 +2086,20 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.CursorLine--
 				ev.CursorPos = ev.getLineLength(ev.CursorLine)
 			}
-		} else {
+		} else if ev.lineUsesVisualBidi() {
 			currentOffset := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
 			newOffset := ev.engine.MoveVisual(currentOffset, -1)
 			if newOffset != currentOffset {
 				ev.CursorLine = ev.li.GetLineAtOffset(newOffset)
 				ev.CursorPos = newOffset - ev.li.GetLineOffset(ev.CursorLine)
+			}
+		} else {
+			if ev.CursorPos > 0 {
+				lineStart := ev.li.GetLineOffset(ev.CursorLine)
+				ev.CursorPos = ev.previousGraphemeBoundaryInLine(lineStart, ev.CursorPos)
+			} else if ev.CursorLine > 0 {
+				ev.CursorLine--
+				ev.CursorPos = ev.getLineLength(ev.CursorLine)
 			}
 		}
 		ev.updateDesiredVisualCol()
@@ -2170,13 +2178,28 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.CursorLine++
 				ev.CursorPos = 0
 			}
-		} else {
+		} else if ev.lineUsesVisualBidi() {
 			currentOffset := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
 			newOffset := ev.engine.MoveVisual(currentOffset, 1)
 			if newOffset != currentOffset {
 				ev.CursorLine = ev.li.GetLineAtOffset(newOffset)
 				ev.CursorPos = newOffset - ev.li.GetLineOffset(ev.CursorLine)
 				ev.CursorVirtualSpaces = 0
+			} else if ev.CursorBeyondEOL {
+				ev.CursorVirtualSpaces++
+			}
+		} else {
+			if ev.CursorPos < lineLen {
+				lineStart := ev.li.GetLineOffset(ev.CursorLine)
+				ev.CursorPos = ev.nextGraphemeBoundaryInLine(lineStart, lineLen, ev.CursorPos)
+			} else if ev.CursorLine < ev.li.LineCount()-1 {
+				if ev.CursorBeyondEOL {
+					ev.CursorVirtualSpaces++
+				} else {
+					ev.CursorLine++
+					ev.CursorPos = 0
+					ev.CursorVirtualSpaces = 0
+				}
 			} else if ev.CursorBeyondEOL {
 				ev.CursorVirtualSpaces++
 			}
@@ -2219,21 +2242,34 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.noteBufferEdit()
 				ev.saveUndo(opOther)
 				ev.modified = true
-				deleteStart := ev.engine.MoveVisual(offset, -1)
-				if deleteStart == offset {
-					deleteStart = offset - 1
+				if ev.CursorPos == 0 {
+					prevLen := ev.getLineLength(ev.CursorLine - 1)
+					delLen := 1
+					if offset >= 2 {
+						prefix, _ := ev.pt.GetRange(offset-2, 2)
+						if len(prefix) == 2 && prefix[0] == '\r' && prefix[1] == '\n' {
+							delLen = 2
+						}
+					}
+					ev.pt.Delete(offset-delLen, delLen)
+					ev.li.UpdateAfterDelete(offset-delLen, delLen)
+					ev.invalidateStates(ev.CursorLine - 1)
+					ev.engine.InvalidateFrom(ev.CursorLine - 1)
+					ev.CursorLine--
+					ev.CursorPos = prevLen
+				} else {
+					deleteStart := ev.li.GetLineOffset(ev.CursorLine) + ev.previousGraphemeBoundaryInLine(ev.li.GetLineOffset(ev.CursorLine), ev.CursorPos)
+					if ev.lineUsesVisualBidi() {
+						deleteStart = ev.engine.MoveVisual(offset, -1)
+					}
+					ev.pt.Delete(deleteStart, offset-deleteStart)
+					ev.li.UpdateAfterDelete(deleteStart, offset-deleteStart)
+					ev.CursorLine = ev.li.GetLineAtOffset(deleteStart)
+					ev.CursorPos = deleteStart - ev.li.GetLineOffset(ev.CursorLine)
+					minLine := ev.CursorLine
+					ev.invalidateStates(minLine)
+					ev.engine.InvalidateFrom(minLine)
 				}
-				oldLine := ev.CursorLine
-				ev.pt.Delete(deleteStart, offset-deleteStart)
-				ev.li.UpdateAfterDelete(deleteStart, offset-deleteStart)
-				ev.CursorLine = ev.li.GetLineAtOffset(deleteStart)
-				ev.CursorPos = deleteStart - ev.li.GetLineOffset(ev.CursorLine)
-				minLine := oldLine
-				if ev.CursorLine < minLine {
-					minLine = ev.CursorLine
-				}
-				ev.invalidateStates(minLine)
-				ev.engine.InvalidateFrom(minLine)
 			}
 		}
 		ev.updateDesiredVisualCol()
@@ -2272,9 +2308,15 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.noteBufferEdit()
 				ev.saveUndo(opOther)
 				ev.modified = true
-				deleteEnd := ev.engine.MoveVisual(offset, 1)
-				if deleteEnd == offset {
-					deleteEnd = offset + 1
+				deleteEnd := offset + 1
+				if ev.CursorPos < ev.getLineLength(ev.CursorLine) {
+					if ev.lineUsesVisualBidi() {
+						deleteEnd = ev.engine.MoveVisual(offset, 1)
+					} else {
+						lineStart := ev.li.GetLineOffset(ev.CursorLine)
+						next := ev.nextGraphemeBoundaryInLine(lineStart, ev.getLineLength(ev.CursorLine), ev.CursorPos)
+						deleteEnd = lineStart + next
+					}
 				}
 				ev.pt.Delete(offset, deleteEnd-offset)
 				ev.li.UpdateAfterDelete(offset, deleteEnd-offset)
@@ -2451,66 +2493,22 @@ type editorTextCluster struct {
 	runeEnd   int
 }
 
-// editorVisualClusters keeps the piece table in logical byte order while
-// returning the grapheme order used on screen. zoin-bot uses the same map for
-// editor painting and textlayout caret coordinates.
+// editorVisualClusters uses textlayout's shared grapheme and BiDi order for
+// painting. zoin-bot keeps byte and rune boundaries from the document intact.
 func editorVisualClusters(text string) []editorTextCluster {
-	type clusterMeta struct {
-		offset    int
-		width     int
-		runeIndex int
-	}
-	metas := make([]clusterMeta, 0, len([]rune(text)))
-	vtui.ForEachClusterAt(text, func(_ string, width, offset, runeIndex int) {
-		metas = append(metas, clusterMeta{offset: offset, width: width, runeIndex: runeIndex})
-	})
-	logical := make([]editorTextCluster, 0, len(metas))
-	for i, meta := range metas {
-		end := len(text)
-		if i+1 < len(metas) {
-			end = metas[i+1].offset
-		}
-		clusterText := text[meta.offset:end]
-		logical = append(logical, editorTextCluster{
-			text:      clusterText,
-			width:     meta.width,
-			byteStart: meta.offset,
-			byteEnd:   end,
-			runeStart: meta.runeIndex,
-			runeEnd:   meta.runeIndex + utf8.RuneCountInString(clusterText),
+	base := textlayout.VisualClustersInVisualOrder(text)
+	clusters := make([]editorTextCluster, 0, len(base))
+	for _, cluster := range base {
+		clusters = append(clusters, editorTextCluster{
+			text:      cluster.Text,
+			width:     cluster.Width,
+			byteStart: cluster.Start,
+			byteEnd:   cluster.End,
+			runeStart: cluster.RuneStart,
+			runeEnd:   cluster.RuneEnd,
 		})
 	}
-	if vtui.DefaultBidiMode != vtui.BidiFull || !vtui.HasRTL(text) {
-		return logical
-	}
-
-	byLogical := make(map[int]editorTextCluster, len(logical))
-	for _, cluster := range logical {
-		byLogical[cluster.runeStart] = cluster
-	}
-	visualText, logicalPositions := vtui.VisualStringWithRuneMap(text)
-	visualMetas := make([]clusterMeta, 0, len(logical))
-	vtui.ForEachClusterAt(visualText, func(_ string, width, offset, runeIndex int) {
-		visualMetas = append(visualMetas, clusterMeta{offset: offset, width: width, runeIndex: runeIndex})
-	})
-	visual := make([]editorTextCluster, 0, len(logical))
-	for i, meta := range visualMetas {
-		if i >= len(logicalPositions) {
-			break
-		}
-		original, ok := byLogical[logicalPositions[i]]
-		if !ok {
-			continue
-		}
-		end := len(visualText)
-		if i+1 < len(visualMetas) {
-			end = visualMetas[i+1].offset
-		}
-		original.text = visualText[meta.offset:end]
-		original.width = meta.width
-		visual = append(visual, original)
-	}
-	return visual
+	return clusters
 }
 
 func (ev *EditorView) fillCells(target []vtui.CharInfo, data []byte, defaultAttr, selAttr uint64, offset int, selActive bool, selMin, selMax int, syntax []uint64, startVisualCol int, isCrossRow bool, crossVCol int, horzCrossAttr, vertCrossAttr uint64, visualRow int) []vtui.CharInfo {

--- a/textlayout/cluster.go
+++ b/textlayout/cluster.go
@@ -13,6 +13,8 @@ type VisualCluster struct {
 	Text       string
 	Width      int
 	Start, End int
+	RuneStart  int
+	RuneEnd    int
 }
 
 // VisualClusters segments a string once and returns its visual clusters. It
@@ -21,10 +23,10 @@ type VisualCluster struct {
 // character and turn long-line layout into quadratic work.
 func VisualClusters(s string) []VisualCluster {
 	clusters := make([]VisualCluster, 0, len(s))
-	previousStart, previousWidth := 0, 0
+	previousStart, previousWidth, previousRuneStart := 0, 0, 0
 	havePrevious := false
 
-	emit := func(start, end, width int) {
+	emit := func(start, end, width, runeStart, runeEnd int) {
 		if start >= end {
 			return
 		}
@@ -34,20 +36,21 @@ func VisualClusters(s string) []VisualCluster {
 			last.Text = s[last.Start:end]
 			last.End = end
 			last.Width = vtui.ClusterWidth(last.Text)
+			last.RuneEnd = runeEnd
 			return
 		}
-		clusters = append(clusters, VisualCluster{Text: raw, Width: width, Start: start, End: end})
+		clusters = append(clusters, VisualCluster{Text: raw, Width: width, Start: start, End: end, RuneStart: runeStart, RuneEnd: runeEnd})
 	}
 
-	vtui.ForEachClusterAt(s, func(_ string, width, offset, _ int) {
+	vtui.ForEachClusterAt(s, func(_ string, width, offset, runeIndex int) {
 		if havePrevious {
-			emit(previousStart, offset, previousWidth)
+			emit(previousStart, offset, previousWidth, previousRuneStart, runeIndex)
 		}
-		previousStart, previousWidth = offset, width
+		previousStart, previousWidth, previousRuneStart = offset, width, runeIndex
 		havePrevious = true
 	})
 	if havePrevious {
-		emit(previousStart, len(s), previousWidth)
+		emit(previousStart, len(s), previousWidth, previousRuneStart, utf8.RuneCountInString(s))
 	}
 	return clusters
 }
@@ -74,6 +77,19 @@ func startsWithLetter(s string) bool {
 
 func endsInIndicVirama(s string) bool {
 	r, _ := utf8.DecodeLastRuneInString(s)
+	return isIndicVirama(r)
+}
+
+func containsIndicVirama(s string) bool {
+	for _, r := range s {
+		if isIndicVirama(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIndicVirama(r rune) bool {
 	switch r {
 	case
 		'\u094D',                     // Devanagari
@@ -101,4 +117,34 @@ func endsInIndicVirama(s string) bool {
 	default:
 		return false
 	}
+}
+
+// TrailingModifierStart returns the byte offset of a terminal script modifier
+// that the editor keeps as a separate backspace step. zoin-bot preserves the
+// established terminal behaviour for final Indic viramas and Thaana marks,
+// while ordinary Latin combining graphemes remain atomic.
+func TrailingModifierStart(s string) int {
+	r, size := utf8.DecodeLastRuneInString(s)
+	if size == 0 {
+		return -1
+	}
+	if containsIndicVirama(s) || isIndicScriptMark(r) || (r >= 0x0780 && r <= 0x07BF && unicode.Is(unicode.Mn, r)) {
+		return len(s) - size
+	}
+	return -1
+}
+
+func isIndicScriptMark(r rune) bool {
+	return (unicode.Is(unicode.Mn, r) || unicode.Is(unicode.Mc, r)) && unicode.In(r,
+		unicode.Devanagari,
+		unicode.Bengali,
+		unicode.Gurmukhi,
+		unicode.Gujarati,
+		unicode.Oriya,
+		unicode.Tamil,
+		unicode.Telugu,
+		unicode.Kannada,
+		unicode.Malayalam,
+		unicode.Sinhala,
+	)
 }

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -58,19 +58,15 @@ type visualCluster struct {
 func logicalTextClusters(text string) []visualCluster {
 	base := VisualClusters(text)
 	logical := make([]visualCluster, 0, len(base))
-	runeIndex := 0
 	for _, cluster := range base {
-		clusterText := cluster.Text
-		clusterRunes := utf8.RuneCountInString(clusterText)
 		logical = append(logical, visualCluster{
-			text:       clusterText,
+			text:       cluster.Text,
 			width:      cluster.Width,
 			byteStart:  cluster.Start,
 			byteEnd:    cluster.End,
-			logicalPos: runeIndex,
-			logicalEnd: runeIndex + clusterRunes,
+			logicalPos: cluster.RuneStart,
+			logicalEnd: cluster.RuneEnd,
 		})
-		runeIndex += clusterRunes
 	}
 	return logical
 }
@@ -103,6 +99,24 @@ func visualClusters(text string) []visualCluster {
 		index++
 	})
 	return visual
+}
+
+// VisualClustersInVisualOrder returns grapheme clusters in terminal order.
+// zoin-bot uses this shared mapping for editor painting and hit testing.
+func VisualClustersInVisualOrder(text string) []VisualCluster {
+	clusters := visualClusters(text)
+	result := make([]VisualCluster, 0, len(clusters))
+	for _, cluster := range clusters {
+		result = append(result, VisualCluster{
+			Text:      cluster.text,
+			Width:     cluster.width,
+			Start:     cluster.byteStart,
+			End:       cluster.byteEnd,
+			RuneStart: cluster.logicalPos,
+			RuneEnd:   cluster.logicalEnd,
+		})
+	}
+	return result
 }
 
 func byteOffsetAtRune(text string, runeIndex int) int {


### PR DESCRIPTION
Follow-up to #644 and issue #632.

The first PR was merged before its full matrix finished. Its CI exposed two regressions in the new visual editor path:

- keep the existing fast grapheme helpers for long LTR lines and use the full visual engine only for actual RTL lines;
- preserve established terminal backspace behaviour for Indic conjunct marks and Thaana marks while keeping ordinary combining graphemes atomic;
- share rune boundaries and visual-order cluster data between textlayout and editor rendering.

Validation on Windows x64:

- go test ./textlayout;
- targeted editor grapheme, long-line performance, BiDi insertion, combining deletion, and rendering tests;
- native build and --version smoke test.

— zoin-bot