### PR TITLE
Tests: remove avoidable queue and archive waits

### DIFF
--- a/cmd/f4/queue_manager.go
+++ b/cmd/f4/queue_manager.go
@@ -161,6 +161,7 @@ type OpQueueManager struct {
 	tasks          []*QueueTask
 	nextID         int
 	activeKeys     map[string]bool
+	wake           chan struct{}
 	frame          *QueueFrame
 	refreshPending bool
 }
@@ -170,9 +171,27 @@ var GlobalQueueManager *OpQueueManager
 func init() {
 	GlobalQueueManager = &OpQueueManager{
 		activeKeys: make(map[string]bool),
+		wake:       make(chan struct{}, 1),
 	}
 	go GlobalQueueManager.workerLoop()
 }
+
+// signalWorker wakes the scheduler as soon as a task is enqueued or a
+// resource is released. The periodic fallback in workerLoop still repairs a
+// missed notification and keeps zero-value test managers usable.
+func (qm *OpQueueManager) signalWorker() {
+	qm.mu.Lock()
+	if qm.wake == nil {
+		qm.wake = make(chan struct{}, 1)
+	}
+	wake := qm.wake
+	qm.mu.Unlock()
+	select {
+	case wake <- struct{}{}:
+	default:
+	}
+}
+
 func (qm *OpQueueManager) RequestRefresh() {
 	qm.mu.Lock()
 	if qm.refreshPending {
@@ -214,6 +233,7 @@ func (qm *OpQueueManager) Enqueue(task *QueueTask) {
 	task.ctx, task.cancel = context.WithCancel(context.Background())
 	qm.tasks = append(qm.tasks, task)
 	qm.mu.Unlock()
+	qm.signalWorker()
 
 	vtui.FrameManager.PostTask(func() {
 		qm.EnsureQueueWorkspace()
@@ -383,8 +403,18 @@ func (qm *OpQueueManager) postTaskCompletion(t *QueueTask) {
 }
 
 func (qm *OpQueueManager) workerLoop() {
+	qm.mu.Lock()
+	if qm.wake == nil {
+		qm.wake = make(chan struct{}, 1)
+	}
+	wake := qm.wake
+	qm.mu.Unlock()
+
 	for {
-		time.Sleep(200 * time.Millisecond)
+		select {
+		case <-wake:
+		case <-time.After(200 * time.Millisecond):
+		}
 
 		qm.mu.Lock()
 		var toRun *QueueTask
@@ -494,6 +524,7 @@ func (qm *OpQueueManager) executeTask(t *QueueTask) {
 		qm.activeKeys[rk] = false
 	}
 	qm.mu.Unlock()
+	qm.signalWorker()
 
 	vtui.DebugLog("QUEUE_DEBUG: Task %d finalized with state %s (Error: %v). Posting OnComplete.", t.ID, finalState, t.ErrorMsg)
 

--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -155,7 +155,8 @@ func TestQueueManager_ConflictDetection(t *testing.T) {
 
 	// 1. Ставим задачу в очередь с текущим состоянием файла
 	task := &QueueTask{
-		Type: "Copy",
+		Type:    "Copy",
+		ResKeys: []string{getResourceKey(v)},
 		Preconditions: []OpPrecondition{
 			{Vfs: v, Path: path, MTime: st.MTime, Size: st.Size, IsDir: false},
 		},
@@ -180,6 +181,7 @@ func TestQueueManager_ConflictDetection(t *testing.T) {
 	qm.mu.Lock()
 	qm.activeKeys = make(map[string]bool)
 	qm.mu.Unlock()
+	qm.signalWorker()
 
 	// Ждем обработки
 	timeout := time.After(2 * time.Second)

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -27,6 +27,10 @@ import (
 
 var TestSkipDelay time.Duration
 
+// archiveVFSIdleTTL is kept as a variable so tests can exercise the cleanup
+// transition without waiting for the production grace period.
+var archiveVFSIdleTTL = 2 * time.Second
+
 type dummyDirInfo struct {
 	name string
 }
@@ -1303,8 +1307,8 @@ func (v *ArchiveVFS) startCleanupTimer() {
 		_ = v.fsys.Close()
 		v.fsys = nil
 	}
-	// 2-second grace period of complete inactivity
-	v.cleanupTimer = time.AfterFunc(2*time.Second, func() {
+	// Two-second grace period of complete inactivity.
+	v.cleanupTimer = time.AfterFunc(archiveVFSIdleTTL, func() {
 		v.mu.Lock()
 		defer v.mu.Unlock()
 		if v.activeCount == 0 && v.isClosed {

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -235,6 +235,10 @@ func TestArchiveVFS_TempFileLeak(t *testing.T) {
 // TestArchiveVFS_DeferredClose verifies that closing the ArchiveVFS is deferred
 // while there are active readers or writers (grace period of inactivity).
 func TestArchiveVFS_DeferredClose(t *testing.T) {
+	oldIdleTTL := archiveVFSIdleTTL
+	archiveVFSIdleTTL = 50 * time.Millisecond
+	t.Cleanup(func() { archiveVFSIdleTTL = oldIdleTTL })
+
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "test.zip")
 
@@ -287,8 +291,8 @@ func TestArchiveVFS_DeferredClose(t *testing.T) {
 	}
 	rc2.Close()
 
-	// 5. Wait for the inactivity timer to expire and perform cleanup (2-second grace period)
-	time.Sleep(2500 * time.Millisecond)
+	// 5. Wait for the shortened test TTL to expire and perform cleanup.
+	time.Sleep(2 * archiveVFSIdleTTL)
 
 	// 6. Try to open the file again. It should fail now as the VFS has been fully cleaned up.
 	_, errRead3 := vArc.Open(context.Background(), vArc.Join(zipPath, "file1.txt"))


### PR DESCRIPTION
## Summary
- wake the operation queue immediately when work is enqueued or a resource is released, retaining the 200 ms polling fallback
- make the archive VFS idle cleanup grace period testable without changing its 2-second production default
- remove timing-dependent queue test assumptions and shorten the deferred-close test from 2.5 seconds to 100 ms

## Validation
- `go test ./... -count=1`
- `go build -o C:\Temp\f4-655.exe .\cmd\f4`
- `C:\Temp\f4-655.exe --version`
- local `go test -race` was not available because this Windows environment has CGO disabled; the repository CI race job remains required