### PR TITLE
netfox: allow explicit SSH private key path

### DIFF
--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -1393,6 +1393,7 @@ NetFox.LabelHost=&Host:
 NetFox.LabelPort=P&ort:
 NetFox.LabelUser=&User:
 NetFox.LabelPassword=Pass&word:
+NetFox.LabelKeyPath=SSH &Key file:
 NetFox.LabelTimeout=Time&out:
 NetFox.LabelCodepage=Cod&epage:
 NetFox.ErrorEmptyName=Name cannot be empty

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -1380,6 +1380,7 @@ NetFox.LabelHost=&Хост:
 NetFox.LabelPort=&Порт:
 NetFox.LabelUser=&Пользователь:
 NetFox.LabelPassword=П&ароль:
+NetFox.LabelKeyPath=Файл SSH-&ключа:
 NetFox.LabelTimeout=Т&аймаут:
 NetFox.LabelCodepage=&Кодировка:
 NetFox.ErrorEmptyName=Имя не может быть пустым

--- a/cmd/f4/lang/uk.lng
+++ b/cmd/f4/lang/uk.lng
@@ -767,6 +767,7 @@ NetFox.LabelHost=&Хост:
 NetFox.LabelPort=&Порт:
 NetFox.LabelUser=&Користувач:
 NetFox.LabelPassword=&Пароль:
+NetFox.LabelKeyPath=Файл SSH-&ключа:
 NetFox.LabelTimeout=&Таймаут:
 NetFox.LabelCodepage=&Кодування:
 NetFox.ErrorEmptyName=Ім'я не може бути порожнім

--- a/plugins/netfox/dialog.go
+++ b/plugins/netfox/dialog.go
@@ -101,7 +101,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 	}
 	activeProto := protos[currIdx]
 
-	dlg := vtui.NewCenteredDialog(60, 21, vtui.Msg("NetFox.ConnectionTitle"))
+	dlg := vtui.NewCenteredDialog(60, 22, vtui.Msg("NetFox.ConnectionTitle"))
 	dlg.ShowClose = true
 
 	editName := vtui.NewEdit(0, 0, 40, name)
@@ -120,6 +120,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 	}
 	editUser := vtui.NewEdit(0, 0, 40, cfg.User)
 	editPass := vtui.NewPasswordEdit(0, 0, 40, cfg.Pass)
+	editKeyPath := vtui.NewEdit(0, 0, 40, cfg.KeyPath)
 	editTimeout := vtui.NewEdit(0, 0, 10, cfg.Timeout)
 	if editTimeout.GetText() == "" {
 		editTimeout.SetText("15")
@@ -151,7 +152,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 		return hbox
 	}
 
-	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 9)
+	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 56, 10)
 
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelName"), editName), vtui.Margins{}, vtui.AlignFill)
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelProtocol"), comboProto), vtui.Margins{Top: 0}, vtui.AlignFill)
@@ -159,12 +160,13 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelPort"), editPort), vtui.Margins{Top: 0}, vtui.AlignFill)
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelUser"), editUser), vtui.Margins{Top: 0}, vtui.AlignFill)
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelPassword"), editPass), vtui.Margins{Top: 0}, vtui.AlignFill)
+	vbox.Add(makeRow(vtui.Msg("NetFox.LabelKeyPath"), editKeyPath), vtui.Margins{Top: 0}, vtui.AlignFill)
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelTimeout"), editTimeout), vtui.Margins{Top: 0}, vtui.AlignFill)
 	vbox.Add(makeRow(vtui.Msg("NetFox.LabelCodepage"), comboCp), vtui.Margins{Top: 0}, vtui.AlignFill)
 	vbox.Apply()
 
-	// 2. Extra Protocol Area (Y: 14) - architectural proxy
-	extraX, extraY, extraW, extraH := dlg.X1+2, dlg.Y1+14, 56, 1
+	// 2. Extra Protocol Area (Y: 15) - architectural proxy
+	extraX, extraY, extraW, extraH := dlg.X1+2, dlg.Y1+15, 56, 1
 	container := &protoUIContainer{
 		active: activeProto,
 		uis:    make(map[string]vtui.UIElement),
@@ -210,7 +212,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 		vtui.FrameManager.Redraw()
 	}
 
