### PR TITLE
Wait for Windows batch commands before returning to panels

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -1612,7 +1612,7 @@ func actionExecute(pf *PanelsFrame, v vfs.VFS, dir, name, path string) {
 						pf.termView.PrintCleanCommand(cleanCmd)
 					}
 
-					pf.executing = true
+					pf.beginManagedExecution()
 					pf.returnToPanels = true
 
 					if !isWindowsShell {

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -249,6 +249,8 @@ type PanelsFrame struct {
 	activeIdx             int    // 0 for left, 1 for right
 	folderHistoryPos      [2]int // position in provider's newest-first folder history
 	executing             bool
+	shellPromptReady      bool
+	ignoreNextPrompt      bool
 	returnToPanels        bool
 	workspaceCommandTitle string
 
@@ -422,7 +424,17 @@ func NewPanelsFrame() *PanelsFrame {
 			if busy {
 				pf.executing = true
 			} else {
-				if pf.executing {
+				pf.shellPromptReady = true
+				ignoredPrompt := pf.executing && pf.ignoreNextPrompt
+				if ignoredPrompt {
+					// A command can be entered before the initial prompt has
+					// finished crossing ConPTY. That prompt belongs to shell
+					// startup, not to the command just sent; consuming it as
+					// completion would return to panels while a batch file is
+					// still running.
+					pf.ignoreNextPrompt = false
+				}
+				if pf.executing && !ignoredPrompt {
 					pf.executing = false
 					pf.workspaceCommandTitle = ""
 					if pf.returnToPanels {
@@ -1353,6 +1365,14 @@ func (pf *PanelsFrame) isPtyBusy() bool {
 	// Managed execution signal from OSC 133
 	return pf.executing
 }
+
+func (pf *PanelsFrame) beginManagedExecution() {
+	pf.executing = true
+	if !pf.shellPromptReady {
+		pf.ignoreNextPrompt = true
+	}
+}
+
 func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 	if pf.shellMode == ShellModeHost && pf.isHostConsoleActive() {
 		return
@@ -2211,7 +2231,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 				if integration != nil {
 					if seq := integration.PtyRunCommand(path, cmd); len(seq) > 0 {
 						fullWireCmd = string(seq)
-						pf.executing = true
+						pf.beginManagedExecution()
 						pf.returnToPanels = pf.showPanels
 					}
 				} else if isWindowsShell {
@@ -2221,7 +2241,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 					} else {
 						fullWireCmd = fmt.Sprintf("%s\r", cmd)
 					}
-					pf.executing = true
+					pf.beginManagedExecution()
 					pf.returnToPanels = pf.showPanels
 				} else {
 					// Unix
@@ -2240,7 +2260,7 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 						} else {
 							fullWireCmd = fmt.Sprintf(" { trap \"printf ''\" INT; printf \"\\033]133;C\\007\"; %s ; FARVTRESULT=$?; printf \"\\033]133;D\\007\"; trap - INT; (exit $FARVTRESULT); }\r", cmd)
 						}
-						pf.executing = true
+						pf.beginManagedExecution()
 						pf.returnToPanels = pf.showPanels
 					}
 				}

--- a/cmd/f4/pty_windows_test.go
+++ b/cmd/f4/pty_windows_test.go
@@ -3,7 +3,13 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
 )
 
 func TestConPTYAvailable_DoesNotPanic(t *testing.T) {
@@ -17,4 +23,74 @@ func TestConPTYAvailable_DoesNotPanic(t *testing.T) {
 			t.Fatal("NewPTY succeeded when conPTYAvailable() reported false")
 		}
 	}
+}
+
+func TestActionExecuteBatchDoesNotReturnPanelsEarly(t *testing.T) {
+	if !conPTYAvailable() {
+		t.Skip("ConPTY unavailable")
+	}
+
+	oldSpawn := spawnLocalShellPTY
+	oldConfig := AppConfig
+	defer func() {
+		spawnLocalShellPTY = oldSpawn
+		AppConfig = oldConfig
+	}()
+	spawnLocalShellPTY = true
+	AppConfig.ConsoleMode = "own"
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for pf.getActivePTY() == nil {
+		if time.Now().After(deadline) {
+			t.Fatal("local ConPTY did not start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	dir := t.TempDir()
+	finished := filepath.Join(dir, "finished.marker")
+	script := filepath.Join(dir, "f4-batch-probe.cmd")
+	content := "@echo off\r\necho started>started.marker\r\nping.exe -n 4 127.0.0.1 >nul\r\necho finished>finished.marker\r\nping.exe -n 4 127.0.0.1 >nul\r\n"
+	if err := os.WriteFile(script, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	actionExecute(pf, vfs.NewOSVFS(dir), dir, filepath.Base(script), script)
+	start := time.Now()
+	for pf.showPanels {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		default:
+		}
+		if time.Since(start) > 5*time.Second {
+			t.Fatal("actionExecute did not hide panels")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	panelsReturned := time.Duration(0)
+	for time.Since(start) < 10*time.Second {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		default:
+		}
+		if pf.showPanels {
+			panelsReturned = time.Since(start)
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if panelsReturned == 0 {
+		t.Fatal("panels did not return after batch completion")
+	}
+	if _, err := os.Stat(finished); err != nil {
+		t.Fatalf("panels returned after %v before batch finished: %v", panelsReturned, err)
+	}
+	t.Logf("panels returned after batch completion in %v", panelsReturned)
 }


### PR DESCRIPTION
Fixes the Windows ConPTY execution race from #409.

Root cause: a batch/.cmd file can be entered before the initial `OSC 133;D` prompt marker has been processed. The startup marker was then mistaken for the command-completion marker, so f4 restored the panels while the batch was still running.

Changes:
- track whether the shell startup prompt has been observed;
- ignore exactly the stale startup completion marker when managed execution begins early;
- use the same guarded execution transition for panel-launched and command-line commands;
- add a native Windows ConPTY regression test that runs a `.cmd` file with work before and after a marker and asserts panels return only after the final marker.

Validation:
- `go test ./... -count=1`
- native Windows build
- `f4-409.exe --version`
- `f4-409.exe --wine-probe`
- `f4-409.exe -test-plugins`
- native `TestActionExecuteBatchDoesNotReturnPanelsEarly`

— zoin-bot
