### PR TITLE
lint: clear two linters' backlogs and check them whole-tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -514,6 +514,19 @@ jobs:
         version: v2.13.1
         args: --new-from-rev=origin/main
 
+    # The step above only reports findings on lines a pull request touched, so
+    # everything the linters have to say about existing code stays invisible —
+    # currently around 2450 findings. Rather than leave that permanently
+    # unspoken, each linter graduates here once its backlog is actually zero,
+    # and from then on it is checked across the whole tree and cannot regrow.
+    # Adding a linter to this list means clearing its debt first, in the same
+    # change.
+    - name: Run whole-tree golangci-lint for the linters with no backlog
+      uses: golangci/golangci-lint-action@v9.3.0
+      with:
+        version: v2.13.1
+        args: --config .golangci-strict.yml
+
     # Unlike the linters above this one is not incremental: it reports only
     # vulnerabilities the code actually reaches, so the whole tree is in scope
     # and the finding count stays at zero rather than accumulating a backlog.

--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -1,0 +1,27 @@
+# Linters that have no backlog left, checked across the whole tree.
+#
+# The main .golangci.yml is paired with --new-from-rev, so it only ever reports
+# findings on lines a pull request touched and says nothing about existing code.
+# A linter moves here once its backlog is genuinely zero, and from then on it is
+# checked everywhere and cannot regrow. Adding one means clearing its debt in
+# the same change.
+#
+# This list is a subset of .golangci.yml's, not a separate set: everything here
+# is also enabled there, so a local `golangci-lint run` with no arguments still
+# covers it. The two files answer different questions — the main one is what we
+# lint at all, this one is which of those we hold at zero everywhere. Running
+# both costs about a second, because the second invocation reuses the first's
+# analysis cache.
+#
+# No exclusion presets here on purpose: this is meant to be the strict end, and
+# a preset silently dropping findings would defeat it.
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - ineffassign
+    - unused
+
+  exclusions:
+    generated: lax

