### PR TITLE
feat: add selectable language-aware GUI fonts

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3779,8 +3779,10 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 			}
 		}
 	}
-	editFont := vtui.NewEdit(0, 0, 30, AppConfig.GuiFont)
-	lblFont := vtui.NewLabel(0, 0, Msg("AppearanceSettings.Font"), editFont)
+	fontChoices := guiFontChoices(AppConfig.Language, AppConfig.GuiFont)
+	comboFont := vtui.NewComboBox(0, 0, 30, fontChoices)
+	comboFont.Edit.SetText(AppConfig.GuiFont)
+	lblFont := vtui.NewLabel(0, 0, Msg("AppearanceSettings.Font"), comboFont)
 	chkSystemMonospace := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.UseSystemMonospace"), false)
 	if AppConfig.GuiUseSystemMonospace {
 		chkSystemMonospace.State = 1
@@ -3788,7 +3790,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	updateFontEditor := func() {
 		usePlatformFont := chkSystemMonospace.State == 1 && (runtime.GOOS == "windows" || runtime.GOOS == "darwin")
 		lblFont.SetDisabled(usePlatformFont)
-		editFont.SetDisabled(usePlatformFont)
+		comboFont.SetDisabled(usePlatformFont)
 	}
 	chkSystemMonospace.OnChange = func(int) { updateFontEditor() }
 	updateFontEditor()
@@ -3874,7 +3876,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	dlg.AddItem(comboStyle)
 	dlg.AddItem(chkSystemMonospace)
 	dlg.AddItem(lblFont)
-	dlg.AddItem(editFont)
+	dlg.AddItem(comboFont)
 	dlg.AddItem(lblSize)
 	dlg.AddItem(editSize)
 	dlg.AddItem(lblTitle)
@@ -3901,7 +3903,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 
 	vbox.Add(chkSystemMonospace, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(lblFont, vtui.Margins{Top: 1}, vtui.AlignLeft)
-	vbox.Add(editFont, vtui.Margins{}, vtui.AlignFill)
+	vbox.Add(comboFont, vtui.Margins{}, vtui.AlignFill)
 
 	rowSize := vtui.NewHBoxLayout(0, 0, width-4, 1)
 	rowSize.Add(lblSize, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -3956,11 +3958,11 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 			AppConfig.ColorStyle = names[comboStyle.Menu.SelectPos]
 		}
 		useSystemMonospace := chkSystemMonospace.State == 1
-		fontChanged := AppConfig.GuiUseSystemMonospace != useSystemMonospace || AppConfig.GuiFont != editFont.GetText() || fmt.Sprintf("%d", AppConfig.GuiFontSize) != editSize.GetText()
+		fontChanged := AppConfig.GuiUseSystemMonospace != useSystemMonospace || AppConfig.GuiFont != comboFont.Edit.GetText() || fmt.Sprintf("%d", AppConfig.GuiFontSize) != editSize.GetText()
 
 		AppConfig.ConsoleTitleTemplate = editTitle.GetText()
 		AppConfig.GuiUseSystemMonospace = useSystemMonospace
-		AppConfig.GuiFont = editFont.GetText()
+		AppConfig.GuiFont = comboFont.Edit.GetText()
 		fmt.Sscanf(editSize.GetText(), "%d", &AppConfig.GuiFontSize)
 		if AppConfig.GuiFontSize <= 0 {
 			AppConfig.GuiFontSize = defaultGuiFontSize(runtime.GOOS)
@@ -4405,8 +4407,10 @@ func actionLanguage(pf *PanelsFrame) {
 	btnOk.OnClick = func() {
 		uiChanged := false
 		helpChanged := false
+		suggestFontChoice := false
 		if idx := comboUI.Menu.SelectPos; idx >= 0 && idx < len(uiLangs) {
 			if AppConfig.Language != uiLangs[idx].code {
+				suggestFontChoice = shouldSuggestFontForLanguage(uiLangs[idx].code, AppConfig.GuiFont)
 				AppConfig.Language = uiLangs[idx].code
 				uiChanged = true
 			}
@@ -4422,7 +4426,9 @@ func actionLanguage(pf *PanelsFrame) {
 			InitLang()
 			InitHelpSystem()
 			vtui.FrameManager.PostTask(func() {
-				if uiChanged {
+				if uiChanged && suggestFontChoice {
+					actionAppearanceSettings(pf)
+				} else if uiChanged {
 					vtui.ShowMessage(Msg("Info.Title"), Msg("Language.Changed"), []string{Msg("vtui.Ok")})
 				}
 				vtui.FrameManager.Redraw()

--- a/cmd/f4/gui_font_catalog.go
+++ b/cmd/f4/gui_font_catalog.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+)
+
+// discoverInstalledGuiFonts is a variable so the settings dialog and the
+// language recommendation can share one catalog while tests can avoid
+// depending on the host's installed fonts.
+var discoverInstalledGuiFonts = platformGuiFontFiles
+
+// guiFontChoices keeps the current value even when it is a manually entered
+// path or family name that the platform catalog cannot discover.
+func guiFontChoices(language, current string) []string {
+	choices := make([]string, 0)
+	appendUnique := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range choices {
+			if sameGuiFontValue(existing, value) {
+				return
+			}
+		}
+		choices = append(choices, value)
+	}
+
+	appendUnique(current)
+	for _, path := range discoverInstalledGuiFonts(language) {
+		appendUnique(path)
+	}
+	return choices
+}
+
+func sameGuiFontValue(left, right string) bool {
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+func shouldSuggestFontForLanguage(language, current string) bool {
+	if !isCJKLanguage(language) {
+		return false
+	}
+	if strings.TrimSpace(current) == "" {
+		return len(discoverInstalledGuiFonts(language)) > 0
+	}
+	for _, path := range discoverInstalledGuiFonts(language) {
+		if sameGuiFontValue(current, path) {
+			return false
+		}
+	}
+	return true
+}
+
+func isCJKLanguage(language string) bool {
+	language = strings.ToLower(strings.TrimSpace(language))
+	if language == "" {
+		return false
+	}
+	for _, prefix := range []string{"zh", "ja", "ko"} {
+		if language == prefix || strings.HasPrefix(language, prefix+"_") || strings.HasPrefix(language, prefix+"-") {
+			return true
+		}
+	}
+	return false
+}
+
+func cjkFontconfigPattern(language string) string {
+	language = strings.ToLower(strings.TrimSpace(language))
+	switch {
+	case strings.HasPrefix(language, "ja"):
+		return ":lang=ja"
+	case strings.HasPrefix(language, "ko"):
+		return ":lang=ko"
+	case strings.HasPrefix(language, "zh"):
+		return ":lang=zh"
+	default:
+		// 100 is fontconfig's spacing value for monospace fonts. The
+		// explicit value is more portable than the human-readable alias.
+		return ":spacing=100"
+	}
+}
+
+func isFontFile(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".otc", ".otf", ".ttc", ".ttf":
+		return true
+	default:
+		return false
+	}
+}
+
+func sortCJKFontPaths(paths []string, language string) {
+	if !isCJKLanguage(language) {
+		sort.Strings(paths)
+		return
+	}
+	sort.SliceStable(paths, func(i, j int) bool {
+		iCJK := looksLikeCJKFontPath(paths[i])
+		jCJK := looksLikeCJKFontPath(paths[j])
+		if iCJK != jCJK {
+			return iCJK
+		}
+		return paths[i] < paths[j]
+	})
+}
+
+func looksLikeCJKFontPath(path string) bool {
+	path = strings.ToLower(path)
+	for _, marker := range []string{
+		"cjk", "chinese", "droid", "gothic", "han", "japan", "jp", "korea", "ko", "ming", "noto", "simsun", "song", "wqy", "yahei",
+	} {
+		if strings.Contains(path, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func parseFontconfigPaths(output string) []string {
+	var paths []string
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(output, "\n") {
+		path := strings.TrimSpace(line)
+		if path == "" || !isFontFile(path) {
+			continue
+		}
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
+}

--- a/cmd/f4/gui_font_catalog_test.go
+++ b/cmd/f4/gui_font_catalog_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestParseFontconfigPathsDeduplicatesAndFilters(t *testing.T) {
+	got := parseFontconfigPaths("/fonts/NotoSansCJK.ttc\n/fonts/NotoSansCJK.ttc\nnot-a-font.txt\n /fonts/Mono.ttf \n")
+	want := []string{"/fonts/Mono.ttf", "/fonts/NotoSansCJK.ttc"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseFontconfigPaths = %#v, want %#v", got, want)
+	}
+}
+
+func TestGuiFontChoicesPreserveManualValueAndCJKRecommendation(t *testing.T) {
+	previous := discoverInstalledGuiFonts
+	discoverInstalledGuiFonts = func(string) []string {
+		return []string{"/fonts/NotoSansCJK.ttc", "/fonts/Mono.ttf", "/fonts/NotoSansCJK.ttc"}
+	}
+	t.Cleanup(func() { discoverInstalledGuiFonts = previous })
+
+	got := guiFontChoices("zh", "/custom/font.otf")
+	want := []string{"/custom/font.otf", "/fonts/NotoSansCJK.ttc", "/fonts/Mono.ttf"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("guiFontChoices = %#v, want %#v", got, want)
+	}
+	if shouldSuggestFontForLanguage("en", "") {
+		t.Fatal("English must not trigger a CJK font recommendation")
+	}
+	if !shouldSuggestFontForLanguage("zh_CN", "") {
+		t.Fatal("empty font must trigger a CJK font recommendation")
+	}
+	if shouldSuggestFontForLanguage("zh-CN", "/fonts/NotoSansCJK.ttc") {
+		t.Fatal("already selected CJK font must not trigger another recommendation")
+	}
+	if !shouldSuggestFontForLanguage("ja", "/custom/font.otf") {
+		t.Fatal("unknown manual font must trigger a CJK font recommendation")
+	}
+}
+
+func TestFontconfigPatternByLanguage(t *testing.T) {
+	for _, test := range []struct {
+		language string
+		want     string
+	}{
+		{language: "zh_CN", want: ":lang=zh"},
+		{language: "ja-JP", want: ":lang=ja"},
+		{language: "ko", want: ":lang=ko"},
+		{language: "en", want: ":spacing=100"},
+	} {
+		if got := cjkFontconfigPattern(test.language); got != test.want {
+			t.Errorf("cjkFontconfigPattern(%q) = %q, want %q", test.language, got, test.want)
+		}
+	}
+}
+
+func TestAppearanceSettingsFontComboRemainsEditable(t *testing.T) {
+	previous := discoverInstalledGuiFonts
+	discoverInstalledGuiFonts = func(string) []string { return []string{"/fonts/NotoSansCJK.ttc", "/fonts/Mono.ttf"} }
+	t.Cleanup(func() { discoverInstalledGuiFonts = previous })
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	AppConfig.GuiFont = "/custom/font.otf"
+	AppConfig.Language = "zh"
+	getUserConfigIniPath = func() string { return t.TempDir() + "/settings.ini" }
+	t.Cleanup(func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	})
+
+	pf := NewPanelsFrame()
+	t.Cleanup(pf.Close)
+	pf.ResizeConsole(80, 25)
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var fontCombo *vtui.ComboBox
+	for _, child := range top.GetChildren() {
+		combo, ok := child.(*vtui.ComboBox)
+		if !ok || len(combo.Menu.Items) == 0 {
+			continue
+		}
+		if combo.Menu.Items[0].Text == "/custom/font.otf" {
+			fontCombo = combo
+			break
+		}
+	}
+	if fontCombo == nil {
+		t.Fatal("font catalog combobox not found")
+	}
+	if fontCombo.DropdownOnly {
+		t.Fatal("font catalog combobox must preserve manual entry")
+	}
+	fontCombo.Edit.SetText("/manually/entered/font.ttf")
+	clickDialogButton(t, top, "Ok")
+	if AppConfig.GuiFont != "/manually/entered/font.ttf" {
+		t.Fatalf("manual font path = %q", AppConfig.GuiFont)
+	}
+}

--- a/cmd/f4/gui_font_catalog_unix.go
+++ b/cmd/f4/gui_font_catalog_unix.go
@@ -1,0 +1,60 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+)
+
+var runFontconfigList = func(pattern string) ([]string, error) {
+	output, err := exec.Command("fc-list", "--format=%{file}\\n", pattern).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseFontconfigPaths(string(output)), nil
+}
+
+func platformGuiFontFiles(language string) []string {
+	if runtime.GOOS == "linux" {
+		if paths, err := runFontconfigList(cjkFontconfigPattern(language)); err == nil && len(paths) > 0 {
+			sortCJKFontPaths(paths, language)
+			return paths
+		}
+	}
+
+	paths := scanStandardFontDirectories(language)
+	sortCJKFontPaths(paths, language)
+	return paths
+}
+
+func scanStandardFontDirectories(language string) []string {
+	dirs := []string{
+		"/usr/share/fonts",
+		"/usr/local/share/fonts",
+		"/System/Library/Fonts",
+		"/Library/Fonts",
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		dirs = append(dirs, filepath.Join(home, ".fonts"), filepath.Join(home, ".local", "share", "fonts"), filepath.Join(home, "Library", "Fonts"))
+	}
+
+	var paths []string
+	seen := make(map[string]struct{})
+	for _, root := range dirs {
+		_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+			if err != nil || entry == nil || entry.IsDir() || !isFontFile(path) {
+				return nil
+			}
+			if _, ok := seen[path]; ok {
+				return nil
+			}
+			seen[path] = struct{}{}
+			paths = append(paths, path)
+			return nil
+		})
+	}
+	return paths
+}

--- a/cmd/f4/gui_font_catalog_windows.go
+++ b/cmd/f4/gui_font_catalog_windows.go
@@ -1,0 +1,61 @@
+//go:build windows
+
+package main
+
+import (
+	"sort"
+	"strings"
+
+	"golang.org/x/sys/windows/registry"
+)
+
+func windowsFontEntries() []fontEntry {
+	var entries []fontEntry
+	for _, hive := range []registry.Key{registry.LOCAL_MACHINE, registry.CURRENT_USER} {
+		key, err := registry.OpenKey(hive, `SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, registry.QUERY_VALUE)
+		if err != nil {
+			continue
+		}
+		names, err := key.ReadValueNames(-1)
+		if err == nil {
+			for _, name := range names {
+				file, _, err := key.GetStringValue(name)
+				if err != nil || !isFontFile(file) {
+					continue
+				}
+				base := strings.TrimSpace(strings.TrimSuffix(name, " (TrueType)"))
+				base = strings.TrimSpace(strings.TrimSuffix(base, " (OpenType)"))
+				entries = append(entries, fontEntry{base: base, file: file})
+			}
+		}
+		key.Close()
+	}
+	return entries
+}
+
+func platformGuiFontFiles(language string) []string {
+	entries := windowsFontEntries()
+	paths := make([]string, 0, len(entries))
+	seen := make(map[string]struct{})
+	for _, entry := range entries {
+		path := fontFilePath(entry.file)
+		if _, ok := seen[path]; ok {
+			continue
+		}
+		seen[path] = struct{}{}
+		paths = append(paths, path)
+	}
+	if isCJKLanguage(language) {
+		sort.SliceStable(paths, func(i, j int) bool {
+			iCJK := looksLikeCJKFontPath(paths[i])
+			jCJK := looksLikeCJKFontPath(paths[j])
+			if iCJK != jCJK {
+				return iCJK
+			}
+			return strings.ToLower(paths[i]) < strings.ToLower(paths[j])
+		})
+	} else {
+		sort.Strings(paths)
+	}
+	return paths
+}

--- a/cmd/f4/gui_font_windows.go
+++ b/cmd/f4/gui_font_windows.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	"golang.org/x/sys/windows/registry"
 )
 
 type fontEntry struct {
@@ -21,34 +19,7 @@ type fontEntry struct {
 // CascadiaMono.ttf and silently fall back to Consolas. Returns "" if the
 // family is not found; callers then keep the original name.
 func windowsFontFile(fontName string) string {
-	key, err := registry.OpenKey(registry.LOCAL_MACHINE,
-		`SOFTWARE\Microsoft\Windows NT\CurrentVersion\Fonts`, registry.QUERY_VALUE)
-	if err != nil {
-		return ""
-	}
-	defer key.Close()
-
-	names, err := key.ReadValueNames(-1)
-	if err != nil {
-		return ""
-	}
-
-	var entries []fontEntry
-	for _, n := range names {
-		file, _, err := key.GetStringValue(n)
-		if err != nil {
-			continue
-		}
-		switch strings.ToLower(filepath.Ext(file)) {
-		case ".ttf", ".ttc", ".otf":
-		default:
-			continue
-		}
-		base := strings.TrimSpace(strings.TrimSuffix(n, " (TrueType)"))
-		base = strings.TrimSpace(strings.TrimSuffix(base, " (OpenType)"))
-		entries = append(entries, fontEntry{base: base, file: file})
-	}
-	return matchWindowsFontFamily(fontName, entries)
+	return matchWindowsFontFamily(fontName, windowsFontEntries())
 }
 
 func matchWindowsFontFamily(fontName string, entries []fontEntry) string {


### PR DESCRIPTION
I, zoin-bot, implemented issue #620.

What changed:
- Replaced the appearance font text field with an editable catalog-backed combo box.
- Keeps any manually entered font name/path and discovers installed fonts via fontconfig and standard Unix font directories; Windows uses both machine and user font registry entries.
- When switching the UI to Chinese, Japanese, or Korean, opens Appearance so the user can choose a discovered CJK-capable font while retaining manual entry.
- Added focused tests for discovery parsing, deduplication, language recommendations, and manual editing.

Validation:
- `go test ./... -count=1`
- `go vet ./...`
- native Linux ARM64 build
- native ARM64 TTY launch into the real two-panel UI and clean F10 exit
- targeted race tests for the new font catalog and Appearance flow

The full local race suite still reports pre-existing races/checkptr failures in unrelated tests; the new tests pass under race.

— zoin-bot