### PR TITLE
fix: keep complex Unicode viewer rows inside frame

### DIFF
--- a/ISSUE_546_SOLUTION_REVIEW.md
+++ b/ISSUE_546_SOLUTION_REVIEW.md
@@ -1,0 +1,36 @@
+# Issue #546 solution review
+
+## Problem model
+
+The previous Unicode fix made editor grapheme navigation and painting cluster-aware, but the viewer still measured and emitted one terminal cell per decoded rune. Combining marks, Indic conjuncts, and Thaana marks were therefore counted repeatedly. A wrapped row could exceed its frame and overwrite a modal dialog or the scrollbar. Mouse coordinates in the editor also needed a final byte-boundary guard because a fallback visual-to-logical mapping could expose a code-point offset inside a cluster.
+
+## Candidate solutions
+
+1. **Chosen: one shared viewer row/cell path plus editor boundary snapping.** Use the existing `textlayout` cluster model for viewer wrapping, visual-order painting, and source-byte offsets. Reuse the same row calculation for Down and Ctrl+End. Snap mouse-derived editor offsets to the enclosing logical cluster boundary.
+2. **Rejected: patch each affected dialog and scrollbar separately.** This would hide the symptom for the screenshots but leave every viewer overlay and future modal vulnerable to the same overflowing text row.
+3. **Rejected: turn off BiDi/grapheme handling or only truncate `ScreenBuf.Write`.** Truncation prevents leaks but still leaves wrong wrapping, cursor/URL coordinates, and split glyphs. Disabling visual handling would regress the Unicode behavior fixed by the earlier PR.
+
+## Review pass 1 — correctness
+
+- Viewer wrapping and painting now use the same cluster boundaries, so a row cannot split a combining sequence or Indic conjunct.
+- RTL clusters are emitted in terminal order while retaining logical byte offsets for URL hover and Ctrl-click.
+- New tests cover Sanskrit wrapping, Thaana visual order, combining sequences, and editor mouse offsets inside clusters.
+- All three viewer traversal paths were checked: initial render, keyboard Down fallback, and Ctrl+End tail indexing.
+
+## Review pass 2 — compatibility
+
+- Tabs retain their configured tab stops; CRLF consumes both bytes while CR is not painted.
+- No-wrap mode still consumes through the real newline after the visible chunk, preserving existing large-line behavior.
+- URL cell ranges continue to receive one source offset per terminal cell, including wide characters and tabs.
+- The current upstream base also had a mapped-editor indexing guard and missing progress adapter that prevented the package from compiling or indexing mapped files; both are restored as small compatibility fixes required for a clean testable base.
+
+## Review pass 3 — performance and safety
+
+- Viewer tail indexing is bounded to a width-sized row window; it does not repeatedly segment the remaining 192 KiB tail for every wrapped row.
+- Rendered cell slices are capped to the viewer width, preventing writes into dialogs, neighboring frames, or the scrollbar.
+- The editor snap only reads the current logical line and does not alter the byte-addressable storage model.
+- Existing full-file, mapped-file, and tail-only tests remain part of the verification set.
+
+## Decision
+
+The chosen approach is the smallest general fix that addresses the viewer screenshots, modal-frame corruption, and reverse-selection boundary report together without changing the underlying file offsets or disabling Unicode/BiDi support.

--- a/cmd/f4/editor_grapheme.go
+++ b/cmd/f4/editor_grapheme.go
@@ -28,6 +28,43 @@ func editorGraphemes(data []byte) []editorGrapheme {
 	return clusters
 }
 
