### PR TITLE
fix: reject unmatched POSIX backticks

### DIFF
--- a/ISSUE_526_SOLUTION_REVIEW.md
+++ b/ISSUE_526_SOLUTION_REVIEW.md
@@ -1,0 +1,56 @@
+# Issue #526 follow-up solution review
+
+## Problem model
+
+PR #573 stopped the command line from sending unmatched POSIX single and
+double quotes to the one-shot shell runner, but the guard did not recognize
+backticks. On POSIX shells an unmatched backtick starts command substitution
+and waits for a closing delimiter, which makes the f4 tab appear frozen. The
+same character is ordinary text for the Windows `cmd.exe` dialect.
+
+## Candidate solutions
+
+1. **Chosen: track shell quote contexts with a small stack.** Extend the
+   existing guard to recognize POSIX backticks, including backticks inside
+   double quotes and quoted/escaped content, while preserving Windows literal
+   backticks and existing POSIX/Windows escape rules.
+2. **Rejected: special-case a lone backtick with a string count.** Counting
+   characters would mis-handle escaped delimiters, backticks inside single
+   quotes, and command substitutions embedded in double quotes.
+3. **Rejected: kill or time out the child shell after it hangs.** That leaves
+   the user without a useful error, makes a valid long-running command
+   indistinguishable from malformed input, and does not prevent backend-specific
+   UI freezes while the child is waiting for continuation input.
+
+## Review pass 1 — shell fidelity
+
+- POSIX `'`, `"`, and `` ` `` contexts are tracked independently and can
+  return to an outer context after a nested delimiter closes.
+- Backslash escaping remains active where the existing scanner allowed it;
+  content inside POSIX single quotes stays literal.
+- Windows keeps caret escaping and treats both apostrophes and backticks as
+  ordinary command text, matching `cmd.exe` behavior.
+
+## Review pass 2 — user-visible behavior
+
+- An unmatched backtick is rejected before command history or PTY dispatch.
+- The existing error dialog path is reused, so the panels remain visible and
+  the user can close the message and correct the command.
+- Tests cover the parser and the real PanelsFrame Enter path, including the
+  guarantee that no malformed command reaches the PTY.
+
+## Review pass 3 — compatibility and risk
+
+- The scanner is linear in command length and allocates only for nested quote
+  contexts.
+- The change is platform-neutral at compile time; the runtime dialect switch
+  keeps the fix POSIX-only, so Windows command syntax is not regressed.
+- The Linux Arch + gogpu report cannot be reproduced with the available
+  Fedora Wayland backend, but the generic cause is prevented before any
+  backend or shell process is involved.
+
+## Decision
+
+Keep PR #573's existing single/double quote protection and make the guard
+model the complete set of relevant POSIX delimiters. This removes the actual
+source of the hang while preserving valid commands and the Windows dialect.

--- a/cmd/f4/command_quotes.go
+++ b/cmd/f4/command_quotes.go
@@ -6,30 +6,52 @@ package main
 // such input would make f4 appear to hang while the child shell waits for the
 // closing quote.
 func commandHasUnmatchedQuote(command string, windowsShell bool) bool {
-	var quote rune
+	quotes := make([]rune, 0, 2)
 	escaped := false
 	for _, ch := range command {
 		if escaped {
 			escaped = false
 			continue
 		}
-		if ch == '^' && windowsShell && quote != '\'' {
+		var current rune
+		if len(quotes) > 0 {
+			current = quotes[len(quotes)-1]
+		}
+		if ch == '^' && windowsShell && current != '\'' {
 			escaped = true
 			continue
 		}
-		if ch == '\\' && !windowsShell && quote != '\'' {
+		if ch == '\\' && !windowsShell && current != '\'' {
 			escaped = true
 			continue
 		}
-		if quote == 0 {
-			if ch == '"' || (!windowsShell && ch == '\'') {
-				quote = ch
+
+		switch current {
+		case '\'':
+			if ch == '\'' {
+				quotes = quotes[:len(quotes)-1]
 			}
-			continue
-		}
-		if ch == quote {
-			quote = 0
+		case '"':
+			switch ch {
+			case '"':
+				quotes = quotes[:len(quotes)-1]
+			case '`':
+				if !windowsShell {
+					quotes = append(quotes, ch)
+				}
+			}
+		case '`':
+			switch ch {
+			case '`':
+				quotes = quotes[:len(quotes)-1]
+			case '\'', '"':
+				quotes = append(quotes, ch)
+			}
+		default:
+			if ch == '"' || (!windowsShell && (ch == '\'' || ch == '`')) {
+				quotes = append(quotes, ch)
+			}
 		}
 	}
