### PR TITLE
zoin-bot: make hotkey settings transactional

### DIFF
--- a/ISSUE_411_SOLUTION_REVIEW.md
+++ b/ISSUE_411_SOLUTION_REVIEW.md
@@ -1,0 +1,48 @@
+# Issue #411 solution review
+
+## Problem model
+
+The hotkey configuration dialog currently edits `GlobalHotkeysMgr` directly.
+Both unbinding and assigning a key persist immediately, so an accidental click
+changes runtime dispatch and writes `hotkeys.ini` before the user can review or
+cancel the rest of the dialog session.
+
+## Candidate solutions
+
+1. Add only a confirmation prompt to unbinding. This reduces accidental
+   deletion, but assignment still persists immediately and there is no way to
+   cancel a sequence of accepted edits.
+2. Give the dialog an isolated `HotkeyManager` draft, confirm destructive
+   unbinds, and commit the draft only from an explicit Save button. This keeps
+   runtime dispatch and disk state unchanged until the user commits, while
+   preserving the existing manager and INI format. **Selected.**
+3. Snapshot and restore the global manager when the dialog closes. This would
+   require temporarily exposing uncommitted bindings to the whole application,
+   and makes nested assignment dialogs and unexpected close paths harder to
+   reason about than an isolated draft.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+The draft deep-copies all nested binding maps, so Bind does not alias the live
+manager. The main dialog renders and refreshes from the draft. Save copies the
+draft into the live manager and calls the existing Save method; Cancel simply
+closes the dialog. The assignment capture frame also receives the draft rather
+than reaching for the global manager.
+
+### Pass 2: adversarial lifecycle
+
+Cancel after one or more accepted assignments or unbinds leaves both the live
+manager and `hotkeys.ini` unchanged. Cancel in the unbind confirmation leaves
+the draft unchanged. Esc in the assignment capture frame leaves the draft
+unchanged. An accepted unbind is still reviewable in the table but is not
+runtime-effective until Save.
+
+### Pass 3: regression and scope
+
+The manager transaction test covers isolation, no early persistence, and the
+explicit commit path. The UI test checks that Save and Cancel are present in
+the native dialog. Existing hotkey, UI, full-suite, race, lint, native ARM64,
+and PTY smoke checks remain the final validation gate. This change is limited
+to configurable hotkey settings and does not alter the hotkey file format.

--- a/cmd/f4/hotkeys.go
+++ b/cmd/f4/hotkeys.go
@@ -145,6 +145,45 @@ func NewHotkeyManager(iniPath string) *HotkeyManager {
 	return hm
 }
 
+func cloneHotkeyBindings(src map[string]map[string]string) map[string]map[string]string {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(map[string]map[string]string, len(src))
+	for area, bindings := range src {
+		dst[area] = make(map[string]string, len(bindings))
+		for key, action := range bindings {
+			dst[area][key] = action
+		}
+	}
+	return dst
+}
+
+// CloneForEdit returns an isolated manager for a settings dialog. Mutations
+// made to the clone do not affect runtime dispatch or the user's INI file
+// until ReplaceBindingsFrom followed by Save is explicitly called.
+func (hm *HotkeyManager) CloneForEdit() *HotkeyManager {
+	if hm == nil {
+		return nil
+	}
+	return &HotkeyManager{
+		Bindings: cloneHotkeyBindings(hm.Bindings),
+		Defaults: cloneHotkeyBindings(hm.Defaults),
+		iniPath:  hm.iniPath,
+	}
+}
+
+// ReplaceBindingsFrom commits an isolated settings-dialog draft to the
+// runtime manager. The caller controls when persistence happens by calling
+// Save separately.
+func (hm *HotkeyManager) ReplaceBindingsFrom(src *HotkeyManager) {
+	if hm == nil || src == nil {
+		return
+	}
+	hm.Bindings = cloneHotkeyBindings(src.Bindings)
+}
+
 // GetActiveBindings returns a map of Area -> Key -> ActionName containing all active bindings.
 func (hm *HotkeyManager) GetActiveBindings() map[string]map[string]string {
 	res := make(map[string]map[string]string)

--- a/cmd/f4/hotkeys_test.go
+++ b/cmd/f4/hotkeys_test.go
@@ -55,6 +55,36 @@ CtrlU=None
 		t.Errorf("Expected CtrlU to still be None after reload, got %q", action)
 	}
 }
