### PR TITLE
fix: keep transient workspace tabs from shifting panels

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3778,7 +3778,7 @@ func actionImportFar2lHistory(pf *PanelsFrame) {
 }
 
 func actionAppearanceSettings(pf *PanelsFrame) {
-	const width, height = 64, 28
+	const width, height = 64, 29
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
 	// Snapshot the whole palette (not just the style name) so a
@@ -3853,6 +3853,10 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	comboWorkspaceTabs.Menu.SetSelectPos(workspaceTabSelection)
 	comboWorkspaceTabs.Edit.SetText(workspaceTabModes[workspaceTabSelection])
 	lblWorkspaceTabs := vtui.NewLabel(0, 0, Msg("AppearanceSettings.WorkspaceTabs"), comboWorkspaceTabs)
+	chkWorkspaceTabsOverlay := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.WorkspaceTabsOverlay"), AppConfig.WorkspaceTabsOverlay)
+	if AppConfig.WorkspaceTabsOverlay {
+		chkWorkspaceTabsOverlay.State = 1
+	}
 
 	ctrlTabModes := []string{
 		Msg("AppearanceSettings.CtrlTabDirect"),
@@ -3919,6 +3923,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	dlg.AddItem(editTitle)
 	dlg.AddItem(lblWorkspaceTabs)
 	dlg.AddItem(comboWorkspaceTabs)
+	dlg.AddItem(chkWorkspaceTabsOverlay)
 	dlg.AddItem(lblCtrlTab)
 	dlg.AddItem(comboCtrlTab)
 	dlg.AddItem(chkAltNumberTabs)
@@ -3953,6 +3958,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	rowWorkspaceTabs.Add(lblWorkspaceTabs, vtui.Margins{Right: 1}, vtui.AlignLeft)
 	rowWorkspaceTabs.Add(comboWorkspaceTabs, vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(rowWorkspaceTabs, vtui.Margins{Top: 1}, vtui.AlignFill)
+	vbox.Add(chkWorkspaceTabsOverlay, vtui.Margins{}, vtui.AlignLeft)
 
 	rowCtrlTab := vtui.NewHBoxLayout(0, 0, width-4, 1)
 	rowCtrlTab.Add(lblCtrlTab, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -4007,6 +4013,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		vtui.ManageCursorStyle = !AppConfig.KeepTerminalCursor
 		AppConfig.EnforceColorCorrection = chkContrast.State == 1
 		AppConfig.WorkspaceTabMode = comboWorkspaceTabs.Menu.SelectPos
+		AppConfig.WorkspaceTabsOverlay = chkWorkspaceTabsOverlay.State == 1
 		AppConfig.CtrlTabShowsMenu = comboCtrlTab.Menu.SelectPos == 1
 		AppConfig.AltNumberSwitchesTabs = chkAltNumberTabs.State == 1
 		AppConfig.RestoreWorkspaceTabs = chkRestoreWorkspaceTabs.State == 1
@@ -4022,6 +4029,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 			ctrlTabMode = vtui.WorkspaceCtrlTabMenu
 		}
 		vtui.FrameManager.ConfigureWorkspaceTabs(vtui.WorkspaceTabMode(AppConfig.WorkspaceTabMode), ctrlTabMode)
+		vtui.FrameManager.ConfigureWorkspaceTabOverlay(AppConfig.WorkspaceTabsOverlay)
 		vtui.FrameManager.ConfigureWorkspaceAltNumberSwitch(AppConfig.AltNumberSwitchesTabs)
 
 		if fontChanged {

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -2068,6 +2068,46 @@ func TestActionAppearanceSettingsSavesWorkspaceTabRestoration(t *testing.T) {
 	}
 }
 
+func TestActionAppearanceSettingsSavesWorkspaceTabOverlay(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	getUserConfigIniPath = func() string { return filepath.Join(t.TempDir(), "settings.ini") }
+	defer func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	}()
+	AppConfig.WorkspaceTabsOverlay = true
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var overlayTabs *vtui.Checkbox
+	for _, child := range top.GetChildren() {
+		checkbox, ok := child.(*vtui.Checkbox)
+		if ok && checkbox.GetText() == Msg("AppearanceSettings.WorkspaceTabsOverlay") {
+			overlayTabs = checkbox
+			break
+		}
+	}
+	if overlayTabs == nil {
+		t.Fatal("workspace tab overlay checkbox not found in Appearance Settings")
+	}
+	if overlayTabs.State != 1 {
+		t.Fatal("workspace tab overlay must be enabled by default")
+	}
+	overlayTabs.Toggle()
+	clickDialogButton(t, top, "Ok")
+	if AppConfig.WorkspaceTabsOverlay {
+		t.Fatal("disabled workspace tab overlay setting was not saved")
+	}
+}
+
 func TestActionAppearanceSettingsSavesWorkspaceTabNumbering(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -667,7 +667,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 		ctrlTabMode = "menu"
 	}
 	sb.WriteString(fmt.Sprintf("WorkspaceTabMode = %s\n", workspaceTabMode))
-	sb.WriteString(fmt.Sprintf("WorkspaceTabsOverlay = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.WorkspaceTabsOverlay]))
+	fmt.Fprintf(&sb, "WorkspaceTabsOverlay = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.WorkspaceTabsOverlay])
 	sb.WriteString(fmt.Sprintf("CtrlTabMode = %s\n", ctrlTabMode))
 	sb.WriteString(fmt.Sprintf("AltNumberSwitchesTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.AltNumberSwitchesTabs]))
 	sb.WriteString(fmt.Sprintf("RestoreWorkspaceTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.RestoreWorkspaceTabs]))

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -149,6 +149,7 @@ type F4Config struct {
 	HelpLanguage             string
 	AlwaysShowMenuBar        bool
 	WorkspaceTabMode         int
+	WorkspaceTabsOverlay     bool
 	CtrlTabShowsMenu         bool
 	AltNumberSwitchesTabs    bool
 	RestoreWorkspaceTabs     bool
@@ -278,6 +279,7 @@ var AppConfig = F4Config{
 	HelpLanguage:             "en",
 	AlwaysShowMenuBar:        false,
 	WorkspaceTabMode:         int(vtui.WorkspaceTabsAlways),
+	WorkspaceTabsOverlay:     true,
 	CtrlTabShowsMenu:         false,
 	AltNumberSwitchesTabs:    true,
 	RestoreWorkspaceTabs:     true,
@@ -431,6 +433,7 @@ func LoadConfig() {
 	default:
 		AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsMultiple)
 	}
+	AppConfig.WorkspaceTabsOverlay = ini.GetString("Interface", "WorkspaceTabsOverlay", "1") != "0"
 	AppConfig.CtrlTabShowsMenu = strings.EqualFold(ini.GetString("Interface", "CtrlTabMode", "direct"), "menu")
 	AppConfig.AltNumberSwitchesTabs = ini.GetString("Interface", "AltNumberSwitchesTabs", "1") != "0"
 	AppConfig.RestoreWorkspaceTabs = ini.GetString("Interface", "RestoreWorkspaceTabs", "1") != "0"
@@ -664,6 +667,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 		ctrlTabMode = "menu"
 	}
 	sb.WriteString(fmt.Sprintf("WorkspaceTabMode = %s\n", workspaceTabMode))
+	sb.WriteString(fmt.Sprintf("WorkspaceTabsOverlay = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.WorkspaceTabsOverlay]))
 	sb.WriteString(fmt.Sprintf("CtrlTabMode = %s\n", ctrlTabMode))
 	sb.WriteString(fmt.Sprintf("AltNumberSwitchesTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.AltNumberSwitchesTabs]))
 	sb.WriteString(fmt.Sprintf("RestoreWorkspaceTabs = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.RestoreWorkspaceTabs]))

--- a/cmd/f4/config_test.go
+++ b/cmd/f4/config_test.go
@@ -45,6 +45,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.ConsoleMode = "host"
 	AppConfig.ConsoleOverlayUI = true
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsNever)
+	AppConfig.WorkspaceTabsOverlay = false
 	AppConfig.CtrlTabShowsMenu = true
 	AppConfig.AltNumberSwitchesTabs = false
 	AppConfig.RestoreWorkspaceTabs = false
@@ -70,6 +71,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.ConsoleMode = "own"
 	AppConfig.ConsoleOverlayUI = false
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsAlways)
+	AppConfig.WorkspaceTabsOverlay = true
 	AppConfig.CtrlTabShowsMenu = false
 	AppConfig.AltNumberSwitchesTabs = true
 	AppConfig.RestoreWorkspaceTabs = true
@@ -89,6 +91,9 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsNever) {
 		t.Errorf("LoadConfig failed to restore workspace tab mode: %d", AppConfig.WorkspaceTabMode)
+	}
+	if AppConfig.WorkspaceTabsOverlay {
+		t.Error("LoadConfig failed to restore disabled workspace tab overlay")
 	}
 	if !AppConfig.CtrlTabShowsMenu {
 		t.Error("LoadConfig failed to restore Ctrl+Tab menu mode")
@@ -373,10 +378,14 @@ func TestConfig_WorkspaceTabModeDefaultsToAlwaysWhenKeyIsAbsent(t *testing.T) {
 	getConfigIniPaths = func() []string { return []string{userIniPath} }
 
 	AppConfig.WorkspaceTabMode = int(vtui.WorkspaceTabsMultiple)
+	AppConfig.WorkspaceTabsOverlay = false
 	LoadConfig()
 	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsAlways) {
 		t.Fatalf("WorkspaceTabMode without a saved key = %d, want always-visible mode %d",
 			AppConfig.WorkspaceTabMode, vtui.WorkspaceTabsAlways)
+	}
+	if !AppConfig.WorkspaceTabsOverlay {
+		t.Fatal("WorkspaceTabsOverlay must default to true when the setting is absent")
 	}
 }
 

--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -745,6 +745,7 @@ AppearanceSettings.WorkspaceTabsAlways=Always reserve top row
 AppearanceSettings.WorkspaceTabsMultiple=Show when multiple
 AppearanceSettings.WorkspaceTabsCtrl=Show while Ctrl is held
 AppearanceSettings.WorkspaceTabsNever=Never show
+AppearanceSettings.WorkspaceTabsOverlay=Overlay transient tabs over the top panel row
 AppearanceSettings.CtrlTab=&Ctrl+Tab behavior:
 AppearanceSettings.CtrlTabDirect=Switch immediately
 AppearanceSettings.CtrlTabMenu=Show Screens menu

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -734,6 +734,7 @@ AppearanceSettings.WorkspaceTabs=&Вкладки пространств:
 AppearanceSettings.WorkspaceTabsAlways=Всегда резервировать верхнюю строку
 AppearanceSettings.WorkspaceTabsMultiple=Показывать, если больше одного
 AppearanceSettings.WorkspaceTabsCtrl=Показывать, пока нажат Ctrl
+AppearanceSettings.WorkspaceTabsOverlay=Рисовать временные вкладки поверх верхней строки панелей
 AppearanceSettings.CtrlTab=Поведение &Ctrl+Tab:
 AppearanceSettings.CtrlTabDirect=Переключать сразу
 AppearanceSettings.CtrlTabMenu=Показывать меню Screens

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -560,6 +560,7 @@ func SetupUI() {
 		ctrlTabMode = vtui.WorkspaceCtrlTabMenu
 	}
 	vtui.FrameManager.ConfigureWorkspaceTabs(vtui.WorkspaceTabMode(AppConfig.WorkspaceTabMode), ctrlTabMode)
+	vtui.FrameManager.ConfigureWorkspaceTabOverlay(AppConfig.WorkspaceTabsOverlay)
 	vtui.FrameManager.ConfigureWorkspaceAltNumberSwitch(AppConfig.AltNumberSwitchesTabs)
 	InitLang()
 	if err := ApplyColorStyle(AppConfig.ColorStyle); err != nil {


### PR DESCRIPTION
## Summary
- add a persisted `WorkspaceTabsOverlay` setting, enabled by default
- configure vtui to draw transient Ctrl+Tab workspace tabs over the panel top row
- add appearance/config regression coverage

Fixes #688

Dependency: vtui overlay support is merged in https://github.com/unxed/vtui/pull/79

## Validation
- targeted appearance/config tests
- `go test ./... -count=1`
- native Windows amd64 build: `--version`, `--wine-probe`, `-test-plugins`
- native Windows TTY launch with `WorkspaceTabMode=ctrl` and portable profile