-	return quote != 0
+	return len(quotes) > 0
 }

--- a/cmd/f4/command_quotes_test.go
+++ b/cmd/f4/command_quotes_test.go
@@ -13,8 +13,15 @@ func TestCommandHasUnmatchedQuote(t *testing.T) {
 		{name: "posix open single quote", command: "echo 'broken", want: true},
 		{name: "posix open double quote", command: `echo "broken`, want: true},
 		{name: "posix escaped quote", command: `echo can\'t`, want: false},
+		{name: "posix closed backtick", command: "echo `date`", want: false},
+		{name: "posix open backtick", command: "echo `date", want: true},
+		{name: "posix backtick in single quote", command: "echo '`literal'", want: false},
+		{name: "posix escaped backtick", command: "echo \\`literal", want: false},
+		{name: "posix backtick inside double quote", command: "echo \"`date\"", want: true},
+		{name: "posix backtick inside closed double quote", command: "echo \"`date`\"", want: false},
 		{name: "windows open double quote", command: `echo "broken`, windowsShell: true, want: true},
 		{name: "windows single quote is literal", command: "echo 'literal", windowsShell: true, want: false},
+		{name: "windows backtick is literal", command: "echo `literal", windowsShell: true, want: false},
 		{name: "windows caret escaped quote", command: `echo ^"literal`, windowsShell: true, want: false},
 	}
 

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -2671,6 +2671,42 @@ func TestPanelsFrame_CommandLineEnter(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_CommandLineEnterRejectsUnmatchedBacktick(t *testing.T) {
+	pf := setupMockPanelsFrame()
+	pty := pf.pty.(*mockPty)
+	defer pf.Close()
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	before := len(pty.written)
+	pf.cmdLine.Edit.SetText("echo `date")
+	pressKey(pf, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_RETURN,
+	})
+
+	if !pf.showPanels {
+		t.Fatal("panels hid after an unmatched backtick instead of showing an error")
+	}
+	if got := string(pty.written[before:]); got != "" {
+		t.Fatalf("unmatched backtick reached the PTY: %q", got)
+	}
+	top := vtui.FrameManager.GetTopFrame()
+	if top == nil || top.GetTitle() != " Error " {
+		t.Fatalf("unmatched backtick did not open an error dialog: top=%T title=%q", top, func() string {
+			if top != nil {
+				return top.GetTitle()
+			}
+			return ""
+		}())
+	}
+	pressKey(top, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_ESCAPE,
+	})
+}
+
 type commandRunnerPanelVFS struct {
 	*vfs.NullVFS
 	path  string

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -2672,6 +2672,10 @@ func TestPanelsFrame_CommandLineEnter(t *testing.T) {
 }
 
 func TestPanelsFrame_CommandLineEnterRejectsUnmatchedBacktick(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("backticks are literal in the Windows shell")
+	}
+
 	pf := setupMockPanelsFrame()
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()


### PR DESCRIPTION
Fixes #526.

The command-line guard now tracks POSIX single quotes, double quotes, and backticks as nested quote contexts. An unmatched backtick is rejected before the command reaches the PTY, preventing the apparent freeze reported on Linux gogpu. Windows backticks remain literal, and existing escape rules are preserved.

Added parser coverage and an end-to-end PanelsFrame regression test. Verified locally with:
- go test ./...
- go vet ./...
- go test -race ./cmd/f4 -run TestCommandHasUnmatchedQuote|TestPanelsFrame_CommandLineEnterRejectsUnmatchedBacktick -count=1
- native Linux ARM64 and Windows amd64 builds
- native ANSI smoke test with repeated unmatched-backtick input; f4 showed the error dialog and remained responsive.