### PR TITLE
Avoid false updater prompts for newer manual builds

### DIFF
--- a/ISSUE_264_SOLUTION_REVIEW.md
+++ b/ISSUE_264_SOLUTION_REVIEW.md
@@ -1,0 +1,35 @@
+# Issue #264 solution review
+
+The report combines two symptoms: manual builds can be compared as if their
+commit hash were a release version, and declining an update could suppress a
+later manual check. The second behavior is already covered by the merged
+fix for #374; this change addresses the remaining version-comparison bug.
+
+## Candidate 1: compare the manual build string with the release tag
+
+This is the current behavior. A commit hash, a development label, and a
+semantic version are different value types, so any unequal strings look like
+an available update. It can ask a newer local checkout to install an older
+release and is rejected.
+
+## Candidate 2: disable stable update checks for manual builds
+
+This avoids false downgrade prompts, but also hides a real update when a user
+builds from an older commit. It is not acceptable for a development build.
+
+## Candidate 3: compare VCS/build time with release publication time (chosen)
+
+Release-tagged builds continue to use exact tag equality. A manual build that
+only exposes a commit hash is compared with the release PublishedAt timestamp:
+newer releases are offered, while older releases are not. Missing or malformed
+metadata keeps the previous safe behavior of offering the release.
+
+## Three-pass review
+
+1. Exact release builds retain tag-based behavior; manual builds no longer
+   compare unlike identifiers.
+2. An older checkout still receives an update prompt, while a newer local
+   checkout cannot be downgraded accidentally.
+3. Missing metadata remains conservative, and the existing #374 session-level
+   decline behavior is untouched. A focused regression test covers newer and
+   older release timestamps plus exact release equality.

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -219,9 +219,8 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		}
 	} else {
 		current := getCurrentVersion()
-		if release.TagName != current && release.TagName != AppConfig.LastUpdateVersion {
-			needsUpdate = true
-		}
+		_, _, buildTimeText := getVCSInfo()
+		needsUpdate = stableReleaseNeedsUpdate(release, current, parseUpdateBuildTime(buildTimeText))
 	}
 
 	if !needsUpdate {
@@ -260,6 +259,37 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 			sessionDismissedUpdateKey = updateKey
 		}
 	})
+}
+
+func stableReleaseNeedsUpdate(release githubRelease, current string, buildTime time.Time) bool {
+	if release.TagName == current || release.TagName == AppConfig.LastUpdateVersion {
+		return false
+	}
+
+	// A release tag is an exact version marker. A manually built binary may
+	// instead expose only a commit hash, which cannot be compared lexically to
+	// a semver release tag. In that case compare the commit/build timestamp to
+	// the release publication time, so a newer local checkout is not told to
+	// install an older release.
+	if !isReleaseVersion(current) && !buildTime.IsZero() {
+		published, err := time.Parse(time.RFC3339, release.PublishedAt)
+		if err == nil {
+			return published.After(buildTime)
+		}
+	}
+
+	// If metadata is missing or malformed, preserve the safe historical
+	// behavior and offer the release rather than silently skipping it.
+	return true
+}
+
+func parseUpdateBuildTime(value string) time.Time {
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04"} {
+		if parsed, err := time.ParseInLocation(layout, value, time.UTC); err == nil {
+			return parsed
+		}
+	}
+	return time.Time{}
 }
 
 // commitInfoFromReleaseBody pulls the commit hash and build time the

--- a/cmd/f4/updater_test.go
+++ b/cmd/f4/updater_test.go
@@ -44,6 +44,27 @@ func TestUpdater_ParseUpdateHelperArgs(t *testing.T) {
 	}
 }
 
+func TestUpdater_ManualBuildVersionUsesBuildTimestamp(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.LastUpdateVersion = ""
+
+	buildTime := time.Date(2026, 8, 21, 12, 0, 0, 0, time.UTC)
+	newerLocalBuild := githubRelease{TagName: "v0.2.0-beta", PublishedAt: "2026-08-20T12:00:00Z"}
+	if stableReleaseNeedsUpdate(newerLocalBuild, "manual-build-sha", buildTime) {
+		t.Fatal("a manual build newer than the release must not request a downgrade")
+	}
+
+	newerRelease := githubRelease{TagName: "v0.2.0-beta", PublishedAt: "2026-08-22T12:00:00Z"}
+	if !stableReleaseNeedsUpdate(newerRelease, "manual-build-sha", buildTime) {
+		t.Fatal("a release newer than a manual build must be offered")
+	}
+
+	if stableReleaseNeedsUpdate(newerRelease, "v0.2.0-beta", buildTime) {
+		t.Fatal("an exact release build must not request an update to itself")
+	}
+}
+
 func (w *memoryWriteSeeker) Write(p []byte) (int, error) {
 	end := w.off + int64(len(p))
 	if w.off < 0 || end < w.off {


### PR DESCRIPTION
## Summary`n- compare manual VCS builds with release publication time instead of comparing a commit hash to a release tag`n- preserve exact release-tag and installed-version behavior`n- add regression coverage and a three-pass solution review`n`n## Validation`n- go test ./... -count=1`n- native Windows x64 build and version check`n- Linux cross-build`n- go vet local output contains only existing unsafe-pointer warnings`n`nFixes #264.`n`n— zoin-bot