-	// 3. Bottom Section (Y: 16-18)
+	// 3. Bottom Section (Y: 17-19)
 	btnOk := vtui.NewButton(0, 0, vtui.Msg("vtui.Save"))
 	// The proxy lives in a dialog of its own: it is a rare thing to touch,
 	// and the connection form has no room left for five more fields.
@@ -219,7 +221,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 	btnOk.IsDefault = true
 	btnProxy.OnClick = func() { showProxyDialog(&cfg) }
 
-	vboxBottom := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+16, 56, 3)
+	vboxBottom := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+17, 56, 3)
 	btnHbox := vtui.NewHBoxLayout(0, 0, 56, 1)
 	btnHbox.HorizontalAlign = vtui.AlignCenter
 	btnHbox.Spacing = 2
@@ -248,6 +250,7 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 		cfg.Port = editPort.GetText()
 		cfg.User = editUser.GetText()
 		cfg.Pass = editPass.GetText()
+		cfg.KeyPath = editKeyPath.GetText()
 		cfg.Timeout = editTimeout.GetText()
 		cfg.Codepage = ""
 		cpSel := comboCp.Menu.SelectPos

--- a/plugins/netfox/fish_dialer_test.go
+++ b/plugins/netfox/fish_dialer_test.go
@@ -81,7 +81,7 @@ func deadTCPPort(t *testing.T) string {
 // so and hands back nothing to close. A closer returned alongside an error
 // would be leaked by every caller, since none of them expect one.
 func TestSSHFishDialerReportsAFailedDial(t *testing.T) {
-	dial := sshFishDialer("127.0.0.1", deadTCPPort(t), "nobody", "", 1, netproxy.Settings{})
+	dial := sshFishDialer("127.0.0.1", deadTCPPort(t), "nobody", "", "", 1, netproxy.Settings{})
 	stdin, stdout, closer, err := dial(context.Background())
 	if err == nil {
 		if closer != nil {
@@ -100,7 +100,7 @@ func TestSSHFishDialerReportsAFailedDial(t *testing.T) {
 func TestSSHFishDialerHonoursACancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	dial := sshFishDialer("127.0.0.1", deadTCPPort(t), "nobody", "", 1, netproxy.Settings{})
+	dial := sshFishDialer("127.0.0.1", deadTCPPort(t), "nobody", "", "", 1, netproxy.Settings{})
 	_, _, closer, err := dial(ctx)
 	if !errors.Is(err, context.Canceled) {
 		if closer != nil {
@@ -117,7 +117,7 @@ func TestSSHFishDialerHonoursACancelledContext(t *testing.T) {
 // opens through a dialer, and a host that cannot be reached must still fail at
 // open time rather than at the first request.
 func TestNewFishVFSReportsAFailedDial(t *testing.T) {
-	v, err := NewFishVFS(nil, "127.0.0.1", deadTCPPort(t), "nobody", "", 1, netproxy.Settings{})
+	v, err := NewFishVFS(nil, "127.0.0.1", deadTCPPort(t), "nobody", "", "", 1, netproxy.Settings{})
 	if err == nil {
 		_ = v.Close() // unexpected open cleanup only
 		t.Fatal("opening a site on a dead port succeeded")

--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -406,8 +406,8 @@ func (s *sshShell) OpenPty(cols, rows int) (any, error) {
 // The command is "exec /bin/sh" rather than a plain shell request, because the
 // account's login shell may well be csh, fish or something else that does not
 // speak the POSIX syntax the helper is written in.
-func sshFishDialer(host, port, user, pass string, timeout int, px netproxy.Settings) FishDialer {
-	return sshFishDialerWith(host, port, user, pass, timeout, px, func(s *ssh.Session) error {
+func sshFishDialer(host, port, user, pass, keyPath string, timeout int, px netproxy.Settings) FishDialer {
+	return sshFishDialerWith(host, port, user, pass, keyPath, timeout, px, func(s *ssh.Session) error {
 		return s.Start("exec /bin/sh")
 	})
 }
@@ -424,8 +424,8 @@ func sshFishDialer(host, port, user, pass string, timeout int, px netproxy.Setti
 // on both. No pseudo-terminal is requested for the same reason as the
 // POSIX side: a ConPTY would echo every request back and inject VT
 // sequences.
-func sshFishDialerPwsh(host, port, user, pass string, timeout int, px netproxy.Settings) FishDialer {
-	return sshFishDialerWith(host, port, user, pass, timeout, px, func(s *ssh.Session) error {
+func sshFishDialerPwsh(host, port, user, pass, keyPath string, timeout int, px netproxy.Settings) FishDialer {
+	return sshFishDialerWith(host, port, user, pass, keyPath, timeout, px, func(s *ssh.Session) error {
 		return s.Start("powershell.exe -NoLogo -NoProfile")
 	})
 }
@@ -434,7 +434,7 @@ func sshFishDialerPwsh(host, port, user, pass string, timeout int, px netproxy.S
 // disagree about is how they ask sshd to give them the shell: exec+cmd
 // on POSIX (which bypasses an exotic login shell), plain shell on
 // Windows (which respects DefaultShell).
-func sshFishDialerWith(host, port, user, pass string, timeout int, px netproxy.Settings, startShell func(*ssh.Session) error) FishDialer {
+func sshFishDialerWith(host, port, user, pass, keyPath string, timeout int, px netproxy.Settings, startShell func(*ssh.Session) error) FishDialer {
 	return func(ctx context.Context) (io.Writer, io.Reader, io.Closer, error) {
 		// DialSSH carries a timeout of its own and cannot be interrupted, so
 		// the context is honoured where it can be: before the dial, and again
@@ -443,7 +443,7 @@ func sshFishDialerWith(host, port, user, pass string, timeout int, px netproxy.S
 		if err := ctx.Err(); err != nil {
 			return nil, nil, nil, err
 		}
-		client, err := DialSSH(host, port, user, pass, timeout, px)
+		client, err := DialSSH(host, port, user, pass, keyPath, timeout, px)
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -480,7 +480,7 @@ func sshFishDialerWith(host, port, user, pass string, timeout int, px netproxy.S
 // through a pair of streams, so the session it hands back is one that can be
 // rebuilt after the connection drops; a site opened any other way would have
 // to be reopened by hand.
-func NewFishVFS(parent vfs.VFS, host, port, user, pass string, timeout int, px netproxy.Settings) (*FishVFS, error) {
+func NewFishVFS(parent vfs.VFS, host, port, user, pass, keyPath string, timeout int, px netproxy.Settings) (*FishVFS, error) {
 	key := fishPoolKey{host: host, port: port, user: user, proxy: px}
 	if conn := globalFishPool.take(key); conn != nil {
 		return newFishVFSFromPooledConn(parent, conn, host, port, user), nil
@@ -501,8 +501,8 @@ func NewFishVFS(parent vfs.VFS, host, port, user, pass string, timeout int, px n
 	// asks sshd for a plain shell (which resolves to PowerShell on
 	// Windows), and delivers the base64-encoded helper.ps1 through it.
 	v, err := NewFishVFSOnDialers(ctx, parent,
-		sshFishDialer(host, port, user, pass, timeout, px), fishplus.HandshakeOptions{},
-		sshFishDialerPwsh(host, port, user, pass, timeout, px), fishplus.HandshakeOptions{Bootstrap: fishplus.BootstrapBase64LinePwsh},
+		sshFishDialer(host, port, user, pass, keyPath, timeout, px), fishplus.HandshakeOptions{},
+		sshFishDialerPwsh(host, port, user, pass, keyPath, timeout, px), fishplus.HandshakeOptions{Bootstrap: fishplus.BootstrapBase64LinePwsh},
 		title)
 	if err != nil {
 		return nil, err
@@ -1345,7 +1345,7 @@ func (p *fishProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vf
 			timeout = t
 		}
 	}
-	res, err := NewFishVFS(parent, cfg.Host, port, cfg.User, cfg.Pass, timeout, cfg.Proxy())
+	res, err := NewFishVFS(parent, cfg.Host, port, cfg.User, cfg.Pass, cfg.KeyPath, timeout, cfg.Proxy())
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/netfox/fish_vfs_test.go
+++ b/plugins/netfox/fish_vfs_test.go
@@ -671,7 +671,7 @@ func TestSSHTimeoutDefaults(t *testing.T) {
 }
 
 func TestDialSSHFailsOnAClosedPort(t *testing.T) {
-	client, err := DialSSH("127.0.0.1", "1", "nobody", "", 2, netproxy.Settings{})
+	client, err := DialSSH("127.0.0.1", "1", "nobody", "", "", 2, netproxy.Settings{})
 	if err == nil {
 		_ = client.Close() // unexpected dial cleanup only
 		t.Fatal("dialing a closed port succeeded")

--- a/plugins/netfox/sftp_uri.go
+++ b/plugins/netfox/sftp_uri.go
@@ -53,7 +53,7 @@ func (p *sftpURIProvider) OpenURI(ctx context.Context, current vfs.VFS, raw stri
 		}
 	}
 
-	v, err := NewSFTPVFS(nil, host, port, name, pass, 15, "", netproxy.Resolve(netproxy.Settings{}))
+	v, err := NewSFTPVFS(nil, host, port, name, pass, "", 15, "", netproxy.Resolve(netproxy.Settings{}))
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/netfox/sftp_vfs.go
+++ b/plugins/netfox/sftp_vfs.go
@@ -91,9 +91,9 @@ func (v *SFTPVFS) encodePath(p string) string {
 	return p
 }
 
-func NewSFTPVFS(parent vfs.VFS, host, port, user, pass string, timeout int, cp string, px netproxy.Settings) (*SFTPVFS, error) {
+func NewSFTPVFS(parent vfs.VFS, host, port, user, pass, keyPath string, timeout int, cp string, px netproxy.Settings) (*SFTPVFS, error) {
 	vtui.DebugLog("NET: Initiating SFTP connection to %s:%s (user: %s)", host, port, user)
-	sshClient, err := DialSSH(host, port, user, pass, timeout, px)
+	sshClient, err := DialSSH(host, port, user, pass, keyPath, timeout, px)
 	if err != nil {
 		return nil, err
 	}
@@ -719,7 +719,7 @@ func (p *sftpProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vf
 			timeout = t
 		}
 	}
-	res, err := NewSFTPVFS(parent, cfg.Host, port, cfg.User, cfg.Pass, timeout, cfg.Codepage, cfg.Proxy())
+	res, err := NewSFTPVFS(parent, cfg.Host, port, cfg.User, cfg.Pass, cfg.KeyPath, timeout, cfg.Codepage, cfg.Proxy())
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/netfox/ssh_agent_forwarding_test.go
+++ b/plugins/netfox/ssh_agent_forwarding_test.go
@@ -26,7 +26,7 @@ func TestDialSSHDoesNotForwardAgent(t *testing.T) {
 	port, publicKey, forwarded := startAgentObservationSSHServer(t)
 	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 
-	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
+	client, err := DialSSH("127.0.0.1", port, "user", "pass", "", 3, netproxy.Settings{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +43,7 @@ func TestSSHFishDialerDoesNotRequestAgentForwarding(t *testing.T) {
 	t.Setenv("SSH_AUTH_SOCK", "agent-present")
 	port, publicKey, forwarded := startAgentObservationSSHServer(t)
 	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
-	dial := sshFishDialerWith("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{}, func(session *ssh.Session) error {
+	dial := sshFishDialerWith("127.0.0.1", port, "user", "pass", "", 3, netproxy.Settings{}, func(session *ssh.Session) error {
 		return session.Shell()
 	})
 

--- a/plugins/netfox/ssh_dial.go
+++ b/plugins/netfox/ssh_dial.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/unxed/f4/internal/netproxy"
@@ -23,11 +24,49 @@ func sshTimeout(seconds int) time.Duration {
 	return time.Duration(seconds) * time.Second
 }
 
+// expandHome turns a leading ~ (or ~/ or ~\) into the user's home directory.
+// Go's os package never does this on its own — that expansion is normally
+// the shell's job — but a path typed into the connection dialog has no
+// shell behind it, so a bare ~/.ssh/key would otherwise resolve to a
+// nonexistent file named literally "~" in the working directory.
+func expandHome(p string) string {
+	if p == "~" {
+		if home, err := os.UserHomeDir(); err == nil {
+			return home
+		}
+		return p
+	}
+	if strings.HasPrefix(p, "~/") || strings.HasPrefix(p, "~\\") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, p[2:])
+		}
+	}
+	return p
+}
+
+// loadKeySigner reads a private key file and returns a Signer for it. If the
+// key is encrypted, pass is tried as its passphrase.
+func loadKeySigner(keyPath, pass string) (ssh.Signer, error) {
+	keyBytes, err := os.ReadFile(expandHome(keyPath))
+	if err != nil {
+		return nil, err
+	}
+	signer, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil && pass != "" {
+		signer, err = ssh.ParsePrivateKeyWithPassphrase(keyBytes, []byte(pass))
+	}
+	return signer, err
+}
+
 // DialSSH opens an SSH connection the way every SSH based NetFox backend
-// needs it: the agent first, then the usual private keys from ~/.ssh, then
-// the password. It is shared by the SFTP and the FISH+ backends so that a
-// site behaves identically whichever of them opens it.
-func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (*ssh.Client, error) {
+// needs it. When keyPath is set, that key is the only key offered (besides
+// whatever the ssh-agent carries) — this avoids servers that cut the
+// handshake short after a handful of failed public-key attempts
+// (MaxAuthTries) before ever reaching the right key. When keyPath is empty,
+// behavior is unchanged: agent, then the usual private keys from ~/.ssh,
+// then the password. It is shared by the SFTP and the FISH+ backends so
+// that a site behaves identically whichever of them opens it.
+func DialSSH(host, port, user, pass, keyPath string, timeout int, px netproxy.Settings) (*ssh.Client, error) {
 	hostKeyCallback, err := sshHostKeyCallback()
 	if err != nil {
 		return nil, err
@@ -44,15 +83,15 @@ func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (
 		}
 	}
 
-	home, _ := os.UserHomeDir()
-	for _, keyName := range []string{"id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"} {
-		keyPath := filepath.Join(home, ".ssh", keyName)
-		if keyBytes, err := os.ReadFile(keyPath); err == nil {
-			signer, err := ssh.ParsePrivateKey(keyBytes)
-			if err != nil && pass != "" {
-				signer, err = ssh.ParsePrivateKeyWithPassphrase(keyBytes, []byte(pass))
-			}
-			if err == nil {
+	if keyPath != "" {
+		if signer, err := loadKeySigner(keyPath, pass); err == nil {
+			auths = append(auths, ssh.PublicKeys(signer))
+		}
+	} else {
+		home, _ := os.UserHomeDir()
+		for _, keyName := range []string{"id_rsa", "id_ed25519", "id_ecdsa", "id_dsa"} {
+			defaultKeyPath := filepath.Join(home, ".ssh", keyName)
+			if signer, err := loadKeySigner(defaultKeyPath, pass); err == nil {
 				auths = append(auths, ssh.PublicKeys(signer))
 			}
 		}

--- a/plugins/netfox/ssh_dial_test.go
+++ b/plugins/netfox/ssh_dial_test.go
@@ -67,7 +67,7 @@ func TestDialSSHVerifiesServerKeyBeforeAuthentication(t *testing.T) {
 	port, publicKey := startTestSSHServer(t)
 	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 
-	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
+	client, err := DialSSH("127.0.0.1", port, "user", "pass", "", 3, netproxy.Settings{})
 	if err != nil {
 		t.Fatalf("known server key rejected: %v", err)
 	}
@@ -84,7 +84,7 @@ func TestDialSSHRejectsChangedServerKey(t *testing.T) {
 	port, _ := startTestSSHServer(t)
 	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), testSSHHostKey(t))
 
-	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
+	client, err := DialSSH("127.0.0.1", port, "user", "pass", "", 3, netproxy.Settings{})
 	if err == nil {
 		if closeErr := client.Close(); closeErr != nil {
 			t.Errorf("close SSH client: %v", closeErr)

--- a/plugins/netfox/vfs.go
+++ b/plugins/netfox/vfs.go
@@ -22,6 +22,7 @@ type NetFoxConfig struct {
 	Port     string            `json:"Port"`
 	User     string            `json:"User"`
 	Pass     string            `json:"Pass"`
+	KeyPath  string            `json:"KeyPath,omitempty"`
 	Timeout  string            `json:"Timeout,omitempty"`
 	Codepage string            `json:"Codepage,omitempty"`
 	Options  map[string]string `json:"Options,omitempty"`


### PR DESCRIPTION
## Problem
NetFox only tried keys with fixed names in ~/.ssh (id_rsa, id_ed25519,
id_ecdsa, id_dsa). A key under a different name (e.g. GCE's
google_compute_engine) was never used, and extra unrelated keys in
~/.ssh could exhaust MaxAuthTries before the right key was tried.

## Fix
Add a `KeyPath` field to the connection config/dialog. When set, only
that key (plus ssh-agent) is offered, skipping the default scan. `~`
in the path is expanded manually.