### PR TITLE
ci: cross-compile the musl test binary for the cell's GOARCH

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -300,8 +300,10 @@ jobs:
           # the musl release asset rather than quietly replacing itself with
           # the static one. The rootfs and qemu are already in place.
           # Rebuilt here rather than carried over: each step is its own
-          # shell, so the Build step's variables are gone by now.
-          go test -c -tags "${BUILD_TAGS:+$BUILD_TAGS,}goffi_musl" \
+          # shell, so the Build step's variables are gone by now -- GOARCH
+          # included. Without it the test binary is built for the runner's
+          # own amd64, and the arm64 cell hands qemu-aarch64 an x86_64 ELF.
+          GOOS=linux GOARCH="$GOARCH_CELL" go test -c -tags "${BUILD_TAGS:+$BUILD_TAGS,}goffi_musl" \
             -gcflags=github.com/go-webgpu/goffi/internal/dl=-std \
             -o /tmp/f4-libc.test ./cmd/f4
           "qemu-$QEMU-static" -L alpine-rootfs /tmp/f4-libc.test \

--- a/cmd/f4/viewer_text.go
+++ b/cmd/f4/viewer_text.go
@@ -117,7 +117,7 @@ func viewerTextCells(text string, attr uint64, tabSize, maxWidth int) ([]vtui.Ch
 	offsets := make([]int, 0, len(text))
 	visualCol := 0
 	for _, cluster := range textlayout.VisualClustersInVisualOrder(text) {
-		width := cluster.Width
+		var width int
 		plainSpaces := false
 		displayText, sanitizedWidth := vtui.SanitizeCluster(cluster.Text)
 		if cluster.Text == "\t" {

--- a/cmd/f4/viewer_text.go
+++ b/cmd/f4/viewer_text.go
@@ -117,6 +117,9 @@ func viewerTextCells(text string, attr uint64, tabSize, maxWidth int) ([]vtui.Ch
 	offsets := make([]int, 0, len(text))
 	visualCol := 0
 	for _, cluster := range textlayout.VisualClustersInVisualOrder(text) {
+		// Rendered width, not cluster.Width: a tab expands to the next stop
+		// and everything else takes the width SanitizeCluster reports after
+		// replacing control characters, so the layout width is never used here.
 		var width int
 		plainSpaces := false
 		displayText, sanitizedWidth := vtui.SanitizeCluster(cluster.Text)


### PR DESCRIPTION
## Summary
- The musl smoke-test step rebuilds `/tmp/f4-libc.test` with `go test -c`, but only `GOARCH_CELL` is in that step's env (`GOARCH` lives on the Build step). The test binary was therefore always compiled for the runner's amd64. The amd64 musl cell passed by coincidence; the arm64 cell handed an x86_64 ELF to `qemu-aarch64-static` and failed with `Invalid ELF image for this architecture`. Pass `GOOS=linux GOARCH="$GOARCH_CELL"` to the `go test -c` invocation.
- Fix the strict-lint `ineffassign` in `viewerTextCells` (`cmd/f4/viewer_text.go`). `width` was initialised from `cluster.Width` but every path overwrote it before reading: a tab gets `tabSize - visualCol % tabSize`, everything else gets the width `SanitizeCluster` reports after control-character replacement. The layout width is intentionally not what gets rendered, so the initialiser was dead. Declare `var width int` and add a comment saying why `cluster.Width` is ignored. No behaviour change.

## Test plan
- [ ] linux/arm64 musl cell: `TestBuildLibcIsMusl|TestUpdateAssetSuffixes` runs under qemu and passes
- [ ] linux/amd64 musl cell still green
- [ ] golangci-lint strict job green
- [x] `go vet ./cmd/f4`, `go test ./cmd/f4 -run TestViewerText` pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzHMNPHgAPc3qzUCxymFJr