### PR TITLE
Fix Unix sudo dispatcher startup mode

### DIFF
--- a/ISSUE_260_SOLUTION_REVIEW.md
+++ b/ISSUE_260_SOLUTION_REVIEW.md
@@ -1,0 +1,49 @@
+# Issue #260 solution review
+
+## Candidate 1: keep the current argument and environment checks
+
+- Keeps the startup path unchanged.
+- Fails after sudo authentication because the elevated dispatcher inherits
+  `F4_ASKPASS_PARENT` and is mistaken for the askpass helper.
+- Rejected.
+
+## Candidate 2: remove the askpass environment check
+
+- Would let the dispatcher start, but the standalone askpass invocation would
+  start the full f4 UI instead of returning a password to sudo.
+- Rejected.
+
+## Candidate 3: dispatch explicit sudo mode before askpass mode (chosen)
+
+- Parses `--sudo-dispatcher` before looking at `F4_ASKPASS_PARENT`, so the
+  authenticated root process always starts the IPC dispatcher.
+- Leaves the environment-based askpass helper path intact for sudo's separate
+  password request process.
+- Covers both separate-value and equals-value argument forms.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+- The dispatcher path is selected before any mount, UI, or askpass startup.
+- A missing dispatcher value is ignored rather than consuming an unrelated
+  argument.
+- The existing askpass environment path remains available to sudo.
+
+### Pass 2: compatibility and failure modes
+
+- Normal f4 startup and mount commands do not contain the dispatcher flag and
+  follow their existing paths.
+- The change is platform-neutral at argument parsing time; the platform-specific
+  dispatcher implementation remains responsible for elevation behavior.
+- The root dispatcher no longer waits for a second password prompt or leaves
+  the client blocked while its socket is absent.
+
+### Pass 3: scope and regression risk
+
+- The fix is limited to startup mode selection and does not alter file access,
+  history ordering, or VFS behavior.
+- Unit tests cover both accepted dispatcher syntaxes and invalid or unrelated
+  arguments.
+- Native Linux execution is unavailable on this Windows x64 host; Linux
+  compilation and the platform-specific unit suite are used for validation.

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -60,6 +60,28 @@ func openEditFileIn(pf *PanelsFrame, path string) {
 	actionOpenEditor(pf, vfs.NewOSVFS(filepath.Dir(abs)), abs)
 }
 
+func sudoDispatcherPath(args []string) string {
+	for i, arg := range args {
+		if arg == "--sudo-dispatcher" {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(arg, "--sudo-dispatcher=") {
+			return arg[len("--sudo-dispatcher="):]
+		}
+	}
+	return ""
+}
+
+func sudoStartupMode(args []string, askpassParent bool) (dispatcher string, askpass bool) {
+	if dispatcher = sudoDispatcherPath(args); dispatcher != "" {
+		return dispatcher, false
+	}
+	return "", askpassParent
+}
+
 func main() {
 	vtui.AppName = "f4"
 	installConsoleCtrlHandler()
@@ -73,7 +95,18 @@ func main() {
 	absExecPath, _ := filepath.Abs(execPath)
 	vfs.InitSudoClient(absExecPath, "")
 
-	if os.Getenv("F4_ASKPASS_PARENT") != "" {
+	// The elevated dispatcher inherits F4_ASKPASS_PARENT from the client that
+	// started sudo. Dispatcher mode must win over askpass mode; otherwise the
+	// post-authentication root process asks for a password again instead of
+	// creating its IPC socket, leaving the original operation waiting forever.
+	var askpassParent bool
+	sudoDispatcher, askpassParent = sudoStartupMode(os.Args[1:], os.Getenv("F4_ASKPASS_PARENT") != "")
+	if sudoDispatcher != "" {
+		vfs.RunSudoDispatcher(sudoDispatcher)
+		return
+	}
+
+	if askpassParent {
 		vfs.RunSudoAskpass()
 		return
 	}
@@ -90,23 +123,6 @@ func main() {
 	// build panels it will never draw.
 	if code, handled := runMountCLI(); handled {
 		os.Exit(code)
-	}
-
-	for i := 1; i < len(os.Args); i++ {
-		arg := os.Args[i]
-		if arg == "--sudo-dispatcher" {
-			if i+1 < len(os.Args) {
-				sudoDispatcher = os.Args[i+1]
-			}
-			break
-		} else if strings.HasPrefix(arg, "--sudo-dispatcher=") {
-			sudoDispatcher = arg[len("--sudo-dispatcher="):]
-			break
-		}
-	}
-	if sudoDispatcher != "" {
-		vfs.RunSudoDispatcher(sudoDispatcher)
-		return
 	}
 
 	// Setup crash/stderr location before any logging starts; in portable mode

--- a/cmd/f4/sudo_dispatcher_args_test.go
+++ b/cmd/f4/sudo_dispatcher_args_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+func TestSudoDispatcherPath(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "separate value", args: []string{"--sudo-dispatcher", "/tmp/f4.sock"}, want: "/tmp/f4.sock"},
+		{name: "equals value", args: []string{"--sudo-dispatcher=/tmp/f4.sock"}, want: "/tmp/f4.sock"},
+		{name: "missing value", args: []string{"--sudo-dispatcher"}},
+		{name: "unrelated arguments", args: []string{"--debug", "--tty", "ansi"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := sudoDispatcherPath(test.args); got != test.want {
+				t.Fatalf("sudoDispatcherPath(%q) = %q, want %q", test.args, got, test.want)
+			}
+		})
+	}
+}
+
+func TestSudoStartupModeDispatcherWinsOverAskpass(t *testing.T) {
+	dispatcher, askpass := sudoStartupMode([]string{"--sudo-dispatcher", "/tmp/f4.sock"}, true)
+	if dispatcher != "/tmp/f4.sock" || askpass {
+		t.Fatalf("sudoStartupMode dispatcher+askpass = (%q, %v), want (%q, false)", dispatcher, askpass, "/tmp/f4.sock")
+	}
+
+	dispatcher, askpass = sudoStartupMode(nil, true)
+	if dispatcher != "" || !askpass {
+		t.Fatalf("sudoStartupMode askpass = (%q, %v), want (empty, true)", dispatcher, askpass)
+	}
+}


### PR DESCRIPTION
Fixes #260. The elevated dispatcher now takes precedence over the inherited F4_ASKPASS_PARENT environment, so after sudo authentication it starts the IPC socket instead of entering askpass mode again. Added startup-mode regression tests and a three-pass solution review. Validated with full Windows tests, Linux amd64 cross-compilation, native Windows build, and native dispatcher-vs-askpass startup validation.