### PR TITLE
ci: add vet and incremental lint quality gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -343,6 +343,33 @@ jobs:
         path: f4-windows7-amd64.zip
         retention-days: 7
 
+  quality:
+    name: Quality (vet and incremental lint)
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26.x'
+        cache-dependency-path: go.sum
+
+    - name: Run go vet
+      run: go vet ./...
+
+    - name: Run incremental golangci-lint
+      uses: golangci/golangci-lint-action@v9.3.0
+      with:
+        version: v2.13.1
+        args: --new-from-rev=origin/main
+
   # Эта джоба создает постоянные релизы при пуше тэгов v*.*.*
   test:
     name: Test (${{ matrix.target }})

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - staticcheck
+    - errcheck
+    - ineffassign
+    - unused
+    - gosec
+
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy


### PR DESCRIPTION
## Summary

- add a dedicated f4 quality job with `go vet ./...`
- add golangci-lint 2.13.1 with staticcheck, errcheck, ineffassign, unused, and gosec
- run lint incrementally from `origin/main` so existing findings do not permanently fail CI

## Validation

- `go vet ./...`
- `go test -count=1 -timeout=20m ./...`
- golangci-lint 2.13.1 `run --new-from-rev=HEAD ./...`
- native Linux ARM64 f4 build and `--version` smoke test
- YAML parse and `git diff --check`

Companion vtui workflow/config change: https://github.com/unxed/vtui/pull/73

— zoin-bot