### PR TITLE
Fix terminal TAB completion for relative directories

### DIFF
--- a/ISSUE_95_SOLUTION_REVIEW.md
+++ b/ISSUE_95_SOLUTION_REVIEW.md
@@ -1,0 +1,39 @@
+# Issue #95 solution review
+
+## Problem
+
+In the built-in terminal, pressing Tab after a command such as `cd "completion-f` did not offer names from the current panel directory. The existing path hint provider intentionally required `/` or `\\` in the token, so a relative name without a separator produced no candidates.
+
+## Candidate solutions
+
+1. Treat every separator-free command-line token as a path. This would make ordinary arguments such as `echo foo` list panel files and would change autocomplete behavior broadly.
+2. Add a second autocomplete implementation in the terminal handler that scans the local filesystem. This would duplicate VFS listing, ranking, coloring, timeout, and replacement logic, and would not work consistently with remote VFS panels.
+3. Reuse the existing VFS path-hint pipeline for separator-free arguments only when the command is `cd`, `chdir`, or `pushd`; preserve quote delimiters and keep the existing separator-based path behavior unchanged. **Chosen.**
+
+## Three-pass review of the chosen solution
+
+### Pass 1 — behavior
+
+- `cd`, `chdir`, and `pushd` resolve a bare relative token against the active panel VFS path.
+- Windows `cd /d <path>` remains supported by accepting option-only arguments before the path.
+- Opening quotes remain in the replacement text, so `cd "prefix` stays a valid shell argument.
+- Directories receive the VFS-appropriate separator and files remain selectable.
+- Non-directory commands do not get unrelated panel-file suggestions.
+
+### Pass 2 — compatibility and scope
+
+- Existing separator-based completion continues through the original `pathHintItems` entry point.
+- Remote and plugin VFS implementations still use their normal `ReadDir` and timeout behavior.
+- Existing replacement spans, fuzzy ranking, panel source selection, colors, and history merging are untouched.
+- The change is platform-neutral Go code; Windows native validation covers the reported path, and Linux amd64 test binaries compile successfully.
+
+### Pass 3 — regression and failure modes
+
+- Added tests cover quoted bare `cd` completion, replacement spans, and rejection for `echo`.
+- Existing path-hint, command-line, and full repository tests pass.
+- A native Windows terminal run showed the completion menu and accepted a directory with Tab without executing the command.
+- If a VFS cannot list the directory, the existing timeout/error path still returns no suggestions rather than blocking indefinitely.
+
+## Conclusion
+
+Candidate 3 is the smallest general fix that addresses the reported Windows workflow while preserving the existing autocomplete contract and VFS abstraction.

--- a/cmd/f4/path_hints.go
+++ b/cmd/f4/path_hints.go
@@ -62,7 +62,7 @@ func pathHintProvider(edit *vtui.Edit, word string, from, to int) []vtui.AutoCom
 		if panel == nil || panel.vfs == nil {
 			continue
 		}
-		group := pathHintItems(panel.vfs, word, from, to)
+		group := pathHintItemsForCommand(panel.vfs, edit, word, from, to)
 		if len(group) == 0 {
 			continue
 		}
@@ -74,28 +74,92 @@ func pathHintProvider(edit *vtui.Edit, word string, from, to int) []vtui.AutoCom
 	return items
 }
 
