### PR TITLE
Coalesce terminal redraws during heavy PTY output

### DIFF
--- a/ISSUE_248_SOLUTION_REVIEW.md
+++ b/ISSUE_248_SOLUTION_REVIEW.md
@@ -1,0 +1,66 @@
+# Issue #248 solution review
+
+## Problem
+
+The local and remote PTY readers parsed every output chunk immediately and
+called `vtui.FrameManager.Redraw()` after every chunk. `FrameManager` coalesces
+the notification channel, but the UI loop consumes the notification before
+the next render, so a sustained ConPTY stream can still force one full frame
+per read. The parser and terminal history must remain lossless and immediate;
+only redundant wake-ups should be removed.
+
+## Candidate 1: redraw after every PTY read
+
+This is the current implementation. It is the simplest and gives the lowest
+possible display latency, but it couples the renderer rate to ConPTY chunking.
+ConPTY can split one command into many reads, so heavy output repeatedly walks
+all visible frames and flushes the renderer while the parser is still busy.
+This directly reproduces the input lag and stutter from the issue.
+
+**Pass 1:** rejected because the Windows stress run produced hundreds of
+redraw requests during a few thousand lines and the UI became visibly slow.
+
+## Candidate 2: parse PTY output on the UI goroutine
+
+Posting every output chunk as a UI task would serialize parsing and rendering,
+and could make the terminal state easier to reason about. It would also block
+keyboard events behind large output bursts, turn parser work into a UI pause,
+and allow the task queue to grow without bound.
+
+**Pass 2:** rejected because it moves the expensive work onto the same path
+that must process user input. It would worsen the reported lag and would not
+help remote PTYs.
+
+## Candidate 3: coalesce redraw requests for 16 ms
+
+The PTY reader continues parsing synchronously in its existing goroutine, so
+no output is discarded and terminal state remains available to subsequent
+input. The first request in a burst calls `Redraw` immediately. Further
+requests are suppressed for 16 ms, approximately one 60 Hz frame, after which
+the next burst wakes the renderer again. The scheduler is per `PanelsFrame`,
+and it is stopped during frame shutdown so a late PTY read cannot wake a closed
+frame.
+
+**Pass 3:** selected. It preserves immediate feedback for short commands,
+caps redundant full-frame work during sustained output, applies equally to
+local and remote PTYs, and does not alter ANSI parsing, scrollback, or shell
+input ordering.
+
+## Regression and validation
+
+- `TestTerminalRedrawSchedulerCoalescesBurst` verifies one redraw for a burst,
+  another redraw after the interval, and no redraw after shutdown.
+- `go test ./... -count=1` passed.
+- Native Windows x64 build passed.
+- A real Windows ConPTY run processed 2,000 generated `cmd.exe` lines through
+  `output-2000`, returned to the prompt, and reduced redraw requests to 47.
+- `git diff --check` passed.
+
+## Risk review
+
+The change does not throttle parsing or PTY reads, so it cannot lose bytes or
+change ANSI state. A frame may display several output chunks at once, which is
+the intended behavior for a terminal UI. The initial redraw is immediate, and
+the 16 ms window is below ordinary terminal input feedback tolerance. The
+scheduler is stopped before PTY shutdown and all calls are mutex-protected,
+covering concurrent reader and close paths.

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -285,11 +285,12 @@ type PanelsFrame struct {
 	rightHeightDecrement int
 
 	// Integrated Terminal
-	pty        PtyBackend
-	remotePtys map[vfs.VFS]PtyBackend
-	ptyMutex   sync.Mutex
-	termView   *TerminalView
-	parser     *AnsiParser
+	pty            PtyBackend
+	remotePtys     map[vfs.VFS]PtyBackend
+	ptyMutex       sync.Mutex
+	termView       *TerminalView
+	parser         *AnsiParser
+	terminalRedraw *terminalRedrawScheduler
 
 	// Process-environment updates use their own locks so an Apply from a
 	// plugin cannot interleave a private assignment script with user input.
@@ -381,6 +382,7 @@ func (pf *PanelsFrame) Passive() Panel { return pf.panels[1-pf.activeIdx] }
 
 func NewPanelsFrame() *PanelsFrame {
 	pf := &PanelsFrame{activeIdx: 1, widePanel: -1, folderHistoryPos: [2]int{-1, -1}}
+	pf.terminalRedraw = newTerminalRedrawScheduler(func() { vtui.FrameManager.Redraw() })
 	pf.SetHelp("Panels")
 	pf.showKeyBar = true
 	pf.showPanels = true
@@ -1053,7 +1055,7 @@ func (pf *PanelsFrame) initPTY() {
 					}
 				} else {
 					pf.parser.Process(buf[:n])
-					vtui.FrameManager.Redraw()
+					pf.terminalRedraw.request()
 				}
 			}
 		}
