### PR TITLE
test: isolate repeated f4 test runs

### DIFF
--- a/cmd/f4/action_menu_test.go
+++ b/cmd/f4/action_menu_test.go
@@ -161,6 +161,7 @@ func TestBuildMenuBarItems_Terminal(t *testing.T) {
 }
 
 func TestBuildMenuBarItems_OnClickRunsAction(t *testing.T) {
+	preserveActionRegistry(t)
 	old := GlobalHotkeysMgr
 	GlobalHotkeysMgr = NewHotkeyManager("")
 	defer func() { GlobalHotkeysMgr = old }()

--- a/cmd/f4/action_menu_visibility_test.go
+++ b/cmd/f4/action_menu_visibility_test.go
@@ -6,6 +6,7 @@ import "testing"
 // a hidden action leaves no item, a visible one still appears, and a menu
 // whose every action is hidden does not show up as an empty group.
 func TestMenuHonoursVisible(t *testing.T) {
+	preserveActionRegistry(t)
 	show := true
 	RegisterAction(Action{
 		Name:     "Test.Visibility.Shown",

--- a/cmd/f4/action_registry_test.go
+++ b/cmd/f4/action_registry_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestActionRegistry(t *testing.T) {
+	preserveActionRegistry(t)
 	called := false
 	testAction := Action{
 		Name:        "Test.Action",

--- a/cmd/f4/appearance_settings_test.go
+++ b/cmd/f4/appearance_settings_test.go
@@ -8,8 +8,12 @@ import (
 func TestEnforceColorCorrection_ConfigRoundtrip(t *testing.T) {
 	tmpDir := t.TempDir()
 
+	oldCfg := AppConfig
 	oldGetConfig := getUserConfigIniPath
-	defer func() { getUserConfigIniPath = oldGetConfig }()
+	defer func() {
+		AppConfig = oldCfg
+		getUserConfigIniPath = oldGetConfig
+	}()
 	getUserConfigIniPath = func() string {
 		return filepath.Join(tmpDir, "settings.ini")
 	}

--- a/cmd/f4/help_lang_test.go
+++ b/cmd/f4/help_lang_test.go
@@ -27,8 +27,10 @@ func TestHelpLanguageSwitch(t *testing.T) {
 	// override on its first call from InitHelpSystem.
 	_ = GetF4ConfigDir()
 	oldF4ConfigDir := cachedF4ConfigDir
+	oldHelpLanguage := AppConfig.HelpLanguage
 	cachedF4ConfigDir = tempDir
 	defer func() { cachedF4ConfigDir = oldF4ConfigDir }()
+	t.Cleanup(func() { AppConfig.HelpLanguage = oldHelpLanguage })
 
 	AppConfig.HelpLanguage = "ru"
 	InitHelpSystem()

--- a/cmd/f4/keybar_injected_test.go
+++ b/cmd/f4/keybar_injected_test.go
@@ -15,6 +15,7 @@ import (
 // Before the fix, the injected VK_F5 fell through PanelsFrame.ProcessKey
 // unhandled, so clicking F5 in the bottom bar did nothing.
 func TestKeyBarClick_DispatchesHotkeyAction(t *testing.T) {
+	preserveActionRegistry(t)
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	if GlobalHotkeysMgr == nil {
 		GlobalHotkeysMgr = NewHotkeyManager("")

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -4387,10 +4387,12 @@ func TestPanelsFrame_ShiftF9_SaveSettings(t *testing.T) {
 	tmp.Close()
 
 	oldGetPath := getUserConfigIniPath
+	oldGetPaths := getConfigIniPaths
 	getUserConfigIniPath = func() string { return tmp.Name() }
 	getConfigIniPaths = func() []string { return []string{tmp.Name()} }
 	defer func() {
 		getUserConfigIniPath = oldGetPath
+		getConfigIniPaths = oldGetPaths
 	}()
 
 	pf := NewPanelsFrame()

--- a/cmd/f4/solaris_streams_mock_linux_test.go
+++ b/cmd/f4/solaris_streams_mock_linux_test.go
@@ -20,7 +20,7 @@ import (
 // master side is closed immediately once the slave is unlocked; nothing in
 // these tests needs it kept open.
 func newMockTTYSlave() (*os.File, error) {
-	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY, 0)
+	masterFd, err := unix.Open("/dev/ptmx", unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func newMockTTYSlave() (*os.File, error) {
 		return nil, errno
 	}
 
-	slaveFd, err := unix.Open(fmt.Sprintf("/dev/pts/%d", n), unix.O_RDWR|unix.O_NOCTTY, 0)
+	slaveFd, err := unix.Open(fmt.Sprintf("/dev/pts/%d", n), unix.O_RDWR|unix.O_NOCTTY|unix.O_CLOEXEC, 0)
 	if err != nil {
 		master.Close()
 		return nil, err

--- a/cmd/f4/test_fallback_lang_test.go
+++ b/cmd/f4/test_fallback_lang_test.go
@@ -7,9 +7,11 @@ import (
 
 func TestConfig_FallbackLanguagePersistence(t *testing.T) {
 	tmpDir := t.TempDir()
+	oldCfg := AppConfig
 	oldGetUserConfigIniPath := getUserConfigIniPath
 	oldGetConfigPaths := getConfigIniPaths
 	defer func() {
+		AppConfig = oldCfg
 		getUserConfigIniPath = oldGetUserConfigIniPath
 		getConfigIniPaths = oldGetConfigPaths
 	}()

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -40,6 +40,23 @@ func pressKey(f vtui.Frame, e *vtinput.InputEvent) bool {
 	return f.ProcessKey(e)
 }
 
+// preserveActionRegistry keeps tests that register synthetic actions from
+// leaking them into later tests or the next -count iteration.
+func preserveActionRegistry(t *testing.T) {
+	t.Helper()
+	oldRegistry := actionRegistry
+	oldOrder := actionOrder
+	actionRegistry = make(map[string]Action, len(oldRegistry))
+	for key, action := range oldRegistry {
+		actionRegistry[key] = action
+	}
+	actionOrder = append([]string(nil), oldOrder...)
+	t.Cleanup(func() {
+		actionRegistry = oldRegistry
+		actionOrder = oldOrder
+	})
+}
+
 func TestMain(m *testing.M) {
 	vfs.InitSudoClient("/usr/bin/f4", "")
 

--- a/cmd/f4/viewer_view_test.go
+++ b/cmd/f4/viewer_view_test.go
@@ -672,6 +672,8 @@ func TestViewerView_EndJump_BusyState(t *testing.T) {
 	}
 }
 func TestViewerView_StateRestoration_Modes(t *testing.T) {
+	oldFileState := GlobalFileState
+	t.Cleanup(func() { GlobalFileState = oldFileState })
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	tmp := filepath.Join(t.TempDir(), "test.txt")
 	os.WriteFile(tmp, []byte("data"), 0644)


### PR DESCRIPTION
I, zoin-bot, fixed issue #641.

The reported test failures were caused by state leaking between repeated package runs:
- synthetic actions remained in the global action registry;
- GlobalFileState and config/language globals were not restored;
- the Linux Solaris-PTY fixture opened real /dev/ptmx descriptors without close-on-exec, so children inherited them.

This PR restores the relevant test state and marks both sides of the Linux PTY fixture close-on-exec. Production runtime code is unchanged.

Validation on Linux ARM64 (Fedora Asahi Remix 44, KDE Wayland):
- full `go test ./... -count=3`;
- focused reported tests, 50 repetitions;
- focused cleanup/PTY tests under `go test -race`, 10 repetitions;
- `go vet ./...`;
- native `go build ./cmd/f4`;
- native `/home/zoin/.cache/f4-build/f4-641 --version`.

— zoin-bot