### PR TITLE
Keep split Windows PTY sync commands hidden

### DIFF
--- a/ISSUE_165_SOLUTION_REVIEW.md
+++ b/ISSUE_165_SOLUTION_REVIEW.md
@@ -1,0 +1,39 @@
+# Issue #165 solution review
+
+## Candidate 1: keep whole-chunk pattern matching
+
+- Keeps the current implementation small and preserves its existing behavior.
+- Fails when ConPTY splits a long `cd /d "..." & rem f4_sync` line between reads; the partial command reaches the terminal renderer and can add visible lines.
+- Rejected.
+
+## Candidate 2: remove every visible `cd /d` fragment after rendering
+
+- Would hide commands even when the command is split.
+- Cannot safely repair already-rendered terminal state and could erase legitimate user-entered commands that happen to begin with `cd /d`.
+- Rejected.
+
+## Candidate 3: stream-aware pending command buffer (chosen)
+
+- Detects the Windows synchronization marker across arbitrary input chunk boundaries, holds only an incomplete marker, and removes it once the complete command and line ending arrive.
+- Preserves ordinary output and non-f4 commands after a quoted `cd`, while retaining the existing screen-clearing behavior for the hidden synchronization command.
+- Bounds the pending buffer so malformed or unrelated long input cannot be retained indefinitely.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+- Input preceding a partial marker is emitted immediately; only the possible technical command suffix is retained.
+- Complete markers are removed with their CR/LF terminator, including when the terminator is split across reads.
+- A normal command after `" & ` remains visible; f4's exact `rem f4_sync` marker is the only command treated as hidden.
+
+### Pass 2: compatibility and failure modes
+
+- Existing Windows and cross-platform ANSI behavior is unchanged for complete chunks, including UTF-8 handling and non-sync commands.
+- The pending bytes are copied before the caller's read buffer can be reused.
+- A malformed command exceeding the bounded buffer is emitted rather than retained forever.
+
+### Pass 3: scope and regression risk
+
+- The fix is isolated to the shared f4 terminal parser and benefits every Windows PTY directory synchronization, not just one path length.
+- Regression tests cover both a long path split inside the path and a split inside the `cd /d` marker.
+- Full f4 tests and a native Windows x64 run that navigated into a deeply nested path were used for validation.

--- a/cmd/f4/ansi_parser.go
+++ b/cmd/f4/ansi_parser.go
@@ -118,7 +118,8 @@ func (p *AnsiParser) exciseWindowsSync(data []byte) []byte {
 			}
 
 			end := tokenEnd
