### PR TITLE
ci: smoke test every Linux binary under qemu-user

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,7 @@ jobs:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         goos: [linux, windows, darwin, freebsd, dragonfly, openbsd, netbsd, illumos, solaris]
         goarch: [amd64, arm64, arm]
@@ -152,6 +153,57 @@ jobs:
         # Build internal dummy plugin
         cd plugins/dummy_internal
         go build "${BUILD_TAG_ARGS[@]}" -trimpath $GCFLAGS -ldflags="$LDFLAGS" -o ../../build/plugins/dummy_internal/f4-internal-dummy-plugin$EXT .
+
+    # A cross-built binary nobody ever started is not evidence of anything,
+    # and the release publishes it all the same. The Linux binaries are
+    # static, so qemu-user runs them with no rootfs and no binfmt setup, and
+    # Go runs every package's init() before main -- so a single --version
+    # call is enough to catch a broken toolchain or an architecture a
+    # dependency cannot actually handle. --version returns before any
+    # terminal setup, so no tty is needed.
+    - name: Smoke test the binary
+      if: matrix.goos == 'linux'
+      run: |
+        set -euo pipefail
+        # GOARCH and qemu-user spell five of these differently.
+        case "${{ matrix.goarch }}" in
+          amd64)    QEMU="" ;;
+          386)      QEMU=i386 ;;
+          arm64)    QEMU=aarch64 ;;
+          mipsle)   QEMU=mipsel ;;
+          mips64le) QEMU=mips64el ;;
+          loong64)  QEMU=loongarch64 ;;
+          *)        QEMU="${{ matrix.goarch }}" ;;
+        esac
+
+        if [ -z "$QEMU" ]; then
+          ./build/f4 --version
+          exit 0
+        fi
+
+        # goffi's fakecgo emits //go:cgo_import_dynamic, so the cells that
+        # keep the FFI backends come out dynamically linked despite
+        # CGO_ENABLED=0 and -extldflags '-static', and qemu then needs the
+        # target's loader. Today that is arm64 alone: amd64 runs natively,
+        # and the noffi cells drop goffi and really are static.
+        PACKAGES=qemu-user-static
+        set --
+        if file build/f4 | grep -q 'dynamically linked'; then
+          case "${{ matrix.goarch }}" in
+            arm64)
+              PACKAGES="$PACKAGES libc6-arm64-cross"
+              set -- -L /usr/aarch64-linux-gnu
+              ;;
+            *)
+              echo "::error::${{ matrix.goarch }} is dynamically linked and has no sysroot configured here"
+              exit 1
+              ;;
+          esac
+        fi
+
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq $PACKAGES
+        "qemu-$QEMU-static" "$@" build/f4 --version
 
     - name: Package
       run: |


### PR DESCRIPTION
**What.** After each Linux build, run the binary once under qemu-user (`f4 --version`). It also sets `fail-fast: false` on the build matrix.

**Why.** The architecture cells added in #669 prove the code compiles; nothing has ever started the binaries, and the nightly release publishes them all the same. The Linux builds need no rootfs, so qemu-user runs them straight off the runner, and Go runs every package's `init()` before `main` — one `--version` call exercises the whole import graph for a couple of seconds per cell. `fail-fast` matters here because the first failure cancels the cells still running, throwing away exactly the per-architecture result the smoke test exists to produce; on the first run that hid loong64, which was the open question.

**What for.** "It compiled" becomes "it starts", on all eleven Linux architectures — including big-endian mips, mips64 and ppc64, and including linux/arm, which had never been run either.

**It already caught something.** The cells that keep the FFI backends are dynamically linked despite `CGO_ENABLED=0` and `-extldflags '-static'`: `fakecgo` inside goffi emits `//go:cgo_import_dynamic`, so the linker records an interpreter. That affects linux/amd64 and linux/arm64; the `noffi` cells and arm are genuinely static. The step installs the cross libc for arm64 and passes `-L`, and a binary that turns out dynamic without a sysroot configured fails loudly rather than being skipped. Whether the released binaries ought to be static is a separate question — happy to open an issue if you want it looked at.

**Result.** 11/11 Linux cells green.
