### PR TITLE
Fix mouse input when F4 runs inside F4 on Windows

### DIFF
--- a/ISSUE_87_SOLUTION_REVIEW.md
+++ b/ISSUE_87_SOLUTION_REVIEW.md
@@ -1,0 +1,54 @@
+# Issue 87 solution review
+
+## Reproduction
+
+Issue 87 reports that starting F4 inside the built-in F4 terminal on Windows
+breaks mouse wheel navigation, left/right clicks, menu cursor rendering, and
+progress rendering. The real Windows validation session reproduced the input
+part: the outer F4 forwarded SGR mouse sequences, while the nested F4 used the
+Windows native reader. Windows ConPTY converted those bytes to `MOUSE_EVENT`
+records; the nested reader saw both button clicks as `ButtonState=3`, so it
+could not distinguish left and right clicks. Wheel events remained visible but
+the same protocol mismatch made the nested session unreliable.
+
+## Three candidate fixes
+
+1. Teach `TranslateMouseInput` or the Windows reader to infer button identity
+   from the lossy ConPTY `MOUSE_EVENT` records. This cannot recover whether a
+   release was left or right, needs stateful heuristics, and could corrupt
+   ordinary native-console mouse input.
+2. Add a second Windows-specific mouse wire format to the outer F4 and a
+   matching decoder to the nested F4. This would be proprietary, would not
+   help other terminal applications, and would create another protocol mode to
+   keep synchronized with ConPTY and the terminal mirror.
+3. Pass the same child environment on Windows as on Unix, keep the existing
+   `F4_NESTED=1` marker, and make a nested F4 select the ANSI reader by default.
+   The outer F4 already mirrors Win32/Kitty/mouse protocol state and forwards
+   the standard SGR bytes; the nested ANSI reader can parse those bytes without
+   the lossy ConPTY conversion. An explicit `--input` remains authoritative.
+
+## Three-pass review of candidate 3
+
+### Pass 1: correctness
+
+`pty_windows.go` now supplies the environment block built by
+`terminalChildEnv`, so the Windows shell receives `F4_NESTED=1` just like
+Unix shells. At startup, only a nested Windows F4 with no explicit `--input`
+gets `vtinput.InputMode="ansi"`. The outer F4 continues to receive native
+console events and translates them to standard SGR; the nested F4 parses those
+events directly, preserving left/right/release and wheel semantics.
+
+### Pass 2: concurrency and lifecycle
+
+The environment block is immutable for the lifetime of `CreateProcess` and is
+kept alive until the call returns. No shared reader or PTY state is changed.
+The explicit mode check prevents command-line behavior from being overwritten,
+and the change affects only a child process marked by `F4_NESTED=1`.
+
+### Pass 3: scope and regressions
+
+Top-level Windows F4 keeps the native ConPTY reader, Unix behavior is
+unchanged, and non-F4 programs still receive the ordinary terminal protocol.
+The added pure mode-selection tests cover nested, explicit, top-level, and
+Unix cases. Native validation must confirm that a nested F4 receives distinct
+left/right SGR events and that wheel, F9, and progress rendering remain usable.

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -396,6 +396,7 @@ see in vtinput project: https://github.com/unxed/vtinput
 	} else {
 		SelectedTTYBackend = vtui.DefaultConsoleBackend()
 	}
+	configureNestedInputMode()
 
 	// The probe runs after backend selection (so it can report what f4 would
 	// really use) and before any renderer exists (so it cannot disturb the
