### PR TITLE
Preserve farcolors expressions when exporting

### DIFF
--- a/cmd/f4/colors.go
+++ b/cmd/f4/colors.go
@@ -362,7 +362,7 @@ func ExportColors(path string) error {
 			if source, ok := colorSourceExpressions[slot.Canonical]; ok && colorSourcePalette[slot.Canonical] == attr {
 				value = source
 			}
-			sb.WriteString(fmt.Sprintf("%s = %s\n", slot.Canonical, value))
+			fmt.Fprintf(&sb, "%s = %s\n", slot.Canonical, value)
 		}
 	}
 

--- a/cmd/f4/colors.go
+++ b/cmd/f4/colors.go
@@ -55,6 +55,7 @@ const (
 
 // SetDefaultF4Palette ensures the palette is large enough and sets f4-specific default colors.
 func SetDefaultF4Palette() {
+	resetColorSources()
 	// Initialize ThemePalette to match the "Tango/Ubuntu" gray theme from far2l
 	vtui.ThemePalette[0] = 0x2E3436 // Default Background (Dark Gray)
 	vtui.ThemePalette[7] = 0xD3D7CF // Default Text (Light Gray)
@@ -254,6 +255,12 @@ var ColorSlots = []ColorSlot{
 // colorMap links farcolors.ini keys to vtui.Palette indices dynamically.
 var colorMap = make(map[string]int)
 
+// colorSourceExpressions keeps the last authored expression for each
+// canonical color key. Several far2l keys intentionally share one runtime
+// palette slot, and contrast correction may adjust an RGB value slightly.
+var colorSourceExpressions = make(map[string]string)
+var colorSourcePalette = make(map[string]uint64)
+
 func init() {
 	for _, slot := range ColorSlots {
 		for _, alias := range slot.Aliases {
@@ -261,6 +268,11 @@ func init() {
 		}
 		colorMap[slot.Canonical] = slot.Index
 	}
+}
+
+func resetColorSources() {
+	colorSourceExpressions = make(map[string]string)
+	colorSourcePalette = make(map[string]uint64)
 }
 
 // InitColors parses the farcolors section and applies it to the vtui.Palette.
@@ -276,17 +288,21 @@ func InitColors(ini *IniFile) {
 // Aliases are applied first so that a canonical key in the same file wins.
 func ApplyColorIni(ini *IniFile) {
 	for _, slot := range ColorSlots {
+		var sourceExpr string
 		for _, alias := range slot.Aliases {
 			expr := ini.GetString("farcolors", alias, "")
 			if expr != "" {
 				vtui.Palette[slot.Index] = ParseFarColor(expr, vtui.Palette[slot.Index])
+				sourceExpr = expr
 			}
 		}
-	}
-	for _, slot := range ColorSlots {
 		expr := ini.GetString("farcolors", slot.Canonical, "")
 		if expr != "" {
 			vtui.Palette[slot.Index] = ParseFarColor(expr, vtui.Palette[slot.Index])
+			sourceExpr = expr
+		}
+		if sourceExpr != "" {
+			colorSourceExpressions[slot.Canonical] = sourceExpr
 		}
 	}
 }
@@ -299,6 +315,11 @@ func FinishColors() {
 	vtui.ThemePalette[0] = vtui.GetRGBBack(vtui.Palette[ColCommandLineUserScreen])
 
 	AdjustContrastLevels()
+	for _, slot := range ColorSlots {
+		if _, ok := colorSourceExpressions[slot.Canonical]; ok {
+			colorSourcePalette[slot.Canonical] = vtui.Palette[slot.Index]
+		}
+	}
 }
 
 // FormatFarColor serializes a vtui palette color attribute to a farcolors.ini string.
@@ -337,7 +358,11 @@ func ExportColors(path string) error {
 		})
 		for _, slot := range slots {
 			attr := vtui.Palette[slot.Index]
-			sb.WriteString(fmt.Sprintf("%s = %s\n", slot.Canonical, FormatFarColor(attr)))
+			value := FormatFarColor(attr)
+			if source, ok := colorSourceExpressions[slot.Canonical]; ok && colorSourcePalette[slot.Canonical] == attr {
+				value = source
+			}
+			sb.WriteString(fmt.Sprintf("%s = %s\n", slot.Canonical, value))
 		}
 	}
 

--- a/cmd/f4/colors_test.go
+++ b/cmd/f4/colors_test.go
@@ -155,6 +155,66 @@ func TestColors_ExportColors_Grouped(t *testing.T) {
 		}
 	}
 }
+
+func TestColors_ExportColorsPreservesAuthoredExpressions(t *testing.T) {
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	AppConfig.EnforceColorCorrection = true
+	defer func() { AppConfig = oldCfg }()
+
+	ini := ParseIni(strings.NewReader(`[farcolors]
+Panel.Cursor.Inactive.Selected = foreground:#feff00 | background:#555753
+Panel.FastFindNoMatch = foreground:#d65f5f | background:#0000a0
+Panel.Scrollbar.Minimal = foreground:#0000ff | background:#0000a0
+WarnDialog.Edit = foreground:#ffffff | background:#0000a0
+WarnDialog.Edit.Selected = foreground:#ffffff | background:#000000
+WarnDialog.Edit.Unchanged = foreground:#a0a0a0 | background:#0000a0
+`))
+	InitColors(ini)
+
+	path := filepath.Join(t.TempDir(), "exported.ini")
+	if err := ExportColors(path); err != nil {
+		t.Fatal(err)
+	}
+	exported := LoadIni(path)
+	for key, want := range map[string]string{
+		"Panel.Cursor.Inactive.Selected": "foreground:#feff00 | background:#555753",
+		"Panel.FastFindNoMatch":          "foreground:#d65f5f | background:#0000a0",
+		"Panel.Scrollbar.Minimal":        "foreground:#0000ff | background:#0000a0",
+		"WarnDialog.Edit":                "foreground:#ffffff | background:#0000a0",
+		"WarnDialog.Edit.Selected":       "foreground:#ffffff | background:#000000",
+		"WarnDialog.Edit.Unchanged":      "foreground:#a0a0a0 | background:#0000a0",
+	} {
+		if got := exported.GetString("farcolors", key, ""); got != want {
+			t.Errorf("%s exported as %q, want authored expression %q", key, got, want)
+		}
+	}
+}
+
+func TestColors_ExportColorsUsesCurrentPaletteAfterDirectChange(t *testing.T) {
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	AppConfig.EnforceColorCorrection = true
+	defer func() { AppConfig = oldCfg }()
+
+	ini := ParseIni(strings.NewReader(`[farcolors]
+Panel.Text = foreground:#123456 | background:#654321
+`))
+	InitColors(ini)
+	vtui.Palette[ColPanelText] = vtui.SetRGBBoth(0, 0xabcdef, 0x102030)
+
+	path := filepath.Join(t.TempDir(), "exported.ini")
+	if err := ExportColors(path); err != nil {
+		t.Fatal(err)
+	}
+	exported := LoadIni(path)
+	if got := exported.GetString("farcolors", "Panel.Text", ""); got != "foreground:#abcdef | background:#102030" {
+		t.Fatalf("direct palette change exported as %q", got)
+	}
+}
+
 func TestColors_AliasesAndCanonicalPrecedence(t *testing.T) {
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()


### PR DESCRIPTION
## Summary\n- preserve the authored farcolors expression for each canonical key while applying styles\n- keep distinct exported values for keys that share one runtime palette slot\n- use the current runtime palette when a slot was changed after loading\n\nThis prevents contrast correction and shared warning-dialog slots from producing misleading export diffs while retaining correct exports for direct palette edits.\n\n## Validation\n- go test ./... -count=1\n- native Windows go build -o C:\\Temp\\f4-406.exe .\\cmd\\f4\n- 4-406.exe --version, --wine-probe, and -test-plugins\n- regression tests for authored expressions and direct runtime changes\n\n— zoin-bot