### PR TITLE
Add panel-only plugin contributions

### DIFF
--- a/cmd/f4/command_palette_coverage_test.go
+++ b/cmd/f4/command_palette_coverage_test.go
@@ -101,6 +101,9 @@ var commandPaletteProcessKeyAudit = map[string]commandPaletteSurfaceAudit{
 	"cmd/f4/panels_frame.go:(*PanelsFrame).ProcessKey": {
 		class: paletteAuditPanelProvider, rationale: "PanelsFrame combines registered actions with audited transient panel-context entries",
 	},
+	"cmd/f4/panel_plugins.go:(*pluginPanelInstance).ProcessKey": {
+		class: paletteAuditPanelProvider, rationale: "native panel plugins receive raw input inside their registered panel surface; their semantic commands are plugin-owned",
+	},
 	"cmd/f4/quick_view_panel.go:(*QuickViewPanel).ProcessKey": {
 		class: paletteAuditPanelProvider, rationale: "the focused Quick View toggle is supplied by the panel-context palette provider",
 	},
@@ -133,6 +136,9 @@ var commandPaletteProcessKeyAudit = map[string]commandPaletteSurfaceAudit{
 	},
 	"plugins/visren/dialog.go:(*tokenButton).ProcessKey": {
 		class: paletteAuditPluginLocal, rationale: "the token button is an embedded VisRen dialog control",
+	},
+	"cmd/f4/rpc_panel.go:(*rpcVUIPanel).ProcessKey": {
+		class: paletteAuditTransportHook, rationale: "RPC panel input is forwarded to the remote plugin, whose .vui document owns its semantic commands",
 	},
 }
 

