### PR TITLE
ci: make the crash report dump look where crashes actually land

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -575,17 +575,58 @@ jobs:
       if: failure()
       shell: bash
       run: |
-        # A crash handler that os.Exit()s bypasses both go test's output and
-        # TestMain's temp-dir cleanup, so the reports it wrote survive here.
-        for base in "${TMPDIR:-/tmp}" "$(cygpath -u "${TEMP:-}" 2>/dev/null)"; do
-          if [ -z "$base" ] || [ ! -d "$base" ]; then
-            continue
+        # Look for crash logs in cache and temp roots (vtui's fallback); never fail.
+        set +e
+        search_roots=()
+        if [ -n "${XDG_CACHE_HOME:-}" ]; then
+          search_roots+=("$XDG_CACHE_HOME/vtui_app/crashes")
+        fi
+        if [ -n "${HOME:-}" ]; then
+          search_roots+=("$HOME/.cache/vtui_app/crashes")
+          search_roots+=("$HOME/Library/Caches/vtui_app/crashes")
+        fi
+        if [ -n "${LOCALAPPDATA:-}" ]; then
+          cache_dir="$LOCALAPPDATA"
+          if command -v cygpath >/dev/null 2>&1; then
+            if converted_cache_dir="$(cygpath -u "$LOCALAPPDATA" 2>/dev/null)"; then
+              cache_dir="$converted_cache_dir"
+            fi
           fi
-          find "$base" -maxdepth 4 -path '*f4-test-config*' -name '*.log' 2>/dev/null | head -20 | while read -r f; do
-            echo "=== $f ==="
-            cat "$f"
+          search_roots+=("$cache_dir/vtui_app/crashes")
+        fi
+        search_roots+=("${TMPDIR:-/tmp}")
+        if [ -n "${TEMP:-}" ]; then
+          temp_dir="$TEMP"
+          if command -v cygpath >/dev/null 2>&1; then
+            if converted_temp_dir="$(cygpath -u "$TEMP" 2>/dev/null)"; then
+              temp_dir="$converted_temp_dir"
+            fi
+          fi
+          search_roots+=("$temp_dir")
+        fi
+        echo "Crash report search roots:"
+        printf '  %s\n' "${search_roots[@]}"
+        report_count=0
+        for _ in {1..20}; do
+          IFS= read -r -d '' report || break
+          report_count=$((report_count + 1))
+          echo "=== $report ==="
+          cat -- "$report"
+        done < <(
+          for base in "${search_roots[@]}"; do
+            [ -d "$base" ] || continue
+            find "$base" -maxdepth 4 -name '*.log' \
+              \( -path '*f4-test-config*' -o -path '*/vtui_app/crashes/*' \) -print0 2>/dev/null
           done
-        done
+        )
+        if [ "$report_count" -eq 0 ]; then
+          echo "No crash reports found."
+        elif [ "$report_count" -eq 20 ]; then
+          echo "Printed 20 crash reports; stopped at the cap."
+        else
+          echo "Printed $report_count crash report(s)."
+        fi
+        exit 0
 
   race:
     name: Race detector


### PR DESCRIPTION
When a test binary dies rather than fails — a nil dereference in a background task, say — vtui's handler writes a report with the stack trace and calls `os.Exit`. That bypasses `go test`, so the log shows `FAIL` and not one word about what happened. The `Dump crash reports on failure` step exists to recover exactly that.

A shuffled test run this week produced a genuine one:

```
[vtui_app] FATAL PANIC IN ASYNC TASK: runtime error: invalid memory address or nil pointer dereference
[vtui_app] Crash report saved to: /home/runner/.cache/vtui_app/crashes/crash_20260822_124033_15009.log
```

The step then printed nothing and failed with exit code 1. The stack trace was lost. Two separate reasons:

**It looked in the wrong place.** The search covered `$TMPDIR` for paths matching `*f4-test-config*`. vtui's `getCrashDir` resolves to `os.UserCacheDir()/vtui_app/crashes`, falling back to `os.TempDir()` only when that fails — so `~/.cache` on Linux, `~/Library/Caches` on macOS, `%LocalAppData%` on Windows, none of which were searched. The temp roots stay, since they are still where the fallback and the older `f4-test-config` logs live.

**It failed on its own.** A diagnostic step must not do that. It only runs under `if: failure()`, so the job is already red and its own exit status carries no information — but a red step looks like a second problem stacked on the real one. It now exits 0 on every path.

It also says what it did: the roots it searched, and either how many reports it printed or that it found none. Silence after a list of directories cannot be told apart from a step that died halfway.

## Verification

Proving this one needs a failing run, since the step is unreachable otherwise. I put the change on a scratch branch on top of a deliberately failing test suite:

- Every cell ran the step to completion — `Dump crash reports on failure: success`, where before it was `failure`.
- The roots resolved correctly per platform. On `windows/arm64`, including the cygpath conversion:
  ```
  /c/Users/runneradmin/.cache/vtui_app/crashes
  /c/Users/runneradmin/Library/Caches/vtui_app/crashes
  /c/Users/runneradmin/AppData/Local/vtui_app/crashes
  /tmp
  /tmp
  No crash reports found.
  ```
- The print path I checked separately against a planted report, since no crash reproduced on that particular run: found, printed, `Printed 1 crash report(s).`, exit 0.

`/tmp` twice is `TMPDIR` and `TEMP` agreeing; a duplicate root is skipped or reprinted harmlessly and is not worth code to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
