### PR TITLE
test: fix arkanoid test compilation

### DIFF
--- a/cmd/f4/arkanoid_test.go
+++ b/cmd/f4/arkanoid_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 


### PR DESCRIPTION
## Summary

- add the missing `math/rand` import used by `TestArkanoid_PhysicsAndCollisions`
- restore compilation of the current `cmd/f4` test package

## Validation

- `go test ./cmd/f4 -run ^TestArkanoid_ -count=1`

This is an independent upstream compile fix exposed while refreshing the merged updater PR #734 against current main.