### PR TITLE
zoin-bot: harden local settings and schema installs

### DIFF
--- a/ISSUE_677_SOLUTION_REVIEW.md
+++ b/ISSUE_677_SOLUTION_REVIEW.md
@@ -1,0 +1,85 @@
+# Issue #677 — solution review
+
+## Findings
+
+1. `cmd/f4/config.go` truncates the live `config.ini` and discards write
+   errors. A crash or full filesystem can leave an empty/partial configuration.
+2. `cmd/f4/colorer_downloader.go` removes the installed schema tree before the
+   downloaded ZIP is validated. Its member path is joined directly, so a
+   crafted archive can escape the destination through `..` or an absolute
+   path. A failed download also destroys a working installation.
+3. `plugins/netfox/vfs.go` ignores JSON and filesystem errors. A damaged file is
+   interpreted as an empty database, and the next save can erase all saved
+   connections. `netfoxWriter.Close` also saves an empty profile when its JSON
+   is invalid.
+4. `plugins/visren/config.go` truncates its settings file in place, so a crash
+   during save loses the previous preference.
+5. `bookmarks.go`, `user_menu_ini.go`, `user_menu_ui.go`, and
+   `file_associations.go` all use a predictable `<target>.tmp`. Concurrent
+   writers can overwrite one another's temporary file, and a stale temporary
+   file can be mistaken for an in-progress save.
+
+## Alternatives
+
+### A — Patch each call site independently
+
+Replace direct writes with `CreateTemp` and rename in every file, and add a
+one-off Colorer path check. This is the smallest diff, but it duplicates the
+durability rules and makes it likely that the next local settings writer will
+reintroduce the same bug.
+
+### B — Shared atomic writer plus staged Colorer installation (selected)
+
+Add a small same-directory atomic writer in `cmd/f4` and reuse it for all
+local INI/settings writers. It creates a unique temporary file, writes and
+syncs it, closes it, then renames it over the target; failures clean up the
+temporary file and leave the old target untouched. Give NetFox and VisRen the
+same transaction pattern in their packages. For Colorer, validate every
+member path before extraction, extract to a new staging directory, and swap it
+with the old tree only after extraction succeeds, retaining a rollback path.
+
+### C — Persistent database / journal for all settings
+
+Move settings and plugin profiles to a journaled store with checksums and
+recovery. This would handle concurrent processes more comprehensively, but it
+is a large refactor, changes on-disk compatibility, and is explicitly outside
+the scope of this ticket.
+
+## Three-pass review of option B
+
+### Pass 1 — correctness
+
+- Same-directory rename gives readers either the old complete file or the new
+  complete file, never a truncated file.
+- A unique temp name removes the fixed-`.tmp` collision.
+- NetFox must fail closed on invalid JSON and invalid writer input; read-only
+  listing may fall back to an empty view, but mutating operations must not.
+- Colorer must reject absolute paths and `..` components before opening a
+  member, and must not touch the installed tree until the staged tree is
+  complete.
+
+### Pass 2 — adversarial review
+
+- A ZIP entry cannot escape through a symlink because extraction happens in a
+  fresh directory and symlink entries are rejected.
+- Cancellation, short writes, close failures, malformed archives, and rename
+  failures must remove only staging/temp files and preserve the prior install.
+- Existing file modes are intentionally kept compatible for ordinary INI
+  files; sensitive plugin configs use `0600`.
+- A concurrent save may be last-writer-wins, but every winner is a complete
+  serialization and no writer can delete another writer's temp file.
+
+### Pass 3 — regression surface
+
+- Add tests for malformed NetFox JSON preservation, invalid NetFox writer input,
+  atomic temp cleanup, Colorer traversal rejection, and failed staged install
+  preserving the old catalog.
+- Run focused package tests, `go vet`, a race-focused test subset, then the
+  full repository tests. Build and run the ARM64 binary locally as a final
+  smoke check.
+
+## Decision
+
+Use option B. Keep the on-disk formats unchanged, make failures visible to
+callers where the APIs already return errors, and document larger journal/
+cross-process coordination ideas without implementing them here.

