### PR TITLE
Fix Windows updater elevation via UAC

### DIFF
--- a/ISSUE_215_SOLUTION_REVIEW.md
+++ b/ISSUE_215_SOLUTION_REVIEW.md
@@ -1,0 +1,44 @@
+# Issue #215 solution review
+
+Reported behavior: a non-administrator Windows installation tried to update
+itself and displayed `failed to spawn sudo process`; the binary had been
+installed from the GitHub release and worked only when launched as
+Administrator.
+
+## Candidate 1: keep the shared sudo fallback
+
+The existing fallback is Unix-specific: it starts `sudo`, creates a Unix
+socket, and passes file descriptors through Unix IPC. It cannot work on
+Windows. Keeping it produces the reported error and is rejected.
+
+## Candidate 2: tell the user to relaunch f4 as Administrator
+
+This would avoid the error but makes every protected update a manual two-step
+operation and does not use the Windows permission model. It is a workaround,
+not an updater fix, and is rejected.
+
+## Candidate 3: use a short-lived Windows UAC update helper (chosen)
+
+The normal process downloads the archive and first tries the existing direct
+installation path. If the executable directory is protected, or extraction
+returns a Windows permission error, it saves the archive to a temporary file
+and starts the same executable with `ShellExecuteExW` and the `runas` verb.
+The elevated process enters a private `--update-helper` path, extracts the
+archive using the existing format-specific extractors, reports its exit code,
+and terminates without starting the UI.
+
+## Three-pass review
+
+1. The helper is isolated from the Unix dispatcher, so Windows cannot invoke
+   `sudo`; the elevated process still uses ordinary Windows file APIs.
+2. The parent waits for completion and reports UAC cancellation or a non-zero
+   helper exit code. A temporary archive is removed after either result, and
+   the helper reuses the existing traversal-safe extractors.
+3. The normal writable-directory path is unchanged, while protected
+   installations get one UAC prompt before extraction. The shared VFS sudo
+   client is also marked unavailable on Windows, preventing the same false
+   Unix fallback for other file operations.
+
+This is the smallest general fix for the reported Windows updater failure;
+implementing a full Windows privileged VFS dispatcher would require a
+separate IPC and handle-transfer design and is outside this ticket.

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -62,6 +62,17 @@ func openEditFileIn(pf *PanelsFrame, path string) {
 
 func main() {
 	vtui.AppName = "f4"
+	if archivePath, archiveKind, found, err := parseUpdateHelperArgs(os.Args[1:]); found {
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(2)
+		}
+		if err := runUpdateHelper(archivePath, archiveKind); err != nil {
+			fmt.Fprintf(os.Stderr, "f4 update helper failed: %v\n", err)
+			os.Exit(1)
+		}
+		return
+	}
 	installConsoleCtrlHandler()
 	var sudoDispatcher string
 

--- a/cmd/f4/manual_uac_validation_windows_test.go
+++ b/cmd/f4/manual_uac_validation_windows_test.go
@@ -1,0 +1,53 @@
+//go:build windows
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// This opt-in test exercises the real ShellExecuteExW/runas path with a
+// native f4 binary. It is intentionally not part of the normal test suite:
+// running it may display a UAC consent prompt.
+func TestManualUACElevationValidation(t *testing.T) {
+	if os.Getenv("F4_RUN_MANUAL_UAC") != "1" {
+		t.Skip("set F4_RUN_MANUAL_UAC=1 to exercise native UAC")
+	}
+	binary := os.Getenv("F4_VALIDATION_BINARY")
+	if binary == "" {
+		t.Fatal("F4_VALIDATION_BINARY must point to a native f4.exe")
+	}
+
+	marker := "f4-uac-validation-" + strconv.Itoa(os.Getpid()) + ".txt"
+	var archive bytes.Buffer
+	zw := zip.NewWriter(&archive)
+	f, err := zw.Create(marker)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte("elevated update helper completed")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExecutable := osExecutable
+	osExecutable = func() (string, error) { return binary, nil }
+	defer func() { osExecutable = oldExecutable }()
+
+	if err := runElevatedUpdate(archive.Bytes(), "zip"); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(filepath.Dir(binary), marker)
+	if data, err := os.ReadFile(path); err != nil {
+		t.Fatalf("elevated helper did not create %s: %v", path, err)
+	} else if string(data) != "elevated update helper completed" {
+		t.Fatalf("unexpected helper output: %q", data)
+	}
+}

--- a/cmd/f4/update_elevation_other.go
+++ b/cmd/f4/update_elevation_other.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package main
+
+import "errors"
+
+func updateDirNeedsElevation(string) bool { return false }
+
+func isPermissionErrorForUpdate(error) bool { return false }
+
+func runElevatedUpdate([]byte, string) error {
+	return errors.New("UAC elevation is only available on Windows")
+}
+
+var runUpdateHelper = runUpdateHelperOS
+
+func runUpdateHelperOS(string, string) error {
+	return errors.New("update helper is only available on Windows")
+}

--- a/cmd/f4/update_elevation_windows.go
+++ b/cmd/f4/update_elevation_windows.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	seeMaskNoCloseProcess = 0x00000040
+	waitObject0           = 0x00000000
+)
+
+// updateDirNeedsElevation probes the destination directory without touching
+// an installed file. This lets a normal user get one UAC prompt before any
+// archive entry is partially installed in a protected directory.
+func updateDirNeedsElevation(dir string) bool {
+	f, err := os.CreateTemp(dir, ".f4-update-permission-*")
+	if err == nil {
+		name := f.Name()
+		_ = f.Close()
+		_ = os.Remove(name)
+		return false
+	}
+	return isPermissionErrorForUpdate(err)
+}
+
+func isPermissionErrorForUpdate(err error) bool {
+	if err == nil {
+		return false
+	}
+	return os.IsPermission(err) || errors.Is(err, windows.ERROR_ACCESS_DENIED) || errors.Is(err, windows.ERROR_PRIVILEGE_NOT_HELD)
+}
+
+func runElevatedUpdate(data []byte, archiveKind string) error {
+	tmp, err := os.CreateTemp("", "f4-update-*.archive")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary update archive: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("failed to save temporary update archive: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary update archive: %w", err)
+	}
+
+	exePath, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("failed to locate f4 for UAC elevation: %w", err)
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve f4 path for UAC elevation: %w", err)
+	}
+
+	verb, err := windows.UTF16PtrFromString("runas")
+	if err != nil {
+		return err
+	}
+	file, err := windows.UTF16PtrFromString(exePath)
+	if err != nil {
+		return err
+	}
+	params, err := windows.UTF16PtrFromString(windows.ComposeCommandLine([]string{updateHelperFlag, tmpPath, archiveKind}))
+	if err != nil {
+		return err
+	}
+
+	info := shellExecuteInfo{
+		cbSize:       uint32(unsafe.Sizeof(shellExecuteInfo{})),
+		fMask:        seeMaskNoCloseProcess | seeMaskFlagNoUI,
+		hwnd:         0,
+		lpVerb:       verb,
+		lpFile:       file,
+		lpParameters: params,
+		nShow:        swShow,
+	}
+	result, _, callErr := procShellExecuteEx.Call(uintptr(unsafe.Pointer(&info)))
+	if result == 0 {
+		if callErr != syscall.Errno(0) {
+			if errors.Is(callErr, windows.ERROR_CANCELLED) {
+				return errors.New("UAC elevation was canceled")
+			}
+			return fmt.Errorf("failed to start elevated updater: %w", callErr)
+		}
+		return errors.New("failed to start elevated updater")
+	}
+	if info.hProcess == 0 {
+		return errors.New("elevated updater did not return a process handle")
+	}
+	defer windows.CloseHandle(windows.Handle(info.hProcess))
+
+	waitResult, err := windows.WaitForSingleObject(windows.Handle(info.hProcess), windows.INFINITE)
+	if err != nil {
+		return fmt.Errorf("failed waiting for elevated updater: %w", err)
+	}
+	if waitResult != waitObject0 {
+		return fmt.Errorf("elevated updater wait returned %d", waitResult)
+	}
+	var exitCode uint32
+	if err := windows.GetExitCodeProcess(windows.Handle(info.hProcess), &exitCode); err != nil {
+		return fmt.Errorf("failed to read elevated updater result: %w", err)
+	}
+	if exitCode != 0 {
+		return fmt.Errorf("elevated updater exited with code %d", exitCode)
+	}
+	return nil
+}
+
+var runUpdateHelper = runUpdateHelperOS
+
+func runUpdateHelperOS(archivePath, archiveKind string) error {
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		return fmt.Errorf("failed to read update archive: %w", err)
+	}
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to locate executable: %w", err)
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable path: %w", err)
+	}
+	return extractUpdateArchive(data, archiveKind, filepath.Dir(exePath))
+}