+
+func TestHotkeyManager_CloneForEditIsTransactional(t *testing.T) {
+	iniPath := filepath.Join(t.TempDir(), "hotkeys.ini")
+	original := NewHotkeyManager(iniPath)
+	draft := original.CloneForEdit()
+
+	draft.Bind("Shell", "F8", "None")
+	draft.Bind("Shell", "CtrlAltT", "Panel.Toggle")
+
+	if got := original.GetAction("Shell", "F8"); got != "File.Delete" {
+		t.Fatalf("editing the draft changed the runtime binding: got %q", got)
+	}
+	if got := original.GetAction("Shell", "CtrlAltT"); got != "" {
+		t.Fatalf("editing the draft added a runtime binding: got %q", got)
+	}
+	if _, err := os.Stat(iniPath); !os.IsNotExist(err) {
+		t.Fatalf("editing the draft persisted hotkeys before Save: stat error = %v", err)
+	}
+
+	original.ReplaceBindingsFrom(draft)
+	original.Save()
+	reloaded := NewHotkeyManager(iniPath)
+	if got := reloaded.GetAction("Shell", "F8"); got != "None" {
+		t.Errorf("committed removal = %q, want None", got)
+	}
+	if got := reloaded.GetAction("Shell", "CtrlAltT"); got != "Panel.Toggle" {
+		t.Errorf("committed addition = %q, want Panel.Toggle", got)
+	}
+}
+
 func TestHotkeyManager_GetActiveBindings(t *testing.T) {
 	hm := NewHotkeyManager("")
 	hm.initDefaults()

--- a/cmd/f4/hotkeys_ui.go
+++ b/cmd/f4/hotkeys_ui.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"sort"
 	"strings"
 
@@ -129,7 +130,15 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 
 	btnAssign := vtui.NewButton(0, 0, Msg("Hotkeys.BtnAssign"))
 	btnUnbind := vtui.NewButton(0, 0, Msg("Hotkeys.BtnUnbind"))
-	btnClose := vtui.NewButton(0, 0, Msg("Hotkeys.BtnClose"))
+	btnSave := vtui.NewButton(0, 0, Msg("vtui.Save"))
+	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
+	btnSave.IsDefault = true
+
+	if GlobalHotkeysMgr == nil {
+		return
+	}
+	original := GlobalHotkeysMgr
+	draft := original.CloneForEdit()
 
 	dlg, table := vtui.NewTableDialog(w, h, Msg("Hotkeys.Title"), []vtui.TableColumn{
 		{Title: "Command", Width: 23},
@@ -137,7 +146,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		{Title: "Area", Width: 10},
 		{Title: "When", Width: 17},
 		{Title: "Description", Width: 0},
-	}, btnAssign, btnUnbind, btnClose)
+	}, btnAssign, btnUnbind, btnSave, btnCancel)
 	useDialogTableColors(table)
 	table.ShowScrollBar = true
 	table.Sortable = true    // click a column header to sort, again to reverse
@@ -150,7 +159,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		hkRows = nil
 		rows = nil
 
-		activeBinds := GlobalHotkeysMgr.GetActiveBindings()
+		activeBinds := draft.GetActiveBindings()
 		actions := GetActions()
 		assignedActions := make(map[string]bool)
 
@@ -194,7 +203,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 				if key == "" || seenNative[displayKey] {
 					continue
 				}
-				if GlobalHotkeysMgr != nil && GlobalHotkeysMgr.GetAction(act.Area, key) != "" {
+				if draft.GetAction(act.Area, key) != "" {
 					continue
 				}
 				seenNative[displayKey] = true
@@ -251,7 +260,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		idx := table.SelectPos
 		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
 			row := hkRows[idx]
-			showAreaSelectDialog(row.Action, row.Area, row.Condition, refresh)
+			showAreaSelectDialog(draft, row.Action, row.Area, row.Condition, refresh)
 		}
 	}
 
