### PR TITLE
Fix PlugRing test plugin download

### DIFF
--- a/ISSUE_309_SOLUTION_REVIEW.md
+++ b/ISSUE_309_SOLUTION_REVIEW.md
@@ -1,0 +1,20 @@
+# Issue #309 solution review
+
+The screenshots show the bundled `hello-plugring` entry failing in the
+published Windows build because its asset URL is `file://plugring/...`. That
+relative local path only exists when f4 is started from a source checkout; a
+GitHub release binary starts with an unrelated working directory and does not
+contain the repository's `plugring` directory.
+
+I compared three approaches:
+
+1. Resolve the relative `file://` path against the process working directory.
+   This is the current behavior and still fails for installed binaries.
+2. Copy the test plugin beside every release binary or teach the installer to
+   locate an executable-relative copy. This makes the catalog depend on a
+   release-packaging detail and does not work for a catalog downloaded from
+   GitHub.
+3. Make the catalog asset a stable absolute HTTPS URL and add a regression
+   test that rejects non-HTTPS bundled assets. This is the chosen solution:
+   the same catalog entry works from a checkout and from a published binary,
+   without changing the installer's handling of normal remote assets.

--- a/cmd/f4/plugring_test.go
+++ b/cmd/f4/plugring_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/unxed/vtui"
+	"gopkg.in/yaml.v3"
 )
 
 func TestResolveAssetURL(t *testing.T) {
@@ -27,6 +29,33 @@ func TestResolveAssetURL(t *testing.T) {
 	plain := "https://example.com/plugin.zip"
 	if ResolveAssetURL(plain) != plain {
 		t.Errorf("ResolveAssetURL altered a string without placeholders")
+	}
+}
+
+func TestBundledPlugRingCatalogUsesRemoteAssets(t *testing.T) {
+	_, sourceFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	catalogPath := filepath.Join(filepath.Dir(sourceFile), "..", "..", "plugring", "index.yaml")
+	data, err := os.ReadFile(catalogPath)
+	if err != nil {
+		t.Fatalf("read bundled PlugRing catalog: %v", err)
+	}
+
+	var items []PlugRingItem
+	if err := yaml.Unmarshal(data, &items); err != nil {
+		t.Fatalf("parse bundled PlugRing catalog: %v", err)
+	}
+	for _, item := range items {
+		u, err := url.Parse(item.URL)
+		if err != nil {
+			t.Errorf("PlugRing item %q has invalid asset URL %q: %v", item.ID, item.URL, err)
+			continue
+		}
+		if u.Scheme != "https" || u.Host == "" {
+			t.Errorf("PlugRing item %q must use an absolute HTTPS asset URL, got %q", item.ID, item.URL)
+		}
 	}
 }
 

--- a/plugring/index.yaml
+++ b/plugring/index.yaml
@@ -4,7 +4,7 @@
   author: "f4 Team"
   description: "A test plugin to verify single-file mechanics and hotkeys."
   category: "tools"
-  url: "file://plugring/hello_plugring.lua"
+  url: "https://raw.githubusercontent.com/unxed/f4/main/plugring/hello_plugring.lua"
   entrypoint: "hello_plugring.lua"
   runtimes:
     - embedded


### PR DESCRIPTION
## Summary\n- publish the bundled Hello PlugRing asset through the stable raw GitHub HTTPS URL\n- add a regression test requiring every bundled PlugRing asset to use an absolute HTTPS URL\n- document the solution review\n\nFixes #309.\n\nValidation:\n- go test ./... -count=1 passed\n- native Windows x64 f4 run with --gui=win32 loaded the local catalog, downloaded the Lua asset over HTTPS, installed it, showed Installed, and hot-loaded the plugin\n- native build passed\n- go vet ./... only reports existing unsafe.Pointer warnings in Win32 files\n\nThe temporary validation installation was moved out of the user profile after the test.