### PR TITLE
test: validate localized overwrite dialog

### DIFF
--- a/ISSUE_453_SOLUTION_REVIEW.md
+++ b/ISSUE_453_SOLUTION_REVIEW.md
@@ -1,0 +1,57 @@
+# Issue #453 solution review
+
+## Problem model
+
+The localized overwrite dialog fix is already present in merged PR #587, but
+the validation that accompanied it did not exercise the production
+`AskOverwrite` constructor. The language test built a representative row of
+buttons directly, while the general layout test could be skipped locally
+because its dependency globs omitted `file_ops.go` and
+`dialog_button_layout.go`. That allowed the validator to report a green result
+without proving that the real conflict dialog stayed inside its frame.
+
+## Candidate solutions
+
+1. **Chosen: validate the production dialog in every bundled language.** Start
+   `AskOverwrite`, inspect the actual `vtui.Window` with `vtui.AssertLayout`,
+   and close it through the real Escape path for each language pack. Add the
+   production layout files to the validator cache dependencies.
+2. **Rejected: add another screenshot or PTY-only test.** A screenshot can
+   reproduce one locale and terminal size, but it does not cover all captions
+   or provide a stable assertion about frame boundaries.
+3. **Rejected: widen the dialog or remove the validator check.** This hides
+   the symptom at one size and permits the same overflow in another language
+   or smaller terminal; it also leaves the validator's blind spot intact.
+
+## Review pass 1 — fidelity
+
+- The new test constructs the exact `AskOverwrite` dialog used by file
+  operations rather than duplicating its button layout.
+- It runs against every embedded language pack, including scripts that were
+  previously excluded from the synthetic test.
+- `vtui.AssertLayout` checks both frame clearance and each widget's painted
+  width.
+
+## Review pass 2 — coverage and maintenance
+
+- The local dependency cache now invalidates when the production file-op or
+  button-row layout changes, so the broad validator cannot be silently stale.
+- The test drives Escape and waits for `AskOverwrite` to return, ensuring the
+  asynchronous UI path is cleaned up for every language.
+- No platform-specific screenshot assumption is embedded in the regression.
+
+## Review pass 3 — risk
+
+- The merged production layout code remains unchanged; this follow-up only
+  makes its regression proof match the real dialog.
+- The test uses the existing silent screen and normal task pump, so it does
+  not access the user's desktop or clipboard.
+- If a future translation overflows, the failing subtest names the language
+  and the exact layout violation.
+
+## Decision
+
+Keep PR #587's production fix and strengthen the validator around the actual
+dialog construction. This directly addresses the owner's concern about why
+the validator missed the report without widening the UI or weakening layout
+rules.

--- a/cmd/f4/dialog_layouts_test.go
+++ b/cmd/f4/dialog_layouts_test.go
@@ -15,6 +15,8 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 	skipIfNoRelevantChanges(t, "layouts",
 		"lang/*.lng",
 		"lang/*.txt",
+		"file_ops.go",
+		"dialog_button_layout.go",
 		"*_dialog*.go",
 		"*_ui*.go",
 		"*_settings*.go",

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -1264,6 +1264,55 @@ func TestAskOverwriteUsesWarningPalette(t *testing.T) {
 	}
 }
 
+func TestAskOverwriteLayout_AllLanguages(t *testing.T) {
+	vtui.SetDefaultPalette()
+	packs := LoadAllLanguagePacks()
+	if len(packs) == 0 {
+		t.Fatal("no language packs bundled")
+	}
+
+	baseStrings := vtui.SnapshotStrings()
+	t.Cleanup(func() { vtui.ReplaceStrings(baseStrings) })
+	for _, pack := range packs {
+		pack := pack
+		t.Run(pack.Name, func(t *testing.T) {
+			vtui.ReplaceStrings(baseStrings)
+			vtui.AddStrings(pack.Strings)
+			vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			result := make(chan int, 1)
+			go func() {
+				choice, _ := AskOverwrite(ctx, "/destination/existing.txt", vfs.VFSItem{}, vfs.VFSItem{}, nil)
+				result <- choice
+			}()
+
+			container := waitForDialog(t, Msg("Warning.Title"))
+			dlg, ok := container.(*vtui.Window)
+			if !ok {
+				t.Fatalf("localized overwrite dialog is %T, want *vtui.Window", container)
+			}
+			vtui.AssertLayout(t, dlg)
+			if !pressKey(dlg, &vtinput.InputEvent{
+				Type:           vtinput.KeyEventType,
+				KeyDown:        true,
+				VirtualKeyCode: vtinput.VK_ESCAPE,
+			}) {
+				t.Fatal("Escape was not handled by the localized overwrite dialog")
+			}
+			select {
+			case choice := <-result:
+				if choice != 6 {
+					t.Fatalf("localized Escape returned choice %d, want cancel (6)", choice)
+				}
+			case <-time.After(2 * time.Second):
+				t.Fatal("localized AskOverwrite did not return after Escape")
+			}
+		})
+	}
+}
+
 // Helper to pump UI tasks until a dialog with the given title appears
 func waitForDialog(t *testing.T, title string) vtui.Container {
 	t.Helper()


### PR DESCRIPTION
## Summary

Follow-up for #453 and the merged production fix in #587.

The previous regression test built a synthetic button row instead of the production `AskOverwrite` dialog, and the broad layout-test cache did not include `file_ops.go` or `dialog_button_layout.go`. This PR validates the real asynchronous overwrite dialog with `vtui.AssertLayout` for every bundled language and updates the cache dependencies so the broad validator is not silently skipped after file-operation layout changes.

## Verification

- `F4_FORCE_TESTS=1 go test ./cmd/f4 -run ...` including all-dialog validation and all 23 language packs
- `go test ./...`
- `go vet ./...`
- focused `go test -race ./cmd/f4` for the localized overwrite tests
- native Linux ARM64 build and Windows amd64 cross-build
- ANSI ARM64 startup smoke with the supplied sample, no panic

Fixes the validator follow-up in #453; #587 remains the production layout fix.