### PR TITLE
Follow up #632: cache bidi detection on long lines

### DIFF
--- a/cmd/f4/editor_grapheme.go
+++ b/cmd/f4/editor_grapheme.go
@@ -35,13 +35,25 @@ func (ev *EditorView) lineUsesVisualBidi() bool {
 	if vtui.DefaultBidiMode != vtui.BidiFull {
 		return false
 	}
+	if ev.bidiCacheValid && ev.bidiCacheSession == ev.editSession && ev.bidiCacheLine == ev.CursorLine {
+		return ev.bidiCacheValue
+	}
 	lineLen := ev.getLineLength(ev.CursorLine)
 	if lineLen <= 0 {
+		ev.bidiCacheSession = ev.editSession
+		ev.bidiCacheLine = ev.CursorLine
+		ev.bidiCacheValue = false
+		ev.bidiCacheValid = true
 		return false
 	}
 	lineStart := ev.li.GetLineOffset(ev.CursorLine)
 	data, err := ev.pt.GetRange(lineStart, lineLen)
-	return err == nil && vtui.HasRTL(string(data))
+	value := err == nil && vtui.HasRTL(string(data))
+	ev.bidiCacheSession = ev.editSession
+	ev.bidiCacheLine = ev.CursorLine
+	ev.bidiCacheValue = value
+	ev.bidiCacheValid = true
+	return value
 }
 
 func nextEditorGraphemeBoundary(data []byte, pos int) int {

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -178,6 +178,14 @@ type EditorView struct {
 	CursorVirtualSpaces int
 	UseEditorConfig     bool
 
+	// bidiCache avoids rescanning an unchanged long line on every cursor key.
+	// zoin-bot keys it by editSession and logical line, so edits and undo/redo
+	// invalidate the result without making the common LTR path line-sized.
+	bidiCacheSession int
+	bidiCacheLine    int
+	bidiCacheValue   bool
+	bidiCacheValid   bool
+
 	highlighting    bool
 	highlightCancel context.CancelFunc
 


### PR DESCRIPTION
This is a follow-up to #644 and #646 for issue #632.

The full CI matrix on the previous follow-up exposed a performance regression in TestEditorView_LongLinePerformance: enabling bidi detection caused every cursor key on a long LTR line to re-read and scan the entire line. This patch caches the result by logical line and edit session, so edits and undo/redo invalidate it while repeated cursor movement stays bounded.

Local validation on Windows 10 x64:
- go test ./textlayout -count=1
- targeted cmd/f4 Unicode, grapheme, bidi, and long-line performance tests
- native go build and --version launch smoke test

Please run the full matrix before merging.

— zoin-bot