--- a/cmd/f4/update_helper_args.go
+++ b/cmd/f4/update_helper_args.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+const updateHelperFlag = "--update-helper"
+
+// parseUpdateHelperArgs extracts the private command line used by the
+// elevated updater. It deliberately accepts the flag only when it is the
+// complete helper invocation, so a normal f4 launch cannot accidentally skip
+// UI startup because a similarly named user argument was supplied.
+func parseUpdateHelperArgs(args []string) (archivePath, archiveKind string, found bool, err error) {
+	for i, arg := range args {
+		if arg != updateHelperFlag {
+			continue
+		}
+		if len(args) != i+3 {
+			return "", "", true, fmt.Errorf("%s requires archive path and archive kind", updateHelperFlag)
+		}
+		var helperArgs [2]string
+		copy(helperArgs[:], args[i+1:])
+		archivePath = strings.TrimSpace(helperArgs[0])
+		archiveKind = strings.TrimSpace(helperArgs[1])
+		if archivePath == "" || archiveKind == "" {
+			return "", "", true, fmt.Errorf("%s requires non-empty archive path and archive kind", updateHelperFlag)
+		}
+		return archivePath, archiveKind, true, nil
+	}
+	return "", "", false, nil
+}

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -369,14 +369,15 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 		update("Extracting and installing...", -1)
 
 		exeDir := filepath.Dir(exePath)
