### PR TITLE
fix: align dialog focus order with layout

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -1896,7 +1896,6 @@ func actionCopyMove(pf *PanelsFrame, isMove bool) {
 	}
 	comboMode.Menu.SetSelectPos(defMode)
 	comboMode.Edit.SetText(modes[defMode])
-	dlg.AddItem(comboMode)
 
 	btnOk := vtui.NewButton(0, 0, Msg("Copy.Btn"))
 	if isMove {
@@ -1917,6 +1916,7 @@ func actionCopyMove(pf *PanelsFrame, isMove bool) {
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
 	btnCancel.OnClick = func() { dlg.Close() }
 	dlg.AddItem(btnCancel)
+	dlg.AddItem(comboMode)
 
 	// Layout Engine
 	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 50-4, 11-4)
@@ -2021,8 +2021,6 @@ func actionCreateLink(pf *PanelsFrame) {
 	comboType.Menu.SetSelectPos(0)
 	comboType.Edit.SetText(linkTypes[0])
 	lblType := vtui.NewLabel(0, 0, Msg("Link.Type"), comboType)
-	dlg.AddItem(lblType)
-	dlg.AddItem(comboType)
 
 	btnOk := vtui.NewButton(0, 0, Msg("Link.Btn"))
 	btnOk.IsDefault = true
@@ -2092,6 +2090,8 @@ func actionCreateLink(pf *PanelsFrame) {
 
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
+	dlg.AddItem(lblType)
+	dlg.AddItem(comboType)
 
 	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 52-4, 11-4)
 	vbox.Add(promptLbl, vtui.Margins{}, vtui.AlignLeft)
@@ -2483,7 +2483,6 @@ func actionDeleteWithDisposition(pf *PanelsFrame, disposition vfs.DeleteDisposit
 	}
 	comboMode.Menu.SetSelectPos(defMode)
 	comboMode.Edit.SetText(modes[defMode])
-	dlg.AddItem(comboMode)
 
 	btnDel := vtui.NewButton(0, 0, Msg(buttonKey))
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
@@ -2496,6 +2495,7 @@ func actionDeleteWithDisposition(pf *PanelsFrame, disposition vfs.DeleteDisposit
 
 	dlg.AddItem(btnDel)
 	dlg.AddItem(btnCancel)
+	dlg.AddItem(comboMode)
 
 	hbox := vtui.NewHBoxLayout(0, 0, 50-4, 1)
 	hbox.HorizontalAlign = vtui.AlignCenter
@@ -2551,13 +2551,13 @@ func actionMkDir(pf *PanelsFrame) {
 	}
 	comboMode.Menu.SetSelectPos(defMode)
 	comboMode.Edit.SetText(modes[defMode])
-	dlg.AddItem(comboMode)
 
 	btnOk := vtui.NewButton(0, 0, Msg("vtui.Ok"))
 	btnOk.IsDefault = true
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
+	dlg.AddItem(comboMode)
 
 	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 40-4, 11-4)
 	vbox.Add(lblPrompt, vtui.Margins{}, vtui.AlignLeft)

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -802,6 +803,11 @@ func TestActionCopyMove_ModeMenuDoesNotCoverButtons(t *testing.T) {
 	}
 
 	assertComboMenuDoesNotCoverButtons(t, dlg, "copy")
+	focusDlg, ok := vtui.FrameManager.GetTopFrame().(dialogFocusContainer)
+	if !ok {
+		t.Fatal("copy dialog does not expose focus traversal")
+	}
+	assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "copy")
 	vtui.FrameManager.Pop()
 }
 
@@ -836,6 +842,47 @@ func assertComboMenuDoesNotCoverButtons(t *testing.T, dlg vtui.Container, name s
 	}
 
 	vtui.FrameManager.Pop()
