### PR TITLE
editor: mend what merging main into #709 quietly undid

### DIFF
--- a/cmd/f4/editor_index_status.go
+++ b/cmd/f4/editor_index_status.go
@@ -104,6 +104,20 @@ func (ev *EditorView) setIndexStatus(s IndexStatus) {
 	}
 }
 
+// noteIndexProgress is what the scan reports through: how far it has read and
+// how many lines that came to. It keeps the phase as it is.
+//
+// Removed once as dead code, correctly at the time: the scan updated its
+// status only at start and finish, so the status line showed 0% for the whole
+// of a scan — which on a file big enough to watch reads as a scan that is
+// stuck rather than one that is working. The batches call it now.
+func (ev *EditorView) noteIndexProgress(scanned int64, lines int) {
+	s := ev.indexStatus
+	s.Scanned = scanned
+	s.Lines = lines
+	ev.setIndexStatus(s)
+}
+
 // indexIsComplete reports whether the index describes the whole buffer, which
 // is the question every caller that needs a line number for a far-away offset
 // actually wants answered.

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -3188,12 +3188,15 @@ func (ev *EditorView) StartIndexing() {
 	ev.retireEditSession()
 	sessionID := ev.editSession
 	ev.probeUnsafeWordWrap()
-	// Mapped and fully decoded files already have their line index; they still
-	// need the safety scan before wrapping can be enabled.
-	if ev.asyncBuf == nil {
+	// Fully decoded files have their line index built with them; they still
+	// need the safety scan before wrapping can be enabled. A mapped file has
+	// neither: it starts with an empty index the scan below fills, and that
+	// scan runs the same safety check on every chunk it reads.
+	if ev.asyncBuf == nil && ev.mapped == nil {
 		// Fully read files (non-UTF-8 codepages) have a complete index and no
 		// line scan; resolve a pending restore here or Loading waits forever.
 		ev.restoreTargetPos()
+		ev.resolveTargetOffset()
 		ctx, cancel := context.WithCancel(context.Background())
 		ev.indexCancel = cancel
 		go func() {


### PR DESCRIPTION
#709 was merged with the "Update branch" merge (84b1643) in it, and that auto-merge quietly undid two things — my fix for it (00adebe on the PR branch) arrived two minutes after the merge, so `main` has the damage without the repair. This is that one commit, cherry-picked onto `main`.

Two casualties, one loud and one silent:

**Loud:** the lint sweep (6cecbf1) removed `noteIndexProgress` as dead code — and on `main` at the time it *was* dead; #709 is what gave it a caller. The merge kept the deletion and the caller both, so `go vet ./cmd/f4/` and the test build do not compile on `main` right now.

**Silent:** the wrap-safety work sends every file without a chunk buffer down an early path on the grounds that its line index was built with it. That was true of mapped files before #709 and is exactly what #709 changes — so the merged condition sends mapped files there too, and they keep their empty index forever: no scan, no line numbers, a status line stuck on "Indexing". Four of the branch's own tests catch it with timeouts.

The early path is for fully decoded files alone again. A mapped file takes the full scan, which runs the wrap-safety check on every chunk it reads anyway — measured on the 8 GB test file, indexing is 3.9 s with the check in the loop — and the early path gets back the pending byte-offset restore the merge had also dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