-			if data[end] == '\r' {
+			switch data[end] {
+			case '\r':
 				if end+1 == len(data) {
 					p.pendingWindowsSync = cloneBytes(command)
 					return visible
@@ -127,7 +128,7 @@ func (p *AnsiParser) exciseWindowsSync(data []byte) []byte {
 				if data[end] == '\n' {
 					end++
 				}
-			} else if data[end] == '\n' {
+			case '\n':
 				end++
 			}
 

--- a/cmd/f4/ansi_parser.go
+++ b/cmd/f4/ansi_parser.go
@@ -26,15 +26,16 @@ const (
 
 // AnsiParser converts a stream of bytes into ScreenBuf operations.
 type AnsiParser struct {
-	State        ParserState
-	Params       []string
-	CurParam     strings.Builder
-	Intermediate string
-	Attr         uint64
-	term         *TerminalView
-	pty          PtyBackend
-	runeBuf      []byte
-	lastRune     rune
+	State              ParserState
+	Params             []string
+	CurParam           strings.Builder
+	Intermediate       string
+	Attr               uint64
+	term               *TerminalView
+	pty                PtyBackend
+	runeBuf            []byte
+	lastRune           rune
+	pendingWindowsSync []byte
 }
 
 func NewAnsiParser(t *TerminalView, p PtyBackend) *AnsiParser {
@@ -43,6 +44,124 @@ func NewAnsiParser(t *TerminalView, p PtyBackend) *AnsiParser {
 		pty:  p,
 		Attr: DefaultTermAttr,
 	}
+}
+
+const maxPendingWindowsSync = 64 * 1024
+
+var (
+	windowsSyncStart = []byte(`cd /d "`)
+	windowsSyncEnd   = []byte(`" & rem f4_sync`)
+	windowsSyncSep   = []byte(`" & `)
+)
+
+func cloneBytes(data []byte) []byte {
+	if len(data) == 0 {
+		return nil
+	}
+	return append([]byte(nil), data...)
+}
+
+func isPartialPrefix(data, prefix []byte) bool {
+	return len(data) > 0 && len(data) < len(prefix) && bytes.Equal(data, prefix[:len(data)])
+}
+
+func longestSuffixPrefix(data, prefix []byte) int {
+	max := len(prefix) - 1
+	if max > len(data) {
+		max = len(data)
+	}
+	for n := max; n > 0; n-- {
+		if bytes.Equal(data[len(data)-n:], prefix[:n]) {
+			return n
+		}
+	}
+	return 0
+}
+
+// exciseWindowsSync removes the command used to synchronize the PTY's current
+// directory. The PTY can split a long command at any byte boundary, so an
+// incomplete command is kept until the next Process call instead of being
+// rendered as terminal output.
+func (p *AnsiParser) exciseWindowsSync(data []byte) []byte {
+	if len(p.pendingWindowsSync) > 0 {
+		combined := make([]byte, 0, len(p.pendingWindowsSync)+len(data))
+		combined = append(combined, p.pendingWindowsSync...)
+		combined = append(combined, data...)
+		data = combined
+		p.pendingWindowsSync = nil
+	}
+
+	var visible []byte
+	for len(data) > 0 {
+		startIdx := bytes.Index(data, windowsSyncStart)
+		if startIdx == -1 {
+			pendingLen := longestSuffixPrefix(data, windowsSyncStart)
+			visible = append(visible, data[:len(data)-pendingLen]...)
+			p.pendingWindowsSync = cloneBytes(data[len(data)-pendingLen:])
+			return visible
+		}
+
+		visible = append(visible, data[:startIdx]...)
+		command := data[startIdx:]
+		endIdx := bytes.Index(command, windowsSyncEnd)
+		separatorIdx := bytes.Index(command, windowsSyncSep)
+
+		if endIdx >= 0 && (separatorIdx < 0 || endIdx <= separatorIdx) {
+			tokenEnd := startIdx + endIdx + len(windowsSyncEnd)
+			if tokenEnd == len(data) {
+				if len(command) > maxPendingWindowsSync {
+					visible = append(visible, command...)
+					return visible
+				}
+				p.pendingWindowsSync = cloneBytes(command)
+				return visible
+			}
+
+			end := tokenEnd
+			if data[end] == '\r' {
+				if end+1 == len(data) {
+					p.pendingWindowsSync = cloneBytes(command)
+					return visible
+				}
+				end++
+				if data[end] == '\n' {
+					end++
+				}
+			} else if data[end] == '\n' {
+				end++
+			}
+
+			vtui.DebugLog("ANSI_PARSER: Excising background Windows CD sync")
+			visible = append(visible, []byte("\r\x1b[2K")...)
+			data = data[end:]
+			continue
+		}
+
+		if separatorIdx < 0 {
+			if len(command) > maxPendingWindowsSync {
+				visible = append(visible, command...)
+				return visible
+			}
+			p.pendingWindowsSync = cloneBytes(command)
+			return visible
+		}
+
+		separatorEnd := startIdx + separatorIdx + len(windowsSyncSep)
+		remainder := data[separatorEnd:]
+		if len(remainder) == 0 || isPartialPrefix(remainder, []byte("rem f4_sync")) {
+			if len(command) > maxPendingWindowsSync {
+				visible = append(visible, command...)
+				return visible
+			}
+			p.pendingWindowsSync = cloneBytes(command)
+			return visible
+		}
+
+		// This is another command after a quoted cd, not f4's marker. Keep
+		// the command itself visible while removing only the technical cd.
+		data = data[separatorEnd:]
+	}
+	return visible
 }
 
 func (p *AnsiParser) Process(data []byte) {
@@ -99,48 +218,7 @@ func (p *AnsiParser) Process(data []byte) {
 		break
 	}
 
-	// Windows f4 sync commands excision
-	for {
-		startIdx := bytes.Index(data, []byte("cd /d \""))
-		if startIdx == -1 {
-			break
-		}
-
-		endIdx := bytes.Index(data[startIdx:], []byte("\" & "))
-		if endIdx != -1 {
-			if bytes.HasPrefix(data[startIdx+endIdx:], []byte("\" & rem f4_sync")) {
-				actualEnd := startIdx + endIdx + len("\" & rem f4_sync")
-				if actualEnd < len(data) && data[actualEnd] == '\r' {
-					actualEnd++
-				}
-				if actualEnd < len(data) && data[actualEnd] == '\n' {
-					actualEnd++
-				}
-				if actualEnd < len(data) && data[actualEnd] == '\r' {
-					actualEnd++
-				}
-				if actualEnd < len(data) && data[actualEnd] == '\n' {
-					actualEnd++
-				}
-				vtui.DebugLog("ANSI_PARSER: Excising background Windows CD sync")
-				newData := make([]byte, 0, startIdx+5+len(data)-actualEnd)
-				newData = append(newData, data[:startIdx]...)
-				newData = append(newData, []byte("\r\x1b[2K")...)
-				newData = append(newData, data[actualEnd:]...)
-				data = newData
-				continue
-			} else {
-				actualEnd := startIdx + endIdx + 4
-				vtui.DebugLog("ANSI_PARSER: Excising technical Windows CD sync from buffer")
-				newData := make([]byte, 0, startIdx+len(data)-actualEnd)
-				newData = append(newData, data[:startIdx]...)
-				newData = append(newData, data[actualEnd:]...)
-				data = newData
-				continue
-			}
-		}
-		break
-	}
+	data = p.exciseWindowsSync(data)
 
 	if len(data) == 0 {
 		return

--- a/cmd/f4/ansi_parser_test.go
+++ b/cmd/f4/ansi_parser_test.go
@@ -756,6 +756,50 @@ func TestAnsiParser_ExcisionExtra(t *testing.T) {
 	}
 }
 
+func TestAnsiParser_WindowsExcision_SplitAcrossChunks(t *testing.T) {
+	tests := []struct {
+		name   string
+		chunks []string
+	}{
+		{
+			name: "long path split after path bytes",
+			chunks: []string{
+				"C:\\Old>cd /d \"C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Internet Explorer\\",
+				"Quick Launch\" & rem f4_sync\r",
+				"\nafter\r\n",
+			},
+		},
+		{
+			name: "command marker split",
+			chunks: []string{
+				"C:\\Old>cd /",
+				"d \"C:\\New\" & rem f4_sync\r\n",
+				"after\r\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tv := NewTerminalView(80, 24)
+			defer tv.Close()
+			parser := NewAnsiParser(tv, nil)
+
+			for _, chunk := range tt.chunks {
+				parser.Process([]byte(chunk))
+			}
+
+			logStr := string(tv.GetAllLogBytes())
+			if strings.Contains(logStr, "cd /d") || strings.Contains(logStr, "f4_sync") || strings.Contains(logStr, "Quick Launch") {
+				t.Fatalf("split technical command leaked into terminal log: %q", logStr)
+			}
+			if !strings.Contains(logStr, "after") {
+				t.Fatalf("data after split technical command was lost: %q", logStr)
+			}
+		})
+	}
+}
+
 type mockClipAuthManager struct {
 	authorized bool
 }


### PR DESCRIPTION
Fixes #165. Windows PTY directory synchronization sends cd /d path & rem f4_sync, but ConPTY can split a long path across reads. The parser now buffers only an incomplete synchronization marker and removes it once complete, so long paths do not leak technical commands into the terminal or add extra output lines. Normal commands after a quoted cd remain visible.\n\nValidation:\n- go test ./... -count=1\n- targeted split-chunk ANSI parser tests\n- native Windows x64 f4 build and --version check\n- native interactive --debug --tty ansi run: navigated from a short directory into a deeply nested path; the new prompt/path appeared without a visible cd command or f4_sync output\n- go vet ./cmd/f4 reports only existing unsafe.Pointer warnings outside the changed files\n\n— zoin-bot