### PR TITLE
test: fix the descriptor double-close behind the flaky darwin/amd64 TempDir failure

### DIFF
--- a/cmd/f4/session_unix_test.go
+++ b/cmd/f4/session_unix_test.go
@@ -48,13 +48,24 @@ func TestClearNonBlock_ClearsFlag(t *testing.T) {
 		t.Fatalf("pipe: %v", err)
 	}
 	readEnd, writeEnd := p[0], p[1]
-	defer syscall.Close(readEnd)
 	defer syscall.Close(writeEnd)
+	// os.NewFile takes ownership of readEnd. Closing the raw descriptor while
+	// leaving f to its finalizer can later close an unrelated, reused fd.
+	f := os.NewFile(uintptr(readEnd), "pipe-read")
+	if f == nil {
+		syscall.Close(readEnd)
+		t.Fatal("os.NewFile returned nil for pipe read end")
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close(pipe-read): %v", err)
+		}
+	}()
 
-	if _, err := unix.FcntlInt(uintptr(readEnd), unix.F_SETFL, unix.O_NONBLOCK); err != nil {
+	if _, err := unix.FcntlInt(f.Fd(), unix.F_SETFL, unix.O_NONBLOCK); err != nil {
 		t.Fatalf("set O_NONBLOCK: %v", err)
 	}
-	flags, err := unix.FcntlInt(uintptr(readEnd), unix.F_GETFL, 0)
+	flags, err := unix.FcntlInt(f.Fd(), unix.F_GETFL, 0)
 	if err != nil {
 		t.Fatalf("F_GETFL: %v", err)
 	}
@@ -62,10 +73,9 @@ func TestClearNonBlock_ClearsFlag(t *testing.T) {
 		t.Fatalf("test setup broken: O_NONBLOCK not observed as set")
 	}
 
-	f := os.NewFile(uintptr(readEnd), "pipe-read")
 	clearNonBlock(f)
 
-	flags, err = unix.FcntlInt(uintptr(readEnd), unix.F_GETFL, 0)
+	flags, err = unix.FcntlInt(f.Fd(), unix.F_GETFL, 0)
 	if err != nil {
 		t.Fatalf("F_GETFL after clearNonBlock: %v", err)
 	}


### PR DESCRIPTION
`Test (darwin/amd64)` fails now and then with something like this:

```
--- FAIL: TestPanelsFrame_CtrlEnterOnDirectoryInsertsWithoutEntering (0.00s)
    testing.go:1464: TempDir RemoveAll cleanup: unlinkat /var/folders/...: bad file descriptor
```

The test named in the failure is not the one at fault — note the empty body and the 0.00s. Nothing it asserts failed; what failed is `t.TempDir()`'s cleanup.

The culprit is `TestClearNonBlock_ClearsFlag`, which runs earlier. It closed the pipe's read end with `syscall.Close` and handed that same descriptor to `os.NewFile`, which takes ownership and sets a finalizer. The raw close freed the number first, so when the `*os.File` was eventually collected, its finalizer closed whatever had been given that number since — in this case the directory `os.RemoveAll` had open while cleaning up the next test's temp dir.

It reproduces under `GOGC=1`, which runs finalizers often enough to hit the window:

```
GOGC=1 GOARCH=amd64 go test -count=3000 \
  -run '^(TestClearNonBlock_ClearsFlag|TestPanelsFrame_CtrlEnterOnDirectoryInsertsWithoutEntering)$' \
  ./cmd/f4
```

66 failures before this change, none after.

The fix gives `os.File` sole ownership: drop the raw close, work through `f.Fd()`, close via `f.Close()`, which also clears the finalizer. I checked the other `os.NewFile` sites in the repo, in tests and in production code — none of them pair a wrapper with a raw close of the same descriptor.
