### PR TITLE
ci: lint the workflow itself

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,12 +186,12 @@ jobs:
         # CGO_ENABLED=0 and -extldflags '-static', and qemu then needs the
         # target's loader. Today that is arm64 alone: amd64 runs natively,
         # and the noffi cells drop goffi and really are static.
-        PACKAGES=qemu-user-static
+        packages=(qemu-user-static)
         set --
         if file build/f4 | grep -q 'dynamically linked'; then
           case "${{ matrix.goarch }}" in
             arm64)
-              PACKAGES="$PACKAGES libc6-arm64-cross"
+              packages+=(libc6-arm64-cross)
               set -- -L /usr/aarch64-linux-gnu
               ;;
             *)
@@ -202,7 +202,7 @@ jobs:
         fi
 
         sudo apt-get update -qq
-        sudo apt-get install -y -qq $PACKAGES
+        sudo apt-get install -y -qq "${packages[@]}"
         "qemu-$QEMU-static" "$@" build/f4 --version
 
     - name: Package
@@ -478,7 +478,13 @@ jobs:
         TARGET: ${{ matrix.target }}
         GCFLAGS: ${{ matrix.gcflags }}
       run: |
-        GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}" go vet -unsafeptr=false $GCFLAGS ./...
+        # An array, so the empty GCFLAGS of most cells contributes no argument
+        # rather than an empty one.
+        flags=(-unsafeptr=false)
+        if [ -n "$GCFLAGS" ]; then
+          flags+=("$GCFLAGS")
+        fi
+        GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}" go vet "${flags[@]}" ./...
 
   quality:
     name: Quality (vet and incremental lint)
@@ -513,6 +519,14 @@ jobs:
     # The tool version is pinned; the vulnerability database it consults is
     # fetched at run time, so a newly published advisory turns this red without
     # any change here — which is the point.
+    # build.yml is approaching 800 lines, most of it shell embedded in run:
+    # blocks that nothing checked. actionlint validates the workflow schema and
+    # every expression, and hands each run: block to shellcheck — which the
+    # ubuntu image already ships, so it needs no setup here. Both classes of
+    # mistake it catches otherwise cost a full CI round trip to discover.
+    - name: Run actionlint
+      run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
     - name: Run govulncheck
       run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
 
@@ -563,7 +577,9 @@ jobs:
         # A crash handler that os.Exit()s bypasses both go test's output and
         # TestMain's temp-dir cleanup, so the reports it wrote survive here.
         for base in "${TMPDIR:-/tmp}" "$(cygpath -u "${TEMP:-}" 2>/dev/null)"; do
-          [ -n "$base" ] && [ -d "$base" ] || continue
+          if [ -z "$base" ] || [ ! -d "$base" ]; then
+            continue
+          fi
           find "$base" -maxdepth 4 -path '*f4-test-config*' -name '*.log' 2>/dev/null | head -20 | while read -r f; do
             echo "=== $f ==="
             cat "$f"
@@ -599,8 +615,16 @@ jobs:
         # FFI pointers, which Go's checkptr rejects under -race. Keep both
         # packages in the instrumented compile below and run all other
         # package tests under the detector.
-        packages=$(go list ./... | grep -Ev '^github.com/unxed/f4/(cmd/f4|luaplug)$')
-        go test -race -timeout 15m $packages
+        mapfile -t packages < <(go list ./... | grep -Ev '^github.com/unxed/f4/(cmd/f4|luaplug)$')
+        # The bare $packages this replaced failed the step when the list came
+        # out empty, because set -e sees the assignment's exit status. mapfile
+        # swallows it, and go test with no arguments would quietly fall back to
+        # the current directory, so check explicitly.
+        if [ ${#packages[@]} -eq 0 ]; then
+          echo "::error::no packages left to run under the race detector"
+          exit 1
+        fi
+        go test -race -timeout 15m "${packages[@]}"
         go test -race -run '^$' ./cmd/f4 ./luaplug
 
   release:
@@ -719,8 +743,8 @@ jobs:
 
     - name: Set Release Metadata
       run: |
-        echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-        echo "BUILD_TIME=$(date +'%Y-%m-%d %H:%M:%S')" >> $GITHUB_ENV
+        echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+        echo "BUILD_TIME=$(date +'%Y-%m-%d %H:%M:%S')" >> "$GITHUB_ENV"
 
     - name: Download all artifacts
       uses: actions/download-artifact@v8


### PR DESCRIPTION
`build.yml` is past 800 lines, and most of it is shell embedded in `run:` blocks that nothing has ever checked — not the schema, not the expressions, not the scripts. A typo in a field name, a reference to a context that does not exist, a quoting bug: today each of those costs a full CI round trip to discover.

actionlint covers all three. It validates the workflow against the Actions schema, type-checks every `${{ }}` expression, and hands each `run:` block to shellcheck — which the ubuntu image already ships, so the step needs no setup of its own. It runs the way `govulncheck` does, through `go run` at a pinned version, so it adds no action dependency.

## It reported six problems, and all six are fixed rather than silenced

**Two unquoted `$GITHUB_ENV` redirects** in the nightly job. Plain missing quotes.

**Three package lists built by string concatenation**, each relying on the shell splitting the result back apart — the apt list in the qemu smoke test, the gcflags in the vet matrix, and the package list for the race detector. All three are arrays now.

**The race detector one needed care.** That step declares `shell: bash`, so it runs under `set -e`, and the bare assignment therefore failed the step when `grep` selected nothing. `mapfile` does not propagate that status, and `go test` with no arguments would quietly fall back to testing the current directory — the detector would have reported green having run almost nothing. The array version checks for an empty list and fails explicitly instead, so the behaviour the old form got for free from `set -e` is kept deliberately.

**One misleading guard** in the crash-report dump:

```bash
[ -n "$base" ] && [ -d "$base" ] || continue
```

This reads as if-then-else but is not: `continue` also runs when the first test succeeds and the second fails. That happens to be the intent here, but only by accident of how the operators associate. An `if` statement says it outright.

## One caveat worth recording

actionlint uses whatever shellcheck is on `PATH`, and the runner's is older than a current local install. shellcheck 0.11 reports neither the `SC2015` above nor the gcflags `SC2086` — both appeared only in CI. So a run here is authoritative and a local run is a fast approximation, and a runner image update can surface a new rule the same way a new advisory turns `govulncheck` red.

---

The `Quality` job is green with this, `actionlint` step included. The run also shows four unrelated failures — `Build (linux/arm)`, `Build (linux/mips)`, `Build (linux/mipsle)` and `Vet (linux/arm)` — which are not from this change: `main` has been red on every 32-bit target since b8a7426 bumped vtui to v0.1.267, whose `graphics_far2l.go:73` does not compile where `int` is 32 bits. I am opening a fix for that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