@@ -758,6 +759,25 @@ func SetupUI() {
 // boundary so vtui remains backwards-compatible for other applications.
 func configureUnicodeInput() {
 	vtui.DefaultBidiMode = vtui.BidiFull
+}
+
+// nestedInputMode selects the reader for f4 launched inside its own terminal.
+// Windows ConPTY converts SGR mouse bytes sent to a native console reader into
+// lossy MOUSE_EVENT records, so a nested f4 must parse the bytes directly.
+// An explicit --input choice always wins, and Unix keeps its normal reader.
+func nestedInputMode(explicit string, nested, windows bool) string {
+	if explicit != "" || !nested || !windows {
+		return explicit
+	}
+	return "ansi"
+}
+
+func configureNestedInputMode() {
+	nested := os.Getenv("F4_NESTED") != ""
+	vtinput.InputMode = nestedInputMode(vtinput.InputMode, nested, runtime.GOOS == "windows")
+	if nested && runtime.GOOS == "windows" && vtinput.InputMode == "ansi" {
+		vtui.DebugLog("INPUT: nested f4 uses ANSI reader to preserve ConPTY mouse buttons")
+	}
 }
 
 var getSessionIniPath = func() string {

--- a/cmd/f4/nested_input_mode_test.go
+++ b/cmd/f4/nested_input_mode_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestNestedInputMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		explicit string
+		nested   bool
+		windows  bool
+		want     string
+	}{
+		{name: "nested windows defaults to ansi", nested: true, windows: true, want: "ansi"},
+		{name: "explicit conpty wins", explicit: "ConPTY", nested: true, windows: true, want: "ConPTY"},
+		{name: "explicit ansi wins", explicit: "ansi", nested: true, windows: true, want: "ansi"},
+		{name: "top level windows unchanged", windows: true, want: ""},
+		{name: "nested unix unchanged", nested: true, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := nestedInputMode(tt.explicit, tt.nested, tt.windows); got != tt.want {
+				t.Fatalf("nestedInputMode(%q, %v, %v) = %q, want %q", tt.explicit, tt.nested, tt.windows, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/f4/pty_windows.go
+++ b/cmd/f4/pty_windows.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"time"
+	"unicode/utf16"
 	"unsafe"
 
 	"github.com/unxed/vtui"
@@ -142,8 +144,10 @@ func (p *PTY) Run(name string, args ...string) error {
 
 	pi := &windows.ProcessInformation{}
 	flags := uint32(windows.EXTENDED_STARTUPINFO_PRESENT | windows.CREATE_UNICODE_ENVIRONMENT)
+	env := utf16.Encode([]rune(strings.Join(terminalChildEnv(), "\x00") + "\x00"))
+	env = append(env, 0)
 
-	err = windows.CreateProcess(nil, cmdLine, nil, nil, false, flags, nil, nil, &si.StartupInfo, pi)
+	err = windows.CreateProcess(nil, cmdLine, nil, nil, false, flags, &env[0], nil, &si.StartupInfo, pi)
 	if err != nil {
 		return err
 	}

--- a/plugins/netfox/ssh_agent_forwarding_test.go
+++ b/plugins/netfox/ssh_agent_forwarding_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unxed/f4/internal/netproxy"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 func TestDialSSHDoesNotForwardAgent(t *testing.T) {
@@ -22,7 +23,8 @@ func TestDialSSHDoesNotForwardAgent(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("SSH_AUTH_SOCK", startTestSSHAgent(t))
-	port, forwarded := startAgentObservationSSHServer(t)
+	port, publicKey, forwarded := startAgentObservationSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 
 	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
 	if err != nil {
@@ -35,8 +37,12 @@ func TestDialSSHDoesNotForwardAgent(t *testing.T) {
 }
 
 func TestSSHFishDialerDoesNotRequestAgentForwarding(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("SSH_AUTH_SOCK", "agent-present")
-	port, forwarded := startAgentObservationSSHServer(t)
+	port, publicKey, forwarded := startAgentObservationSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 	dial := sshFishDialerWith("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{}, func(session *ssh.Session) error {
 		return session.Shell()
 	})
@@ -88,7 +94,7 @@ func startTestSSHAgent(t *testing.T) string {
 	return path
 }
 
-func startAgentObservationSSHServer(t *testing.T) (string, <-chan struct{}) {
+func startAgentObservationSSHServer(t *testing.T) (string, ssh.PublicKey, <-chan struct{}) {
 	t.Helper()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -127,7 +133,7 @@ func startAgentObservationSSHServer(t *testing.T) (string, <-chan struct{}) {
 		}
 	}()
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-	return port, forwarded
+	return port, signer.PublicKey(), forwarded
 }
 
 func observeAgentForwarding(conn net.Conn, config *ssh.ServerConfig, forwarded chan<- struct{}) {


### PR DESCRIPTION
## Summary
- pass the same child environment to Windows ConPTY processes as Unix, including `F4_NESTED=1`
- make nested Windows F4 parse the outer terminal's standard ANSI/SGR input by default while preserving explicit `--input` choices
- add nested input-mode regression coverage and a three-pass issue solution review

## Validation
- `go test ./cmd/f4 -run 'TestNestedInputMode|TestTranslateMouseInput|TestPanelsFrame_MouseForwarding_ToPTY' -count=1`
- `go test ./... -count=1` (all packages pass; two existing netfox SSH tests require a missing `~/.ssh/known_hosts`)
- native Windows build
- real Windows ConPTY nested-F4 validation: left/right/release/wheel events arrived in the inner F4 as distinct `Src:sgr_mouse` events; F9 opened the inner menu; Copy/Operations Queue rendered normally