### PR TITLE
ci: remove unused frame manager snapshot helper

### DIFF
--- a/cmd/f4/frame_manager_test_helpers_test.go
+++ b/cmd/f4/frame_manager_test_helpers_test.go
@@ -8,34 +8,9 @@ import (
 	"github.com/unxed/vtui"
 )
 
-// snapshotFrameManagerState saves a byte-for-byte copy of the current
-// *vtui.FrameManager and returns a function that restores it in place.
-//
-// vtui.frameManager embeds several sync.Mutex fields, so a plain Go
-// assignment of the dereferenced value (oldFM := *vtui.FrameManager) trips
-// `go vet`'s copylocks check -- rightly so in general, since copying a
-// mutex that might be locked produces two independently-lockable copies of
-// what was meant to be one lock. That risk doesn't apply here: this runs
-// at test setup and teardown, well before or after anything in the test
-// itself could be holding one of those locks, so a byte-for-byte copy is
-// exactly as safe as the struct assignment it replaces -- it's just
-// performed as a raw memory copy via unsafe instead of a typed Go
-// assignment, so it isn't the kind of expression the copylocks checker
-// looks for.
-func snapshotFrameManagerState(t *testing.T) func() {
-	t.Helper()
-	size := unsafe.Sizeof(*vtui.FrameManager)
-	backup := make([]byte, size)
-	copy(backup, unsafe.Slice((*byte)(unsafe.Pointer(vtui.FrameManager)), size))
-	return func() {
-		copy(unsafe.Slice((*byte)(unsafe.Pointer(vtui.FrameManager)), size), backup)
-	}
-}
-
 // swapFrameManager replaces the global vtui.FrameManager with a fresh,
 // independent instance seeded with a byte-for-byte copy of the current
-// one (see snapshotFrameManagerState for why that copy is safe here), and
-// returns a function that restores the original pointer.
+// one, and returns a function that restores the original pointer.
 //
 // vtui.frameManager is unexported, so this package has no way to spell
 // its type in order to declare a second instance the normal way (no


### PR DESCRIPTION
Fix the remaining whole-tree Quality failure on current `main`.

The current base contains an unused `snapshotFrameManagerState` test helper in `cmd/f4/frame_manager_test_helpers_test.go`. `golangci-lint` reports it as unused, which blocks the release matrix even though `swapFrameManager` is the helper used by the tests.

This follow-up removes only the dead helper and updates the nearby comment. The mapped-indexing repair and `noteIndexProgress` method are already present in the current base through the editor repair merges.

Validation:
- `go test ./... -count=1` passed;
- `git diff --check` passed;
- the removed helper has no remaining references.

This repair unblocks the CI validation of the already merged PR #711 for issue #362.

— zoin-bot