### PR TITLE
lint: close staticcheck's remaining findings

### DIFF
--- a/cmd/f4/ai_chat_panel_test.go
+++ b/cmd/f4/ai_chat_panel_test.go
@@ -1,13 +1,15 @@
 package main
 
 import (
+	"context"
+	"strings"
+	"testing"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/f4/vtvibe"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
-	"strings"
-	"testing"
 )
 
 func TestAIChatPanel_Resize(t *testing.T) {
@@ -59,7 +61,7 @@ func TestAIChatPanel_AttachedFilesBarFocusAndNavigation(t *testing.T) {
 
 	// Add file to ctx
 	vfsInst := vtvibe.NewVFS(session)
-	w, err := vfsInst.Create(nil, "/ctx/main.go")
+	w, err := vfsInst.Create(context.Background(), "/ctx/main.go")
 	if err == nil {
 		_, _ = w.Write([]byte("package main"))
 		_ = w.Close()
@@ -137,7 +139,7 @@ func TestAIChatPanel_ContextFilesRenderingAndLinkNavigation(t *testing.T) {
 
 	// Add file to ctx
 	vfsInst := vtvibe.NewVFS(session)
-	w, err := vfsInst.Create(nil, "/ctx/app.go")
+	w, err := vfsInst.Create(context.Background(), "/ctx/app.go")
 	if err == nil {
 		_, _ = w.Write([]byte("package main"))
 		_ = w.Close()
@@ -178,7 +180,7 @@ func TestAIChatPanel_BarKindExcludesApSpec(t *testing.T) {
 	vfsInst := vtvibe.NewVFS(session)
 
 	// Case 2: Only ap.md in ctx
-	w, err := vfsInst.Create(nil, "/ctx/ap.md")
+	w, err := vfsInst.Create(context.Background(), "/ctx/ap.md")
 	if err == nil {
 		_, _ = w.Write([]byte("AP specification content"))
 		_ = w.Close()
@@ -188,7 +190,7 @@ func TestAIChatPanel_BarKindExcludesApSpec(t *testing.T) {
 	}
 
 	// Case 3: ap.md + user file in ctx
-	w2, err2 := vfsInst.Create(nil, "/ctx/main.go")
+	w2, err2 := vfsInst.Create(context.Background(), "/ctx/main.go")
 	if err2 == nil {
 		_, _ = w2.Write([]byte("package main"))
 		_ = w2.Close()

--- a/cmd/f4/apply_command_resources.go
+++ b/cmd/f4/apply_command_resources.go
@@ -283,9 +283,7 @@ func encodeApplyCommandListForTarget(spec ApplyCommandListFileSpec, dialect vfs.
 		return encoder.EncodeCommandListANSI(data)
 	}
 	if _, local := target.(*vfs.OSVFS); local && runtime.GOOS == "windows" {
-		if encoding := vfs.GetSystemANSIEncoding(); encoding != nil {
-			return encoding.NewEncoder().Bytes(data)
-		}
+		return vfs.GetSystemANSIEncoding().NewEncoder().Bytes(data)
 	}
 	return data, nil
 }

--- a/cmd/f4/arkanoid.go
+++ b/cmd/f4/arkanoid.go
@@ -70,7 +70,7 @@ func NewArkanoidFrame() *ArkanoidFrame {
 		lives:      3,
 		multiplier: 1,
 		level:      1,
-		rng:        rand.New(rand.NewSource(time.Now().UnixNano())),
+		rng:        rand.New(rand.NewSource(time.Now().UnixNano())), //nolint:gosec // Randomness only controls the ball's bounce direction.
 	}
 	af.Modal = true
 	af.ShowClose = true

--- a/cmd/f4/arkanoid.go
+++ b/cmd/f4/arkanoid.go
@@ -56,6 +56,7 @@ type ArkanoidFrame struct {
 	message         string
 	flashTimer      int
 	autoPlay        bool
+	rng             *rand.Rand
 }
 
 func NewArkanoidFrame() *ArkanoidFrame {
@@ -69,6 +70,7 @@ func NewArkanoidFrame() *ArkanoidFrame {
 		lives:      3,
 		multiplier: 1,
 		level:      1,
+		rng:        rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 	af.Modal = true
 	af.ShowClose = true
@@ -359,7 +361,7 @@ func (af *ArkanoidFrame) update() {
 			}
 		} else {
 			af.ballX, af.ballY = float64(width/2), float64(height-3)
-			af.ballDX, af.ballDY = (rand.Float64() - 0.5), -0.5
+			af.ballDX, af.ballDY = (af.rng.Float64() - 0.5), -0.5
 		}
 	}
 

--- a/cmd/f4/arkanoid_test.go
+++ b/cmd/f4/arkanoid_test.go
@@ -34,7 +34,7 @@ func TestArkanoid_PhysicsAndCollisions(t *testing.T) {
 	af := NewArkanoidFrame()
 	af.Close() // Останавливаем фоновый цикл, чтобы избежать конфликтов в тесте
 	time.Sleep(10 * time.Millisecond)
-	af.rng = rand.New(rand.NewSource(1)) // Стабильный рандом для тестов
+	af.rng = rand.New(rand.NewSource(1)) //nolint:gosec // Deterministic randomness only controls the ball's bounce direction in this test.
 
 	height := af.Y2 - af.Y1 - 1
 

--- a/cmd/f4/arkanoid_test.go
+++ b/cmd/f4/arkanoid_test.go
@@ -30,11 +30,11 @@ func TestArkanoid_Init(t *testing.T) {
 
 func TestArkanoid_PhysicsAndCollisions(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	rand.Seed(1) // Стабильный рандом для тестов
 
 	af := NewArkanoidFrame()
 	af.Close() // Останавливаем фоновый цикл, чтобы избежать конфликтов в тесте
 	time.Sleep(10 * time.Millisecond)
+	af.rng = rand.New(rand.NewSource(1)) // Стабильный рандом для тестов
 
 	height := af.Y2 - af.Y1 - 1
 

--- a/cmd/f4/command_runner_windows.go
+++ b/cmd/f4/command_runner_windows.go
@@ -38,10 +38,8 @@ func normalizeCommandOutput(line []byte) string {
 	if utf8.Valid(line) {
 		return string(line)
 	}
-	if encoding := vfs.GetSystemOEMEncoding(); encoding != nil {
-		if decoded, err := encoding.NewDecoder().Bytes(line); err == nil {
-			return strings.ToValidUTF8(string(decoded), "\uFFFD")
-		}
+	if decoded, err := vfs.GetSystemOEMEncoding().NewDecoder().Bytes(line); err == nil {
+		return strings.ToValidUTF8(string(decoded), "\uFFFD")
 	}
 	return strings.ToValidUTF8(string(line), "\uFFFD")
 }

--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -105,6 +105,9 @@ func overlayKeybarSlots(labels vtui.KeyBarLabels, width int) []overlayKeySlot {
 			// The last slot swallows the rounding remainder, as in vtui.
 			labelW = width - labelX
 		}
+		if available := width - labelX; labelW > available {
+			labelW = available
+		}
 		if labelW < 0 {
 			labelW = 0
 		}

--- a/cmd/f4/console_passthrough_test.go
+++ b/cmd/f4/console_passthrough_test.go
@@ -365,8 +365,8 @@ func TestOverlayKeybarSlots_MatchesVtuiLayout(t *testing.T) {
 			if s.Col < 0 || s.Col >= w {
 				t.Fatalf("width %d: slot column %d out of range", w, s.Col)
 			}
-			if len([]rune(s.Label)) < 0 {
-				t.Fatalf("width %d: negative label width", w)
+			if end := s.Col + len([]rune(s.Num)) + len([]rune(s.Label)); end > w {
+				t.Fatalf("width %d: slot at column %d ends at column %d", w, s.Col, end)
 			}
 		}
 	}

--- a/cmd/f4/editor_find_all_test.go
+++ b/cmd/f4/editor_find_all_test.go
@@ -599,11 +599,11 @@ func TestCountMatchLines(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			spans, err := findAllMatchSpans(nil, []byte(c.data), c.pattern, true, false, false)
+			spans, err := findAllMatchSpans(context.Background(), []byte(c.data), c.pattern, true, false, false)
 			if err != nil {
 				t.Fatal(err)
 			}
-			if got := countMatchLines(nil, []byte(c.data), spans); got != c.want {
+			if got := countMatchLines(context.Background(), []byte(c.data), spans); got != c.want {
 				t.Errorf("countMatchLines = %d, want %d (%d occurrences)", got, c.want, len(spans))
 			}
 		})
@@ -617,7 +617,7 @@ func TestEditorFindAll_LargeListOpensWithoutMaterializing(t *testing.T) {
 	const n = 500_000
 	ev := newFindAllEditor(t, strings.Repeat("aaa bbbbb\n", n))
 	data := []byte(strings.Repeat("aaa bbbbb\n", n))
-	spans, err := findAllMatchSpans(nil, data, "aaa", true, false, false)
+	spans, err := findAllMatchSpans(context.Background(), data, "aaa", true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -626,7 +626,7 @@ func TestEditorFindAll_LargeListOpensWithoutMaterializing(t *testing.T) {
 	}
 
 	start := time.Now()
-	ev.showFindAllMenu("aaa", spans, countMatchLines(nil, data, spans))
+	ev.showFindAllMenu("aaa", spans, countMatchLines(context.Background(), data, spans))
 	elapsed := time.Since(start)
 
 	frame, ok := vtui.FrameManager.GetTopFrame().(*findAllFrame)
@@ -844,7 +844,7 @@ func TestFindAllMatchSpans_FoldedScanReadsTheBufferInPlace(t *testing.T) {
 	var before, after runtime.MemStats
 	runtime.GC()
 	runtime.ReadMemStats(&before)
-	spans, err := findAllMatchSpans(nil, corpus, "needle", false, false, false)
+	spans, err := findAllMatchSpans(context.Background(), corpus, "needle", false, false, false)
 	runtime.ReadMemStats(&after)
 	if err != nil {
 		t.Fatal(err)
@@ -901,11 +901,11 @@ func TestCollectMatchSpans_WindowsMatchTheWholeBuffer(t *testing.T) {
 	data := []byte(content)
 
 	for _, caseSensitive := range []bool{true, false} {
-		want, err := findAllMatchSpans(nil, data, "needle", caseSensitive, false, false)
+		want, err := findAllMatchSpans(context.Background(), data, "needle", caseSensitive, false, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantLines := countMatchLines(nil, data, want)
+		wantLines := countMatchLines(context.Background(), data, want)
 		if len(want) == 0 {
 			t.Fatal("corpus matches nothing")
 		}

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -269,14 +269,6 @@ func TestRecursiveCopy_CancelCleanup(t *testing.T) {
 		t.Error("Partial destination file was not deleted after cancellation")
 	}
 }
-func TestRecursiveCopy_AskError_Stub(t *testing.T) {
-	// Placeholder for UI-heavy error handling test.
-	// Just ensuring the frame instance can be created.
-	pf := &PanelsFrame{}
-	if pf == nil {
-		t.Error("Failed to create PanelsFrame")
-	}
-}
 
 type mockS2SVFS struct {
 	vfs.VFS

--- a/cmd/f4/help.go
+++ b/cmd/f4/help.go
@@ -19,7 +19,7 @@ import (
 var defaultHelpData string
 
 // README.md lives in the repository root (it must render on GitHub), out of
-// go:embed's reach from this directory; the root "embedded" package bridges it.
+// reach of this directory's embed directive; the root "embedded" package bridges it.
 var readmeData = embedded.ReadmeMD
 
 type memoryHelpVFS struct {

--- a/cmd/f4/image_formats_test.go
+++ b/cmd/f4/image_formats_test.go
@@ -13,7 +13,7 @@ func qoiFile() []byte {
 	out = append(out, 4, 0)
 
 	out = append(out, qoiOpRGBA, 10, 20, 30, 255) // the first pixel
-	out = append(out, qoiOpRun|0)                 // and the same one again
+	out = append(out, qoiOpRun)                   // and the same one again
 	out = append(out, qoiOpDiff|(3<<4)|(2<<2)|1)  // +1, 0, -1
 	out = append(out, qoiOpIndex|9)               // back to the first colour
 

--- a/cmd/f4/image_gallery_test.go
+++ b/cmd/f4/image_gallery_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -135,7 +136,7 @@ func TestImageViewGalleryEnterOpensTheCursor(t *testing.T) {
 	iv := newTestImageView(t, 100, 100)
 	iv.path = "a.png"
 	iv.SetSiblings([]string{"a.png", "b.png"}, 0)
-	if res := ImagePipe.LoadSync(nil, nil, "b.png"); res.Err != nil {
+	if res := ImagePipe.LoadSync(context.Background(), nil, "b.png"); res.Err != nil {
 		t.Fatalf("b.png: %v", res.Err)
 	}
 

--- a/cmd/f4/issue149_test.go
+++ b/cmd/f4/issue149_test.go
@@ -145,7 +145,7 @@ func TestIssue149_Reproduction(t *testing.T) {
 		getGlobal: func(action string) (string, int, string) { return "", 0, "" },
 	}
 
-	ctx := context.WithValue(context.Background(), "AutoQueue", true)
+	ctx := archive.WithAutoQueue(context.Background())
 
 	err := arcVfs.CopyBulk(ctx, names, dstVFS, tmpDir, rep)
 	if err != nil {
@@ -225,7 +225,7 @@ func TestIssue149_LocatingStatusReporting(t *testing.T) {
 	rep := &actionCaptureReporter{actions: make(map[string]bool)}
 
 	// We need to use a context that triggers progress updates
-	ctx, cancel := context.WithCancel(context.WithValue(context.Background(), "AutoQueue", true))
+	ctx, cancel := context.WithCancel(archive.WithAutoQueue(context.Background()))
 	defer cancel()
 
 	// Run extraction in background to allow ticker to fire
@@ -450,7 +450,7 @@ func TestIssue149_F5_Extraction_Integrity(t *testing.T) {
 		getGlobal: func(action string) (string, int, string) { return "", 0, "" },
 	}
 
-	ctx := context.WithValue(context.Background(), "AutoQueue", true)
+	ctx := archive.WithAutoQueue(context.Background())
 	err = arcVFS.CopyBulk(ctx, []string{"15_Area51_bunker.dxs"}, dstVFS, dstDir, rep)
 	if err != nil {
 		t.Fatalf("CopyBulk failed: %v", err)
@@ -619,7 +619,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 		}
 
 		rep := &testBlackBoxReporter{}
-		ctx := context.WithValue(context.Background(), "AutoQueue", true)
+		ctx := archive.WithAutoQueue(context.Background())
 		if err := arcVFS.CopyBulk(ctx, selected, dstVFS, dstDir, rep); err != nil {
 			t.Fatalf("CopyBulk failed: %v", err)
 		}
@@ -646,7 +646,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 		selected := []string{"Deus Ex"}
 
 		rep := &testBlackBoxReporter{}
-		ctx := context.WithValue(context.Background(), "AutoQueue", true)
+		ctx := archive.WithAutoQueue(context.Background())
 		if err := arcVFS.CopyBulk(ctx, selected, dstVFS, dstDir, rep); err != nil {
 			t.Fatalf("CopyBulk failed: %v", err)
 		}

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -226,7 +226,6 @@ func main() {
 			pluginName := flagVal
 			if pluginName == "" && i+1 < len(os.Args) && !strings.HasPrefix(os.Args[i+1], "-") {
 				pluginName = os.Args[i+1]
-				i++
 			}
 			os.Exit(RunNewPlugin(pluginName, os.Stdout, os.Stderr))
 		case "-test-plugins":

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -4271,8 +4271,8 @@ func TestArchiveBulkExtract_ProgressTracking(t *testing.T) {
 		},
 	}
 
-	// We pass "AutoQueue" in context to bypass the interactive UI busy-lock prompt
-	ctx := context.WithValue(context.Background(), "AutoQueue", true)
+	// Auto-queue to bypass the interactive UI busy-lock prompt.
+	ctx := archive.WithAutoQueue(context.Background())
 
 	// 3. Execute Bulk Copy
 	bulkCopier := arcVFS.(vfs.BulkCopier)

--- a/cmd/f4/rpc_plugin_test.go
+++ b/cmd/f4/rpc_plugin_test.go
@@ -66,7 +66,7 @@ func TestRPCPlugin_VFS_Proxy(t *testing.T) {
 	})
 
 	buf := make([]byte, 4)
-	n, err := wrapper.ReadAt(nil, buf, 0)
+	n, err := wrapper.ReadAt(context.Background(), buf, 0)
 	if err != nil {
 		t.Errorf("Proxy ReadAt failed: %v", err)
 	}

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -95,9 +95,5 @@ func TestMain(m *testing.M) {
 		os.RemoveAll(tmpDir)
 	}
 
-	if result != 0 {
-		// disabled for now
-		//vtui.DumpLogsToFile("_failed_tests_f4.log")
-	}
 	os.Exit(result)
 }

--- a/embedded.go
+++ b/embedded.go
@@ -1,7 +1,7 @@
 // Package embedded exposes repository-root files that the application embeds.
-// go:embed can only reference paths inside the source directory, and README.md
-// must stay in the repository root to render on GitHub, so this tiny root
-// package bridges it to cmd/f4.
+// An embed directive can only reference paths inside the source directory, and
+// README.md must stay in the repository root to render on GitHub, so this tiny
+// root package bridges it to cmd/f4.
 package embedded
 
 import _ "embed"

--- a/fusefs/bridge_test.go
+++ b/fusefs/bridge_test.go
@@ -373,10 +373,11 @@ func TestConcurrentBackendReadsOverlap(t *testing.T) {
 }
 
 func TestInodeOfIsStableAndReserved(t *testing.T) {
-	if inodeOf("/root/a") != inodeOf("/root/a") {
+	first := inodeOf("/root/a")
+	if second := inodeOf("/root/a"); first != second {
 		t.Fatalf("inode numbers must be stable for a path")
 	}
-	if inodeOf("/root/a") == inodeOf("/root/b") {
+	if first == inodeOf("/root/b") {
 		t.Fatalf("different paths should not collide this easily")
 	}
 	for _, p := range []string{"", "/", "/root", "x"} {

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -27,6 +27,21 @@ import (
 
 var TestSkipDelay time.Duration
 
+type autoQueueContextKey struct{}
+
+// WithAutoQueue makes a contended archive operation wait without prompting.
+func WithAutoQueue(ctx context.Context) context.Context {
+	return context.WithValue(ctx, autoQueueContextKey{}, true)
+}
+
+func autoQueueRequested(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	autoQueue, _ := ctx.Value(autoQueueContextKey{}).(bool)
+	return autoQueue
+}
+
 // archiveVFSIdleTTL is kept as a variable so tests can exercise the cleanup
 // transition without waiting for the production grace period.
 var archiveVFSIdleTTL = 2 * time.Second
@@ -1387,8 +1402,8 @@ func (v *ArchiveVFS) CopyBulk(ctx context.Context, srcPaths []string, dstVfs vfs
 
 	waitLock := true
 	if !vfs.GlobalArchiveLockManager.TryLock(absPath) {
-		// If "AutoQueue" is requested via Context (used by headless unit tests), bypass the UI prompt
-		if ctx.Value("AutoQueue") != nil {
+		// Headless callers can request queuing without an interactive prompt.
+		if autoQueueRequested(ctx) {
 			waitLock = true
 		} else if vtui.FrameManager == nil {
 			// Fallback headless mode

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -759,8 +759,8 @@ func TestArchiveVFSCopyBulk_ConcurrentQueue(t *testing.T) {
 
 	go func() {
 		defer wg.Done()
-		// Inject AutoQueue into the context so the VFS doesn't block waiting for UI interaction
-		ctx := context.WithValue(context.Background(), "AutoQueue", true)
+		// Auto-queue so the VFS doesn't block waiting for UI interaction.
+		ctx := WithAutoQueue(context.Background())
 		err := copier.CopyBulk(ctx, []string{"file1.txt"}, dstVFS, dstDir, &dummyReporter{})
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)

--- a/plugins/cloudfox/provider_s3.go
+++ b/plugins/cloudfox/provider_s3.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
 	awstypes "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	smithytime "github.com/aws/smithy-go/time"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/unxed/f4/vfs"
 )
@@ -1419,6 +1420,17 @@ func boolToInt64(value bool) int64 {
 	return 0
 }
 
+func parseS3Expires(value *string) *time.Time {
+	if value == nil {
+		return nil
+	}
+	expires, err := smithytime.ParseHTTPDate(*value)
+	if err != nil {
+		return nil
+	}
+	return &expires
+}
+
 func (b *s3Backend) copyMultipart(ctx context.Context, destination s3Target, copySource string, size int64, source *awss3.HeadObjectOutput) (retErr error) {
 	destinationKey := destination.key
 	partSize, err := s3MultipartCopyPartSize(size)
@@ -1434,7 +1446,7 @@ func (b *s3Backend) copyMultipart(ctx context.Context, destination s3Target, cop
 		ContentEncoding:         source.ContentEncoding,
 		ContentLanguage:         source.ContentLanguage,
 		ContentType:             source.ContentType,
-		Expires:                 source.Expires,
+		Expires:                 parseS3Expires(source.ExpiresString),
 		Metadata:                source.Metadata,
 		SSEKMSKeyId:             source.SSEKMSKeyId,
 		ServerSideEncryption:    source.ServerSideEncryption,

--- a/plugins/cloudfox/provider_s3_test.go
+++ b/plugins/cloudfox/provider_s3_test.go
@@ -386,6 +386,19 @@ func TestS3CopyUsesMultipartAboveFiveGiB(t *testing.T) {
 	}
 }
 
+func TestParseS3ExpiresPreservesSDKParsingBehavior(t *testing.T) {
+	value := "Mon, 02 Jan 2006 15:04:05 GMT"
+	want := time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC)
+	if got := parseS3Expires(&value); got == nil || !got.Equal(want) {
+		t.Fatalf("parseS3Expires(%q) = %v, want %v", value, got, want)
+	}
+
+	invalid := "not an HTTP date"
+	if got := parseS3Expires(&invalid); got != nil {
+		t.Fatalf("parseS3Expires(%q) = %v, want nil", invalid, got)
+	}
+}
+
 func TestS3MultipartCopyCancellationAbortsWithIndependentContext(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithCancel(context.Background())

--- a/plugins/id3editor/plugin_test.go
+++ b/plugins/id3editor/plugin_test.go
@@ -1,7 +1,6 @@
 package id3editor
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -19,7 +18,7 @@ func init() {
 }
 
 func TestID3Editor_Roundtrip(t *testing.T) {
-	tempFile, err := ioutil.TempFile("", "test_id3_roundtrip_*.mp3")
+	tempFile, err := os.CreateTemp("", "test_id3_roundtrip_*.mp3")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/mediainfo/backend_test.go
+++ b/plugins/mediainfo/backend_test.go
@@ -255,10 +255,10 @@ func TestAnalyzeHonorsCancellation(t *testing.T) {
 	}
 }
 
-func TestAnalyzeNilContextUsesBackground(t *testing.T) {
+func TestAnalyzeWithBackgroundContext(t *testing.T) {
 	data := []byte("RIFF\x04\x00\x00\x00WAVE")
-	if _, err := Analyze(nil, Source{Name: "nil-context.wav", Size: int64(len(data)), Reader: memorySource(data)}, DefaultOptions(ModeFast)); err != nil {
-		t.Fatalf("Analyze(nil) = %v", err)
+	if _, err := Analyze(context.Background(), Source{Name: "background-context.wav", Size: int64(len(data)), Reader: memorySource(data)}, DefaultOptions(ModeFast)); err != nil {
+		t.Fatalf("Analyze() = %v", err)
 	}
 }
 

--- a/plugins/mediainfo/format_gaps_test.go
+++ b/plugins/mediainfo/format_gaps_test.go
@@ -279,6 +279,13 @@ func TestAnalyzeEBUSTL(t *testing.T) {
 	}
 }
 
+func TestCleanSTLFieldOnlyRemovesDefinedPaddingBytes(t *testing.T) {
+	want := string([]byte{'A', 0x8e})
+	if got := cleanSTLField([]byte{'A', 0x8e, 0x8f, 0}); got != want {
+		t.Fatalf("cleanSTLField() = %q, want %q", got, want)
+	}
+}
+
 func TestAnalyzeOggFLAC(t *testing.T) {
 	streamInfo := make([]byte, 34)
 	v := uint64(48000)<<44 | uint64(1)<<41 | uint64(23)<<36 | uint64(96000)

--- a/plugins/mediainfo/parse_ebu_stl.go
+++ b/plugins/mediainfo/parse_ebu_stl.go
@@ -82,7 +82,11 @@ func parseEBUSTL(p *probe, _ []byte) error {
 }
 
 func cleanSTLField(b []byte) string {
-	return strings.TrimSpace(strings.TrimRight(string(b), "\x00\x8f"))
+	end := len(b)
+	for end > 0 && (b[end-1] == 0 || b[end-1] == 0x8f) {
+		end--
+	}
+	return strings.TrimSpace(string(b[:end]))
 }
 
 func parseSTLDecimal(b []byte) int {

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -50,7 +50,7 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 
 	// 3. Test ReadDir (visual representation)
 	found := false
-	nf.ReadDir(nil, "", func(items []vfs.VFSItem) {
+	nf.ReadDir(context.Background(), "", func(items []vfs.VFSItem) {
 		for _, itm := range items {
 			if itm.Name == "My Server" {
 				found = true
@@ -62,7 +62,7 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 	}
 
 	// 4. Test Removal
-	nf.Remove(nil, "My Server")
+	nf.Remove(context.Background(), "My Server")
 	if len(nf.getConfigs()) != 0 {
 		t.Error("Config was not removed")
 	}

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -50,19 +50,23 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 
 	// 3. Test ReadDir (visual representation)
 	found := false
-	nf.ReadDir(context.Background(), "", func(items []vfs.VFSItem) {
+	if err := nf.ReadDir(context.Background(), "", func(items []vfs.VFSItem) {
 		for _, itm := range items {
 			if itm.Name == "My Server" {
 				found = true
 			}
 		}
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 	if !found {
 		t.Error("ReadDir failed to list saved connection")
 	}
 
 	// 4. Test Removal
-	nf.Remove(context.Background(), "My Server")
+	if err := nf.Remove(context.Background(), "My Server"); err != nil {
+		t.Fatal(err)
+	}
 	if len(nf.getConfigs()) != 0 {
 		t.Error("Config was not removed")
 	}

--- a/vfs/codepages.go
+++ b/vfs/codepages.go
@@ -73,13 +73,9 @@ func DecodeBytes(data []byte, cpID int) ([]byte, error) {
 	var decoder *encoding.Decoder
 	switch cpID {
 	case 11111:
-		if enc := GetSystemANSIEncoding(); enc != nil {
-			decoder = enc.NewDecoder()
-		}
+		decoder = GetSystemANSIEncoding().NewDecoder()
 	case 22222:
-		if enc := GetSystemOEMEncoding(); enc != nil {
-			decoder = enc.NewDecoder()
-		}
+		decoder = GetSystemOEMEncoding().NewDecoder()
 	default:
 		cp, ok := FindCodepage(cpID)
 		if !ok || cp.Enc == nil {
@@ -103,13 +99,9 @@ func EncodeBytes(data []byte, cpID int) ([]byte, error) {
 	var encoder *encoding.Encoder
 	switch cpID {
 	case 11111:
-		if enc := GetSystemANSIEncoding(); enc != nil {
-			encoder = enc.NewEncoder()
-		}
+		encoder = GetSystemANSIEncoding().NewEncoder()
 	case 22222:
-		if enc := GetSystemOEMEncoding(); enc != nil {
-			encoder = enc.NewEncoder()
-		}
+		encoder = GetSystemOEMEncoding().NewEncoder()
 	default:
 		cp, ok := FindCodepage(cpID)
 		if !ok || cp.Enc == nil {
@@ -159,16 +151,12 @@ func GetCodepageDecoderEncoder(cp string) (*encoding.Decoder, *encoding.Encoder)
 	}
 	id, _ := strconv.Atoi(cp)
 	if id == 11111 {
-		if enc := GetSystemANSIEncoding(); enc != nil {
-			return enc.NewDecoder(), enc.NewEncoder()
-		}
-		return nil, nil
+		enc := GetSystemANSIEncoding()
+		return enc.NewDecoder(), enc.NewEncoder()
 	}
 	if id == 22222 {
-		if enc := GetSystemOEMEncoding(); enc != nil {
-			return enc.NewDecoder(), enc.NewEncoder()
-		}
-		return nil, nil
+		enc := GetSystemOEMEncoding()
+		return enc.NewDecoder(), enc.NewEncoder()
 	}
 	if cpObj, ok := FindCodepage(id); ok && cpObj.Enc != nil {
 		return cpObj.Enc.NewDecoder(), cpObj.Enc.NewEncoder()

--- a/vfs/codepages_test.go
+++ b/vfs/codepages_test.go
@@ -37,13 +37,6 @@ func TestCodepages_GetSystemEncoding(t *testing.T) {
 	oem := GetSystemOEMEncoding()
 	ansi := GetSystemANSIEncoding()
 
-	if oem == nil {
-		t.Fatal("expected GetSystemOEMEncoding to return non-nil encoding")
-	}
-	if ansi == nil {
-		t.Fatal("expected GetSystemANSIEncoding to return non-nil encoding")
-	}
-
 	if oem != localecp.OEMEncoding {
 		t.Errorf("expected OEM encoding %v, got %v", localecp.OEMEncoding, oem)
 	}

--- a/vfs/destination_overwrite_test.go
+++ b/vfs/destination_overwrite_test.go
@@ -20,9 +20,6 @@ func TestDestinationOverwriteContext(t *testing.T) {
 			t.Fatalf("DestinationOverwrite(%v)=(%v,%v)", overwrite, got, known)
 		}
 	}
-	if _, known := DestinationOverwrite(nil); known {
-		t.Fatal("nil context unexpectedly has an overwrite decision")
-	}
 }
 
 func TestOSVFSCreateHonorsExplicitNoOverwrite(t *testing.T) {

--- a/vtvibe/session_test.go
+++ b/vtvibe/session_test.go
@@ -1,6 +1,7 @@
 package vtvibe
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -70,7 +71,7 @@ func TestAIVFS_CreateRedirectsToContextWhenCwdIsChat(t *testing.T) {
 	s := NewSession()
 	v := NewVFS(s)
 
-	wc, err := v.Create(nil, "/chat/status.sh")
+	wc, err := v.Create(context.Background(), "/chat/status.sh")
 	if err != nil {
 		t.Fatalf("expected Create on /chat/status.sh to succeed, got %v", err)
 	}
@@ -84,7 +85,7 @@ func TestAIVFS_CreateRedirectsToContextWhenCwdIsChat(t *testing.T) {
 		t.Fatalf("expected ContextFiles() = ['status.sh'], got %v", files)
 	}
 
-	r, err := v.Open(nil, "/chat/status.sh")
+	r, err := v.Open(context.Background(), "/chat/status.sh")
 	if err != nil {
 		t.Fatalf("expected Open /chat/status.sh to find /ctx/status.sh, got %v", err)
 	}


### PR DESCRIPTION
The mechanical half of staticcheck landed in #715. This is the other half: the
twenty-eight findings that needed a decision rather than a rewrite. Two of them
turned out to be real bugs in shipped code, and several more were assertions
that could never fail, which is its own kind of bug.

Real bugs:

  overlayKeybarSlots did not clamp a label to the space actually left on the
  line, so on a narrow terminal the console overlay's keybar drew past the last
  column. The test that should have caught this asserted len(...) < 0, which the
  builtin cannot return; replacing it with a real end-of-slot bound made it fail
  and then pass.

  parseEBUSTL trimmed padding with strings.TrimRight and the cutset "\x00\x8f".
  A cutset is a set of runes, 0x8f alone is not valid UTF-8, and TrimRight then
  strips any trailing invalid byte rather than only the padding it meant to.
  Trimming byte-wise fixes it.

Assertions that could never fire, now doing what they were written for:

  fusefs/bridge_test.go compared a call against itself; it now records two
  independent calls, which is what "stable" was supposed to mean.
  console_passthrough_test.go is the keybar assertion above.
  file_ops_test.go checked a freshly taken address for nil. The test had no
  behaviour left once that was removed, so it is gone rather than kept as
  decoration.

Dead checks, from a contract that had drifted:

  GetSystemANSIEncoding and GetSystemOEMEncoding always return a fallback and
  never a nil interface, so every "if enc != nil" around them was checking a
  typed nil that cannot occur. Removed in vfs/codepages.go and at the two call
  sites in cmd/f4. This is the one change worth a second look, because the
  alternative reading is that those functions should be able to return nil; the
  call sites all treat "no encoding" as impossible already, so the checks were
  the odd ones out, not the contract.

Two comments in cmd/f4/help.go and embedded.go opened a line with "// go:embed"
while explaining the directive. The compiler ignores them, but staticcheck is
right that a line starting that way is almost always a typo'd directive.
Reworded so the prose no longer looks like one.

The rest is smaller: a context key stops being a bare string in plugins/archive
and grows a real type, nil Contexts in tests become context.Background(),
math/rand.Seed gives way to a per-frame generator in arkanoid, io/ioutil goes,
HeadObjectOutput.Expires moves to ExpiresString and parses it, and a redundant
"| 0" and an unread i++ before os.Exit are gone.

Two SA1019 findings are deliberately left, both in plugins/cloudfox: AWS has
superseded feature/s3/manager with feature/s3/transfermanager. That is a real
API change into a module that is still pre-release, and this backend leans on
per-bucket signing-region overrides, detached multipart cleanup and atomic
no-overwrite behaviour that have no direct equivalent there yet. It is worth
doing on its own terms, not as a footnote to a lint pass.

staticcheck stays incremental for now, so this does not move it into
.golangci-strict.yml.