-		switch archiveKind {
-		case "7z":
-			err = extract7zToDir(archiveData.Bytes(), exeDir)
-		case "targz":
-			err = extractTarGzToDir(archiveData.Bytes(), exeDir)
-		default:
-			// 4 workers: benchmark-optimal.
-			err = extractZipToDirParallel(archiveData.Bytes(), exeDir, min(runtime.GOMAXPROCS(0), 4))
+		if updateDirNeedsElevation(exeDir) {
+			vtui.DebugLog("UPDATER: %q is not writable, requesting UAC elevation", exeDir)
+			err = runElevatedUpdate(archiveData.Bytes(), archiveKind)
+		} else {
+			err = extractUpdateArchive(archiveData.Bytes(), archiveKind, exeDir)
+			if err != nil && isPermissionErrorForUpdate(err) {
+				vtui.DebugLog("UPDATER: extraction needs elevation, retrying through UAC: %v", err)
+				err = runElevatedUpdate(archiveData.Bytes(), archiveKind)
+			}
 		}
 
 		if err != nil {
@@ -407,6 +408,18 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			}
 		}
 	})
+}
+
+func extractUpdateArchive(data []byte, archiveKind, destDir string) error {
+	switch archiveKind {
+	case "7z":
+		return extract7zToDir(data, destDir)
+	case "targz":
+		return extractTarGzToDir(data, destDir)
+	default:
+		// 4 workers: benchmark-optimal.
+		return extractZipToDirParallel(data, destDir, min(runtime.GOMAXPROCS(0), 4))
+	}
 }
 
 func writeFileSafe(targetPath string, r io.Reader, mode os.FileMode) error {

--- a/cmd/f4/updater_test.go
+++ b/cmd/f4/updater_test.go
@@ -27,6 +27,23 @@ type memoryWriteSeeker struct {
 	off  int64
 }
 
+func TestUpdater_ParseUpdateHelperArgs(t *testing.T) {
+	archive, kind, found, err := parseUpdateHelperArgs([]string{updateHelperFlag, `C:\Users\Test User\f4-update.archive`, "zip"})
+	if err != nil || !found {
+		t.Fatalf("parseUpdateHelperArgs() failed: found=%v err=%v", found, err)
+	}
+	if archive != `C:\Users\Test User\f4-update.archive` || kind != "zip" {
+		t.Fatalf("parseUpdateHelperArgs() = %q, %q; want archive path and zip", archive, kind)
+	}
+
+	if _, _, found, err := parseUpdateHelperArgs([]string{updateHelperFlag, "archive.zip"}); !found || err == nil {
+		t.Fatalf("malformed helper invocation: found=%v err=%v", found, err)
+	}
+	if _, _, found, err := parseUpdateHelperArgs([]string{"--gui=win32"}); found || err != nil {
+		t.Fatalf("normal invocation parsed as update helper: found=%v err=%v", found, err)
+	}
+}
+
 func (w *memoryWriteSeeker) Write(p []byte) (int, error) {
 	end := w.off + int64(len(p))
 	if w.off < 0 || end < w.off {

--- a/vfs/sudo_client.go
+++ b/vfs/sudo_client.go
@@ -40,9 +40,11 @@ func GetSudoClient() *SudoClient {
 
 // IsAvailable checks if the SudoClient has been initialized.
 func (c *SudoClient) IsAvailable() bool {
-	res := c != nil
-	if !res {
+	res := c != nil && sudoClientSupported()
+	if c == nil {
 		vtui.DebugLog("SUDO_CLIENT: IsAvailable() returning FALSE (client is nil)")
+	} else if !sudoClientSupported() {
+		vtui.DebugLog("SUDO_CLIENT: IsAvailable() returning FALSE (platform does not support the Unix dispatcher)")
 	}
 	return res
 }

--- a/vfs/sudo_client_platform_unix.go
+++ b/vfs/sudo_client_platform_unix.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package vfs
+
+func sudoClientSupported() bool { return true }

--- a/vfs/sudo_client_platform_windows.go
+++ b/vfs/sudo_client_platform_windows.go
@@ -1,0 +1,8 @@
+//go:build windows
+
+package vfs
+
+// Windows uses UAC elevation for operations that need administrator access.
+// The Unix socket dispatcher cannot work there, so callers must not attempt
+// to start it (in particular, this prevents an accidental `sudo` invocation).
+func sudoClientSupported() bool { return false }

--- a/vfs/sudo_client_windows_test.go
+++ b/vfs/sudo_client_windows_test.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package vfs
+
+import "testing"
+
+func TestSudoClient_IsUnavailableOnWindows(t *testing.T) {
+	client := &SudoClient{}
+	if client.IsAvailable() {
+		t.Fatal("Windows must not advertise the Unix sudo dispatcher as available")
+	}
+}


### PR DESCRIPTION
## Summary
- stop the Unix sudo dispatcher from being advertised on Windows
- use a short-lived `ShellExecuteExW` `runas` helper for protected update directories
- add early `--update-helper` handling and regression coverage

## Validation
- `go test ./... -count=1`
- native Windows x64 build
- native `--update-helper` archive extraction
- opt-in native `ShellExecuteExW/runas` validation passed
- Linux cross-build passed
- `go vet ./cmd/f4 ./vfs` reports only the repository's existing unsafe-pointer warnings

Fixes #215.

— zoin-bot