### PR TITLE
zoin-bot: fail clearly when static GUI backends need FFI

### DIFF
--- a/ISSUE_693_SOLUTION_REVIEW.md
+++ b/ISSUE_693_SOLUTION_REVIEW.md
@@ -1,0 +1,65 @@
+# Issue #693 solution review
+
+## Problem observed
+
+The generic Linux release is built with `goffi_static`.  That makes the
+binary fully static, but also makes foreign-function loading unavailable.
+When the user explicitly selects `--gui=gogpu`, vtui creates a native window
+before the first Wayland/library call fails.  The result is a blank window and
+an opaque backend failure instead of a usable f4 session or an actionable
+message.
+
+The current ARM64 host reproduced this with a statically linked binary:
+
+```text
+GOGPU_HOST: app.Run() exited with: wayland: failed to open libwayland:
+... goffi: FFI is disabled in this build ...
+```
+
+## Candidate solutions
+
+1. **f4-side backend preflight (chosen).** Check goffi availability before
+   calling vtui for `gogpu`, `wayland`, or `ebiten`. Return a clear error for an
+   explicitly requested unavailable backend; automatic selection can continue
+   to the next backend. Keep X11 available because it has a pure-Go path in
+   these static artifacts.
+2. **vtui-side preflight.** Add the same check inside each vtui GUI host.
+   This would protect every vtui consumer, but requires a vtui change, a new
+   vtui release, and an f4 dependency update. It is a useful follow-up, but it
+   is broader than the regression reported here and would delay the f4 fix.
+3. **Fake or silently downgrade the GPU host.** Keep the window alive and
+   render through a substitute without reporting that the requested backend is
+   unavailable. This hides the missing capability, can leave a blank window,
+   and makes explicit backend selection misleading; it is rejected.
+
+## Three review passes
+
+### Pass 1: static-build behavior
+
+The preflight uses `ffi.Available()`, the capability API provided by the
+goffi fork already used by f4. It is false for `goffi_static` and true for
+normal dynamic builds (and for Windows, where the static tag is intentionally
+ignored). Thus the check affects only binaries that cannot perform the calls
+the selected backends require.
+
+### Pass 2: fallback and explicit selection
+
+`RunGui` checks before constructing a renderer or window. Automatic selection
+receives an ordinary backend error and continues to X11 when that display is
+available. An explicit `--gui=gogpu`, `--gui=wayland`, or `--gui=ebiten` fails
+immediately with the reason and suggests `--gui=x11` or `--tty=ansi`. No
+window is created in either case.
+
+### Pass 3: portability and compatibility
+
+The helper is shared by Linux, macOS, and Windows entry points, where the
+existing goffi module provides the capability query. Other Unix targets use a
+small no-op shim because goffi is not part of their f4 GUI build path. External
+UI backends (`qt` and `ext:`) bypass the check because f4 does not own their
+loading path. The change uses only the existing goffi module and does not
+alter renderer setup, session state, or the X11/ANSI paths.
+
+The regression tests exercise the backend classification and unavailable
+error without opening a display. The static ARM64 binary is also built and
+run to verify that explicit `--gui=gogpu` now fails before the old blank-window
+path.

--- a/cmd/f4/gui_backend_capability.go
+++ b/cmd/f4/gui_backend_capability.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+func guiBackendRequiresFFI(backend string) bool {
+	switch strings.ToLower(strings.TrimSpace(backend)) {
+	case "ebiten", "gogpu", "wayland":
+		return true
+	default:
+		return false
+	}
+}
+
+func unavailableGUIBackendError(backend string, ffiAvailable bool) error {
+	if !guiBackendRequiresFFI(backend) || ffiAvailable {
+		return nil
+	}
+	return fmt.Errorf("GUI backend %q is unavailable in a static build without FFI; use --gui=x11 or --tty=ansi", backend)
+}
+
+func checkGUIBackendAvailability(backend string) error {
+	return unavailableGUIBackendError(backend, ffiAvailableForGUI())
+}

--- a/cmd/f4/gui_backend_capability_ffi.go
+++ b/cmd/f4/gui_backend_capability_ffi.go
@@ -1,0 +1,9 @@
+//go:build linux || darwin || windows
+
+package main
+
+import "github.com/go-webgpu/goffi/ffi"
+
+func ffiAvailableForGUI() bool {
+	return ffi.Available()
+}

--- a/cmd/f4/gui_backend_capability_stub.go
+++ b/cmd/f4/gui_backend_capability_stub.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin && !windows
+
+package main
+
+// goffi does not support these targets. Their GUI backends already perform
+// their own platform checks, so f4 must not import goffi just to preflight
+// them.
+func ffiAvailableForGUI() bool {
+	return true
+}