+// pathHintItemsForCommand adds the current-directory lookup needed by shell
+// directory commands such as `cd "prefix`. A bare token is deliberately not
+// treated as a path for every command: doing so would make typing an ordinary
+// argument such as `echo foo` unexpectedly list panel files.
+func pathHintItemsForCommand(v vfs.VFS, edit *vtui.Edit, word string, from, to int) []vtui.AutoCompleteItem {
+	if strings.ContainsAny(strings.Trim(word, `"`), `/\`) {
+		return pathHintItems(v, word, from, to)
+	}
+	if !allowsBarePathCompletion(edit, from) {
+		return nil
+	}
+	return pathHintItemsWithOptions(v, word, from, to, true)
+}
+
+func allowsBarePathCompletion(edit *vtui.Edit, wordFrom int) bool {
+	if edit == nil {
+		return false
+	}
+	runes := []rune(edit.GetText())
+	if wordFrom <= 0 || wordFrom > len(runes) {
+		return false
+	}
+	fields := strings.Fields(string(runes[:wordFrom]))
+	if len(fields) == 0 {
+		return false
+	}
+	command := strings.Trim(fields[0], `"`)
+	switch strings.ToLower(command) {
+	case "cd", "chdir", "pushd":
+	default:
+		return false
+	}
+	// Windows `cd /d <path>` is also a directory argument. Do not treat a
+	// previous non-option argument as another bare path request.
+	for _, field := range fields[1:] {
+		if !strings.HasPrefix(field, "/") && !strings.HasPrefix(field, "-") {
+			return false
+		}
+	}
+	return true
+}
+
 // pathHintItems does the actual work, decoupled from the panel for tests:
 // split the token at the last path separator, list the directory through
 // the VFS and rank the entries (fuzzy when a needle follows the separator).
 func pathHintItems(v vfs.VFS, word string, from, to int) []vtui.AutoCompleteItem {
-	word = strings.Trim(word, `"`)
+	return pathHintItemsWithOptions(v, word, from, to, false)
+}
+
+func pathHintItemsWithOptions(v vfs.VFS, word string, from, to int, allowBare bool) []vtui.AutoCompleteItem {
+	quotePrefix := ""
+	quoteSuffix := ""
+	if strings.HasPrefix(word, `"`) {
+		quotePrefix = `"`
+		word = strings.TrimPrefix(word, `"`)
+	}
+	if strings.HasSuffix(word, `"`) {
+		quoteSuffix = `"`
+		word = strings.TrimSuffix(word, `"`)
+	}
 	if word == "" {
 		return nil
 	}
 	sepIdx := strings.LastIndexAny(word, `/\`)
-	if sepIdx < 0 {
+	if sepIdx < 0 && !allowBare {
 		return nil
 	}
-	dirPart := word[:sepIdx+1] // includes the trailing separator
-	needle := word[sepIdx+1:]
+	dirPart := ""
+	needle := word
+	if sepIdx >= 0 {
+		dirPart = word[:sepIdx+1] // includes the trailing separator
+		needle = word[sepIdx+1:]
+	}
 
 	dir := dirPart
+	if dirPart == "" {
+		dir = v.GetPath()
+	}
 	if !v.IsAbs(dirPart) {
 		base := v.GetPath()
 		if base == "" {
 			return nil
 		}
-		dir = v.Join(base, dirPart)
+		if dirPart != "" {
+			dir = v.Join(base, dirPart)
+		}
 	}
 
 	// A slow remote VFS degrades to "no hint" instead of freezing the UI.
@@ -121,7 +185,14 @@ func pathHintItems(v vfs.VFS, word string, from, to int) []vtui.AutoCompleteItem
 	})
 
 	matcher := vtui.NewFuzzyMatcher(needle, false) // nil for an empty needle
-	sep := dirPart[len(dirPart)-1:]
+	sep := ""
+	if dirPart != "" {
+		sep = dirPart[len(dirPart)-1:]
+	} else if strings.Contains(v.GetPath(), `\`) {
+		sep = `\`
+	} else {
+		sep = `/`
+	}
 
 	type cand struct {
 		item       vfs.VFSItem
@@ -155,10 +226,11 @@ func pathHintItems(v vfs.VFS, word string, from, to int) []vtui.AutoCompleteItem
 	base := vtui.Palette[vtui.ColDialogText]
 	items := make([]vtui.AutoCompleteItem, 0, len(cands))
 	for _, c := range cands {
-		text := dirPart + c.item.Name
+		text := quotePrefix + dirPart + c.item.Name
 		if c.item.IsDir {
 			text += sep
 		}
+		text += quoteSuffix
 
 		// Display form: full path or just the final element; the highlight
 		// marker prefixes the name exactly like in the panels.

--- a/cmd/f4/path_hints_test.go
+++ b/cmd/f4/path_hints_test.go
@@ -102,6 +102,30 @@ func TestPathHintItems_Rejects(t *testing.T) {
 	}
 }
 
+func TestPathHintItems_BareDirectoryArgumentPreservesQuote(t *testing.T) {
+	dir := setupPathHintDir(t)
+	v := vfs.NewOSVFS(dir)
+
+	edit := vtui.NewEdit(0, 0, 80, `cd "sub`)
+	from, to, word := edit.WordUnderCursor()
+	items := pathHintItemsForCommand(v, edit, word, from, to)
+	if len(items) != 2 {
+		t.Fatalf("Expected both matching directories, got %d: %v", len(items), items)
+	}
+	if !strings.HasPrefix(items[0].Text, `"subdir`) || !strings.HasSuffix(items[0].Text, string(filepath.Separator)) {
+		t.Errorf("Bare quoted path should preserve its opening quote and separator: %q", items[0].Text)
+	}
+	if items[0].ReplaceFrom != from || items[0].ReplaceTo != to {
+		t.Errorf("Replacement span changed: got %d-%d, want %d-%d", items[0].ReplaceFrom, items[0].ReplaceTo, from, to)
+	}
+
+	other := vtui.NewEdit(0, 0, 80, `echo "sub`)
+	from, to, word = other.WordUnderCursor()
+	if items := pathHintItemsForCommand(v, other, word, from, to); items != nil {
+		t.Fatalf("Bare arguments to non-directory commands must not list panel entries: %v", items)
+	}
+}
+
 func TestPathHintItems_QuotedPath(t *testing.T) {
 	dir := setupPathHintDir(t)
 	v := vfs.NewOSVFS(dir)


### PR DESCRIPTION
Fixes #95. The existing VFS-backed path completion now also handles separator-free relative names for cd, chdir, and pushd, including quoted Windows commands such as cd "prefix. Ordinary command arguments remain unchanged, and opening quotes are preserved in replacements. Added regression tests and ISSUE_95_SOLUTION_REVIEW.md. Validated with full Go tests, Linux amd64 cross-compilation, native Windows build, and a real Windows terminal run where TAB listed and inserted a matching directory without executing the command.