--- a/cmd/f4/atomic_file.go
+++ b/cmd/f4/atomic_file.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// writeFileAtomically publishes a complete file without exposing a truncated
+// target. The temporary file lives beside the target so Rename is atomic on
+// filesystems that support atomic same-directory replacement.
+func writeFileAtomically(path string, data []byte, mode os.FileMode) (returnErr error) {
+	dir := filepath.Dir(path)
+	if dir == "" {
+		dir = "."
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+
+	f, err := os.CreateTemp(dir, ".f4-atomic-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := f.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			if closeErr := f.Close(); returnErr == nil && closeErr != nil {
+				returnErr = closeErr
+			}
+		}
+		if returnErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if err := f.Chmod(mode); err != nil {
+		return err
+	}
+	for len(data) > 0 {
+		written, err := f.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		closed = true
+		return err
+	}
+	closed = true
+	// The deferred Close is now harmless and the temp name is removed only if
+	// publication fails.
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	returnErr = nil
+	// Directory fsync is a best-effort durability improvement. It is not
+	// available on every supported platform, while the same-directory rename
+	// remains the atomic publication point.
+	if d, err := os.Open(dir); err == nil {
+		_ = d.Sync()
+		_ = d.Close()
+	}
+	return nil
+}

--- a/cmd/f4/atomic_file.go
+++ b/cmd/f4/atomic_file.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 // writeFileAtomically publishes a complete file without exposing a truncated
@@ -58,8 +59,15 @@ func writeFileAtomically(path string, data []byte, mode os.FileMode) (returnErr 
 	closed = true
 	// The deferred Close is now harmless and the temp name is removed only if
 	// publication fails.
-	if err := os.Rename(tmpPath, path); err != nil {
-		return err
+	var renameErr error
+	for attempt := 0; attempt < 20; attempt++ {
+		if renameErr = os.Rename(tmpPath, path); renameErr == nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if renameErr != nil {
+		return renameErr
 	}
 	returnErr = nil
 	// Directory fsync is a best-effort durability improvement. It is not

--- a/cmd/f4/atomic_file_test.go
+++ b/cmd/f4/atomic_file_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -11,7 +12,7 @@ import (
 func TestWriteFileAtomicallyPublishesCompleteData(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.ini")
-	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte("old\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	want := []byte(strings.Repeat("new\n", 1000))
@@ -29,7 +30,7 @@ func TestWriteFileAtomicallyPublishesCompleteData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if mode.Mode().Perm() != 0o600 {
+	if runtime.GOOS != "windows" && mode.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %o, want 600", mode.Mode().Perm())
 	}
 	if leftovers, err := filepath.Glob(filepath.Join(dir, ".f4-atomic-*")); err != nil {
@@ -47,7 +48,8 @@ func TestWriteFileAtomicallyConcurrentWritersNeverPublishPartialData(t *testing.
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			data := []byte(strings.Repeat(string(rune('A'+i)), 4096))
+			letters := "ABCDEFGHIJKLMNOP"
+			data := []byte(strings.Repeat(string(letters[i]), 4096))
 			if err := writeFileAtomically(path, data, 0o600); err != nil {
 				t.Errorf("writer %d: %v", i, err)
 			}

--- a/cmd/f4/atomic_file_test.go
+++ b/cmd/f4/atomic_file_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+func TestWriteFileAtomicallyPublishesCompleteData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.ini")
+	if err := os.WriteFile(path, []byte("old\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := []byte(strings.Repeat("new\n", 1000))
+	if err := writeFileAtomically(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("published data was incomplete: got %d bytes, want %d", len(got), len(want))
+	}
+	mode, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %o, want 600", mode.Mode().Perm())
+	}
+	if leftovers, err := filepath.Glob(filepath.Join(dir, ".f4-atomic-*")); err != nil {
+		t.Fatal(err)
+	} else if len(leftovers) != 0 {
+		t.Fatalf("atomic temporary files remain: %v", leftovers)
+	}
+}
+
+func TestWriteFileAtomicallyConcurrentWritersNeverPublishPartialData(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.ini")
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			data := []byte(strings.Repeat(string(rune('A'+i)), 4096))
+			if err := writeFileAtomically(path, data, 0o600); err != nil {
+				t.Errorf("writer %d: %v", i, err)
+			}
+		}(i)
+	}
+	wg.Wait()
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 4096 {
+		t.Fatalf("final file length = %d, want 4096", len(got))
+	}
+	for _, b := range got {
+		if b != got[0] {
+			t.Fatalf("final file contains a partial mix of writers")
+		}
+	}
+}

--- a/cmd/f4/bookmarks.go
+++ b/cmd/f4/bookmarks.go
@@ -140,11 +140,7 @@ func SaveBookmarks(path string, s BookmarkSet) error {
 		buf.WriteByte('\n')
 	}
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomically(path, []byte(buf.String()), 0o644)
 }
 
 // truncPathLeft shortens path to at most width display cells by dropping

--- a/cmd/f4/colorer_downloader.go
+++ b/cmd/f4/colorer_downloader.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -22,6 +23,8 @@ func SchemasExist() bool {
 }
 
 var colorerDownloadURL = "https://github.com/elfmz/far2l/archive/refs/tags/v_2.8.0.zip"
+
+const maxColorerDownload = 256 << 20
 
 func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 	url := colorerDownloadURL
@@ -45,6 +48,9 @@ func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 		}
 
 		contentLength := resp.ContentLength
+		if contentLength > maxColorerDownload {
+			return fmt.Errorf("colorer schemas download exceeds %d bytes", maxColorerDownload)
+		}
 		var buf bytes.Buffer
 		tmpBuf := make([]byte, 32*1024)
 		var downloaded int64
@@ -55,6 +61,9 @@ func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 			}
 			n, readErr := resp.Body.Read(tmpBuf)
 			if n > 0 {
+				if downloaded+int64(n) > maxColorerDownload {
+					return fmt.Errorf("colorer schemas download exceeds %d bytes", maxColorerDownload)
+				}
 				buf.Write(tmpBuf[:n])
 				downloaded += int64(n)
 				pct := -1
@@ -72,54 +81,7 @@ func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 		}
 
 		update("Extracting schemas...", -1)
-		os.RemoveAll(destDir)
-		os.MkdirAll(destDir, 0755)
-
-		zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
-		if err != nil {
-			return err
-		}
-
-		prefix := "far2l-v_2.8.0/colorer/configs/"
-		for _, f := range zr.File {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			if !strings.HasPrefix(f.Name, prefix) {
-				continue
-			}
-			relPath := strings.TrimPrefix(f.Name, prefix)
-			if relPath == "" {
-				continue
-			}
-
-			targetPath := filepath.Join(destDir, filepath.FromSlash(relPath))
-			if f.FileInfo().IsDir() {
-				os.MkdirAll(targetPath, 0755)
-				continue
-			}
-
-			rc, err := f.Open()
-			if err != nil {
-				return err
-			}
-
-			os.MkdirAll(filepath.Dir(targetPath), 0755)
-			out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, f.Mode())
-			if err != nil {
-				rc.Close()
-				return err
-			}
-
-			_, err = io.Copy(out, rc)
-			rc.Close()
-			out.Close()
-			if err != nil {
-				return err
-			}
-		}
-
-		return nil
+		return installColorerSchemas(buf.Bytes(), destDir, ctx)
 	}, func(err error) {
 		if err != nil {
 			vtui.ShowMessage(" Error ", fmt.Sprintf("Failed to download Colorer schemas:\n%v\n\nFalling back to Chroma.", err), []string{"&Ok"})
@@ -131,4 +93,137 @@ func DownloadColorerSchemas(pf *PanelsFrame, onComplete func(success bool)) {
 			onComplete(true)
 		}
 	})
+}
+
+// installColorerSchemas validates and extracts a downloaded schema archive in
+// a fresh sibling directory, then swaps it into place. The old installation
+// is never removed before the new one is complete.
+func installColorerSchemas(data []byte, destDir string, ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return err
+	}
+	prefix := "far2l-v_2.8.0/colorer/configs/"
+	seen := make(map[string]struct{})
+	for _, f := range zr.File {
+		if !strings.HasPrefix(f.Name, prefix) {
+			continue
+		}
+		relPath := strings.TrimPrefix(f.Name, prefix)
+		if relPath == "" {
+			continue
+		}
+		if _, err := sanitizeExtractPath(relPath, destDir); err != nil {
+			return fmt.Errorf("invalid Colorer archive member %q: %w", f.Name, err)
+		}
+		if f.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("symlink is not allowed in Colorer archive member %q", f.Name)
+		}
+		key := path.Clean(filepath.ToSlash(relPath))
+		if _, exists := seen[key]; exists {
+			return fmt.Errorf("duplicate Colorer archive member %q", f.Name)
+		}
+		seen[key] = struct{}{}
+	}
+
+	parent := filepath.Dir(destDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return err
+	}
+	if info, err := os.Lstat(destDir); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to replace symlink Colorer catalog %q", destDir)
+	}
+	stage, err := os.MkdirTemp(parent, ".f4-colorer-stage-*")
+	if err != nil {
+		return err
+	}
+	stageLive := true
+	defer func() {
+		if stageLive {
+			_ = os.RemoveAll(stage)
+		}
+	}()
+
+	for _, f := range zr.File {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if !strings.HasPrefix(f.Name, prefix) {
+			continue
+		}
+		relPath := strings.TrimPrefix(f.Name, prefix)
+		if relPath == "" {
+			continue
+		}
+		targetPath, err := sanitizeExtractPath(relPath, stage)
+		if err != nil {
+			return err
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		mode := f.Mode().Perm()
+		if mode == 0 {
+			mode = 0o644
+		}
+		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		if err != nil {
+			_ = rc.Close()
+			return err
+		}
+		_, copyErr := io.Copy(out, rc)
+		closeInErr := rc.Close()
+		if copyErr == nil {
+			copyErr = closeInErr
+		}
+		if copyErr == nil {
+			copyErr = out.Sync()
+		}
+		closeOutErr := out.Close()
+		if copyErr == nil {
+			copyErr = closeOutErr
+		}
+		if copyErr != nil {
+			return copyErr
+		}
+	}
+
+	backup := ""
+	if _, err := os.Lstat(destDir); err == nil {
+		backup, err = os.MkdirTemp(parent, ".f4-colorer-backup-*")
+		if err != nil {
+			return err
+		}
+		_ = os.Remove(backup)
+		if err := os.Rename(destDir, backup); err != nil {
+			_ = os.RemoveAll(backup)
+			return err
+		}
+	}
+	if err := os.Rename(stage, destDir); err != nil {
+		if backup != "" {
+			_ = os.Rename(backup, destDir)
+		}
+		return err
+	}
+	stageLive = false
+	if backup != "" {
+		// Cleanup failure cannot invalidate the newly installed catalog; leave
+		// the backup for recovery and report the successful install.
+		_ = os.RemoveAll(backup)
+	}
+	return nil
 }