--- a/cmd/f4/gui_backend_capability_test.go
+++ b/cmd/f4/gui_backend_capability_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGUIBackendRequiresFFI(t *testing.T) {
+	tests := []struct {
+		backend string
+		want    bool
+	}{
+		{backend: "gogpu", want: true},
+		{backend: "wayland", want: true},
+		{backend: " ebiten ", want: true},
+		{backend: "x11", want: false},
+		{backend: "ansi", want: false},
+		{backend: "", want: false},
+	}
+
+	for _, tt := range tests {
+		if got := guiBackendRequiresFFI(tt.backend); got != tt.want {
+			t.Errorf("guiBackendRequiresFFI(%q) = %v, want %v", tt.backend, got, tt.want)
+		}
+	}
+}
+
+func TestUnavailableGUIBackendError(t *testing.T) {
+	if err := unavailableGUIBackendError("gogpu", false); err == nil ||
+		!strings.Contains(err.Error(), "static build without FFI") ||
+		!strings.Contains(err.Error(), "--gui=x11") {
+		t.Fatalf("unavailable gogpu error = %v, want actionable static-build guidance", err)
+	}
+
+	for _, tt := range []struct {
+		backend   string
+		available bool
+	}{
+		{backend: "gogpu", available: true},
+		{backend: "wayland", available: true},
+		{backend: "x11", available: false},
+		{backend: "ansi", available: false},
+	} {
+		if err := unavailableGUIBackendError(tt.backend, tt.available); err != nil {
+			t.Errorf("unavailableGUIBackendError(%q, %v) = %v, want nil", tt.backend, tt.available, err)
+		}
+	}
+}

--- a/cmd/f4/gui_unix.go
+++ b/cmd/f4/gui_unix.go
@@ -31,6 +31,9 @@ func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
 	}
+	if err := checkGUIBackendAvailability(backend); err != nil {
+		return err
+	}
 
 	var startupComplete atomic.Bool
 	return runGuiWithStartupRecovery(backend, &startupComplete, func() error {

--- a/cmd/f4/gui_windows.go
+++ b/cmd/f4/gui_windows.go
@@ -12,6 +12,9 @@ func RunGui(backend string) error {
 	if backend == "qt" || strings.HasPrefix(backend, "ext:") {
 		return RunExternalUIWithMapping(backend)
 	}
+	if err := checkGUIBackendAvailability(backend); err != nil {
+		return err
+	}
 	stopIconManager := startWindowsWindowIconManager()
 	defer stopIconManager()
 	return vtui.RunInGUIWindow(AppConfig.GuiCols, AppConfig.GuiRows, backend, effectiveGuiFont(), float64(AppConfig.GuiFontSize), func() {

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/coregx/coregex v0.12.19
 	github.com/danielpaulus/go-ios v1.2.2-0.20260805152531-ebec9a0b076c
 	github.com/ebitengine/purego v0.11.0-alpha.8
+	github.com/go-webgpu/goffi v0.6.3
 	github.com/google/uuid v1.6.0
 	github.com/hanwen/go-fuse/v2 v2.11.0
 	github.com/jlaffaye/ftp v0.2.0
@@ -107,7 +108,6 @@ require (
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/emmansun/base64 v0.9.0 // indirect
 	github.com/fogleman/gg v1.3.0 // indirect
-	github.com/go-webgpu/goffi v0.6.3 // indirect
 	github.com/go-webgpu/webgpu v0.5.5 // indirect
 	github.com/gogpu/gg v0.52.2 // indirect
 	github.com/gogpu/gogpu v0.52.1 // indirect


### PR DESCRIPTION
## Summary

Fixes #693.

Static Linux artifacts are built with `goffi_static`, which disables foreign-function loading. Explicit `--gui=gogpu` previously created a blank native window before Wayland loading failed. f4 now preflights FFI-dependent GUI backends (`gogpu`, `wayland`, and `ebiten`) before creating a renderer or window. Automatic backend selection can continue to X11, while explicit selection returns actionable guidance to use X11 or ANSI. Unsupported Unix targets use a no-op shim so their existing platform checks and CI builds remain unchanged.

## Verification

- `GOTMPDIR=... go test -p 1 ./...` — passed
- `go vet ./cmd/f4` and `go vet -tags goffi_static ./cmd/f4` — passed
- Linux ARM64 `goffi_static` binary — statically linked
- Repeated native runs of `--attached --gui=gogpu` — exit before window creation with the clear static-build/FFI error
- Cross-builds passed for Linux ARM64, Windows AMD64, macOS ARM64, FreeBSD AMD64 (with the project fakecgo flag), OpenBSD, NetBSD, DragonFly, Illumos, and Solaris