### PR TITLE
ci: run go vet for every platform the matrix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -413,6 +413,73 @@ jobs:
         path: f4-windows7-amd64.zip
         retention-days: 7
 
+  # go vet in the quality job below only ever sees the linux build of the tree,
+  # which leaves the 44 windows-only and 8 darwin-only files here unexamined by
+  # any of its analyzers — printf, copylocks, lostcancel, loopclosure and two
+  # dozen more. The build matrix already covers nine GOOS values, so vet them.
+  #
+  # A matrix rather than a loop in one job: a cross-GOOS vet has to build every
+  # dependency for that target from scratch, so each cell costs about as much as
+  # a build (~75s) and running them in sequence would add ten minutes to the
+  # quality job. fail-fast is off so one broken platform does not hide the rest.
+  #
+  # One cell per GOOS, plus one 32-bit cell. Only winepath_{windows,other}.go are
+  # selected by GOARCH, and windows/amd64 and any non-windows target between them
+  # cover both sides, so a second 64-bit arch would vet identical files. Word
+  # size is the exception: the shift analyzer sizes types through the target's
+  # TypesSizes, so a shift that is fine against a 64-bit int is a finding against
+  # a 32-bit one. linux/arm is the matrix's 32-bit cell that builds without the
+  # noffi tag. linux/amd64 is absent because the quality job vets it with the
+  # full analyzer set.
+  #
+  # unsafeptr is the one analyzer that cannot come along. Every one of these
+  # platforms converts a uintptr handed back by a syscall wrapper into a pointer
+  # — the view MapViewOfFile mapped, strings Wine allocated on the process heap,
+  # a pseudoconsole HANDLE, a buffer owned by an NSString — and the analyzer
+  # cannot tell foreign memory from Go's. Those wrappers return uintptr by
+  # signature, and vet accepts a uintptr-to-pointer conversion only for reflect
+  # headers, reflect.Value.Pointer and pointer arithmetic, so moving the
+  # conversion elsewhere only moves the diagnostic. The linux run keeps the full
+  # set, unsafeptr included, so a genuine round trip in portable code still
+  # fails the build.
+  vet:
+    name: Vet (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { target: windows/amd64 }
+          - { target: linux/arm }
+          - { target: darwin/arm64 }
+          # goffi's fakecgo shim needs the same flag the build step passes.
+          - { target: freebsd/amd64, gcflags: -gcflags=github.com/go-webgpu/goffi/internal/fakecgo=-std }
+          - { target: openbsd/amd64 }
+          - { target: netbsd/amd64 }
+          - { target: dragonfly/amd64 }
+          - { target: illumos/amd64 }
+          - { target: solaris/amd64 }
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        submodules: recursive
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26.x'
+        cache-dependency-path: go.sum
+
+    - name: Run go vet
+      env:
+        TARGET: ${{ matrix.target }}
+        GCFLAGS: ${{ matrix.gcflags }}
+      run: |
+        GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}" go vet -unsafeptr=false $GCFLAGS ./...
+
   quality:
     name: Quality (vet and incremental lint)
     runs-on: ubuntu-latest

--- a/cmd/f4/window_icon_windows.go
+++ b/cmd/f4/window_icon_windows.go
@@ -179,8 +179,14 @@ func findGogpuWindow(pid uint32) uintptr {
 	return search.hwnd
 }
 
