### PR TITLE
Fix panel sorting for leading punctuation

### DIFF
--- a/ISSUE_278_SOLUTION_REVIEW.md
+++ b/ISSUE_278_SOLUTION_REVIEW.md
@@ -1,0 +1,56 @@
+# Issue #278 solution review
+
+## Reproduction
+
+The report compares the same directory in far2l and f4. A directory containing
+`_test_folder`, `9test`, `archive`, and `unxed` is a minimal reproduction when
+the panel is sorted by name: f4's previous code used `strings.ToLower(name)` and
+therefore placed `_test_folder` after the alphabetic names. The supplied
+screenshots show the same family of leading-symbol cases and the case where the
+behavior was not visible because the active sort state differed.
+
+## Three candidate solutions
+
+1. Prefix or replace underscores with a hand-written sentinel before comparing.
+   This fixes the named example but is incorrect for other punctuation,
+   non-ASCII symbols, and extension sorting, and would diverge from far2l in
+   more cases.
+
+2. Call a platform-specific comparator such as Windows `CompareString` and
+   provide unrelated implementations on Unix. This could match one host's
+   locale but would make panel order vary by operating system and would not be
+   available for every VFS or cross-build.
+
+3. Use the portable Unicode string collator from `golang.org/x/text`, with
+   case ignored and a forced identity tie-break. Apply it consistently to name
+   sorting, extension sorting, and equal primary keys. This follows far2l's
+   string-collation model without a one-character special case and keeps order
+   deterministic across platforms.
+
+The third solution is selected.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+`sortEntries` now compares names with `collate.New(language.Und,
+collate.IgnoreCase, collate.Force)`. Leading punctuation sorts before digits and
+letters, so `_test_folder` precedes `9test`, `archive`, and `unxed`. Extension
+sorting uses the same comparator, and equal size/time/extension keys fall back
+to names. Parent-directory and directory-first rules remain outside the name
+comparator, so `..` and folders keep their existing placement.
+
+### Pass 2: concurrency and stability
+
+The collator is created per sort operation because its comparison method reuses
+internal iterator state and is not safe for concurrent calls. The comparator
+returns false for equal names in both directions and applies reverse ordering
+by negating a three-way comparison, removing the previous `!res` equal-key
+violation in reverse mode.
+
+### Pass 3: scope and regression safety
+
+Production behavior changes only the ordering of sortable panel entries. New
+tests cover the reported leading-underscore order and equal-key reverse sorting;
+the existing name, size, time, and sort-mode tests remain green. No VFS,
+rendering, or file-operation behavior is changed.

--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -15,6 +15,8 @@ import (
 	"unicode"
 
 	"github.com/mattn/go-runewidth"
+	"golang.org/x/text/collate"
+	"golang.org/x/text/language"
 
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
@@ -762,6 +764,15 @@ func (fp *FileSystemPanel) sortEntries() {
 		return
 	}
 
+	// far2l uses a string collation order for panel names: punctuation such as
+	// '_' sorts before digits and letters, unlike Go's byte/code-point order.
+	// Keep the collator local because collate.Collator reuses iterator state and
+	// is not safe for concurrent use.
+	nameCollator := collate.New(language.Und, collate.IgnoreCase, collate.Force)
+	compareName := func(left, right string) int {
+		return nameCollator.CompareString(left, right)
+	}
+
 	sort.Slice(fp.entries, func(i, j int) bool {
 		ei, ej := fp.entries[i], fp.entries[j]
 
@@ -778,30 +789,39 @@ func (fp *FileSystemPanel) sortEntries() {
 			return ei.IsDir
 		}
 
-		res := false
+		cmp := 0
 		switch fp.sortMode {
 		case SortName:
-			res = strings.ToLower(ei.Name) < strings.ToLower(ej.Name)
+			cmp = compareName(ei.Name, ej.Name)
 		case SortExt:
-			extI := strings.ToLower(filepath.Ext(ei.Name))
-			extJ := strings.ToLower(filepath.Ext(ej.Name))
-			if extI != extJ {
-				res = extI < extJ
-			} else {
-				res = strings.ToLower(ei.Name) < strings.ToLower(ej.Name)
+			cmp = compareName(filepath.Ext(ei.Name), filepath.Ext(ej.Name))
+			if cmp == 0 {
+				cmp = compareName(ei.Name, ej.Name)
 			}
 		case SortTime:
-			res = ei.MTime.After(ej.MTime)
+			if ei.MTime.After(ej.MTime) {
+				cmp = -1
+			} else if ei.MTime.Before(ej.MTime) {
+				cmp = 1
+			}
 		case SortSize:
-			res = ei.Size > ej.Size
+			if ei.Size > ej.Size {
+				cmp = -1
+			} else if ei.Size < ej.Size {
+				cmp = 1
+			}
 		default:
-			res = strings.ToLower(ei.Name) < strings.ToLower(ej.Name)
+			cmp = compareName(ei.Name, ej.Name)
 		}
 
-		if fp.sortReverse {
-			return !res
+		// Keep equal primary keys deterministic and match far2l's name tie-break.
+		if cmp == 0 {
+			cmp = compareName(ei.Name, ej.Name)
 		}
-		return res
+		if fp.sortReverse {
+			cmp = -cmp
+		}
+		return cmp < 0
 	})
 }
 

--- a/cmd/f4/file_panel_sorting_regression_test.go
+++ b/cmd/f4/file_panel_sorting_regression_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+func TestFileSystemPanel_SortingLeadingUnderscoreUsesStringCollation(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewNullVFS(0))
+	if fp.cancelLoad != nil {
+		fp.cancelLoad()
+	}
+
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "unxed", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "_test_folder", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "9test", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "archive", IsDir: true}},
+	}
+	fp.sortMode = SortName
+	fp.sortEntries()
+
+	want := []string{"_test_folder", "9test", "archive", "unxed"}
+	for i, name := range want {
+		if got := fp.entries[i].Name; got != name {
+			t.Fatalf("sorted entry %d = %q, want %q; all entries = %v", i, got, name, entryNames(fp.entries))
+		}
+	}
+}
+
+func TestFileSystemPanel_SortingTiesRemainDeterministicWhenReversed(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewNullVFS(0))
+	if fp.cancelLoad != nil {
+		fp.cancelLoad()
+	}
+
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "same-b", Size: 10}},
+		{VFSItem: vfs.VFSItem{Name: "same-a", Size: 10}},
+	}
+	fp.sortMode = SortSize
+	fp.sortReverse = true
+	fp.sortEntries()
+
+	if got := entryNames(fp.entries); got[0] != "same-b" || got[1] != "same-a" {
+		t.Fatalf("reversed equal-size sort = %v, want [same-b same-a]", got)
+	}
+}
+
+func entryNames(entries []*fileEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name
+	}
+	return names
+}


### PR DESCRIPTION
## Summary

Fixes #278.

- replace byte/code-point filename ordering with portable Unicode string collation aligned with far2l's punctuation ordering;
- apply the same comparator to name sorting, extension sorting, and equal primary keys;
- keep .. and directory-first behavior unchanged;
- make reverse sorting strict and deterministic for equal keys;
- add leading-underscore and reverse tie regression tests;
- document the three-pass solution review in ISSUE_278_SOLUTION_REVIEW.md.

## Validation

- go test ./cmd/f4 -count=1
- go test ./... -count=1
- go vet ./... (no vet errors; existing Windows unsafe-pointer diagnostics remain warnings)
- native Windows build
- real native Windows TTY launch over a directory containing _test_folder, 9test, archive, and unxed; rendered order confirmed _test_folder, 9test, archive, unxed
- git diff --check