### PR TITLE
security: verify SSH host keys

### DIFF
--- a/ISSUE_724_SOLUTION_REVIEW.md
+++ b/ISSUE_724_SOLUTION_REVIEW.md
@@ -1,0 +1,41 @@
+# Issue #724 solution review
+
+## Problem
+
+`plugins/netfox/ssh_dial.go` used `ssh.InsecureIgnoreHostKey`, so both SFTP
+and FISH+ accepted any SSH server key. Because authentication can fall back to
+a password, an active network attacker could impersonate the server and see
+the password and session contents.
+
+## Candidate solutions
+
+1. Accept an unknown key once and write it to `known_hosts` (TOFU). This keeps
+   first-use connections convenient, but silently trusting a key on the first
+   connection does not protect the exact first connection described by the
+   report.
+2. Use the user's OpenSSH `known_hosts` database and reject both unknown and
+   changed keys. This matches the trust model users already configure for SSH,
+   works for SFTP and FISH+ through their shared dialer, and is safe through
+   HTTP CONNECT and SOCKS5 proxies.
+3. Add a new f4-specific host-key field to every NetFox site. This would allow
+   explicit pinning but requires new UI, persistence, migration, and a second
+   trust database without evidence that the project needs one.
+
+## Chosen solution
+
+Use `~/.ssh/known_hosts` (and `known_hosts2` when present) through
+`golang.org/x/crypto/ssh/knownhosts`. A missing database is an explicit error;
+there is no insecure fallback or interactive trust-on-first-use path. The
+callback is created before any authentication methods are used, so no password
+or agent operation begins until the server key is verified.
+
+## Verification
+
+- Unit-test accepted, unknown, and changed host keys with temporary OpenSSH
+  known-hosts files.
+- Run the full Go test suite and vet the NetFox package.
+- Build and run the native Windows amd64 binary; verify that an SSH endpoint
+  with a known key connects and an unknown/changed key is rejected before
+  authentication.
+
+— zoin-bot

--- a/plugins/netfox/ssh_dial.go
+++ b/plugins/netfox/ssh_dial.go
@@ -2,15 +2,17 @@ package netfox
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/unxed/f4/internal/netproxy"
 	"github.com/unxed/vtui"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	"net"
-	"os"
-	"path/filepath"
-	"time"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // sshTimeout turns the timeout a site configuration carries into a duration,
@@ -27,6 +29,11 @@ func sshTimeout(seconds int) time.Duration {
 // the password. It is shared by the SFTP and the FISH+ backends so that a
 // site behaves identically whichever of them opens it.
 func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (*ssh.Client, error) {
+	hostKeyCallback, err := sshHostKeyCallback()
+	if err != nil {
+		return nil, err
+	}
+
 	auths := []ssh.AuthMethod{}
 	var agentClient agent.Agent
 	var agentConn net.Conn
@@ -60,7 +67,7 @@ func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (
 	config := &ssh.ClientConfig{
 		User:            user,
 		Auth:            auths,
-		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		HostKeyCallback: hostKeyCallback,
 		Timeout:         sshTimeout(timeout),
 	}
 	// ssh.Dial would open the socket itself; going through netproxy instead
@@ -81,6 +88,45 @@ func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (
 		}
 	}
 	return client, nil
+}
+
+func sshHostKeyCallback() (ssh.HostKeyCallback, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("SSH host-key verification: determine home directory: %w", err)
+	}
+	return sshHostKeyCallbackForHome(home)
+}
+
+func sshHostKeyCallbackForHome(home string) (ssh.HostKeyCallback, error) {
+	if home == "" {
+		return nil, fmt.Errorf("SSH host-key verification: home directory is empty")
+	}
+
+	knownHosts := make([]string, 0, 2)
+	for _, name := range []string{"known_hosts", "known_hosts2"} {
+		path := filepath.Join(home, ".ssh", name)
+		info, err := os.Stat(path)
+		switch {
+		case err == nil && !info.IsDir():
+			knownHosts = append(knownHosts, path)
+		case err == nil:
+			return nil, fmt.Errorf("SSH host-key verification: %s is a directory", path)
+		case os.IsNotExist(err):
+			continue
+		default:
+			return nil, fmt.Errorf("SSH host-key verification: inspect %s: %w", path, err)
+		}
+	}
+	if len(knownHosts) == 0 {
+		return nil, fmt.Errorf("SSH host-key verification: no ~/.ssh/known_hosts file found")
+	}
+
+	callback, err := knownhosts.New(knownHosts...)
+	if err != nil {
+		return nil, fmt.Errorf("SSH host-key verification: read known_hosts: %w", err)
+	}
+	return callback, nil
 }
 
 // dialSSHVia opens the transport through px and speaks SSH over it.