--- a/cmd/f4/panel_plugins.go
+++ b/cmd/f4/panel_plugins.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+type registeredPanelProvider struct {
+	provider vfs.PanelProvider
+	token    *struct{}
+}
+
+var panelProviderRegistry = struct {
+	sync.RWMutex
+	byID map[string]registeredPanelProvider
+}{byID: make(map[string]registeredPanelProvider)}
+
+const panelProviderCommandPrefix = "panel."
+
+// RegisterPanelProvider implements the optional panel-only contribution API.
+// A provider is intentionally also exposed as a regular command so it is
+// available from the plugin menu and command palette without a second API.
+func (c *coreAPI) RegisterPanelProvider(provider vfs.PanelProvider) (vfs.Registration, error) {
+	provider.ID = strings.TrimSpace(provider.ID)
+	provider.Title = strings.TrimSpace(provider.Title)
+	if provider.ID == "" {
+		return nil, errors.New("panel provider ID is empty")
+	}
+	if provider.Title == "" {
+		return nil, fmt.Errorf("panel provider %q has an empty title", provider.ID)
+	}
+	if provider.Open == nil {
+		return nil, fmt.Errorf("panel provider %q has no open handler", provider.ID)
+	}
+
+	registryID := strings.ToLower(provider.ID)
+	commandID := panelProviderCommandPrefix + registryID
+	token := &struct{}{}
+	panelProviderRegistry.Lock()
+	if _, exists := panelProviderRegistry.byID[registryID]; exists {
+		panelProviderRegistry.Unlock()
+		return nil, fmt.Errorf("panel provider %q is already registered", provider.ID)
+	}
+	panelProviderRegistry.byID[registryID] = registeredPanelProvider{provider: provider, token: token}
+	panelProviderRegistry.Unlock()
+
+	command, err := c.RegisterPluginCommand(vfs.PluginCommand{
+		ID:          commandID,
+		Location:    vfs.PluginCommandPanel,
+		Label:       "Open " + provider.Title,
+		Description: provider.Description,
+		SearchTerms: []string{"panel", "plugin", provider.ID},
+		Run: func(app vfs.App) {
+			openRegisteredPanelProvider(app, registryID)
+		},
+	})
+	if err != nil {
+		panelProviderRegistry.Lock()
+		if current, ok := panelProviderRegistry.byID[registryID]; ok && current.token == token {
+			delete(panelProviderRegistry.byID, registryID)
+		}
+		panelProviderRegistry.Unlock()
+		return nil, fmt.Errorf("register panel provider %q command: %w", provider.ID, err)
+	}
+
+	return &unregisterFunc{fn: func() {
+		command.Unregister()
+		panelProviderRegistry.Lock()
+		if current, ok := panelProviderRegistry.byID[registryID]; ok && current.token == token {
+			delete(panelProviderRegistry.byID, registryID)
+		}
+		panelProviderRegistry.Unlock()
+	}}, nil
+}
+
+func lookupPanelProvider(id string) (vfs.PanelProvider, bool) {
+	panelProviderRegistry.RLock()
+	entry, ok := panelProviderRegistry.byID[strings.ToLower(strings.TrimSpace(id))]
+	panelProviderRegistry.RUnlock()
+	return entry.provider, ok
+}
+
+func openRegisteredPanelProvider(app vfs.App, providerID string) {
+	pf, ok := app.(*PanelsFrame)
+	if !ok || pf == nil || !pf.showPanels || pf.closed {
+		return
+	}
+	provider, ok := lookupPanelProvider(providerID)
+	if !ok {
+		return
+	}
+
+	slot := pf.activeIdx
+	ctx := pf.panelPluginContext(slot)
+	controller, err := provider.Open(ctx)
+	if err != nil {
+		vtui.DebugLog("PANEL [%s]: open failed: %v", provider.ID, err)
+		vtui.ShowToast(fmt.Sprintf("Panel %s: %v", provider.Title, err), 3e9)
+		return
+	}
+	if controller == nil {
+		vtui.DebugLog("PANEL [%s]: open returned nil controller", provider.ID)
+		return
+	}
+
+	if old := pf.altPanels[slot]; old != nil {
+		if closer, ok := old.(interface{ Close() }); ok {
+			closer.Close()
+		} else {
+			pf.altPanels[slot] = nil
+		}
+	}
+	instance := &pluginPanelInstance{
+		providerID: provider.ID,
+		title:      provider.Title,
+		host:       pf,
+		slot:       slot,
+		controller: controller,
+	}
+	instance.closeFn = func() {
+		if pf.altPanels[slot] == instance {
+			pf.altPanels[slot] = nil
+			// PanelsFrame.Close holds ptyMutex while closing overlays. Do not
+			// re-enter ResizeConsole from that path.
+			if !pf.closed {
+				pf.ResizeConsole(pf.lastW, pf.lastH)
+				vtui.FrameManager.HardRefresh()
+			}
+		}
+	}
+	instance.SetPositionForPanel()
+	instance.SetContext(ctx)
+	pf.altPanels[slot] = instance
+	if slot == 0 {
+		pf.showLeftPanel = true
+	} else {
+		pf.showRightPanel = true
+	}
+	pf.ResizeConsole(pf.lastW, pf.lastH)
+	vtui.FrameManager.HardRefresh()
+}
+
+// pluginPanelInstance adapts the public vfs panel contract to f4's existing
+// AltPanel slot. The FileSystemPanel remains underneath as the logical panel,
+// so ordinary file actions and VFS providers keep their existing assumptions.
+type pluginPanelInstance struct {
+	providerID string
+	title      string
+	host       *PanelsFrame
+	slot       int
+	controller vfs.PanelController
+	closeFn    func()
+	closeOnce  sync.Once
+}
+
+func (p *pluginPanelInstance) Source() *FileSystemPanel {
+	if p == nil || p.host == nil || p.slot < 0 || p.slot >= len(p.host.panels) {
+		return nil
+	}
+	fsp, _ := p.host.panels[p.slot].(*FileSystemPanel)
+	return fsp
+}
+
+func (p *pluginPanelInstance) Kind() string { return "plugin:" + p.providerID }
+
+func (p *pluginPanelInstance) Show(scr *vtui.ScreenBuf) {
+	if p == nil || p.controller == nil {
+		return
+	}
+	if p.host != nil {
+		p.SetContext(p.host.panelPluginContext(p.slot))
+	}
+	p.controller.Show(scr)
+}
+
+func (p *pluginPanelInstance) ProcessKey(e *vtinput.InputEvent) bool {
+	if p == nil || p.controller == nil {
+		return false
+	}
+	if p.host != nil {
+		p.SetContext(p.host.panelPluginContext(p.slot))
+	}
+	if p.controller.ProcessKey(e) {
+		return true
+	}
+	// Escape is the common close gesture for a panel plugin that does not
+	// claim it. A plugin that wants to own Escape simply returns true.
+	if e != nil && e.KeyDown && e.VirtualKeyCode == vtinput.VK_ESCAPE {
+		p.Close()
+		return true
+	}
+	return false
+}
+
+func (p *pluginPanelInstance) ProcessMouse(e *vtinput.InputEvent) bool {
+	if p == nil || p.controller == nil {
+		return false
+	}
+	if p.host != nil {
+		p.SetContext(p.host.panelPluginContext(p.slot))
+	}
+	return p.controller.ProcessMouse(e)
+}
+
+func (p *pluginPanelInstance) SetFocus(focused bool) {
+	if p != nil && p.controller != nil {
+		p.controller.SetFocus(focused)
+	}
+}
+
+func (p *pluginPanelInstance) IsFocused() bool {
+	return p != nil && p.controller != nil && p.controller.IsFocused()
+}
+
+func (p *pluginPanelInstance) SetPosition(x1, y1, x2, y2 int) {
+	if p != nil && p.controller != nil {
+		p.controller.SetPosition(x1, y1, x2, y2)
+	}
+}
+
+func (p *pluginPanelInstance) SetPositionForPanel() {
+	if p == nil || p.host == nil || p.controller == nil {
+		return
+	}
+	x1, y1, x2, y2 := p.host.panels[p.slot].GetPosition()
+	p.controller.SetPosition(x1, y1, x2, y2)
+}
+
+func (p *pluginPanelInstance) GetPosition() (int, int, int, int) {
+	if p == nil || p.controller == nil {
+		return 0, 0, 0, 0
+	}
+	return p.controller.GetPosition()
+}
+
+func (p *pluginPanelInstance) GetSelectedName() string {
+	if p == nil || p.controller == nil {
+		return ""
+	}
+	return p.controller.GetSelectedName()
+}
+
+func (p *pluginPanelInstance) SetContext(ctx vfs.PanelContext) {
+	if p != nil && p.controller != nil {
+		p.controller.SetContext(ctx)
+	}
+}
+
+func (p *pluginPanelInstance) Close() {
+	if p == nil {
+		return
+	}
+	p.closeOnce.Do(func() {
+		if p.controller != nil {
+			_ = p.controller.Close()
+		}
+		if p.closeFn != nil {
+			p.closeFn()
+		}
+	})
+}
+
+func (pf *PanelsFrame) panelPluginContext(slot int) vfs.PanelContext {
+	ctx := vfs.PanelContext{Side: slot, ActiveSide: pf.activeIdx}
+	if slot == pf.activeIdx {
+		ctx.Current = pf.panelPluginState(slot, true)
+		ctx.Other = pf.panelPluginState(1-slot, false)
+	} else {
+		ctx.Current = pf.panelPluginState(slot, false)
+		ctx.Other = pf.panelPluginState(1-slot, true)
+	}
+	if alt, ok := pf.altPanels[slot].(*pluginPanelInstance); ok && alt.controller != nil {
+		ctx.Bounds[0], ctx.Bounds[1], ctx.Bounds[2], ctx.Bounds[3] = alt.controller.GetPosition()
+	} else if panel := pf.panels[slot]; panel != nil {
+		ctx.Bounds[0], ctx.Bounds[1], ctx.Bounds[2], ctx.Bounds[3] = panel.GetPosition()
+	}
+	return ctx
+}
+
+func (pf *PanelsFrame) panelPluginState(slot int, active bool) vfs.PanelState {
+	state := vfs.PanelState{Side: slot, Active: active}
+	if slot < 0 || slot >= len(pf.panels) {
+		return state
+	}
+	fsp, ok := pf.panels[slot].(*FileSystemPanel)
+	if !ok || fsp == nil || fsp.vfs == nil {
+		return state
+	}
+	state.Path = fsp.vfs.GetPath()
+	state.SelectedName = fsp.GetSelectedName()
+	state.SelectedNames = append([]string(nil), fsp.GetSelectedNames()...)
+	return state
+}

