### PR TITLE
test: loosen hang guard in manual update-check dispatch test

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -97,9 +97,14 @@ func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T)
 		close(dispatchDone)
 	}()
 
+	// The server will not answer until allowResponse is closed below, so a
+	// dispatch that waited for the update check could never finish here.
+	// The deadline only guards against a hang; keep it generous so the
+	// synchronous click work (SaveConfig, dialog close) does not trip it
+	// on a loaded CI runner.
 	select {
 	case <-dispatchDone:
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(10 * time.Second):
 		t.Fatal("manual update check blocked mouse dispatch")
 	}
 


### PR DESCRIPTION
## Summary
- `TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch` failed on CI with "manual update check blocked mouse dispatch" after 250 ms.
- Production code is fine (`CheckForUpdates` already runs in a goroutine); the synchronous part of the click (`SaveConfig`, dialog close) plus scheduling occasionally exceeds 250 ms on a loaded runner.
- The "does not block" property is enforced structurally — the test server only replies after `allowResponse` is closed, which happens after dispatch completes — so the timer is purely a hang guard. Raised it to 10 s and documented why.

## Test plan
- [x] `go test -count=3 -run TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch ./cmd/f4`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzHMNPHgAPc3qzUCxymFJr