-func findGogpuWindowCallback(hwnd, data uintptr) uintptr {
-	search := (*windowSearch)(unsafe.Pointer(data))
+// The lParam arrives as unsafe.Pointer rather than uintptr so the pointer to
+// search never round-trips through an integer. EnumWindows keeps it alive for
+// the duration of the call — Call is //go:uintptrescapes — but a bare uintptr
+// would still lose the provenance that vet's unsafeptr check and the runtime's
+// checkptr instrumentation both look for. syscall.NewCallback accepts any
+// pointer-sized non-float argument, so the signature stays valid.
+func findGogpuWindowCallback(hwnd uintptr, data unsafe.Pointer) uintptr {
+	search := (*windowSearch)(data)
 	var pid uint32
 	procIconGetWindowThreadPID.Call(hwnd, uintptr(unsafe.Pointer(&pid)))
 	if pid != search.pid || windowClassName(hwnd) != gogpuWindowClass {

--- a/plugins/archive/provider_special_unix_test.go
+++ b/plugins/archive/provider_special_unix_test.go
@@ -1,21 +1,21 @@
-//go:build !windows
+//go:build unix
 
 package archive
 
 import (
 	"context"
 	"path/filepath"
-	"syscall"
 	"testing"
 
 	"github.com/unxed/f4/vfs"
+	"golang.org/x/sys/unix"
 )
 
 func TestArchiveProvider_CanOpen_SpecialFile(t *testing.T) {
 	p := &ArchiveProvider{}
 	tmpDir := t.TempDir()
 	fifoPath := filepath.Join(tmpDir, "test.fifo")
-	if err := syscall.Mkfifo(fifoPath, 0o666); err != nil {
+	if err := unix.Mkfifo(fifoPath, 0o666); err != nil {
 		t.Fatalf("Mkfifo failed: %v", err)
 	}
 	parent := vfs.NewOSVFS(tmpDir)

--- a/vfs/os_vfs_unix_test.go
+++ b/vfs/os_vfs_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build unix
 
 package vfs
 
@@ -6,9 +6,10 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestOSVFS_SpecialFiles(t *testing.T) {
@@ -16,7 +17,7 @@ func TestOSVFS_SpecialFiles(t *testing.T) {
 	v := NewOSVFS(tmpDir)
 
 	fifoPath := filepath.Join(tmpDir, "test.fifo")
-	err := syscall.Mkfifo(fifoPath, 0666)
+	err := unix.Mkfifo(fifoPath, 0666)
 	if err != nil {
 		t.Skipf("Mkfifo not supported or failed: %v", err)
 	}


### PR DESCRIPTION
`go vet` runs on ubuntu, so it only ever sees the linux build of the tree. The 44 windows-only and 8 darwin-only files here — pty handling, memory mapping, the Wine bridge, the trash implementations — are examined by none of its analyzers. That is not hypothetical: `printf`, `copylocks`, `lostcancel`, `loopclosure`, `waitgroup`, `testinggoroutine` and two dozen more simply do not look at half of this repository. The build matrix already compiles nine GOOS values, so this vets them.

## It found something on the first run

`syscall.Mkfifo` does not exist on illumos or solaris, and two test files reach for it from behind a `!windows` constraint that claims both. The tests in those packages have never compiled there — nothing noticed, because there are no illumos or solaris runners.

They now use `golang.org/x/sys/unix.Mkfifo`, which both platforms do provide, and carry the `unix` constraint instead of `!windows` — the latter also promised plan9, js and wasip1, where neither `syscall.Mkfifo` nor `x/sys/unix` exists at all.

## Nine cells, not twenty-five

The build matrix has 24 cells, but vet can only distinguish ten configurations, and this covers all of them:

| | |
|---|---|
| darwin, dragonfly, freebsd, illumos, netbsd, openbsd, solaris, windows | 64-bit only in the matrix — one cell each |
| linux 64-bit | `amd64`, `arm64`, `mips64`, `mips64le`, `riscv64`, `loong64`, `ppc64`, `ppc64le` — vetted by the quality job |
| linux 32-bit | `arm`, `mips`, `mipsle` — one cell, `linux/arm` |

Only `winepath_windows.go` / `winepath_other.go` are selected by GOARCH, and `windows/amd64` together with any non-windows target already covers both sides — so a second 64-bit architecture would vet byte-for-byte identical files.

Word size is the exception that earns its own cell: the `shift` analyzer sizes types through the target's `TypesSizes`, so a shift that is fine against a 64-bit `int` is a finding against a 32-bit one. `linux/arm` is the matrix's 32-bit cell that builds without the `noffi` tag — and `noffi` changes nothing here anyway, since no file in this repository sits behind it.

## A matrix rather than a loop

Vetting a foreign GOOS has to build every dependency for that target from scratch, so a cell costs about as much as a build. I measured it: the eight non-linux targets took **9m20s** in sequence, ~75s each. As a matrix that is one cell's wall clock, and with `fail-fast: false` one broken platform no longer hides the rest behind it — which is how the illumos breakage above was found alongside seven passes rather than one per push.

## Why `-unsafeptr=false` on those platforms

Every one of them converts a `uintptr` handed back by a syscall wrapper into a pointer, and the analyzer has no way to tell foreign memory from Go's:

| | |
|---|---|
| `vfs/trash_darwin.go` | a `UTF8String` buffer owned by an `NSString` |
| `cmd/f4/mapped_file_windows.go` | the view `MapViewOfFile` mapped |
| `cmd/f4/pty_windows.go` | an `HPCON`, which is a handle and not a pointer at all |
| `cmd/f4/winepath_windows.go` | strings Wine allocated on the process heap |
| `tools/wine_color_probe` | Wine's static version buffer |

I traced each one. None is a lifetime bug, and none can be written differently: `Proc.Call` and `MapViewOfFile` return `uintptr` by signature, and vet accepts a uintptr-to-pointer conversion only for reflect headers, `reflect.Value.Pointer` and pointer arithmetic — so moving the conversion elsewhere only moves the diagnostic. The linux run in the quality job keeps the full analyzer set, `unsafeptr` included, so a genuine round trip in portable code still fails the build.

## The one site worth fixing, fixed rather than excused

The `EnumWindows` callback took its lParam — a pointer to a Go local — in as `uintptr` and converted back. That is safe today: `Call` is `//go:uintptrescapes`, so the argument is heap-allocated and kept live for the duration of the call, and `EnumWindows` is synchronous. But the integer round trip discards provenance that `checkptr` instrumentation objects to independently of vet. Taking `unsafe.Pointer` directly removes the conversion; `syscall.NewCallback` accepts any pointer-sized non-float argument, so the callback signature stays valid.

---

Verified green end to end on a fork run before this was opened: 9/9 vet cells, 25/25 builds, all six test cells, the race detector and the quality job. Rebased onto main after #680 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
