### PR TITLE
Fix Shift+F4 absolute existing-file paths

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -1659,7 +1659,13 @@ func actionNewFile(pf *PanelsFrame) {
 			if name == "" {
 				name = "newfile.txt"
 			}
-			path := activeVfs.Join(dir, name)
+			// Shift+F4 also accepts a complete path. Joining an absolute
+			// name to the active directory duplicates the path prefix and
+			// makes an existing file look like a new, empty file.
+			path := name
+			if !activeVfs.IsAbs(name) {
+				path = activeVfs.Join(dir, name)
+			}
 			if AppConfig.UseExternalEditor {
 				actionEditFileExternal(pf, activeVfs, path, 0)
 				return

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -745,6 +745,69 @@ func TestActionNewFile_Flow(t *testing.T) {
 		t.Errorf("Expected New File dialog, got %v", top)
 	}
 }
+
+func TestActionNewFile_AbsoluteExistingPath(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	root := t.TempDir()
+	path := filepath.Join(root, "existing.txt")
+	want := []byte("already here\n")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	fsp := pf.panels[0].(*FileSystemPanel)
+	fsp.vfs = vfs.NewOSVFS(root)
+	pvfs := fsp.vfs
+
+	actionNewFile(pf)
+	dlg, ok := vtui.FrameManager.GetTopFrame().(vtui.Container)
+	if !ok {
+		t.Fatalf("New File dialog is not a container: %T", vtui.FrameManager.GetTopFrame())
+	}
+	var edit *vtui.Edit
+	var okButton *vtui.Button
+	for _, child := range dlg.GetChildren() {
+		switch value := child.(type) {
+		case *vtui.Edit:
+			edit = value
+		case *vtui.Button:
+			if strings.Contains(value.GetText(), Msg("vtui.Ok")) {
+				okButton = value
+			}
+		}
+	}
+	if edit == nil || okButton == nil {
+		t.Fatal("New File dialog controls not found")
+	}
+	edit.SetText(path)
+	okButton.OnClick()
+
+	var editor *EditorView
+	deadline := time.After(2 * time.Second)
+	for editor == nil {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			editor, _ = findOpenedEditor(pvfs, path)
+		case <-deadline:
+			t.Fatal("Timeout waiting for existing file editor")
+		}
+	}
+	defer editor.Close()
+
+	got, err := editor.pt.GetRange(0, editor.pt.Size())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("opened content = %q, want %q", got, want)
+	}
+}
 func TestDelete_FocusCustomization(t *testing.T) {
 	fm := vtui.FrameManager
 	fm.Init(vtui.NewSilentScreenBuf())


### PR DESCRIPTION
Closes #675

## Problem
Shift+F4 accepts a complete path, but the action always joined the entered value to the active panel directory. An absolute path such as `/tmp/000tmp/f4/README.md` therefore became `/tmp/000tmp/f4/tmp/000tmp/f4/README.md`. The editor then opened an empty new target and saving failed because the duplicated parent path did not exist.

## Fix
Keep absolute input paths unchanged and join only relative names to the active directory. Added a regression test that drives the Shift+F4 dialog with an absolute path to an existing file and verifies that the existing content is opened.

## Validation
- `go test ./... -count=1`
- Native Windows build and `f4-675.exe --version`
- `f4-675.exe --wine-probe`
- `f4-675.exe -test-plugins`
- Native `--gui=win32 --debug` smoke test: Shift+F4 with `c:\code\f4-675\readme.md` opened the existing README; Ctrl+S completed without the reported save error.

— zoin-bot