--- a/plugins/netfox/ssh_dial_test.go
+++ b/plugins/netfox/ssh_dial_test.go
@@ -71,7 +71,9 @@ func TestDialSSHVerifiesServerKeyBeforeAuthentication(t *testing.T) {
 	if err != nil {
 		t.Fatalf("known server key rejected: %v", err)
 	}
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Errorf("close SSH client: %v", err)
+	}
 }
 
 func TestDialSSHRejectsChangedServerKey(t *testing.T) {
@@ -84,7 +86,9 @@ func TestDialSSHRejectsChangedServerKey(t *testing.T) {
 
 	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
 	if err == nil {
-		client.Close()
+		if closeErr := client.Close(); closeErr != nil {
+			t.Errorf("close SSH client: %v", closeErr)
+		}
 		t.Fatal("changed server key was accepted")
 	}
 }
@@ -137,7 +141,11 @@ func startTestSSHServer(t *testing.T) (string, ssh.PublicKey) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { listener.Close() })
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Errorf("close test SSH listener: %v", err)
+		}
+	})
 	go func() {
 		for {
 			conn, err := listener.Accept()
@@ -147,14 +155,14 @@ func startTestSSHServer(t *testing.T) (string, ssh.PublicKey) {
 			go func() {
 				serverConn, channels, requests, err := ssh.NewServerConn(conn, config)
 				if err != nil {
-					conn.Close()
+					_ = conn.Close()
 					return
 				}
 				go ssh.DiscardRequests(requests)
 				for channel := range channels {
-					channel.Reject(ssh.Prohibited, "test server")
+					_ = channel.Reject(ssh.Prohibited, "test server")
 				}
-				serverConn.Close()
+				_ = serverConn.Close()
 			}()
 		}
 	}()

--- a/plugins/netfox/ssh_dial_test.go
+++ b/plugins/netfox/ssh_dial_test.go
@@ -1,0 +1,170 @@
+package netfox
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/internal/netproxy"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func TestSSHHostKeyCallbackAcceptsKnownKey(t *testing.T) {
+	home := t.TempDir()
+	key := testSSHHostKey(t)
+	writeKnownHosts(t, home, "[example.test]:2222", key)
+
+	callback, err := sshHostKeyCallbackForHome(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := callback("example.test:2222", testSSHRemoteAddr{}, key); err != nil {
+		t.Fatalf("known host key rejected: %v", err)
+	}
+}
+
+func TestSSHHostKeyCallbackRejectsUnknownAndChangedKeys(t *testing.T) {
+	home := t.TempDir()
+	knownKey := testSSHHostKey(t)
+	writeKnownHosts(t, home, "[example.test]:2222", knownKey)
+
+	callback, err := sshHostKeyCallbackForHome(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unknownKey := testSSHHostKey(t)
+	if err := callback("other.test:2222", testSSHRemoteAddr{}, unknownKey); err == nil {
+		t.Fatal("unknown host key was accepted")
+	}
+	if err := callback("example.test:2222", testSSHRemoteAddr{}, unknownKey); err == nil {
+		t.Fatal("changed host key was accepted")
+	}
+}
+
+func TestSSHHostKeyCallbackRequiresKnownHostsFile(t *testing.T) {
+	_, err := sshHostKeyCallbackForHome(t.TempDir())
+	if err == nil {
+		t.Fatal("missing known_hosts file was accepted")
+	}
+	if !strings.Contains(err.Error(), "known_hosts") {
+		t.Fatalf("missing known_hosts error = %v", err)
+	}
+}
+
+func TestDialSSHVerifiesServerKeyBeforeAuthentication(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("SSH_AUTH_SOCK", "")
+	port, publicKey := startTestSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
+
+	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
+	if err != nil {
+		t.Fatalf("known server key rejected: %v", err)
+	}
+	client.Close()
+}
+
+func TestDialSSHRejectsChangedServerKey(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("SSH_AUTH_SOCK", "")
+	port, _ := startTestSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), testSSHHostKey(t))
+
+	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
+	if err == nil {
+		client.Close()
+		t.Fatal("changed server key was accepted")
+	}
+}
+
+func testSSHHostKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := ssh.NewPublicKey(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func writeKnownHosts(t *testing.T, home, address string, key ssh.PublicKey) {
+	t.Helper()
+	sshDir := filepath.Join(home, ".ssh")
+	if err := os.MkdirAll(sshDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sshDir, "known_hosts")
+	if err := os.WriteFile(path, []byte(knownhosts.Line([]string{address}, key)+"\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startTestSSHServer(t *testing.T) (string, ssh.PublicKey) {
+	t.Helper()
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := ssh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := &ssh.ServerConfig{
+		PasswordCallback: func(conn ssh.ConnMetadata, password []byte) (*ssh.Permissions, error) {
+			if conn.User() == "user" && string(password) == "pass" {
+				return nil, nil
+			}
+			return nil, fmt.Errorf("test SSH server rejected credentials")
+		},
+	}
+	config.AddHostKey(signer)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				serverConn, channels, requests, err := ssh.NewServerConn(conn, config)
+				if err != nil {
+					conn.Close()
+					return
+				}
+				go ssh.DiscardRequests(requests)
+				for channel := range channels {
+					channel.Reject(ssh.Prohibited, "test server")
+				}
+				serverConn.Close()
+			}()
+		}
+	}()
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	return port, signer.PublicKey()
+}
+
+type testSSHRemoteAddr struct{}
+
+func (testSSHRemoteAddr) Network() string { return "tcp" }
+func (testSSHRemoteAddr) String() string  { return "127.0.0.1:2222" }
+
+var _ net.Addr = testSSHRemoteAddr{}


### PR DESCRIPTION
## Summary
- verify SSH server keys for both SFTP and FISH+ through the shared NetFox dialer
- use the user's `~/.ssh/known_hosts` and optional `known_hosts2`; reject unknown or changed keys without TOFU fallback
- add callback and end-to-end SSH regression tests

## Validation
- `go test ./... -count=1` on Windows 10 x64
- `go vet ./plugins/netfox/...`
- native Windows amd64 build, `--version`, `--wine-probe`, and `-test-plugins`

Fixes #724

— zoin-bot