--- a/cmd/f4/arkanoid.go
+++ b/cmd/f4/arkanoid.go
@@ -477,8 +477,7 @@ func (af *ArkanoidFrame) Show(scr *vtui.ScreenBuf) {
 	scr.FillRect(x1, y1, x1+width-3, y1+height-3, ' ', cgaBlack)
 
 	// Ракетка (подсвечивается при удачном стринге)
-	paddleAttr := vtui.SetRGBBoth(0, 0xC0C0C0, 0)
-	paddleAttr = cgaCyan
+	paddleAttr := cgaCyan
 	if af.flashTimer > 0 {
 		paddleAttr = cgaWhite // Ракетка "вспыхивает" от гордости за игрока
 	}
@@ -493,10 +492,6 @@ func (af *ArkanoidFrame) Show(scr *vtui.ScreenBuf) {
 	intW := af.X2 - af.X1 - 1
 	//gridStep := 5
 	brickW := 4
-	margin := (intW - 49) / 2
-	if margin < 0 {
-		margin = 0
-	}
 
 	for _, br := range af.bricks {
 		var charToDraw rune
@@ -542,7 +537,7 @@ func (af *ArkanoidFrame) Show(scr *vtui.ScreenBuf) {
 	}
 
 	// Мяч (эволюционирует от Cyan до Yellow)
-	ballAttr := cgaWhite
+	var ballAttr uint64
 	switch {
 	case af.combo > 12:
 		ballAttr = cgaYellow

--- a/cmd/f4/async_buffer_test.go
+++ b/cmd/f4/async_buffer_test.go
@@ -49,7 +49,7 @@ func TestAsyncBuffer_LoadingCycle(t *testing.T) {
 		}
 
 		// Check if data is now available
-		data, err = buf.Read(0, 5)
+		_, err = buf.Read(0, 5)
 		if err == nil {
 			success = true
 			break

--- a/cmd/f4/editor_index_status.go
+++ b/cmd/f4/editor_index_status.go
@@ -104,15 +104,6 @@ func (ev *EditorView) setIndexStatus(s IndexStatus) {
 	}
 }
 
-// noteIndexProgress is what the scan reports through: how far it has read and
-// how many lines that came to. It keeps the phase as it is.
-func (ev *EditorView) noteIndexProgress(scanned int64, lines int) {
-	s := ev.indexStatus
-	s.Scanned = scanned
-	s.Lines = lines
-	ev.setIndexStatus(s)
-}
-
 // indexIsComplete reports whether the index describes the whole buffer, which
 // is the question every caller that needs a line number for a far-away offset
 // actually wants answered.

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -30,18 +30,6 @@ import (
 )
 import "golang.org/x/arch/x86/x86asm"
 
-type visualCell struct {
-	info       vtui.CharInfo
-	byteOffset int // Offset in bytes from the start of the logical line
-}
-
-type lineFragment struct {
-	cells           []visualCell
-	startOffset     int // Absolute offset of the fragment start
-	startByteInLine int // Byte in the logical line where the fragment starts
-	endByteInLine   int // Byte where the fragment ends
-}
-
 var (
 	LastEditorSearch          string
 	LastEditorReplace         string
@@ -2534,7 +2522,7 @@ func (ev *EditorView) fillCellsWithLinks(target []vtui.CharInfo, data []byte, de
 	}
 
 	for _, cluster := range clusters {
-		w := cluster.width
+		var w int
 		displayText, sanitizedWidth := vtui.SanitizeCluster(cluster.text)
 		if cluster.text == "\t" {
 			w = tabSize - (visualCol % tabSize)

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -36,9 +36,7 @@ func (m *mockCrashingHighlighter) Name() string                                 
 func (m *mockCrashingHighlighter) Match(filename, content string) bool              { return true }
 func (m *mockCrashingHighlighter) Create(filename, content string) vtui.Highlighter { return m }
 
-type mockStatefulHighlighter struct {
-	statesComputed int
-}
+type mockStatefulHighlighter struct{}
 
 func (m *mockStatefulHighlighter) Highlight(line string, prev any, base uint64) ([]uint64, any) {
 	depth := 0

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -2046,56 +2046,6 @@ func TestRecursiveCopyClosesTheDestinationBeforeSucceeding(t *testing.T) {
 	}
 }
 
-type mockReadAtCloser struct{}
-
-func (m *mockReadAtCloser) ReadAt(ctx context.Context, p []byte, off int64) (n int, err error) {
-	return 0, io.EOF
-}
-func (m *mockReadAtCloser) Read(ctx context.Context, p []byte) (n int, err error) {
-	return 0, io.EOF
-}
-func (m *mockReadAtCloser) Close() error { return nil }
-func (m *mockReadAtCloser) Size() int64  { return 10 }
-
-type mockWriteCloser struct{}
-
-func (m *mockWriteCloser) Write(p []byte) (n int, err error) { return len(p), nil }
-func (m *mockWriteCloser) Close() error                      { return nil }
-
-type mockVFS struct {
-	vfs.VFS
-	onOpen func(ctx context.Context, path string) (vfs.ReadAtCloser, error)
-}
-
-func (m *mockVFS) IsAtRoot() bool            { return true }
-func (m *mockVFS) GetPath() string           { return "/" }
-func (m *mockVFS) IsAbs(path string) bool    { return true }
-func (m *mockVFS) SetPath(path string) error { return nil }
-func (m *mockVFS) Join(elem ...string) string {
-	return strings.Join(elem, "/")
-}
-func (m *mockVFS) Abs(path string) (string, error) { return path, nil }
-func (m *mockVFS) Base(path string) string         { return "file.txt" }
-func (m *mockVFS) Dir(path string) string          { return "/" }
-func (m *mockVFS) Stat(ctx context.Context, path string) (vfs.VFSItem, error) {
-	return vfs.VFSItem{Name: "file.txt", Size: 10, IsDir: false}, nil
-}
-func (m *mockVFS) Open(ctx context.Context, path string) (vfs.ReadAtCloser, error) {
-	if m.onOpen != nil {
-		return m.onOpen(ctx, path)
-	}
-	return &mockReadAtCloser{}, nil
-}
-func (m *mockVFS) Create(ctx context.Context, path string) (io.WriteCloser, error) {
-	return &mockWriteCloser{}, nil
-}
-func (m *mockVFS) Remove(ctx context.Context, path string) error { return nil }
-func (m *mockVFS) GetCapabilities() vfs.VFSCapabilities {
-	return vfs.VFSCapabilities{HasRandomAccess: true}
-}
-func (m *mockVFS) Close() error   { return nil }
-func (m *mockVFS) Clone() vfs.VFS { return m }
-
 type mockReporter struct {
 	lastAction     string
 	lastFilename   string

--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -2263,21 +2263,6 @@ func (fp *FileSystemPanel) Refresh() {
 	}
 }
 
-func (fp *FileSystemPanel) cursorSizeOnBottomBorder() string {
-	if AppConfig.ShowPanelFileInfo || (fp.viewMode != ViewModeBrief && fp.viewMode != ViewModeMedium) {
-		return ""
-	}
-	idx := fp.GetCursorIndex()
-	if idx < 0 || idx >= len(fp.entries) {
-		return ""
-	}
-	entry := fp.entries[idx]
-	if entry == nil || entry.IsDir || entry.Name == ".." {
-		return ""
-	}
-	return " " + formatIntWithSpaces(entry.Size) + " B "
-}
-
 func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 	fp.frame.Show(scr)
 	titleAttr := vtui.Palette[ColPanelTitle]

--- a/cmd/f4/history_dialog.go
+++ b/cmd/f4/history_dialog.go
@@ -133,10 +133,6 @@ func (s *historySearch) selectedSecondary() string {
 	return rec.Extra
 }
 
-func (s *historySearch) setSecondary(items []string, visible bool) {
-	s.setSecondaryWidth(items, visible, 24)
-}
-
 func (s *historySearch) setSecondaryWidth(items []string, visible bool, width int) {
 	s.secondary = make([]string, len(s.all))
 	copy(s.secondary, items)

--- a/cmd/f4/image_view.go
+++ b/cmd/f4/image_view.go
@@ -116,7 +116,7 @@ func NewImageView(ctx context.Context, v vfs.VFS, path string) (*ImageView, erro
 	iv.index = -1
 	iv.topBar = NewTopBar(
 		func() string {
-			base := iv.path
+			var base string
 			if v != nil {
 				base = v.Base(iv.path)
 			} else {

--- a/cmd/f4/info_usage.go
+++ b/cmd/f4/info_usage.go
@@ -57,7 +57,6 @@ func (meter infoUsageMeter) rowsWithWidth(section string, innerW, y, requestedMe
 			labelRoom = 1
 		}
 		labelPad = runewidth.Truncate(" "+meter.Label, labelRoom, "…")
-		labelWidth = runewidth.StringWidth(labelPad)
 	}
 	if meterWidth < 1 {
 		// Degenerate one-cell interiors cannot display a meaningful meter,

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -280,10 +280,9 @@ func main() {
 				i++
 			}
 		case "--sudo-dispatcher":
-			if flagVal != "" {
-				sudoDispatcher = flagVal
-			} else if i+1 < len(os.Args) {
-				sudoDispatcher = os.Args[i+1]
+			// Handled before regular argument parsing; still consume its
+			// separate value here so it is not interpreted as another flag.
+			if flagVal == "" && i+1 < len(os.Args) {
 				i++
 			}
 		}

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -297,8 +297,10 @@ func TestPanelsFrame_Layout(t *testing.T) {
 	pf.ResizeConsole(80, 25)
 
 	// After hiding KeyBar, CommandLine should move to the bottom row
-	expectedKeyBarY = 24 // Still the last line, but invisible
 	expectedCmdLineY = 24
+	if pf.keyBar.Y1 != expectedKeyBarY {
+		t.Errorf("KeyBar should remain at %d when hidden, got %d", expectedKeyBarY, pf.keyBar.Y1)
+	}
 	if pf.cmdLine.Y1 != expectedCmdLineY {
 		t.Errorf("CommandLine should be at %d when KeyBar hidden, got %d", expectedCmdLineY, pf.cmdLine.Y1)
 	}

--- a/cmd/f4/plugring_rows_test.go
+++ b/cmd/f4/plugring_rows_test.go
@@ -5,15 +5,6 @@ import (
 	"testing"
 )
 
-func plugRingRowAt(t *testing.T, rows []interface{ GetCellText(int) string }, i int) plugRingRow {
-	t.Helper()
-	row, ok := rows[i].(plugRingRow)
-	if !ok {
-		t.Fatalf("row %d is %T", i, rows[i])
-	}
-	return row
-}
-
 func TestBuildPlugRingRowsGroupsByCategory(t *testing.T) {
 	items := []PlugRingItem{
 		{ID: "zip", Name: "Zip", Category: "archive", Entrypoint: "plugin.lua"},

--- a/cmd/f4/semantic.go
+++ b/cmd/f4/semantic.go
@@ -547,7 +547,7 @@ func semanticViewerLineLen(data []byte, width int, wrap bool) (lineLen int, text
 			lineLen += size
 			continue
 		}
-		rw := 1
+		var rw int
 		if r == '\t' {
 			rw = tabSize - (visualWidth % tabSize)
 		} else {

--- a/cmd/f4/simple_exec.go
+++ b/cmd/f4/simple_exec.go
@@ -130,19 +130,6 @@ func captureHostConsoleBuffer(w, h int) {
 	captureHostConsoleBufferImpl(w, h)
 }
 
-func restoreHostConsoleBuffer() {
-	restoreHostConsoleBufferImpl()
-}
-
-// restoreHostConsoleBufferIfSize blits the saved console snapshot back only when
-// it still matches the current screen. Restoring a stale, differently sized
-// snapshot leaves fragments of the old panels hanging over the command output.
-func restoreHostConsoleBufferIfSize(w, h int) {
-	if hostConsoleBufferMatches(w, h) {
-		restoreHostConsoleBufferImpl()
-	}
-}
-
 // runSimpleCapturedCommand executes a command via LocalCommandRunner and displays
 // the streaming output in a scrollable f4 window.
 func (pf *PanelsFrame) runSimpleCapturedCommand(dir, command string) {

--- a/cmd/f4/simple_exec_other.go
+++ b/cmd/f4/simple_exec_other.go
@@ -9,6 +9,3 @@ func modMsvcrtProcImpl() interface {
 }
 
 func captureHostConsoleBufferImpl(w, h int) {}
-func restoreHostConsoleBufferImpl()         {}
-
-func hostConsoleBufferMatches(w, h int) bool { return false }

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -295,8 +295,6 @@ func (tv *TerminalView) rowHasText(y int) bool {
 	}
 	return false
 }
-func (tv *TerminalView) flushLogUnsafe() {}
-
 func (tv *TerminalView) pushRowToGridHistory(y int) {
 	lineCopy := make([]vtui.CharInfo, len(tv.Lines[y]))
 	copy(lineCopy, tv.Lines[y])

--- a/cmd/f4/user_menu_subst.go
+++ b/cmd/f4/user_menu_subst.go
@@ -115,7 +115,6 @@ func SubstFileName(cmd string, ctx *SubstContext) SubstResult {
 				if ctx.AskUser != nil {
 					answered, accepted := ctx.AskUser(title, init)
 					if !accepted {
-						cancelled = true
 						return SubstResult{Cancelled: true}
 					}
 					value = answered

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -457,7 +457,7 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 				continue
 			}
 
-			rw := 1
+			var rw int
 			if r == '\t' {
 				rw = tabSize - (visualWidth % tabSize)
 			} else {
@@ -609,7 +609,7 @@ func (vv *ViewerView) ProcessKey(e *vtinput.InputEvent) bool {
 						lineLen += size
 						break
 					}
-					rw := 1
+					var rw int
 					if r == '\t' {
 						rw = tabSize - (visualWidth % tabSize)
 					} else {
@@ -861,7 +861,7 @@ func (vv *ViewerView) jumpToEnd() {
 						lineLen += size
 						continue
 					}
-					rw := 1
+					var rw int
 					if r == '\t' {
 						rw = tabSize - (visualWidth % tabSize)
 					} else {

--- a/cmd/f4/vtvibe_ap.go
+++ b/cmd/f4/vtvibe_ap.go
@@ -214,7 +214,6 @@ func aiShowPatchResult(pf *PanelsFrame, root string, dry bool, exitCode int, out
 		}
 		if hasReport {
 			attachReportIdx = currIdx
-			currIdx++
 		}
 
 		if code == viewLogIdx {

--- a/cmd/f4/window_position.go
+++ b/cmd/f4/window_position.go
@@ -2,21 +2,6 @@ package main
 
 import "github.com/unxed/vtui"
 
-// saveGuiWindowPosition captures the native GUI position for the explicit
-// Shift+F9 settings save. It deliberately does not run during ordinary
-// session saves: the user asked for the position to change only when settings
-// are saved from the application.
-func saveGuiWindowPosition() bool {
-	x, y, ok := vtui.GetWindowPosition()
-	if !ok {
-		return false
-	}
-	AppConfig.GuiPosX = x
-	AppConfig.GuiPosY = y
-	AppConfig.GuiPositionSaved = true
-	return true
-}
-
 // restoreGuiWindowPosition applies a position saved by Shift+F9. GUI hosts
 // call this from their setup callback while the native window is still being
 // initialized, so the first visible frame appears at the saved location.

--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -3,7 +3,6 @@ package archive
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -69,17 +68,6 @@ func (p *ArchivePlugin) Init(api vfs.HostAPI) error {
 	return nil
 }
 
-type ioCtxReader struct {
-	r   io.Reader
-	ctx context.Context
-}
-
-func (cr *ioCtxReader) Read(p []byte) (int, error) {
-	if cr.ctx.Err() != nil {
-		return 0, cr.ctx.Err()
-	}
-	return cr.r.Read(p)
-}
 func actionArchiveCommands(app vfs.App) {
 	app.Menu(" Archive Commands ", []string{"&1. Add to archive", "&2. Extract files"}, func(idx int) {
 		switch idx {

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -31,17 +31,6 @@ var TestSkipDelay time.Duration
 // transition without waiting for the production grace period.
 var archiveVFSIdleTTL = 2 * time.Second
 
-type dummyDirInfo struct {
-	name string
-}
-
-func (d dummyDirInfo) Name() string       { return d.name }
-func (d dummyDirInfo) Size() int64        { return 0 }
-func (d dummyDirInfo) Mode() fs.FileMode  { return fs.ModeDir | 0755 }
-func (d dummyDirInfo) ModTime() time.Time { return time.Now() }
-func (d dummyDirInfo) IsDir() bool        { return true }
-func (d dummyDirInfo) Sys() any           { return nil }
-
 type ctxReader struct {
 	r   vfs.ReadAtCloser
 	ctx context.Context
@@ -59,12 +48,6 @@ type readerAtAdapter struct {
 func (a readerAtAdapter) ReadAt(p []byte, off int64) (int, error) {
 	return a.r.ReadAt(a.ctx, p, off)
 }
-
-type nopWriteCloser struct {
-	io.Writer
-}
-
-func (n *nopWriteCloser) Close() error { return nil }
 
 type ArchiveVFS struct {
 	mu          sync.Mutex

--- a/plugins/cloudfox/provider_real_semantics_test.go
+++ b/plugins/cloudfox/provider_real_semantics_test.go
@@ -531,7 +531,6 @@ func restoreRealYandexTrash(t *testing.T, ctx context.Context, backend *yandexDi
 }
 
 func realYandexTrashEntries(ctx context.Context, backend *yandexDiskBackend) ([]yandexResource, error) {
-	const pageSize = 1000
 	var result []yandexResource
 	for offset := 0; ; {
 		query := url.Values{

--- a/plugins/cloudfox/provider_real_sharing_integration_test.go
+++ b/plugins/cloudfox/provider_real_sharing_integration_test.go
@@ -591,7 +591,7 @@ func awaitRealAnonymousShareState(t *testing.T, parent context.Context, rawURL s
 	ctx, cancel := context.WithTimeout(parent, 90*time.Second)
 	defer cancel()
 	client := newRealAnonymousShareClient(nil)
-	lastClass := "state-mismatch"
+	var lastClass string
 	for {
 		accessible, err := probeRealAnonymousShare(ctx, client, rawURL)
 		if err == nil && accessible == wanted {

--- a/plugins/cloudfox/uri.go
+++ b/plugins/cloudfox/uri.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path"
 	"strings"
 )
 
@@ -140,13 +139,4 @@ func validUUID(s string) bool {
 		}
 	}
 	return true
-}
-
-func cleanDisplayPath(p string) string {
-	p = strings.ReplaceAll(p, "\\", "/")
-	cleaned := path.Clean("/" + strings.TrimPrefix(p, "/"))
-	if cleaned == "/." {
-		return "/"
-	}
-	return cleaned
 }

--- a/plugins/cloudfox/vault.go
+++ b/plugins/cloudfox/vault.go
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"golang.org/x/crypto/argon2"
@@ -459,8 +458,4 @@ func zero(b []byte) {
 	}
 	// Keep the wipe observable to the compiler.
 	_ = subtle.ConstantTimeByteEq(0, 0)
-}
-
-func (v *VaultStore) ensureDirectory() error {
-	return os.MkdirAll(filepath.Dir(v.path), 0o700)
 }

--- a/plugins/envman/plugin.go
+++ b/plugins/envman/plugin.go
@@ -327,15 +327,6 @@ func (plugin *Plugin) setLastApplied(snapshot vfs.ProcessEnvironmentSnapshot) {
 	plugin.mu.Unlock()
 }
 
-func (plugin *Plugin) log(format string, arguments ...any) {
-	plugin.mu.Lock()
-	api := plugin.api
-	plugin.mu.Unlock()
-	if api != nil {
-		api.Log(fmt.Sprintf(format, arguments...))
-	}
-}
-
 func snapshotLines(snapshot vfs.ProcessEnvironmentSnapshot) []string {
 	lines := make([]string, 0, len(snapshot.Variables))
 	for _, variable := range snapshot.Variables {

--- a/plugins/id3editor/plugin_test.go
+++ b/plugins/id3editor/plugin_test.go
@@ -6,33 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/unxed/f4/vfs"
 	"github.com/unxed/id3-go"
 	v1 "github.com/unxed/id3-go/v1"
 	"github.com/unxed/vtui"
 )
-
-type mockApp struct {
-	vfs.App
-	activeVFS     vfs.VFS
-	selectedNames []string
-	messages      []string
-}
-
-func (m *mockApp) GetActivePanelVFS() vfs.VFS {
-	return m.activeVFS
-}
-
-func (m *mockApp) GetSelectedNames() []string {
-	return m.selectedNames
-}
-
-func (m *mockApp) Message(title, msg string, buttons []string) int {
-	m.messages = append(m.messages, msg)
-	return 0
-}
-
-func (m *mockApp) RefreshAll() {}
 
 func init() {
 	vtui.AddStrings(map[string]string{

--- a/plugins/mediainfo/source.go
+++ b/plugins/mediainfo/source.go
@@ -157,12 +157,6 @@ func (r *boundedReaderAt) ReadAt(p []byte, off int64) (int, error) {
 	return n, err
 }
 
-func (r *boundedReaderAt) stats() (int64, int) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return r.bytes, r.ops
-}
-
 type probe struct {
 	ctx      context.Context
 	src      Source

--- a/plugins/netfox/fishplus/exec_test.go
+++ b/plugins/netfox/fishplus/exec_test.go
@@ -84,7 +84,7 @@ func TestRunAgainstLocalShell(t *testing.T) {
 
 	// A command reading stdin must not take the request stream with it,
 	// which is the whole reason this is a job.
-	if _, code, err = c.RunOutput(ctx, dir, "cat"); err != nil {
+	if _, _, err = c.RunOutput(ctx, dir, "cat"); err != nil {
 		t.Fatalf("a command reading stdin: %v", err)
 	}
 	if err := c.Session().Noop(ctx); err != nil {

--- a/plugins/visren/dialog.go
+++ b/plugins/visren/dialog.go
@@ -269,18 +269,6 @@ func cropPadHighlighted(value string, offset, width int, baseAttr, matchAttr uin
 	return cells
 }
 
-func cropPad(value string, offset, width int) string {
-	runes := []rune(value)
-	if offset > len(runes) {
-		offset = len(runes)
-	}
-	if offset < 0 {
-		offset = 0
-	}
-	value = runewidth.Truncate(string(runes[offset:]), width, "")
-	return value + strings.Repeat(" ", maxInt(0, width-runewidth.StringWidth(value)))
-}
-
 func (p *previewList) ProcessKey(e *vtinput.InputEvent) bool {
 	if !e.KeyDown || len(p.rows) == 0 {
 		return false

--- a/plugins/visren/replace.go
+++ b/plugins/visren/replace.go
@@ -166,31 +166,6 @@ func parseFarRegex(expr string) (string, string, error) {
 	return "", "", fmt.Errorf("unterminated /regular expression/")
 }
 
-func (p *replacementProgram) apply(input string) string {
-	result, _ := p.applyWithRanges(input)
-	return result
-}
-
-func replaceFold(input, search, repl string) string {
-	if search == "" {
-		return input
-	}
-	lowerInput, lowerSearch := strings.ToLower(input), strings.ToLower(search)
-	var out strings.Builder
-	for {
-		idx := strings.Index(lowerInput, lowerSearch)
-		if idx < 0 {
-			out.WriteString(input)
-			break
-		}
-		out.WriteString(input[:idx])
-		out.WriteString(repl)
-		input = input[idx+len(search):]
-		lowerInput = lowerInput[idx+len(search):]
-	}
-	return out.String()
-}
-
 func farReplacement(src string) string {
 	// coregex follows Go's $1 expansion. Far additionally accepts a backslash
 	// before a literal replacement character; remove that quoting here.

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -757,11 +757,6 @@ func (we *WrapEngine) LogicalToVisual(byteOffset int) (visualRow, visualCol int)
 	return totalRow, 0
 }
 
-func (we *WrapEngine) logNav(msg string, offset int, row int, col int) {
-	// Only log if specifically requested to avoid flooding
-	// vtui.DebugLog("LAYOUT_NAV: %s Offset:%d -> VRow:%d VCol:%d", msg, offset, row, col)
-}
-
 // VisualToLogical переводит (строка, колонка) на экране в байтовый оффсет документа.
 func (we *WrapEngine) VisualToLogical(visualRow, visualCol int) int {
 	if visualRow < 0 {

--- a/vfs/os_vfs_search.go
+++ b/vfs/os_vfs_search.go
@@ -169,13 +169,6 @@ func newFindQueryMatcher(q FindQuery) (*findQueryMatcher, error) {
 	return m, nil
 }
 
-func (m *findQueryMatcher) matches(data []byte) bool {
-	if m == nil {
-		return true
-	}
-	return m.hasMatch(data) != m.query.NotContaining
-}
-
 func (m *findQueryMatcher) hasMatch(data []byte) bool {
 	if m == nil {
 		return false

--- a/vtvibe/provider.go
+++ b/vtvibe/provider.go
@@ -86,11 +86,6 @@ func (c Config) Chat(ctx context.Context, msgs []Message) (string, Usage, error)
 	if c.APIKey == "" && !isLocal(c.BaseURL) {
 		return "", Usage{}, ErrNoKey
 	}
-	body, err := json.Marshal(chatRequest{Model: c.Model, Messages: msgs})
-	if err != nil {
-		return "", Usage{}, err
-	}
-
 	req := chatRequest{Model: c.Model, Messages: msgs}
 	if strings.Contains(strings.ToLower(c.Model), "gemini") {
 		// Embed native Gemini search tools directly into OpenAI-compatible payload
@@ -102,7 +97,7 @@ func (c Config) Chat(ctx context.Context, msgs []Message) (string, Usage, error)
 			*/
 		}
 	}
-	body, err = json.Marshal(req)
+	body, err := json.Marshal(req)
 	if err != nil {
 		return "", Usage{}, err
 	}

--- a/vtvibe/session.go
+++ b/vtvibe/session.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -288,10 +287,6 @@ func (s *Session) Turns() []Turn {
 	defer s.mu.Unlock()
 	return append([]Turn(nil), s.turns...)
 }
-
-// fenceRe matches an opening fence with an optional info string. The part
-// after a colon is treated as a file path: ```go:vtvibe/pack.go
-var fenceRe = regexp.MustCompile("(?m)^```([^\n`]*)$")
 
 // saveArtifacts drops every named code block of the answer into out/, so the
 // user copies a finished file back to disk with F5 instead of selecting text.


### PR DESCRIPTION
golangci-lint runs with `--new-from-rev=origin/main`, so it only ever reports findings on lines a pull request touched. Everything the linters have to say about the existing tree is computed and then discarded before printing — currently around 2450 findings.

That is a fair way to adopt linters on a codebase that predates them, but as set up it has no way out. `main` is a moving target, so anything that lands becomes "old" and stops being checked forever, and the size of what is being ignored is invisible to everyone. `gosec` is the extreme: it sits in the enabled list and reports almost nothing.

This starts a way out, smallest backlog first. A linter graduates to `.golangci-strict.yml` once its backlog is genuinely zero, and from then on it is checked across the whole tree and cannot regrow. Adding one to that list means clearing its debt in the same change — the list is a promise, not a wish.

The strict list is a **subset** of the main one, not a separate set, so a local `golangci-lint run` with no arguments still covers everything. Running both costs about a second: measured on CI, the first invocation takes 29s and the second 1.1s, because it reuses the first's analysis cache.

## ineffassign — 19 findings

**One was a real bug.** A panel test computed the row its hidden KeyBar was expected on, directly below a comment saying it must stay on row 24, and never asserted it. The test could not fail. It asserts now.

Sixteen were initialisers that every branch overwrote — paddle and ball colours, rune widths in the editor and viewer, an image title. Deleted.

Two were worth more than deletion:

- `vtvibe` marshalled its chat request to JSON, then added the Gemini tool block to the request and marshalled again over the top. The first pass was not merely wasted, it encoded a request missing the tools.
- `main`'s second argument pass assigned `--sudo-dispatcher` after the early pass had already dispatched on it, with nothing left to read the value.

## unused — 64 findings, 272 lines

33 methods on types that were never once constructed, 10 dead methods on live types, 9 functions, a field, a constant, a variable.

Two hazards here rather than one. A method may be the only thing keeping its type inside an interface, so deleting it drops the type out silently and the failure surfaces somewhere else entirely. And a function may be referenced solely from a file behind a build tag this platform does not compile — with 150+ constrained files and nine GOOS values, "nothing references it" on Linux means little. The second was checked by cross-building rather than by reading.

The one that needed a real decision was `findQueryMatcher.matches`, which inverted the result for the "files not containing" search mode and looked like the only implementation of it. It is not: the streaming search inverts on its own at both of its exits, and a test covers that path. The method was a duplicate nobody called.

No `//nolint` anywhere, and nothing silenced to reach zero.

## Verification

Whole fork CI run green: 25 builds, 9 vet cells, 6 test cells, race detector, quality. `ineffassign` and `unused` both report 0 across the tree, and the strict config was checked against a deliberately planted violation to confirm it actually fails rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