--- a/cmd/f4/colorer_plugin_test.go
+++ b/cmd/f4/colorer_plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -305,6 +306,43 @@ Loop:
 
 	if !SchemasExist() {
 		t.Error("SchemasExist returned false after successful extraction")
+	}
+}
+
+func TestColorer_StagedInstallRejectsTraversalAndPreservesExistingTree(t *testing.T) {
+	dest := filepath.Join(t.TempDir(), "colorer", "configs")
+	if err := os.MkdirAll(filepath.Join(dest, "base"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	catalog := filepath.Join(dest, "base", "catalog.xml")
+	if err := os.WriteFile(catalog, []byte("old-catalog"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	member, err := zw.Create("far2l-v_2.8.0/colorer/configs/../escape.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := member.Write([]byte("must not escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := installColorerSchemas(buf.Bytes(), dest, context.Background()); err == nil {
+		t.Fatal("traversal archive unexpectedly installed")
+	}
+	got, err := os.ReadFile(catalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old-catalog" {
+		t.Fatalf("existing catalog changed after rejected archive: %q", got)
+	}
+	if _, err := os.Stat(filepath.Join(filepath.Dir(dest), "escape.txt")); !os.IsNotExist(err) {
+		t.Fatalf("archive member escaped staging directory: %v", err)
 	}
 }
 

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -635,7 +635,6 @@ func saveConfigWithWindowSize(windowSize bool) {
 	ApplyProxySettings()
 
 	path := getUserConfigIniPath()
-	os.MkdirAll(filepath.Dir(path), 0755)
 	guiCols, guiRows := AppConfig.GuiCols, AppConfig.GuiRows
 	if !windowSize {
 		guiCols, guiRows = persistedGuiWindowSize()
@@ -802,7 +801,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 		sb.WriteString(fmt.Sprintf("%s=%s\n", k, layoutKeys[k]))
 	}
 
-	err := os.WriteFile(path, []byte(sb.String()), 0644)
+	err := writeFileAtomically(path, []byte(sb.String()), 0644)
 	if err != nil {
 		vtui.DebugLog("CONFIG: Failed to save application settings: %v", err)
 		return

--- a/cmd/f4/file_associations.go
+++ b/cmd/f4/file_associations.go
@@ -174,11 +174,7 @@ func SaveAssociations(path string, list []FileAssoc) error {
 		fmt.Fprintf(&buf, "State=%d\n", encodeAssocState(a.Enabled))
 	}
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomically(path, []byte(buf.String()), 0o644)
 }
 
 func parseAssocState(v string) uint32 {

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -476,6 +476,9 @@ func writeFileSafe(targetPath string, r io.Reader, mode os.FileMode) error {
 
 func sanitizeExtractPath(name, destDir string) (string, error) {
 	// Archive paths are always slash-separated
+	if strings.ContainsRune(name, '\\') || strings.ContainsRune(name, '\x00') {
+		return "", fmt.Errorf("invalid path in archive: %s", name)
+	}
 	cleanName := path.Clean(name)
 	if path.IsAbs(cleanName) || strings.HasPrefix(cleanName, "../") || cleanName == ".." {
 		return "", fmt.Errorf("invalid path in archive: %s", name)

--- a/cmd/f4/updater_test.go
+++ b/cmd/f4/updater_test.go
@@ -258,6 +258,14 @@ func TestUpdater_Extractors(t *testing.T) {
 	runtime.KeepAlive(sw)
 }
 
+func TestSanitizeExtractPathRejectsPlatformSeparators(t *testing.T) {
+	for _, name := range []string{`..\\outside`, `folder\\..\\outside`, "nul\x00name"} {
+		if _, err := sanitizeExtractPath(name, t.TempDir()); err == nil {
+			t.Errorf("sanitizeExtractPath(%q) accepted an unsafe archive name", name)
+		}
+	}
+}
+
 func TestUpdater_GetCurrentVersion(t *testing.T) {
 	/*
 		tests := []struct {

--- a/cmd/f4/user_menu_ini.go
+++ b/cmd/f4/user_menu_ini.go
@@ -85,11 +85,7 @@ func SaveMainMenu(path string, items []UserMenuItem) error {
 	first := true
 	writeTree(&buf, items, mainMenuRoot, &first)
 
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(buf.String()), 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomically(path, []byte(buf.String()), 0o644)
 }
 
 func buildTree(sections map[string]map[string]string, prefix string) []UserMenuItem {

--- a/cmd/f4/user_menu_ui.go
+++ b/cmd/f4/user_menu_ui.go
@@ -114,21 +114,11 @@ func saveFarMenuFile(path string, items []UserMenuItem) error {
 			return err
 		}
 	}
-	tmp := path + ".tmp"
-	f, err := os.Create(tmp)
-	if err != nil {
+	var buf bytes.Buffer
+	if err := WriteFarMenu(&buf, items); err != nil {
 		return err
 	}
-	if err := WriteFarMenu(f, items); err != nil {
-		f.Close()
-		os.Remove(tmp)
-		return err
-	}
-	if err := f.Close(); err != nil {
-		os.Remove(tmp)
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeFileAtomically(path, buf.Bytes(), 0o644)
 }
 
 // loadRootForMode reads the current root menu from disk based on the

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -67,6 +67,47 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 	}
 }
 
+func TestNetFoxVFS_DamagedConfigIsNeverOverwritten(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "connections.json")
+	original := []byte("{not-json\n")
+	if err := os.WriteFile(dbPath, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	nf := NewNetFoxVFS(dbPath)
+	if err := nf.SaveConfig("new", NetFoxConfig{Type: "sftp", Host: "example"}); err == nil {
+		t.Fatal("saving over damaged connections file unexpectedly succeeded")
+	}
+	got, err := os.ReadFile(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("damaged file changed after rejected save: %q", got)
+	}
+}
+
+func TestNetFoxVFS_InvalidWriterDoesNotSaveEmptyConfig(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "connections.json")
+	nf := NewNetFoxVFS(dbPath)
+	if err := nf.SaveConfig("existing", NetFoxConfig{Type: "sftp", Host: "example"}); err != nil {
+		t.Fatal(err)
+	}
+	writer, err := nf.Create(nil, "existing")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := writer.Write([]byte("not-json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err == nil {
+		t.Fatal("invalid JSON writer unexpectedly succeeded")
+	}
+	configs := nf.getConfigs()
+	if got := configs["existing"].Host; got != "example" {
+		t.Fatalf("invalid writer changed existing profile: %q", got)
+	}
+}
+
 func TestNetFox_TimeoutAndDial(t *testing.T) {
 	// 1. Start a local mock TCP server that does NOT send the FTP greeting (simulating wrong protocol)
 	l, err := net.Listen("tcp", "127.0.0.1:0")

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -2,6 +2,7 @@ package netfox
 
 import (
 	"bytes"
+	"context"
 	"github.com/unxed/f4/internal/netproxy"
 	"github.com/unxed/f4/vfs"
 	"net"
@@ -92,7 +93,7 @@ func TestNetFoxVFS_InvalidWriterDoesNotSaveEmptyConfig(t *testing.T) {
 	if err := nf.SaveConfig("existing", NetFoxConfig{Type: "sftp", Host: "example"}); err != nil {
 		t.Fatal(err)
 	}
-	writer, err := nf.Create(nil, "existing")
+	writer, err := nf.Create(context.TODO(), "existing")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/netfox/vfs.go
+++ b/plugins/netfox/vfs.go
@@ -119,7 +119,9 @@ func saveNetFoxConfigs(configs map[string]NetFoxConfig) ([]byte, error) {
 		encodedConfigs[k] = cfg
 	}
 
-	data, err := json.MarshalIndent(encodedConfigs, "", "  ")
+	// Password fields have already been obfuscated above; this is the
+	// persistence boundary for the encoded representation.
+	data, err := json.MarshalIndent(encodedConfigs, "", "  ") // #nosec G117 -- secrets are obfuscated before serialization.
 	if err != nil {
 		return nil, fmt.Errorf("netfox: encode connections: %w", err)
 	}

--- a/plugins/netfox/vfs.go
+++ b/plugins/netfox/vfs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"github.com/unxed/f4/internal/netproxy"
 	"github.com/unxed/f4/vfs"
@@ -53,24 +54,27 @@ type NetFoxVFS struct {
 }
 
 func NewNetFoxVFS(dbPath string) *NetFoxVFS {
-	os.MkdirAll(filepath.Dir(dbPath), 0755)
+	_ = os.MkdirAll(filepath.Dir(dbPath), 0700)
 	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
-		os.WriteFile(dbPath, []byte("{}"), 0644)
+		_ = writeNetFoxFile(dbPath, []byte("{}\n"))
 	}
 	return &NetFoxVFS{path: dbPath}
 }
 
-func (v *NetFoxVFS) getConfigs() map[string]NetFoxConfig {
-	v.mu.Lock()
-	defer v.mu.Unlock()
+func (v *NetFoxVFS) readConfigsLocked() (map[string]NetFoxConfig, error) {
 	data, err := os.ReadFile(v.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return make(map[string]NetFoxConfig), nil
+	}
 	if err != nil {
-		return make(map[string]NetFoxConfig)
+		return nil, fmt.Errorf("netfox: read connections: %w", err)
 	}
 	var configs map[string]NetFoxConfig
-	json.Unmarshal(data, &configs)
+	if err := json.Unmarshal(data, &configs); err != nil {
+		return nil, fmt.Errorf("netfox: damaged connections file: %w", err)
+	}
 	if configs == nil {
-		configs = make(map[string]NetFoxConfig)
+		return nil, errors.New("netfox: connections file is not a JSON object")
 	}
 
 	// Transparently decrypt passwords
@@ -89,14 +93,20 @@ func (v *NetFoxVFS) getConfigs() map[string]NetFoxConfig {
 			configs[k] = cfg
 		}
 	}
+	return configs, nil
+}
+
+func (v *NetFoxVFS) getConfigs() map[string]NetFoxConfig {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	configs, err := v.readConfigsLocked()
+	if err != nil {
+		return make(map[string]NetFoxConfig)
+	}
 	return configs
 }
 
-func (v *NetFoxVFS) saveConfigs(configs map[string]NetFoxConfig) {
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	os.MkdirAll(filepath.Dir(v.path), 0755)
-
+func saveNetFoxConfigs(configs map[string]NetFoxConfig) ([]byte, error) {
 	// Encrypt passwords before saving
 	encodedConfigs := make(map[string]NetFoxConfig)
 	for k, cfg := range configs {
@@ -109,14 +119,83 @@ func (v *NetFoxVFS) saveConfigs(configs map[string]NetFoxConfig) {
 		encodedConfigs[k] = cfg
 	}
 
-	data, _ := json.MarshalIndent(encodedConfigs, "", "  ")
-	os.WriteFile(v.path, data, 0644)
+	data, err := json.MarshalIndent(encodedConfigs, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("netfox: encode connections: %w", err)
+	}
+	return append(data, '\n'), nil
 }
 
-func (v *NetFoxVFS) SaveConfig(name string, cfg NetFoxConfig) {
-	configs := v.getConfigs()
-	configs[name] = cfg
-	v.saveConfigs(configs)
+func writeNetFoxFile(path string, data []byte) (returnErr error) {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("netfox: create connections directory: %w", err)
+	}
+	f, err := os.CreateTemp(dir, ".netfox-*.tmp")
+	if err != nil {
+		return fmt.Errorf("netfox: create temporary connections file: %w", err)
+	}
+	tmpPath := f.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			if closeErr := f.Close(); returnErr == nil && closeErr != nil {
+				returnErr = closeErr
+			}
+		}
+		if returnErr != nil {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+	if err := f.Chmod(0o600); err != nil {
+		return err
+	}
+	for len(data) > 0 {
+		written, err := f.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	if err := f.Close(); err != nil {
+		closed = true
+		return err
+	}
+	closed = true
+	if err := os.Rename(tmpPath, path); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (v *NetFoxVFS) updateConfigs(mutate func(map[string]NetFoxConfig) error) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	configs, err := v.readConfigsLocked()
+	if err != nil {
+		return err
+	}
+	if err := mutate(configs); err != nil {
+		return err
+	}
+	data, err := saveNetFoxConfigs(configs)
+	if err != nil {
+		return err
+	}
+	return writeNetFoxFile(v.path, data)
+}
+
+func (v *NetFoxVFS) SaveConfig(name string, cfg NetFoxConfig) error {
+	return v.updateConfigs(func(configs map[string]NetFoxConfig) error {
+		configs[name] = cfg
+		return nil
+	})
 }
 
 func (v *NetFoxVFS) IsAtRoot() bool         { return true }
@@ -163,22 +242,22 @@ func (v *NetFoxVFS) Remove(ctx context.Context, p string) error {
 	if name == "<Add connection>" {
 		return fmt.Errorf("cannot remove <Add connection>")
 	}
-	configs := v.getConfigs()
-	delete(configs, name)
-	v.saveConfigs(configs)
-	return nil
+	return v.updateConfigs(func(configs map[string]NetFoxConfig) error {
+		delete(configs, name)
+		return nil
+	})
 }
 
 func (v *NetFoxVFS) Rename(ctx context.Context, old, new string) error {
 	oldName := v.Base(old)
 	newName := v.Base(new)
-	configs := v.getConfigs()
-	if cfg, ok := configs[oldName]; ok {
-		configs[newName] = cfg
-		delete(configs, oldName)
-		v.saveConfigs(configs)
-	}
-	return nil
+	return v.updateConfigs(func(configs map[string]NetFoxConfig) error {
+		if cfg, ok := configs[oldName]; ok {
+			configs[newName] = cfg
+			delete(configs, oldName)
+		}
+		return nil
+	})
 }
 
 func (v *NetFoxVFS) SetAttributes(ctx context.Context, path string, item vfs.VFSItem) error {
@@ -224,11 +303,13 @@ type netfoxWriter struct {
 func (w *netfoxWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
 func (w *netfoxWriter) Close() error {
 	var cfg NetFoxConfig
-	json.Unmarshal(w.buf.Bytes(), &cfg)
-	configs := w.v.getConfigs()
-	configs[w.name] = cfg
-	w.v.saveConfigs(configs)
-	return nil
+	if err := json.Unmarshal(w.buf.Bytes(), &cfg); err != nil {
+		return fmt.Errorf("netfox: invalid connection JSON: %w", err)
+	}
+	return w.v.updateConfigs(func(configs map[string]NetFoxConfig) error {
+		configs[w.name] = cfg
+		return nil
+	})
 }
 func (v *NetFoxVFS) Create(ctx context.Context, p string) (io.WriteCloser, error) {
 	return &netfoxWriter{v: v, name: v.Base(p)}, nil

--- a/plugins/visren/config.go
+++ b/plugins/visren/config.go
@@ -2,6 +2,7 @@ package visren
 
 import (
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -48,5 +49,35 @@ func saveConfig(cfg config) error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(path, append(data, '\n'), 0o600)
+	data = append(data, '\n')
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".visren-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+	}()
+	if err := tmp.Chmod(0o600); err != nil {
+		return err
+	}
+	for len(data) > 0 {
+		written, err := tmp.Write(data)
+		if err != nil {
+			return err
+		}
+		if written == 0 {
+			return io.ErrShortWrite
+		}
+		data = data[written:]
+	}
+	if err := tmp.Sync(); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
 }

--- a/plugins/visren/config_test.go
+++ b/plugins/visren/config_test.go
@@ -3,6 +3,7 @@ package visren
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/unxed/f4/vfs"
@@ -30,7 +31,7 @@ func TestSaveConfigKeepsPreviousFileOnSuccessiveAtomicSave(t *testing.T) {
 	}
 	if mode, err := os.Stat(configPath()); err != nil {
 		t.Fatal(err)
-	} else if mode.Mode().Perm() != 0o600 {
+	} else if runtime.GOOS != "windows" && mode.Mode().Perm() != 0o600 {
 		t.Fatalf("config mode = %o, want 600", mode.Mode().Perm())
 	}
 }

--- a/plugins/visren/config_test.go
+++ b/plugins/visren/config_test.go
@@ -1,0 +1,36 @@
+package visren
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestSaveConfigKeepsPreviousFileOnSuccessiveAtomicSave(t *testing.T) {
+	dir := t.TempDir()
+	oldDir := vfs.CustomConfigDir
+	vfs.CustomConfigDir = dir
+	defer func() { vfs.CustomConfigDir = oldDir }()
+
+	if err := saveConfig(config{WordDiv: "first"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := saveConfig(config{WordDiv: "second"}); err != nil {
+		t.Fatal(err)
+	}
+	if got := loadConfig().WordDiv; got != "second" {
+		t.Fatalf("loaded WordDiv = %q, want second", got)
+	}
+	if leftovers, err := filepath.Glob(filepath.Join(dir, ".visren-*.tmp")); err != nil {
+		t.Fatal(err)
+	} else if len(leftovers) != 0 {
+		t.Fatalf("temporary config files remain: %v", leftovers)
+	}
+	if mode, err := os.Stat(configPath()); err != nil {
+		t.Fatal(err)
+	} else if mode.Mode().Perm() != 0o600 {
+		t.Fatalf("config mode = %o, want 600", mode.Mode().Perm())
+	}
+}


### PR DESCRIPTION
## Summary

Fixes five local data-integrity/security weaknesses found during issue #677 audit:

- publish application config, bookmarks, menus, and file associations through unique same-directory atomic files;
- make Colorer schema downloads size-bounded, traversal-safe, symlink-safe, and staged with rollback-preserving installation;
- make NetFox reject damaged/non-object JSON and invalid writer input without overwriting saved connections, while saving atomically with private permissions;
- save VisRen preferences atomically;
- harden the shared archive path sanitizer against platform separators and NUL bytes.

The three-pass solution review is included in `ISSUE_677_SOLUTION_REVIEW.md`. Larger journal/database refactors are documented but intentionally not started.

## Validation

- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp CGO_ENABLED=0 go test ./... -count=1`
- `GOTMPDIR=/home/zoin/.cache/f4-go-tmp go vet ./...`
- focused `go test -race` for atomic writers, Colorer, NetFox, and VisRen
- full repository compile with `go test ./... -run ^`
- native ARM64 build and `/tmp/f4-677-arm64 --version`

— zoin-bot