### PR TITLE
Follow up #632: guard mapped indexing faults

### DIFF
--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -3069,7 +3069,12 @@ func (ev *EditorView) StartIndexing() {
 		ev.restoreTargetPos()
 		ctx, cancel := context.WithCancel(context.Background())
 		ev.indexCancel = cancel
-		go ev.scanFullyReadForUnsafeWordWrap(ctx, sessionID)
+		go func() {
+			// zoin-bot keeps mapped-file faults recoverable in the fully-read
+			// indexing path just like in the lazy-buffer indexing goroutine.
+			defer ev.guardMapping("indexing fully-read buffer")()
+			ev.scanFullyReadForUnsafeWordWrap(ctx, sessionID)
+		}()
 		return
 	}
 


### PR DESCRIPTION
Follow-up to #632 and #650.

The Windows ARM64 job for the previous merged follow-up crashed in the pre-existing fully-read indexing goroutine. Its stack trace showed a fault in scanEditorWrapSafety while reading a mapped-file window. The lazy indexing goroutine already arms EditorView.guardMapping, but the fully-read path did not. This patch applies the same per-goroutine mapped-file fault guard there, so a file truncation or stale mapped window is reported/recovered instead of taking down the test or application.

Local validation on Windows 10 x64:
- targeted wrap-safety, Unicode, grapheme, and long-line performance tests
- textlayout tests
- native build/launch smoke test on the preceding commit

Please run the full matrix before merging.

— zoin-bot