### PR TITLE
test: seed known hosts for SSH forwarding fixtures

### DIFF
--- a/ISSUE_744_SOLUTION_REVIEW.md
+++ b/ISSUE_744_SOLUTION_REVIEW.md
@@ -1,0 +1,38 @@
+# Issue #744 solution review
+
+## Evidence
+
+The failed merged-run showed two independent problems. The missing
+`math/rand` import in `cmd/f4/arkanoid_test.go` was already isolated and
+merged through PR #743. The remaining cross-platform failures were the two
+NetFox agent-forwarding tests: the security change now requires a known-hosts
+file, but those tests created temporary homes without populating one.
+
+## Candidate solutions
+
+1. **Chosen: make the test fixture satisfy the production security contract.**
+   The local SSH server already has a generated host key; write that key to
+   the temporary home's `~/.ssh/known_hosts` before calling either dialer.
+   This preserves strict host-key verification and keeps the tests isolated.
+2. **Rejected: weaken `DialSSH` when running tests or allow unknown hosts.**
+   That would hide the security regression and test a different authentication
+   path from production.
+3. **Rejected: depend on the runner's real `~/.ssh/known_hosts`.** CI runners
+   and developer machines differ, and the tests would become nondeterministic
+   or expose unrelated user configuration.
+
+## Three review passes
+
+- **Coverage:** both direct SSH and FISH+ dialer tests now install the generated
+  server key in the exact temporary home they configure.
+- **Safety:** host-key verification remains strict; no global `InsecureIgnoreHostKey`
+  callback or production fallback is introduced.
+- **Portability:** the fixture uses the existing `writeKnownHosts` helper and
+  `knownhosts.Normalize`, so Linux, Windows, and macOS all use the same
+  address format.
+
+## Decision
+
+Fix the tests, not the SSH security behavior. The compile failure is already
+fixed in merged PR #743; this change addresses the remaining deterministic
+CI failure exposed by the same run.

--- a/plugins/netfox/ssh_agent_forwarding_test.go
+++ b/plugins/netfox/ssh_agent_forwarding_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/unxed/f4/internal/netproxy"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 func TestDialSSHDoesNotForwardAgent(t *testing.T) {
@@ -22,7 +23,8 @@ func TestDialSSHDoesNotForwardAgent(t *testing.T) {
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("SSH_AUTH_SOCK", startTestSSHAgent(t))
-	port, forwarded := startAgentObservationSSHServer(t)
+	port, publicKey, forwarded := startAgentObservationSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 
 	client, err := DialSSH("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{})
 	if err != nil {
@@ -35,8 +37,12 @@ func TestDialSSHDoesNotForwardAgent(t *testing.T) {
 }
 
 func TestSSHFishDialerDoesNotRequestAgentForwarding(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("SSH_AUTH_SOCK", "agent-present")
-	port, forwarded := startAgentObservationSSHServer(t)
+	port, publicKey, forwarded := startAgentObservationSSHServer(t)
+	writeKnownHosts(t, home, knownhosts.Normalize("127.0.0.1:"+port), publicKey)
 	dial := sshFishDialerWith("127.0.0.1", port, "user", "pass", 3, netproxy.Settings{}, func(session *ssh.Session) error {
 		return session.Shell()
 	})
@@ -88,7 +94,7 @@ func startTestSSHAgent(t *testing.T) string {
 	return path
 }
 
-func startAgentObservationSSHServer(t *testing.T) (string, <-chan struct{}) {
+func startAgentObservationSSHServer(t *testing.T) (string, ssh.PublicKey, <-chan struct{}) {
 	t.Helper()
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
@@ -127,7 +133,7 @@ func startAgentObservationSSHServer(t *testing.T) (string, <-chan struct{}) {
 		}
 	}()
 	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
-	return port, forwarded
+	return port, signer.PublicKey(), forwarded
 }
 
 func observeAgentForwarding(conn net.Conn, config *ssh.ServerConfig, forwarded chan<- struct{}) {


### PR DESCRIPTION
## Summary

- seed the generated local SSH server key in each temporary test home
- keep strict production host-key verification while making agent-forwarding tests deterministic
- document the CI diagnosis and alternatives for issue #744

## Validation

- `go test ./plugins/netfox -count=1`
- `go test -race ./plugins/netfox -run ... -count=3`
- `go vet ./plugins/netfox`
- native Linux ARM64 f4 build and `--version` smoke

Fixes the remaining NetFox failures reported by issue #744; the separate missing `math/rand` compile error is already fixed by merged PR #743.