+}
+
+type dialogFocusContainer interface {
+	vtui.Container
+	GetFocusedItem() vtui.UIElement
+	SetFocusedItem(vtui.UIElement)
+	ProcessKey(*vtinput.InputEvent) bool
+}
+
+func assertDialogTabOrderMatchesVisualOrder(t *testing.T, dlg dialogFocusContainer, name string) {
+	t.Helper()
+
+	var want []vtui.UIElement
+	for _, item := range dlg.GetChildren() {
+		if item.CanFocus() && !item.IsDisabled() {
+			want = append(want, item)
+		}
+	}
+	sort.SliceStable(want, func(i, j int) bool {
+		ix1, iy1, _, _ := want[i].GetPosition()
+		jx1, jy1, _, _ := want[j].GetPosition()
+		if iy1 != jy1 {
+			return iy1 < jy1
+		}
+		return ix1 < jx1
+	})
+	if len(want) == 0 {
+		t.Fatalf("%s dialog has no focusable controls", name)
+	}
+
+	dlg.SetFocusedItem(want[0])
+	for i, expected := range want {
+		if got := dlg.GetFocusedItem(); got != expected {
+			t.Fatalf("%s focus step %d = %T, want %T", name, i, got, expected)
+		}
+		if i+1 < len(want) && !dlg.ProcessKey(&vtinput.InputEvent{
+			Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_TAB,
+		}) {
+			t.Fatalf("%s Tab at focus step %d was not handled", name, i)
+		}
+	}
 }
 
 func TestActionCopy_ShiftF5_Prefill(t *testing.T) {
@@ -2507,6 +2554,11 @@ func TestActionCreateLink_Flow(t *testing.T) {
 	}
 
 	assertComboMenuDoesNotCoverButtons(t, dlg, "link")
+	focusDlg, ok := top.(dialogFocusContainer)
+	if !ok {
+		t.Fatal("link dialog does not expose focus traversal")
+	}
+	assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "link")
 
 	linkPath := filepath.Join(dstDir, "link.txt")
 	editDest.SetText(linkPath)

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -3340,12 +3340,12 @@ func (pf *PanelsFrame) showDummyOpDialog() {
 	comboMode.DropdownOnly = true
 	comboMode.Menu.SetSelectPos(0)
 	comboMode.Edit.SetText(comboMode.Menu.Items[0].Text)
-	dlg.AddItem(comboMode)
 
 	btnStart := vtui.NewButton(0, 0, Msg("Op.BtnStart"))
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
 	dlg.AddItem(btnStart)
 	dlg.AddItem(btnCancel)
+	dlg.AddItem(comboMode)
 
 	hbox := vtui.NewHBoxLayout(0, 0, 50-4, 1)
 	hbox.HorizontalAlign = vtui.AlignCenter

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -3362,6 +3362,11 @@ func TestLayout_F4InternalDialogs_Validity(t *testing.T) {
 		if dlg, ok := top.(vtui.Container); ok {
 			vtui.AssertLayout(t, dlg)
 			assertComboMenuDoesNotCoverButtons(t, dlg, "dummy operation")
+			focusDlg, ok := top.(dialogFocusContainer)
+			if !ok {
+				t.Fatal("dummy operation dialog does not expose focus traversal")
+			}
+			assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "dummy operation")
 			fm.Pop()
 		} else {
 			t.Fatal("Top frame is not a container")
@@ -3470,6 +3475,11 @@ func TestLayout_F4ActionDialogs_Validity(t *testing.T) {
 		actionCopyMove(pf, false)
 		dlg := fm.GetTopFrame().(vtui.Container)
 		vtui.AssertLayout(t, dlg)
+		focusDlg, ok := fm.GetTopFrame().(dialogFocusContainer)
+		if !ok {
+			t.Fatal("copy dialog does not expose focus traversal")
+		}
+		assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "copy")
 		fm.Pop()
 	})
 
@@ -3478,6 +3488,11 @@ func TestLayout_F4ActionDialogs_Validity(t *testing.T) {
 		actionCopyMove(pf, true)
 		dlg := fm.GetTopFrame().(vtui.Container)
 		vtui.AssertLayout(t, dlg)
+		focusDlg, ok := fm.GetTopFrame().(dialogFocusContainer)
+		if !ok {
+			t.Fatal("move dialog does not expose focus traversal")
+		}
+		assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "move")
 		fm.Pop()
 	})
 
@@ -3486,6 +3501,11 @@ func TestLayout_F4ActionDialogs_Validity(t *testing.T) {
 		dlg := fm.GetTopFrame().(vtui.Container)
 		vtui.AssertLayout(t, dlg)
 		assertComboMenuDoesNotCoverButtons(t, dlg, "make directory")
+		focusDlg, ok := fm.GetTopFrame().(dialogFocusContainer)
+		if !ok {
+			t.Fatal("make directory dialog does not expose focus traversal")
+		}
+		assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "make directory")
 		fm.Pop()
 	})
 
@@ -3495,6 +3515,11 @@ func TestLayout_F4ActionDialogs_Validity(t *testing.T) {
 		dlg := fm.GetTopFrame().(vtui.Container)
 		vtui.AssertLayout(t, dlg)
 		assertComboMenuDoesNotCoverButtons(t, dlg, "delete")
+		focusDlg, ok := fm.GetTopFrame().(dialogFocusContainer)
+		if !ok {
+			t.Fatal("delete dialog does not expose focus traversal")
+		}
+		assertDialogTabOrderMatchesVisualOrder(t, focusDlg, "delete")
 		fm.Pop()
 	})
 	t.Run("FindFileDialog", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- align Tab traversal in operation dialogs with the controls' visual top-to-bottom order
- cover copy, move, link, delete, mkdir, and dummy-operation dialogs with regression checks

Fixes #701

## Validation
- `go test ./... -count=1`
- native Windows amd64 build: `--version`, `--wine-probe`, `-test-plugins`