@@ -1107,6 +1109,9 @@ func workspaceContainsPanelsFrame(screen *vtui.AppScreen, target *PanelsFrame) b
 }
 
 func (pf *PanelsFrame) Close() {
+	if pf.terminalRedraw != nil {
+		pf.terminalRedraw.stop()
+	}
 	if pf.shellMode == ShellModeHost && pf.isHostConsoleActive() {
 		pf.leaveHostConsole()
 	}
@@ -3771,7 +3776,7 @@ func (pf *PanelsFrame) getActivePTYUnsafe() PtyBackend {
 						if elapsed > 10*time.Millisecond {
 							vtui.DebugLog("PTY_PROFILE(Remote): Parsed %d bytes in %v", n, elapsed)
 						}
-						vtui.FrameManager.Redraw()
+						pf.terminalRedraw.request()
 					}
 				}
 				pty.Close()

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2482,6 +2483,47 @@ func TestPanelsFrame_PTYLockContention(t *testing.T) {
 		// Успех
 	case <-time.After(2 * time.Second):
 		t.Fatal("DEADLOCK DETECTED: getActivePTY blocked by PTY processing loop")
+	}
+}
+
+func TestTerminalRedrawSchedulerCoalescesBurst(t *testing.T) {
+	var mu sync.Mutex
+	redraws := 0
+	scheduler := newTerminalRedrawScheduler(func() {
+		mu.Lock()
+		redraws++
+		mu.Unlock()
+	})
+
+	for i := 0; i < 100; i++ {
+		scheduler.request()
+	}
+
+	time.Sleep(2 * time.Millisecond)
+	mu.Lock()
+	got := redraws
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("burst triggered %d redraws, want 1", got)
+	}
+
+	time.Sleep(terminalRedrawInterval + 10*time.Millisecond)
+	scheduler.request()
+	mu.Lock()
+	got = redraws
+	mu.Unlock()
+	if got != 2 {
+		t.Fatalf("redraw after interval counted %d times, want 2", got)
+	}
+
+	scheduler.stop()
+	scheduler.request()
+	time.Sleep(2 * time.Millisecond)
+	mu.Lock()
+	got = redraws
+	mu.Unlock()
+	if got != 2 {
+		t.Fatalf("stopped scheduler triggered %d redraws, want 2", got)
 	}
 }
 func TestPanelsFrame_Clone_Comprehensive(t *testing.T) {

--- a/cmd/f4/terminal_redraw.go
+++ b/cmd/f4/terminal_redraw.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"sync"
+	"time"
+)
+
+// terminalRedrawInterval bounds how often a burst of PTY output can wake the
+// UI renderer. PTY data is still parsed immediately; only redundant frame
+// requests are coalesced while the renderer is catching up.
+const terminalRedrawInterval = 16 * time.Millisecond
+
+type terminalRedrawScheduler struct {
+	mu      sync.Mutex
+	pending bool
+	stopped bool
+	redraw  func()
+}
+
+func newTerminalRedrawScheduler(redraw func()) *terminalRedrawScheduler {
+	return &terminalRedrawScheduler{redraw: redraw}
+}
+
+func (s *terminalRedrawScheduler) request() {
+	if s == nil {
+		return
+	}
+
+	s.mu.Lock()
+	if s.stopped || s.pending {
+		s.mu.Unlock()
+		return
+	}
+	s.pending = true
+	redraw := s.redraw
+	s.mu.Unlock()
+
+	// Keep the first frame of a burst responsive, then suppress further
+	// requests until the interval expires. FrameManager.Redraw itself is
+	// asynchronous and non-blocking, so this is safe from the PTY reader.
+	if redraw != nil {
+		redraw()
+	}
+	time.AfterFunc(terminalRedrawInterval, func() {
+		s.mu.Lock()
+		s.pending = false
+		s.mu.Unlock()
+	})
+}
+
+func (s *terminalRedrawScheduler) stop() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.stopped = true
+	s.pending = false
+	s.mu.Unlock()
+}


### PR DESCRIPTION
## Summary

zoin-bot coalesces redundant terminal redraw requests during sustained local or remote PTY output. ANSI parsing and scrollback remain immediate and lossless; the first redraw in each burst is immediate and subsequent requests are limited to one per 16 ms.

## Validation

- `go test ./... -count=1`
- Native Windows x64 build
- Real Windows ConPTY stress output through `output-2000`
- Ctrl+C during continuous ConPTY output returned to the prompt without a crash
- `git diff --check`

The race test was not available because this runner has no C compiler for `CGO_ENABLED=1`. `go vet ./cmd/f4 ./vfs` reports only existing unsafe.Pointer warnings in unchanged Windows files.