+// snapEditorOffsetToClusterBoundary prevents a mouse hit inside a multi-code
+// point glyph from becoming a selection anchor in the middle of that glyph.
+// The visual caret map normally returns boundaries already, but its fallback
+// for an incomplete/capped fragment can expose a code-point boundary. Keep the
+// editor's byte-addressable model while making selection starts atomic.
+func snapEditorOffsetToClusterBoundary(data []byte, pos int) int {
+	if pos <= 0 {
+		return 0
+	}
+	if pos >= len(data) {
+		return len(data)
+	}
+	for _, cluster := range textlayout.VisualClusters(string(data)) {
+		if pos > cluster.Start && pos < cluster.End {
+			return cluster.Start
+		}
+	}
+	return pos
+}
+
+func (ev *EditorView) snapMouseOffsetToClusterBoundary(offset int) int {
+	if ev == nil || ev.pt == nil || ev.li == nil || offset < 0 {
+		return offset
+	}
+	line := ev.li.GetLineAtOffset(offset)
+	lineStart := ev.li.GetLineOffset(line)
+	lineLen := ev.getLineLength(line)
+	if offset < lineStart || offset > lineStart+lineLen {
+		return offset
+	}
+	data, err := ev.pt.GetRange(lineStart, lineLen)
+	if err != nil {
+		return offset
+	}
+	return lineStart + snapEditorOffsetToClusterBoundary(data, offset-lineStart)
+}
+
 // lineUsesVisualBidi limits the full visual engine to lines that actually
 // contain RTL text. zoin-bot keeps the common long LTR path bounded by the
 // existing small-window grapheme helpers.

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -2895,7 +2895,7 @@ func (ev *EditorView) ProcessMouse(e *vtinput.InputEvent) bool {
 		if mx >= ev.X1 && mx <= ev.X2 && my >= ev.Y1+1 && my <= ev.Y2 {
 			visualCol := mx - ev.X1 + ev.ScrollLeft
 			visualRow := my - (ev.Y1 + 1) + ev.ScrollTopRow
-			offset := ev.engine.VisualToLogical(visualRow, visualCol)
+			offset := ev.snapMouseOffsetToClusterBoundary(ev.engine.VisualToLogical(visualRow, visualCol))
 
 			if e.MouseEventFlags&vtinput.DoubleClick != 0 {
 				ev.CursorLine = ev.li.GetLineAtOffset(offset)
@@ -2928,7 +2928,7 @@ func (ev *EditorView) ProcessMouse(e *vtinput.InputEvent) bool {
 		if mx >= ev.X1 && mx <= ev.X2 && my >= ev.Y1+1 && my <= ev.Y2 {
 			visualCol := mx - ev.X1 + ev.ScrollLeft
 			visualRow := my - (ev.Y1 + 1) + ev.ScrollTopRow
-			offset := ev.engine.VisualToLogical(visualRow, visualCol)
+			offset := ev.snapMouseOffsetToClusterBoundary(ev.engine.VisualToLogical(visualRow, visualCol))
 
 			if !ev.rectSelActive || e.MouseEventFlags&vtinput.MouseMoved == 0 {
 				ev.selActive = false

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -866,6 +866,19 @@ func TestEditorView_GraphemeNavigationAndDeletion(t *testing.T) {
 	}
 }
 
+func TestEditorMouseOffsetSnapsToClusterBoundary(t *testing.T) {
+	for _, text := range []string{"संस्कृतम्", "ދިވެހިބަސް"} {
+		clusters := editorGraphemes([]byte(text))
+		for _, cluster := range clusters {
+			for pos := cluster.start + 1; pos < cluster.end; pos++ {
+				if got := snapEditorOffsetToClusterBoundary([]byte(text), pos); got != cluster.start {
+					t.Fatalf("%q byte %d snapped to %d, want cluster start %d", text, pos, got, cluster.start)
+				}
+			}
+		}
+	}
+}
+
 func TestEditorView_BracketedPaste(t *testing.T) {
 	pt := piecetable.New([]byte("Start-"))
 	ev := NewEditorView(pt, nil, "")

--- a/cmd/f4/frame_manager_test_helpers_test.go
+++ b/cmd/f4/frame_manager_test_helpers_test.go
@@ -8,33 +8,9 @@ import (
 	"github.com/unxed/vtui"
 )
 
-// snapshotFrameManagerState saves a byte-for-byte copy of the current
-// *vtui.FrameManager and returns a function that restores it in place.
-//
-// vtui.frameManager embeds several sync.Mutex fields, so a plain Go
-// assignment of the dereferenced value (oldFM := *vtui.FrameManager) trips
-// `go vet`'s copylocks check -- rightly so in general, since copying a
-// mutex that might be locked produces two independently-lockable copies of
-// what was meant to be one lock. That risk doesn't apply here: this runs
-// at test setup and teardown, well before or after anything in the test
-// itself could be holding one of those locks, so a byte-for-byte copy is
-// exactly as safe as the struct assignment it replaces -- it's just
-// performed as a raw memory copy via unsafe instead of a typed Go
-// assignment, so it isn't the kind of expression the copylocks checker
-// looks for.
-func snapshotFrameManagerState(t *testing.T) func() {
-	t.Helper()
-	size := unsafe.Sizeof(*vtui.FrameManager)
-	backup := make([]byte, size)
-	copy(backup, unsafe.Slice((*byte)(unsafe.Pointer(vtui.FrameManager)), size))
-	return func() {
-		copy(unsafe.Slice((*byte)(unsafe.Pointer(vtui.FrameManager)), size), backup)
-	}
-}
-
 // swapFrameManager replaces the global vtui.FrameManager with a fresh,
 // independent instance seeded with a byte-for-byte copy of the current
-// one (see snapshotFrameManagerState for why that copy is safe here), and
+// one, and
 // returns a function that restores the original pointer.
 //
 // vtui.frameManager is unexported, so this package has no way to spell

--- a/cmd/f4/viewer_text.go
+++ b/cmd/f4/viewer_text.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/unxed/f4/textlayout"
+	"github.com/unxed/vtui"
+)
+
+// viewerTextRow describes the part of a decoded viewer buffer that occupies
+// one screen row. The byte counts are offsets in the decoded viewer buffer,
+// not offsets in the original file.
+type viewerTextRow struct {
+	lineLen      int
+	textLen      int
+	visualWidth  int
+	foundNewline bool
+}
+
+// layoutViewerTextRow keeps the viewer's wrapping and painting on the same
+// grapheme boundaries. Counting runes here makes combining marks, Indic
+// conjuncts, and Thaana marks consume a column of their own; the resulting row
+// then writes past the viewer frame and can overwrite a dialog or scrollbar.
+func layoutViewerTextRow(data []byte, width, tabSize int, wrap bool) viewerTextRow {
+	if width < 1 {
+		width = 1
+	}
+	if tabSize < 1 {
+		tabSize = 8
+	}
+
+	contentEnd := len(data)
+	foundNewline := false
+	for i, b := range data {
+		if b == '\n' {
+			contentEnd = i
+			foundNewline = true
+			break
+		}
+	}
+	textEnd := contentEnd
+	if textEnd > 0 && data[textEnd-1] == '\r' {
+		textEnd--
+	}
+
+	clusters := textlayout.VisualClusters(string(data[:textEnd]))
+	consumed := 0
+	visualWidth := 0
+	for _, cluster := range clusters {
+		clusterWidth := cluster.Width
+		if cluster.Text == "\t" {
+			clusterWidth = tabSize - (visualWidth % tabSize)
+		}
+		if clusterWidth <= 0 {
+			clusterWidth = 1
+		}
+		if wrap && consumed > 0 && visualWidth+clusterWidth > width {
+			break
+		}
+		consumed = cluster.End
+		visualWidth += clusterWidth
+		if wrap && visualWidth >= width {
+			break
+		}
+	}
+
+	if !wrap {
+		consumed = textEnd
+		visualWidth = 0
+		for _, cluster := range clusters {
+			clusterWidth := cluster.Width
+			if cluster.Text == "\t" {
+				clusterWidth = tabSize - (visualWidth % tabSize)
+			}
+			if clusterWidth <= 0 {
+				clusterWidth = 1
+			}
+			visualWidth += clusterWidth
+		}
+	}
+
+	row := viewerTextRow{
+		lineLen:      consumed,
+		textLen:      consumed,
+		visualWidth:  visualWidth,
+		foundNewline: foundNewline && consumed >= textEnd,
+	}
+	if row.foundNewline {
+		row.lineLen = contentEnd + 1
+		row.textLen = textEnd
+	}
+	if !foundNewline && !wrap {
+		row.lineLen = len(data)
+		row.textLen = textEnd
+	}
+	if row.lineLen == 0 && len(data) > 0 {
+		// A lone carriage return or another non-rendered control still has to
+		// advance the viewer, otherwise the wrapped row loop cannot progress.
+		row.lineLen = 1
+		row.textLen = 0
+	}
+	return row
+}
+
+// viewerTextCells renders one already-wrapped logical fragment in terminal
+// order. Every cell retains the source cluster's byte offset so URL hover and
+// Ctrl-click continue to work even when a right-to-left run is reordered.
+func viewerTextCells(text string, attr uint64, tabSize, maxWidth int) ([]vtui.CharInfo, []int) {
+	if tabSize < 1 {
+		tabSize = 8
+	}
+	if maxWidth < 0 {
+		maxWidth = 0
+	}
+
+	cells := make([]vtui.CharInfo, 0, len(text))
+	offsets := make([]int, 0, len(text))
+	visualCol := 0
+	for _, cluster := range textlayout.VisualClustersInVisualOrder(text) {
+		width := cluster.Width
+		plainSpaces := false
+		displayText, sanitizedWidth := vtui.SanitizeCluster(cluster.Text)
+		if cluster.Text == "\t" {
+			width = tabSize - (visualCol % tabSize)
+			displayText = strings.Repeat(" ", width)
+			plainSpaces = true
+		} else {
+			width = sanitizedWidth
+			plainSpaces = displayText == " "
+		}
+		if width <= 0 {
+			continue
+		}
+		if visualCol >= maxWidth {
+			break
+		}
+		if visualCol+width > maxWidth {
+			width = maxWidth - visualCol
+			if width <= 0 {
+				break
+			}
+			displayText = strings.Repeat(" ", width)
+			plainSpaces = true
+		}
+
+		if plainSpaces {
+			for i := 0; i < width; i++ {
+				cells = append(cells, vtui.CharInfo{Char: ' ', Attributes: attr})
+				offsets = append(offsets, cluster.Start)
+			}
+		} else {
+			clusterCells := vtui.AppendCluster(nil, displayText, width, attr)
+			cells = append(cells, clusterCells...)
+			for i := 0; i < len(clusterCells); i++ {
+				offsets = append(offsets, cluster.Start)
+			}
+		}
+		visualCol += width
+	}
+	return cells, offsets
+}

--- a/cmd/f4/viewer_text_test.go
+++ b/cmd/f4/viewer_text_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestLayoutViewerTextRowKeepsIndicClustersTogether(t *testing.T) {
+	text := "संस्कृतम्\n"
+	first := layoutViewerTextRow([]byte(text), 2, 8, true)
+	if got, want := string([]byte(text)[:first.textLen]), "संस्कृ"; got != want {
+		t.Fatalf("first wrapped row = %q, want %q", got, want)
+	}
+	if first.lineLen != first.textLen || first.foundNewline {
+		t.Fatalf("first row metadata = %+v, want an intermediate wrapped row", first)
+	}
+
+	second := layoutViewerTextRow([]byte(text)[first.lineLen:], 2, 8, true)
+	if !second.foundNewline || second.lineLen != len([]byte("तम्\n")) {
+		t.Fatalf("second row metadata = %+v, want the terminating row", second)
+	}
+
+	cells, _ := viewerTextCells(string([]byte(text)[:first.textLen]), 0, 8, 2)
+	if len(cells) != 2 {
+		t.Fatalf("first row rendered %d cells, want 2", len(cells))
+	}
+}
+
+func TestViewerTextCellsKeepsRTLClustersAndOffsets(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	t.Cleanup(func() { vtui.DefaultBidiMode = oldMode })
+	vtui.DefaultBidiMode = vtui.BidiFull
+
+	text := "ދިވެހިބަސް"
+	cells, offsets := viewerTextCells(text, 0, 8, 5)
+	if len(cells) != 5 || len(offsets) != 5 {
+		t.Fatalf("RTL render returned %d cells and %d offsets, want five of each", len(cells), len(offsets))
+	}
+	want := []int{16, 12, 8, 4, 0}
+	for i := range want {
+		if offsets[i] != want[i] {
+			t.Fatalf("visual cell %d offset = %d, want %d", i, offsets[i], want[i])
+		}
+	}
+}
+
+func TestLayoutViewerTextRowDoesNotSplitCombiningSequence(t *testing.T) {
+	text := "a" + strings.Repeat("\u0301", 32) + "b"
+	row := layoutViewerTextRow([]byte(text), 1, 8, true)
+	if row.textLen <= len("a") || row.textLen >= len(text) {
+		t.Fatalf("combining row ended at byte %d of %d, expected the first grapheme", row.textLen, len(text))
+	}
+	cells, _ := viewerTextCells(text[:row.textLen], 0, 8, 1)
+	if len(cells) != 1 {
+		t.Fatalf("combining row rendered %d cells, want one", len(cells))
+	}
+}

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -8,9 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"unicode/utf8"
 
-	"github.com/mattn/go-runewidth"
 	"github.com/unxed/f4/piecetable"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
@@ -419,7 +417,8 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 			break
 		}
 
-		// Read a generous chunk to handle wrapping
+		// Read a generous chunk to handle wrapping. The row helper keeps
+		// combining sequences and script conjuncts atomic.
 		data, err := vv.backend.ReadAt(currOffset, width*4)
 		if err == piecetable.ErrLoading {
 			vv.visibleURLRows = append(vv.visibleURLRows, nil)
@@ -436,88 +435,23 @@ func (vv *ViewerView) renderText(scr *vtui.ScreenBuf, width, contentHeight int) 
 			break
 		}
 
-		lineLen := 0
-		textLen := 0
-		visualWidth := 0
-		foundNewline := false
 		tabSize := 8
 		if AppConfig.EditorTabSize > 0 {
 			tabSize = AppConfig.EditorTabSize
 		}
-
-		for lineLen < len(data) {
-			r, size := utf8.DecodeRune(data[lineLen:])
-			if r == '\n' {
-				lineLen += size
-				foundNewline = true
-				break
-			}
-			if r == '\r' {
-				lineLen += size
-				continue
-			}
-
-			var rw int
-			if r == '\t' {
-				rw = tabSize - (visualWidth % tabSize)
-			} else {
-				rw = runewidth.RuneWidth(r)
-				if rw <= 0 {
-					rw = 1
-				}
-			}
-			if vv.WrapMode && visualWidth+rw > width {
-				// Wrap occurred
-				break
-			}
-			visualWidth += rw
-			lineLen += size
-			textLen = lineLen
-		}
+		row := layoutViewerTextRow(data, width, tabSize, vv.WrapMode)
 
 		// Build []vtui.CharInfo for the line
-		vv.rowCells = vv.rowCells[:0]
-		cellByteOffsets := make([]int, 0, textLen)
-		lineBytes := data[:textLen]
-		visualCol := 0
-		lineByteOffset := 0
+		var cellByteOffsets []int
+		vv.rowCells, cellByteOffsets = viewerTextCells(string(data[:row.textLen]), attr, tabSize, width)
 
-		for len(lineBytes) > 0 {
-			r, size := utf8.DecodeRune(lineBytes)
-			lineBytes = lineBytes[size:]
-
-			if r == '\t' {
-				w := tabSize - (visualCol % tabSize)
-				for i := 0; i < w; i++ {
-					vv.rowCells = append(vv.rowCells, vtui.CharInfo{Char: ' ', Attributes: attr})
-					cellByteOffsets = append(cellByteOffsets, lineByteOffset)
-				}
-				visualCol += w
-			} else {
-				displayRune, w := vtui.SanitizeRune(r)
-				if r < 0x20 || r == 0x7F {
-					displayRune = ' '
-				}
-				if w > 0 {
-					charVal := uint64(displayRune)
-					for i := 0; i < w; i++ {
-						vv.rowCells = append(vv.rowCells, vtui.CharInfo{Char: charVal, Attributes: attr})
-						cellByteOffsets = append(cellByteOffsets, lineByteOffset)
-						charVal = uint64(vtui.WideCharFiller)
-					}
-					visualCol += w
-				}
-			}
-			lineByteOffset += size
-		}
-
-		rowLinks := urlCellRanges(string(data[:textLen]), cellByteOffsets)
+		rowLinks := urlCellRanges(string(data[:row.textLen]), cellByteOffsets)
 		applyURLHoverAttr(vv.rowCells, rowLinks, vv.hoverURL)
 		vv.visibleURLRows = append(vv.visibleURLRows, rowLinks)
 		scr.Write(vv.X1, vv.Y1+1+y, vv.rowCells)
-		currOffset += int64(lineLen)
+		currOffset += int64(row.lineLen)
 
-		if !foundNewline && !vv.WrapMode {
+		if !row.foundNewline && !vv.WrapMode {
 			// In no-wrap mode, we must consume until the actual newline
 			tempOff := currOffset
 			for {
@@ -597,35 +531,13 @@ func (vv *ViewerView) ProcessKey(e *vtinput.InputEvent) bool {
 			}
 			data, err := vv.backend.ReadAt(vv.TopOffset, width*4)
 			if err == nil && len(data) > 0 {
-				lineLen := 0
-				visualWidth := 0
 				tabSize := 8
 				if AppConfig.EditorTabSize > 0 {
 					tabSize = AppConfig.EditorTabSize
 				}
-				for lineLen < len(data) {
-					r, size := utf8.DecodeRune(data[lineLen:])
-					if r == '\n' {
-						lineLen += size
-						break
-					}
-					var rw int
-					if r == '\t' {
-						rw = tabSize - (visualWidth % tabSize)
-					} else {
-						rw = runewidth.RuneWidth(r)
-						if rw <= 0 {
-							rw = 1
-						}
-					}
-					if vv.WrapMode && visualWidth+rw > width {
-						break
-					}
-					visualWidth += rw
-					lineLen += size
-				}
-				if lineLen > 0 {
-					vv.TopOffset += int64(lineLen)
+				row := layoutViewerTextRow(data, width, tabSize, vv.WrapMode)
+				if row.lineLen > 0 {
+					vv.TopOffset += int64(row.lineLen)
 				}
 			}
 		}
@@ -847,37 +759,19 @@ func (vv *ViewerView) jumpToEnd() {
 			scanPos := 0
 			for scanPos < len(data) {
 				offsets = append(offsets, currOff+int64(scanPos))
-				lineLen := 0
-				visualWidth := 0
-				foundNewline := false
-				for scanPos+lineLen < len(data) {
-					r, size := utf8.DecodeRune(data[scanPos+lineLen:])
-					if r == '\n' {
-						lineLen += size
-						foundNewline = true
-						break
+				rowData := data[scanPos:]
+				if vv.WrapMode {
+					maxRowData := width * 4
+					if maxRowData < len(rowData) {
+						rowData = rowData[:maxRowData]
 					}
-					if r == '\r' {
-						lineLen += size
-						continue
-					}
-					var rw int
-					if r == '\t' {
-						rw = tabSize - (visualWidth % tabSize)
-					} else {
-						rw = runewidth.RuneWidth(r)
-						if rw <= 0 {
-							rw = 1
-						}
-					}
-					if vv.WrapMode && visualWidth+rw > width {
-						break
-					}
-					visualWidth += rw
-					lineLen += size
 				}
-				scanPos += lineLen
-				if !foundNewline && !vv.WrapMode {
+				row := layoutViewerTextRow(rowData, width, tabSize, vv.WrapMode)
+				scanPos += row.lineLen
+				if !row.foundNewline && !vv.WrapMode {
+					break
+				}
+				if row.lineLen == 0 {
 					break
 				}
 			}


### PR DESCRIPTION
## Summary

Fixes #546.

- Render viewer rows and cells from the shared grapheme-cluster layout so combining marks, Indic conjuncts, and RTL clusters cannot overflow dialogs or the scrollbar.
- Preserve logical byte offsets for URL hover and Ctrl-click after visual RTL ordering.
- Snap editor mouse selection anchors to grapheme boundaries.
- Restore mapped-editor indexing compatibility on the current main base and add the missing progress adapter required by the existing indexing path.

## Verification

- `go test ./...`
- `go vet ./...`
- focused `go test -race ./cmd/f4 -run ...` for the new viewer/editor tests
- native Linux ARM64 build and ANSI PTY smoke test with the supplied Unicode sample; exited cleanly without panic.