--- a/cmd/f4/panel_plugins_test.go
+++ b/cmd/f4/panel_plugins_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+	"github.com/vmihailenco/msgpack/v5"
+)
+
+type panelPluginTestController struct {
+	vtui.ScreenObject
+	context vfs.PanelContext
+	keys    int
+	closed  bool
+}
+
+func (p *panelPluginTestController) SetContext(ctx vfs.PanelContext) { p.context = ctx }
+func (p *panelPluginTestController) ProcessKey(event *vtinput.InputEvent) bool {
+	p.keys++
+	return event == nil || event.VirtualKeyCode != vtinput.VK_ESCAPE
+}
+func (p *panelPluginTestController) Close() error {
+	p.closed = true
+	return nil
+}
+func (p *panelPluginTestController) GetSelectedName() string { return "plugin-row" }
+
+func TestPanelProviderOpensInActiveSlotAndReceivesContext(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	pf := setupMockPanelsFrame()
+	pf.ResizeConsole(80, 25)
+	defer pf.Close()
+
+	controller := &panelPluginTestController{}
+	registration, err := (&coreAPI{}).RegisterPanelProvider(vfs.PanelProvider{
+		ID:    "test.panel.active-slot",
+		Title: "Test panel",
+		Open: func(ctx vfs.PanelContext) (vfs.PanelController, error) {
+			controller.SetContext(ctx)
+			return controller, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer registration.Unregister()
+
+	openRegisteredPanelProvider(pf, "test.panel.active-slot")
+	instance, ok := pf.altPanels[1].(*pluginPanelInstance)
+	if !ok {
+		t.Fatalf("active slot contains %T, want pluginPanelInstance", pf.altPanels[1])
+	}
+	if pf.panels[1] == nil {
+		t.Fatal("logical file panel was removed")
+	}
+	pf.Show(vtui.NewSilentScreenBuf())
+	if controller.context.Side != 1 || controller.context.ActiveSide != 1 || !controller.context.Current.Active {
+		t.Fatalf("unexpected panel context: %+v", controller.context)
+	}
+	if controller.context.Other.Side != 0 || controller.context.Other.Active {
+		t.Fatalf("unexpected neighbouring panel context: %+v", controller.context.Other)
+	}
+
+	if !instance.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_F4}) {
+		t.Fatal("panel did not consume its key")
+	}
+	if controller.keys != 1 {
+		t.Fatalf("panel key count = %d, want 1", controller.keys)
+	}
+	instance.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_ESCAPE})
+	if pf.altPanels[1] != nil || !controller.closed {
+		t.Fatal("Escape did not close an unhandled plugin panel")
+	}
+}
+
+func TestRPCPanelProviderOpensVUIAndForwardsEvent(t *testing.T) {
+	coreSess, pluginSess := setupTestSessions()
+
+	document := []byte(`{"vuiVersion":1,"root":{"type":"Dialog","props":{"title":"Panel"}}}`)
+	pluginSess.Register("Plugin.OpenPanel", func(data msgpack.RawMessage) (any, error) {
+		var request RPCPanelOpenRequest
+		if err := msgpack.Unmarshal(data, &request); err != nil {
+			return nil, err
+		}
+		if request.ID != "remote.panel" || request.Context.Side != 1 {
+			t.Fatalf("unexpected open request: %+v", request)
+		}
+		return RPCPanelOpenResponse{Document: document}, nil
+	})
+	pluginSess.Register("Plugin.PanelEvent", func(data msgpack.RawMessage) (any, error) {
+		var request RPCPanelEventRequest
+		if err := msgpack.Unmarshal(data, &request); err != nil {
+			return nil, err
+		}
+		if request.Kind != "key" || request.Event.VirtualKeyCode != vtinput.VK_F4 {
+			t.Fatalf("unexpected event request: %+v", request)
+		}
+		return RPCPanelEventResponse{Handled: true, Document: document}, nil
+	})
+	pluginSess.Register("Plugin.ClosePanel", func(data msgpack.RawMessage) (any, error) { return nil, nil })
+
+	api := &coreAPI{}
+	registrations := &pluginSessionRegistrations{}
+	if err := registerRPCPluginPanels(api, coreSess, "test-rpc", []PluginPanelDescriptor{{
+		ID: "remote.panel", Title: "Remote panel",
+	}}, registrations); err != nil {
+		t.Fatal(err)
+	}
+	defer registrations.Unregister()
+
+	provider, ok := lookupPanelProvider("remote.panel")
+	if !ok {
+		t.Fatal("RPC panel was not registered")
+	}
+	panel, err := provider.Open(vfs.PanelContext{Side: 1, ActiveSide: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	panel.SetPosition(0, 0, 39, 19)
+	if !panel.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_F4}) {
+		t.Fatal("RPC panel did not return handled=true")
+	}
+	if err := panel.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRPCPanelDocumentRoundTripsAsJSON(t *testing.T) {
+	var doc vtui.VuiDocument
+	if err := json.Unmarshal([]byte(`{"vuiVersion":1,"root":{"type":"Dialog"}}`), &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Root == nil || doc.Root.Type != "Dialog" {
+		t.Fatalf("bad .vui document: %+v", doc)
+	}
+}

--- a/cmd/f4/plughost.go
+++ b/cmd/f4/plughost.go
@@ -61,6 +61,10 @@ func startPluginSession(sess *f4rpc.Session, api vfs.HostAPI, name string, bridg
 		registrations.Unregister()
 		return nil, err
 	}
+	if err := registerRPCPluginPanels(api, sess, name, res.Panels, registrations); err != nil {
+		registrations.Unregister()
+		return nil, err
+	}
 	for _, drive := range res.Drives {
 		driveName := drive // closure capture
 		api.RegisterDrive(driveName, func() vfs.VFS {

--- a/cmd/f4/rpc_commands.go
+++ b/cmd/f4/rpc_commands.go
@@ -32,6 +32,7 @@ type PluginCommandDescriptor struct {
 type PluginInitResponse struct {
 	Drives   []string
 	Commands []PluginCommandDescriptor
+	Panels   []PluginPanelDescriptor
 }
 
 // UnmarshalMsgpack keeps the command extension backwards compatible with
@@ -45,6 +46,7 @@ func (r *PluginInitResponse) UnmarshalMsgpack(data []byte) error {
 	if err := msgpack.Unmarshal(data, &legacy); err == nil {
 		r.Drives = append(r.Drives[:0], legacy...)
 		r.Commands = nil
+		r.Panels = nil
 		return nil
 	}
 	type responseAlias PluginInitResponse

--- a/cmd/f4/rpc_panel.go
+++ b/cmd/f4/rpc_panel.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+// PluginPanelDescriptor is the transport-safe declaration returned from
+// Plugin.Init. The panel document itself is opened lazily when the user runs
+// the generated command.
+type PluginPanelDescriptor struct {
+	ID          string
+	Title       string
+	Description string
+}
+
+type RPCPanelOpenRequest struct {
+	ID      string
+	Context vfs.PanelContext
+}
+
+// Document is UTF-8 JSON in the vtui .vui document format. Keeping the wire
+// payload as bytes lets MessagePack carry the exact document without making
+// the RPC protocol depend on vtui's Go struct field names.
+type RPCPanelOpenResponse struct {
+	Document []byte
+}
+
+type RPCPanelEventRequest struct {
+	ID      string
+	Kind    string // "key" or "mouse"
+	Event   vtinput.InputEvent
+	Context vfs.PanelContext
+}
+
+type RPCPanelEventResponse struct {
+	Handled  bool
+	Document []byte
+	Close    bool
+}
+
+func registerRPCPluginPanels(
+	api vfs.HostAPI,
+	back PluginTransport,
+	pluginName string,
+	descriptors []PluginPanelDescriptor,
+	registrations *pluginSessionRegistrations,
+) error {
+	if len(descriptors) == 0 {
+		return nil
+	}
+	contributions, ok := api.(vfs.PanelContributionHost)
+	if !ok {
+		return fmt.Errorf("plugin %q declares panels, but the host has no panel contribution API", pluginName)
+	}
+	if back == nil {
+		return fmt.Errorf("plugin %q panel transport is nil", pluginName)
+	}
+	for _, raw := range descriptors {
+		descriptor := raw
+		descriptor.ID = strings.TrimSpace(descriptor.ID)
+		descriptor.Title = strings.TrimSpace(descriptor.Title)
+		if descriptor.ID == "" {
+			return fmt.Errorf("plugin %q declares a panel with an empty ID", pluginName)
+		}
+		if descriptor.Title == "" {
+			return fmt.Errorf("plugin %q panel %q has no title", pluginName, descriptor.ID)
+		}
+		panelID := descriptor.ID
+		registration, err := contributions.RegisterPanelProvider(vfs.PanelProvider{
+			ID:          panelID,
+			Title:       descriptor.Title,
+			Description: descriptor.Description,
+			Open: func(ctx vfs.PanelContext) (vfs.PanelController, error) {
+				var response RPCPanelOpenResponse
+				if err := back.Call("Plugin.OpenPanel", RPCPanelOpenRequest{ID: panelID, Context: ctx}, &response); err != nil {
+					return nil, fmt.Errorf("open panel %q: %w", panelID, err)
+				}
+				return newRPCVUIPanel(back, panelID, response.Document)
+			},
+		})
+		if err != nil {
+			return fmt.Errorf("register plugin %q panel %q: %w", pluginName, panelID, err)
+		}
+		if !registrations.Add(registration) {
+			return fmt.Errorf("plugin %q disconnected while registering panel %q", pluginName, panelID)
+		}
+	}
+	return nil
+}
+
+// rpcVUIPanel is a small host-side adapter for a vtui .vui tree. The remote
+// plugin owns behavior: f4 forwards raw key/mouse events plus the latest panel
+// context and replaces the tree when the plugin returns a new document.
+type rpcVUIPanel struct {
+	sess    PluginTransport
+	id      string
+	window  *vtui.Window
+	context vfs.PanelContext
+	focused bool
+	mu      sync.Mutex
+	closed  bool
+}
+
+func newRPCVUIPanel(sess PluginTransport, id string, document []byte) (*rpcVUIPanel, error) {
+	if len(document) == 0 {
+		return nil, fmt.Errorf("panel %q returned an empty .vui document", id)
+	}
+	window, err := loadRPCVUIDocument(document)
+	if err != nil {
+		return nil, fmt.Errorf("panel %q returned invalid .vui document: %w", id, err)
+	}
+	return &rpcVUIPanel{sess: sess, id: id, window: window}, nil
+}
+
+func loadRPCVUIDocument(document []byte) (*vtui.Window, error) {
+	var parsed vtui.VuiDocument
+	if err := json.Unmarshal(document, &parsed); err != nil {
+		return nil, err
+	}
+	return vtui.LoadVuiDocument(&parsed)
+}
+
+func (p *rpcVUIPanel) Show(scr *vtui.ScreenBuf) { p.window.Show(scr) }
+
+func (p *rpcVUIPanel) ProcessKey(e *vtinput.InputEvent) bool {
+	return p.processEvent("key", e)
+}
+
+func (p *rpcVUIPanel) ProcessMouse(e *vtinput.InputEvent) bool {
+	return p.processEvent("mouse", e)
+}
+
+func (p *rpcVUIPanel) processEvent(kind string, event *vtinput.InputEvent) bool {
+	if p == nil || event == nil {
+		return false
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return false
+	}
+	ctx := p.context
+	sess := p.sess
+	id := p.id
+	p.mu.Unlock()
+	var response RPCPanelEventResponse
+	err := sess.Call("Plugin.PanelEvent", RPCPanelEventRequest{
+		ID: id, Kind: kind, Event: *event, Context: ctx,
+	}, &response)
+	if err != nil {
+		vtui.DebugLog("PANEL [%s]: event failed: %v", id, err)
+		return false
+	}
+	if len(response.Document) > 0 {
+		if err := p.replaceDocument(response.Document); err != nil {
+			vtui.DebugLog("PANEL [%s]: invalid render document: %v", id, err)
+			return false
+		}
+	}
+	if response.Close {
+		_ = p.Close()
+		return true
+	}
+	return response.Handled
+}
+
+func (p *rpcVUIPanel) replaceDocument(document []byte) error {
+	window, err := loadRPCVUIDocument(document)
+	if err != nil {
+		return err
+	}
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	x1, y1, x2, y2 := p.window.GetPosition()
+	focused := p.focused
+	window.SetPosition(x1, y1, x2, y2)
+	window.SetFocus(focused)
+	p.window = window
+	p.mu.Unlock()
+	vtui.FrameManager.Redraw()
+	return nil
+}
+
+func (p *rpcVUIPanel) SetFocus(focused bool) {
+	p.mu.Lock()
+	p.focused = focused
+	if p.window != nil {
+		p.window.SetFocus(focused)
+	}
+	p.mu.Unlock()
+}
+
+func (p *rpcVUIPanel) IsFocused() bool {
+	p.mu.Lock()
+	focused := p.focused
+	p.mu.Unlock()
+	return focused
+}
+
+func (p *rpcVUIPanel) SetPosition(x1, y1, x2, y2 int) {
+	p.mu.Lock()
+	if p.window != nil {
+		p.window.SetPosition(x1, y1, x2, y2)
+	}
+	p.mu.Unlock()
+}
+
+func (p *rpcVUIPanel) GetPosition() (int, int, int, int) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.window == nil {
+		return 0, 0, 0, 0
+	}
+	return p.window.GetPosition()
+}
+
+func (p *rpcVUIPanel) GetSelectedName() string { return "" }
+
+func (p *rpcVUIPanel) SetContext(ctx vfs.PanelContext) {
+	ctx.Current.SelectedNames = append([]string(nil), ctx.Current.SelectedNames...)
+	ctx.Other.SelectedNames = append([]string(nil), ctx.Other.SelectedNames...)
+	p.mu.Lock()
+	p.context = ctx
+	p.mu.Unlock()
+}
+
+func (p *rpcVUIPanel) Close() error {
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	p.closed = true
+	sess := p.sess
+	id := p.id
+	p.mu.Unlock()
+	if sess == nil {
+		return nil
+	}
+	return sess.Call("Plugin.ClosePanel", map[string]string{"ID": id}, nil)
+}

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -60,6 +60,43 @@ Because F4-RPC is a full-duplex protocol, plugins can call back into `f4` at any
 *   `Host.AskOverwrite` / `Host.AskError`: Invokes f4's native, rich collision/error dialogs (Retry, Skip, Overwrite All, etc.) during mutations.
 *   `Host.RegisterGlobalHotkey`: Registers a system-wide hotkey that triggers the plugin's `Plugin.OnHotkey` endpoint regardless of which panel is active.
 
+### E. Panel-only plugins
+
+A plugin does not have to mount a VFS to provide a full-screen panel surface.
+Native Go plugins can opt into the optional `vfs.PanelContributionHost` and
+register a `vfs.PanelProvider`. f4 publishes one searchable `Open <title>`
+command for each provider. Opening it replaces the active file-panel surface
+for that slot; the underlying `FileSystemPanel` remains alive as the logical
+source for normal file actions.
+
+The host calls the panel controller with the ordinary `vtui` drawing and input
+interfaces. Before each draw and input event it supplies a `PanelContext` with
+the panel side, screen bounds, active side, current path, cursor name, marked
+names, and the corresponding snapshot from the other file panel. `Esc` closes
+the panel when the controller does not consume it. This keeps panel plugins
+portable and prevents them from reaching into f4's private panel state.
+
+RPC plugins declare panel descriptors in the structured `Plugin.Init` result:
+
+```text
+Panels: [{ ID, Title, Description }]
+```
+
+The host then uses these calls lazily:
+
+* `Plugin.OpenPanel` receives `{ ID, Context }` and returns a UTF-8 JSON `.vui`
+  document in `Document`.
+* `Plugin.PanelEvent` receives `{ ID, Kind, Event, Context }`, where `Kind` is
+  `key` or `mouse`, and returns `{ Handled, Document, Close }`. `Document` is
+  optional; when present it replaces the current widget tree.
+* `Plugin.ClosePanel` receives `{ ID }` when the panel is dismissed.
+
+The `.vui` document is rendered by the same `vtui` controls and wire format
+used by the bindings in the `vtui` repository. The plugin owns semantic
+behavior and may return a new document after any event; f4 owns placement,
+focus routing, and panel context delivery. Existing VFS-only plugins continue
+to use the legacy response shape unchanged.
+
 ## 3. Design Philosophy & Comparisons
 
 If you are coming from the classic Far Manager ecosystem or modern text editors, here is how F4-RPC compares.

--- a/sdk/f4plugin/plugin.go
+++ b/sdk/f4plugin/plugin.go
@@ -129,6 +129,55 @@ type PluginRunCommandRequest struct {
 	ID string
 }
 
+// PanelState and PanelContext are the transport-safe snapshot delivered to a
+// panel plugin. They intentionally contain no host pointers or VFS handles.
+type PanelState struct {
+	Side          int
+	Active        bool
+	Path          string
+	SelectedName  string
+	SelectedNames []string
+}
+
+type PanelContext struct {
+	Side       int
+	ActiveSide int
+	Bounds     [4]int
+	Current    PanelState
+	Other      PanelState
+}
+
+type PanelDescriptor struct {
+	ID          string
+	Title       string
+	Description string
+}
+
+type PanelEventRequest struct {
+	ID      string
+	Kind    string
+	Event   vtinput.InputEvent
+	Context PanelContext
+}
+
+type PanelEventResponse struct {
+	Handled bool
+	// Document is UTF-8 JSON in the vtui .vui format. An empty value keeps the
+	// current document, which is useful for events that only need consuming.
+	Document []byte
+	Close    bool
+}
+
+// PanelProvider is an optional extension for plugins that own a full panel
+// surface. The host sends raw input and a fresh context snapshot; the plugin
+// may return a new .vui document after each event.
+type PanelProvider interface {
+	PanelDescriptors() []PanelDescriptor
+	OpenPanel(id string, context PanelContext) ([]byte, error)
+	HandlePanelEvent(request PanelEventRequest) (PanelEventResponse, error)
+	ClosePanel(id string) error
+}
+
 // CommandProvider is an optional extension. Existing Plugin implementations
 // remain source-compatible; implementations that opt in get commands in f4's
 // plugin menus and command palette.
@@ -166,9 +215,19 @@ func Run(p Plugin) {
 	sess.Register("Plugin.Init", func(data msgpack.RawMessage) (any, error) {
 		drives, err := p.Init(host)
 		if commands, ok := p.(CommandProvider); ok {
-			return map[string]any{
+			response := map[string]any{
 				"Drives":   drives,
 				"Commands": commands.PluginCommands(),
+			}
+			if panels, ok := p.(PanelProvider); ok {
+				response["Panels"] = panels.PanelDescriptors()
+			}
+			return response, err
+		}
+		if panels, ok := p.(PanelProvider); ok {
+			return map[string]any{
+				"Drives": drives,
+				"Panels": panels.PanelDescriptors(),
 			}, err
 		}
 		// Preserve the original wire shape unless the plugin opts into the
@@ -186,6 +245,49 @@ func Run(p Plugin) {
 			return nil, err
 		}
 		return nil, commands.RunPluginCommand(request.ID)
+	})
+
+	sess.Register("Plugin.OpenPanel", func(data msgpack.RawMessage) (any, error) {
+		panels, ok := p.(PanelProvider)
+		if !ok {
+			return nil, fmt.Errorf("plugin does not implement PanelProvider")
+		}
+		var request struct {
+			ID      string
+			Context PanelContext
+		}
+		if err := msgpack.Unmarshal(data, &request); err != nil {
+			return nil, err
+		}
+		document, err := panels.OpenPanel(request.ID, request.Context)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"Document": document}, nil
+	})
+
+	sess.Register("Plugin.PanelEvent", func(data msgpack.RawMessage) (any, error) {
+		panels, ok := p.(PanelProvider)
+		if !ok {
+			return nil, fmt.Errorf("plugin does not implement PanelProvider")
+		}
+		var request PanelEventRequest
+		if err := msgpack.Unmarshal(data, &request); err != nil {
+			return nil, err
+		}
+		return panels.HandlePanelEvent(request)
+	})
+
+	sess.Register("Plugin.ClosePanel", func(data msgpack.RawMessage) (any, error) {
+		panels, ok := p.(PanelProvider)
+		if !ok {
+			return nil, fmt.Errorf("plugin does not implement PanelProvider")
+		}
+		var request struct{ ID string }
+		if err := msgpack.Unmarshal(data, &request); err != nil {
+			return nil, err
+		}
+		return nil, panels.ClosePanel(request.ID)
 	})
 
 	sess.Register("VFS.ReadDir", func(data msgpack.RawMessage) (any, error) {

--- a/vfs/contributions.go
+++ b/vfs/contributions.go
@@ -1,6 +1,11 @@
 package vfs
 
-import "context"
+import (
+	"context"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
 
 // Registration is a live plugin contribution. Unregister is safe to call
 // more than once.
@@ -86,6 +91,67 @@ type ContributionHost interface {
 	RegisterPluginCommand(PluginCommand) (Registration, error)
 	RegisterCommandPrefix(id, prefix string, handler func(App, string)) (CommandPrefixRegistration, error)
 	RegisterMacroCallProvider(MacroCallProvider) (Registration, error)
+}
+
+// PanelState is the immutable, UI-safe snapshot of one file panel exposed to
+// a panel plugin. VFS handles are deliberately omitted: a panel plugin gets
+// paths and selection metadata, while file operations continue to go through
+// the normal VFS/plugin APIs.
+type PanelState struct {
+	Side          int
+	Active        bool
+	Path          string
+	SelectedName  string
+	SelectedNames []string
+}
+
+// PanelContext describes the panel slot occupied by a plugin and both file
+// panels around it. It is refreshed before every draw and input event, so a
+// plugin never has to guess whether the neighbouring selection changed.
+type PanelContext struct {
+	Side       int
+	ActiveSide int
+	Bounds     [4]int
+	Current    PanelState
+	Other      PanelState
+}
+
+// Panel is the drawable/input surface a native or RPC panel plugin supplies.
+// Implementations normally compose vtui controls and forward these methods
+// to their root control.
+type Panel interface {
+	Show(*vtui.ScreenBuf)
+	ProcessKey(*vtinput.InputEvent) bool
+	ProcessMouse(*vtinput.InputEvent) bool
+	SetFocus(bool)
+	IsFocused() bool
+	SetPosition(x1, y1, x2, y2 int)
+	GetPosition() (x1, y1, x2, y2 int)
+	GetSelectedName() string
+}
+
+// PanelController adds lifecycle and state delivery to a drawable panel.
+type PanelController interface {
+	Panel
+	SetContext(PanelContext)
+	Close() error
+}
+
+// PanelProvider describes a panel-only plugin contribution. The host exposes
+// an automatically searchable "Open <Title>" command for every provider.
+// Open is called on the UI goroutine and should construct controls quickly;
+// long-running work belongs in the existing task APIs.
+type PanelProvider struct {
+	ID          string
+	Title       string
+	Description string
+	Open        func(PanelContext) (PanelController, error)
+}
+
+// PanelContributionHost is separate from ContributionHost so older host
+// implementations and test doubles remain source-compatible.
+type PanelContributionHost interface {
+	RegisterPanelProvider(PanelProvider) (Registration, error)
 }
 
 // ProcessEnvironmentVariable is one name/value pair in f4's actual process


### PR DESCRIPTION
Closes #658

## What changed

- Add an optional `vfs.PanelContributionHost` / `vfs.PanelProvider` contract for native panel-only plugins.
- Expose a searchable `Open <title>` command and place the opened panel in the active panel slot while preserving the underlying `FileSystemPanel` as the logical source.
- Deliver active/passive panel state, cursor, marked selection, side, active side, and bounds through `PanelContext`.
- Add RPC panel descriptors and lazy `Plugin.OpenPanel`, `Plugin.PanelEvent`, and `Plugin.ClosePanel` calls.
- Render RPC panel responses from the existing vtui `.vui` document format and forward key/mouse input to the plugin.
- Document the native and RPC contracts in `docs/PLUGINS.md` and extend the Go SDK.
- Add tests for active-slot placement, context delivery, Escape lifecycle, RPC `.vui` loading, and event forwarding.

## Validation

- `go test ./... -count=1`
- `go build -o C:\\Temp\\f4-658.exe .\\cmd\\f4`
- `f4-658.exe --version`
- `f4-658.exe --wine-probe`
- `f4-658.exe -test-plugins`

The local Windows environment has CGO disabled, so the local race detector is not available; the GitHub race job remains required.

— zoin-bot