@@ -260,14 +269,25 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
 			row := hkRows[idx]
 			if row.RawKey != "" && row.Area != "" {
-				GlobalHotkeysMgr.Bind(row.Area, row.RawKey, "None")
-				GlobalHotkeysMgr.Save()
-				refresh()
+				question := fmt.Sprintf("%s %s?", plainLabel(Msg("Hotkeys.BtnUnbind")), row.Key)
+				vtui.ShowMessageOn(dlg, Msg("Hotkeys.Title"), question, []string{Msg("vtui.Ok"), Msg("vtui.Cancel")}).OnResult = func(choice int) {
+					if choice != 0 {
+						return
+					}
+					draft.Bind(row.Area, row.RawKey, "None")
+					refresh()
+				}
 			}
 		}
 	}
 
-	btnClose.OnClick = func() { dlg.Close() }
+	btnSave.OnClick = func() {
+		original.ReplaceBindingsFrom(draft)
+		original.Save()
+		dlg.Close()
+	}
+
+	btnCancel.OnClick = func() { dlg.Close() }
 
 	table.OnAction = func(idx int) {
 		btnAssign.OnClick()
@@ -277,7 +297,7 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 	refresh()
 }
 
-func showAreaSelectDialog(actionName, defaultArea, defaultCond string, onComplete func()) {
+func showAreaSelectDialog(hm *HotkeyManager, actionName, defaultArea, defaultCond string, onComplete func()) {
 	dlg := vtui.NewCenteredDialog(40, 11, Msg("Hotkeys.SelectTitle"))
 	dlg.ShowClose = true
 
@@ -359,7 +379,7 @@ func showAreaSelectDialog(actionName, defaultArea, defaultCond string, onComplet
 
 		dlg.Close()
 		vtui.FrameManager.PostTask(func() {
-			vtui.FrameManager.Push(NewHotkeyAssignFrame(fullName, area, onComplete))
+			vtui.FrameManager.Push(NewHotkeyAssignFrame(hm, fullName, area, onComplete))
 		})
 	}
 	vtui.FrameManager.Push(dlg)
@@ -367,16 +387,18 @@ func showAreaSelectDialog(actionName, defaultArea, defaultCond string, onComplet
 
 type HotkeyAssignFrame struct {
 	*vtui.Window
+	hm         *HotkeyManager
 	actionName string
 	area       string
 	onComplete func()
 }
 
-func NewHotkeyAssignFrame(actionName, area string, onComplete func()) *HotkeyAssignFrame {
+func NewHotkeyAssignFrame(hm *HotkeyManager, actionName, area string, onComplete func()) *HotkeyAssignFrame {
 	width, height := 42, 9
 	base := vtui.NewCenteredDialog(width, height, Msg("Hotkeys.AssignTitle"))
 	f := &HotkeyAssignFrame{
 		Window:     base,
+		hm:         hm,
 		actionName: actionName,
 		area:       area,
 		onComplete: onComplete,
@@ -427,8 +449,9 @@ func (f *HotkeyAssignFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	keyStr := EventToFarString(e)
 
-	GlobalHotkeysMgr.Bind(f.area, keyStr, f.actionName)
-	GlobalHotkeysMgr.Save()
+	if f.hm != nil {
+		f.hm.Bind(f.area, keyStr, f.actionName)
+	}
 
 	f.Close()
 	if f.onComplete != nil {

--- a/cmd/f4/hotkeys_ui_test.go
+++ b/cmd/f4/hotkeys_ui_test.go
@@ -144,8 +144,99 @@ func TestActionHotkeyConfigBuildsNativeRowsAndFitsScreen(t *testing.T) {
 		t.Fatalf("native rows missing: select=%v toggle-focus=%v", selectInsert, toggleFocus)
 	}
 
+	var hasSave, hasCancel bool
+	for _, child := range dlg.GetChildren() {
+		button, ok := child.(*vtui.Button)
+		if !ok {
+			continue
+		}
+		switch getCleanText(button) {
+		case "Save":
+			hasSave = true
+		case "Cancel":
+			hasCancel = true
+		}
+	}
+	if !hasSave || !hasCancel {
+		t.Fatalf("hotkey dialog must expose transactional buttons: save=%v cancel=%v", hasSave, hasCancel)
+	}
+
 	x1, _, x2, _ := dlg.GetPosition()
 	if got, want := x2-x1+1, 156; got != want {
 		t.Errorf("dialog width = %d, want %d", got, want)
+	}
+}
+
+func TestActionHotkeyConfigUnbindUsesDraftUntilSave(t *testing.T) {
+	previous := GlobalHotkeysMgr
+	manager := NewHotkeyManager("")
+	GlobalHotkeysMgr = manager
+	t.Cleanup(func() { GlobalHotkeysMgr = previous })
+
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(160, 40)
+	vtui.FrameManager.Init(screen)
+	actionHotkeyConfig(nil)
+
+	openDialog := func() (*vtui.Window, *vtui.Table, *vtui.Button, *vtui.Button) {
+		top, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+		if !ok {
+			t.Fatalf("top frame = %T, want hotkey dialog", vtui.FrameManager.GetTopFrame())
+		}
+		var table *vtui.Table
+		var unbind, save *vtui.Button
+		for _, child := range top.GetChildren() {
+			switch candidate := child.(type) {
+			case *vtui.Table:
+				table = candidate
+			case *vtui.Button:
+				switch getCleanText(candidate) {
+				case "Unbind":
+					unbind = candidate
+				case "Save":
+					save = candidate
+				}
+			}
+		}
+		if table == nil || unbind == nil || save == nil {
+			t.Fatalf("hotkey dialog controls missing: table=%v unbind=%v save=%v", table != nil, unbind != nil, save != nil)
+		}
+		for i, row := range table.Rows {
+			hotkey, ok := row.(hotkeyRow)
+			if ok && hotkey.Action == "File.Delete" && hotkey.RawKey == "F8" {
+				table.SelectPos = i
+				return top, table, unbind, save
+			}
+		}
+		t.Fatal("File.Delete/F8 row not found")
+		return nil, nil, nil, nil
+	}
+
+	mainDialog, _, unbind, save := openDialog()
+	unbind.OnClick()
+	confirmation, ok := vtui.FrameManager.GetTopFrame().(vtui.Container)
+	if !ok {
+		t.Fatalf("confirmation frame = %T, want container", vtui.FrameManager.GetTopFrame())
+	}
+	clickDialogButton(t, confirmation, "Cancel")
+	if got := manager.GetAction("Shell", "F8"); got != "File.Delete" {
+		t.Fatalf("cancelled confirmation changed live binding: got %q", got)
+	}
+
+	unbind.OnClick()
+	confirmation, ok = vtui.FrameManager.GetTopFrame().(vtui.Container)
+	if !ok {
+		t.Fatalf("confirmation frame = %T, want container", vtui.FrameManager.GetTopFrame())
+	}
+	clickDialogButton(t, confirmation, "Ok")
+	if got := manager.GetAction("Shell", "F8"); got != "File.Delete" {
+		t.Fatalf("accepted draft removal changed live binding before Save: got %q", got)
+	}
+	if mainDialog.IsDone() {
+		t.Fatal("unbind confirmation closed the main dialog")
+	}
+	save.OnClick()
+	if got := manager.GetAction("Shell", "F8"); got != "None" {
+		t.Fatalf("saved removal = %q, want None", got)
 	}
 }


### PR DESCRIPTION
I, zoin-bot, fixed issue #411 on Linux ARM64 (Fedora Asahi Remix 44, KDE Wayland).

Root cause:
- Hotkey assignment and unbinding mutated GlobalHotkeysMgr and wrote hotkeys.ini immediately.
- Closing the dialog provided no rollback, so an accidental unbind could require manual config repair.

Fix:
- Added an isolated deep-copied HotkeyManager draft for the whole dialog session.
- Unbind now asks for confirmation and only changes the draft.
- Assignments also stay in the draft; Save commits and persists all edits, while Cancel/Esc discards them.
- Added manager transaction tests, UI confirmation/commit tests, and ISSUE_411_SOLUTION_REVIEW.md with three candidate solutions and three review passes.

Validation on the device:
- go test ./... -count=1 -timeout=180s
- go test -race ./cmd/f4 -run hotkey transaction tests -count=1
- go vet ./...
- golangci-lint v2.13.1 incremental run: 0 issues
- native ARM64 build and --version
- native ANSI-PTY startup, menu navigation, Hotkey Configurator open, Save/Cancel controls, and clean exit

Signed — zoin-bot