### PR TITLE
fix: keep hidden sort mode clickable

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -1095,6 +1095,9 @@ func (fp *FileSystemPanel) headerSortModeAt(x, y int) (SortMode, bool) {
 	if !fp.table.ShowHeader || y != fp.table.Y1 || x < fp.table.X1 || x > fp.table.X2 {
 		return SortUnsorted, false
 	}
+	if mode, ok := fp.hiddenSortModeHeaderAt(x); ok {
+		return mode, true
+	}
 	columnX := fp.table.X1
 	for column, tableColumn := range fp.table.Columns {
 		if x >= columnX && x < columnX+tableColumn.Width {
@@ -1110,6 +1113,28 @@ func (fp *FileSystemPanel) headerSortModeAt(x, y int) (SortMode, bool) {
 		}
 	}
 	return SortUnsorted, false
+}
+
+func (fp *FileSystemPanel) hiddenSortModeHeaderAt(x int) (SortMode, bool) {
+	if fp.sortMode == SortUnsorted || len(fp.table.Columns) == 0 {
+		return SortUnsorted, false
+	}
+
+	for column := range fp.table.Columns {
+		mode, sortable := fp.columnSortMode(column)
+		if sortable && mode == fp.sortMode {
+			return SortUnsorted, false
+		}
+	}
+
+	width := fp.table.Columns[0].Width
+	right := hiddenSortColumnTitle(fp.sortMode, fp.sortIsAscending(), width)
+	rightWidth := runewidth.StringWidth(right)
+	columnEnd := fp.table.X1 + width
+	if rightWidth >= width {
+		return fp.sortMode, x >= fp.table.X1 && x < columnEnd
+	}
+	return fp.sortMode, x >= columnEnd-rightWidth && x < columnEnd
 }
 
 // panelScrollMetrics maps the panel's item-based scrolling onto the

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -3284,6 +3284,23 @@ func TestFileSystemPanel_HeaderClickSortsAndToggles(t *testing.T) {
 		t.Fatalf("reversed Name title has no down arrow: %q", fp.table.Columns[0].Title)
 	}
 
+	// When the active mode is not represented by a visible column, its
+	// right-aligned label is embedded in the Name header. Clicking that label
+	// must toggle the active mode instead of resetting it to Name.
+	release()
+	fp.sortMode = SortExt
+	fp.sortReverse = false
+	fp.updateSortColumnTitles()
+	hiddenTitle := hiddenSortColumnTitle(SortExt, fp.sortIsAscending(), fp.table.Columns[0].Width)
+	hiddenX := fp.table.X1 + fp.table.Columns[0].Width - runewidth.StringWidth(hiddenTitle)
+	if !fp.ProcessMouse(&vtinput.InputEvent{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		MouseX: int16(hiddenX), MouseY: int16(fp.table.Y1),
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}) || fp.sortMode != SortExt || !fp.sortReverse {
+		t.Fatalf("hidden Extension header click: mode=%v reverse=%v title=%q", fp.sortMode, fp.sortReverse, fp.table.Columns[0].Title)
+	}
+
 	// Separator clicks do not select either adjacent sort column.
 	release()
 	separatorX := fp.table.X1 + fp.table.Columns[0].Width


### PR DESCRIPTION
## Summary
- keep the hidden active sort-mode label clickable when it is embedded in the Name header
- add regression coverage for toggling Extension from that embedded label

Fixes #395

## Validation
- `go test ./... -count=1`
- Windows amd64 build: `--version`, `--wine-probe`, `-test-plugins`