### PR TITLE
Fix Auto Update dialog missed first click

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3600,7 +3600,11 @@ func actionUpdateSettings(pf *PanelsFrame) {
 		AppConfig.UpdateInterval = comboInterval.Menu.SelectPos
 		SaveConfig()
 		dlg.Close()
-		CheckForUpdates(pf, true)
+		// Do not hold the UI mouse-dispatch loop while the manual update
+		// check waits for GitHub. The dialog is already closed, so the
+		// network request can safely continue in the background and post
+		// its result back through FrameManager when it completes.
+		go CheckForUpdates(pf, true)
 	}
 
 	vtui.FrameManager.Push(dlg)

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -74,12 +74,13 @@ func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T)
 	}
 	checkButton := buttons[1]
 	x, y, _, _ := checkButton.GetPosition()
+	mx, my := checkedMouseCoordinate(t, x), checkedMouseCoordinate(t, y)
 
 	window.ProcessMouse(&vtinput.InputEvent{
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
-		MouseX:      int16(x),
-		MouseY:      int16(y),
+		MouseX:      mx,
+		MouseY:      my,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 
@@ -87,8 +88,8 @@ func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T)
 	go func() {
 		window.ProcessMouse(&vtinput.InputEvent{
 			Type:        vtinput.MouseEventType,
-			MouseX:      int16(x),
-			MouseY:      int16(y),
+			MouseX:      mx,
+			MouseY:      my,
 			KeyDown:     false,
 			ButtonState: 0,
 		})
@@ -112,6 +113,14 @@ func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T)
 	case <-time.After(1 * time.Second):
 		t.Fatal("manual update check did not finish after the response was released")
 	}
+}
+
+func checkedMouseCoordinate(t *testing.T, value int) int16 {
+	t.Helper()
+	if value < -32768 || value > 32767 {
+		t.Fatalf("mouse coordinate %d does not fit in int16", value)
+	}
+	return int16(value) // #nosec G115 -- the range is checked immediately above.
 }
 
 func TestActionExecute_RemoteRejection(t *testing.T) {

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -3,16 +3,116 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/unxed/f4/vfs"
-	"github.com/unxed/vtinput"
-	"github.com/unxed/vtui"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
 )
+
+func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldCfg := AppConfig
+	oldAPIURL := githubAPIURL
+	oldOS := currentOS
+	oldArch := currentArch
+	t.Cleanup(func() {
+		AppConfig = oldCfg
+		githubAPIURL = oldAPIURL
+		currentOS = oldOS
+		currentArch = oldArch
+	})
+
+	requestStarted := make(chan struct{})
+	allowResponse := make(chan struct{})
+	requestFinished := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		close(requestStarted)
+		select {
+		case <-allowResponse:
+		case <-r.Context().Done():
+			return
+		}
+		defer close(requestFinished)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"7f1fec5","assets":[{"name":"f4-windows-amd64.zip","browser_download_url":"http://127.0.0.1/update.zip"}]}`))
+	}))
+	defer server.Close()
+
+	githubAPIURL = server.URL + "/repos/unxed/f4/releases"
+	currentOS = "windows"
+	currentArch = "amd64"
+	AppConfig.UpdateChannel = 0
+	AppConfig.UpdateInterval = 0
+
+	actionUpdateSettings(nil)
+	window := vtui.FrameManager.GetTopFrame()
+	if window == nil {
+		t.Fatal("update settings dialog was not opened")
+	}
+	container, ok := window.(interface{ GetChildren() []vtui.UIElement })
+	if !ok {
+		t.Fatal("update settings dialog does not expose its controls")
+	}
+	var buttons []*vtui.Button
+	for _, child := range container.GetChildren() {
+		if button, ok := child.(*vtui.Button); ok {
+			buttons = append(buttons, button)
+		}
+	}
+	if len(buttons) != 3 {
+		t.Fatalf("expected three update-settings buttons, got %d", len(buttons))
+	}
+	checkButton := buttons[1]
+	x, y, _, _ := checkButton.GetPosition()
+
+	window.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      int16(x),
+		MouseY:      int16(y),
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	})
+
+	dispatchDone := make(chan struct{})
+	go func() {
+		window.ProcessMouse(&vtinput.InputEvent{
+			Type:        vtinput.MouseEventType,
+			MouseX:      int16(x),
+			MouseY:      int16(y),
+			KeyDown:     false,
+			ButtonState: 0,
+		})
+		close(dispatchDone)
+	}()
+
+	select {
+	case <-dispatchDone:
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("manual update check blocked mouse dispatch")
+	}
+
+	select {
+	case <-requestStarted:
+	case <-time.After(1 * time.Second):
+		t.Fatal("manual update check did not start in the background")
+	}
+	close(allowResponse)
+	select {
+	case <-requestFinished:
+	case <-time.After(1 * time.Second):
+		t.Fatal("manual update check did not finish after the response was released")
+	}
+}
 
 func TestActionExecute_RemoteRejection(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())


### PR DESCRIPTION
Closes #666

## Root cause

The Auto Update settings dialog closed on `Check now`, but its click handler then ran the manual GitHub request synchronously on the UI event-dispatch goroutine. Until the request returned, f4 could not redraw the closed dialog or process the next input event, which made the first mouse click appear lost and left the underlying panel in a stale visual state.

## Fix

The manual check now runs in a background goroutine after the dialog closes. Its existing result/error delivery still goes through `FrameManager.PostTask`, so UI changes remain on the UI thread. The same issue was audited across update-check call sites; startup checks were already asynchronous.

## Regression coverage

Added `TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch`, which holds an HTTP response open and verifies that the dialog's mouse dispatch returns immediately while the request continues and completes in the background.

## Validation

- `go test ./... -count=1`
- `go build -o C:\Temp\f4-666.exe .\cmd\f4`
- Native Windows `f4-666.exe --version`, `--wine-probe`, and `-test-plugins`
- Native Windows `--gui=win32` smoke test: opened the Auto Update settings through the command palette, activated `Check now`, observed immediate frame removal/redraw and a background `UPDATER: Checking for updates` log entry.

The maximized test display exposed a host-only logical/physical size mismatch (160x49 logical cells in a 1440x853 capture), so the dialog was partly outside the screenshot; the native backend still accepted and processed the event path successfully.

— zoin-bot