### PR TITLE
Fix Shell macros during Fast Find

### DIFF
--- a/cmd/f4/macro.go
+++ b/cmd/f4/macro.go
@@ -336,6 +336,18 @@ func isPanelFastFindToggleKey(e *vtinput.InputEvent) bool {
 	return fsp != nil && fsp.fastFindMode
 }
 
+func isPanelFastFindActive() bool {
+	if vtui.FrameManager == nil {
+		return false
+	}
+	pf, ok := vtui.FrameManager.GetTopFrame().(*PanelsFrame)
+	if !ok || !pf.showPanels {
+		return false
+	}
+	fsp := pf.getActivePanel()
+	return fsp != nil && fsp.fastFindMode
+}
+
 func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 	if e.Type != vtinput.KeyEventType {
 		return false
@@ -398,6 +410,11 @@ func (m *MacroManager) Filter(e *vtinput.InputEvent) bool {
 	}
 
 	currentArea := m.GetCurrentArea()
+	if currentArea == "Shell" && isPanelFastFindActive() {
+		// zoin-bot: Fast Find is a transient panel input mode, so Shell macros
+		// must not consume keys before PanelsFrame can update its query.
+		return false
+	}
 	if currentArea == "Shell" && (isPanelBookmarkHotkey(e) || isPanelFastFindToggleKey(e)) {
 		return false
 	}

--- a/cmd/f4/macro_test.go
+++ b/cmd/f4/macro_test.go
@@ -379,6 +379,45 @@ func TestMacroFastFindDeleteBypassesPanelToggle(t *testing.T) {
 	}
 }
 
+func TestMacroShellDoesNotRunDuringFastFind(t *testing.T) {
+	oldCfg := AppConfig
+	oldHotkeys := GlobalHotkeysMgr
+	oldMacroMgr := MacroMgr
+	defer func() {
+		AppConfig = oldCfg
+		GlobalHotkeysMgr = oldHotkeys
+		MacroMgr = oldMacroMgr
+	}()
+
+	AppConfig.NavigationMode = NavigationClassic
+	MacroMgr = nil
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	pf, left, _ := newSearchFirstTestFrame(t)
+	vtui.FrameManager.Push(pf)
+	vtui.FrameManager.SyncCurrentScreen()
+	t.Cleanup(func() {
+		pf.Close()
+		vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	})
+
+	mgr := NewMacroManager("")
+	key := &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_A,
+		Char:           'a',
+	}
+	keyStr := EventToFarString(key)
+	mgr.Macros["Shell"] = map[string][]*vtinput.InputEvent{
+		keyStr: {{Type: vtinput.KeyEventType, KeyDown: true, Char: 'x', VirtualKeyCode: vtinput.VK_X}},
+	}
+
+	left.fastFindMode = true
+	if mgr.Filter(key) {
+		t.Fatal("Shell macro consumed input while Fast Find was active")
+	}
+}
+
 func TestMacroPlaybackLogic(t *testing.T) {
 	mgr := NewMacroManager("unused.ini")
 


### PR DESCRIPTION
Fixes #377

Shell-area macros were still resolved while the active PanelsFrame was in Fast Find mode. Because Fast Find is a transient panel input state, those keys must reach the panel search handler instead of macro playback.

This adds a modal-state guard before area/common/Lua macro dispatch and regression coverage for a Shell macro while Fast Find is active.

Validation:
- `go test ./... -count=1`
- native Windows amd64 `./cmd/f4` build
- `--version`
- `--wine-probe`
- `-test-plugins`

— zoin-bot