### PR TITLE
fix: apply file attributes to all selected entries

### DIFF
--- a/ISSUE_266_SOLUTION_REVIEW.md
+++ b/ISSUE_266_SOLUTION_REVIEW.md
@@ -1,0 +1,70 @@
+# Issue #266 solution review
+
+## Reproduction
+
+1. Open a directory containing at least two objects.
+2. Mark two files or directories in the active panel.
+3. Press `Ctrl+A` or choose `File attributes` from the `Files` menu.
+4. Change an attribute and press `Set`.
+
+Before this fix, `actionFileAttributes` called `getRawSelectedName()`. That
+always returned only the row under the cursor, even when the panel had an
+explicit multi-selection, so the dialog could update only one object.
+
+## Candidate solutions
+
+### 1. Repeat the old single-file dialog from the action
+
+The action could open the same dialog once per selected path. This would make
+all objects reachable, but would require the user to repeat the same change and
+would be especially poor for remote or mixed file selections.
+
+### 2. Apply the first item's complete metadata to every selected object
+
+This is simple, but copying the first object's full metadata would overwrite
+object-specific fields such as Windows directory/reparse/compression flags and
+could change unrelated ownership or timestamps.
+
+### 3. Use one dialog with a stable target snapshot and apply edited fields to all
+
+The selected paths and their metadata are captured before the asynchronous
+dialog opens. On Set, edited common fields are applied to every target while
+target-specific metadata is retained. The Windows path edits only the ordinary
+Read-only/Hidden/System/Archive bits and preserves each target's advanced bits.
+
+Selected solution: option 3.
+
+## Three-pass review
+
+### Pass 1 — functional correctness
+
+- `GetSelectedNames()` supplies all explicit selections and still falls back to
+  the cursor for the normal single-object case.
+- Each selected path is `Lstat`-checked before opening the dialog, so symlink
+  metadata is not silently replaced by target metadata.
+- Unix mode/owner/group/mtime edits are sent to every target.
+- Windows ordinary flags and last-write time are sent to every target.
+- A selected `..` entry is excluded by the existing selection contract.
+
+### Pass 2 — safety and compatibility
+
+- The asynchronous operation uses an immutable path/metadata snapshot; later
+  cursor movement cannot retarget the operation.
+- Windows advanced flags are merged per target rather than copied from the
+  first row.
+- Symlink target editing remains available for a single symlink and is not
+  ambiguously applied to a multi-selection.
+- Existing single-file dialog entry points remain wrappers around the new
+  target-aware implementation.
+- Set errors now remain visible instead of closing the Windows dialog silently.
+
+### Pass 3 — scope and regression risk
+
+- The action registry already contains `File.Attributes` in the `Files` menu;
+  a menu regression test now guards that discoverability path.
+- No file-operation or selection semantics were changed outside attributes.
+- Tests cover the action using two selected entries and the Windows metadata
+  merge behavior that protects per-object advanced flags.
+- Native Windows validation must confirm that the real TTY action updates both
+  selected objects, not merely that the helper receives two paths.
+

--- a/cmd/f4/action_menu_test.go
+++ b/cmd/f4/action_menu_test.go
@@ -100,6 +100,20 @@ func TestBuildMenuBarItems_Shell(t *testing.T) {
 	if files[0].Shortcut != "F3" {
 		t.Errorf("Expected View shortcut 'F3', got %q", files[0].Shortcut)
 	}
+	attrAction, ok := GetAction("File.Attributes")
+	if !ok {
+		t.Fatal("File.Attributes action is not registered")
+	}
+	var foundAttributes bool
+	for _, item := range files {
+		if item.Text == attrAction.DisplayLabel() || item.Text == "&"+attrAction.DisplayLabel() {
+			foundAttributes = true
+			break
+		}
+	}
+	if !foundAttributes {
+		t.Errorf("Files menu is missing %q", attrAction.DisplayLabel())
+	}
 
 	// Options menu honors MenuSeparatorBefore.
 	var sawSeparator bool

--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -4373,25 +4373,39 @@ func showPluginFileDialog(parent *vtui.Window, startPath string, onSelect func(s
 
 func actionFileAttributes(pf *PanelsFrame) {
 	fsp := pf.getActivePanel()
-	if fsp == nil {
+	if fsp == nil || fsp.vfs == nil {
 		return
 	}
 
-	name := fsp.getRawSelectedName()
-	if name == "" || name == ".." {
+	names := fsp.GetSelectedNames()
+	if len(names) == 0 {
 		return
 	}
 
-	fullPath := fsp.vfs.Join(fsp.vfs.GetPath(), name)
+	paths := make([]string, 0, len(names))
+	for _, name := range names {
+		if name != "" && name != ".." {
+			paths = append(paths, fsp.vfs.Join(fsp.vfs.GetPath(), name))
+		}
+	}
+	if len(paths) == 0 {
+		return
+	}
 
 	vtui.RunAsync(func(ctx *vtui.TaskContext) {
-		item, err := vfs.Lstat(ctx.Context, fsp.vfs, fullPath)
-		ctx.RunOnUI(func() {
+		targets := make([]attributesTarget, 0, len(paths))
+		for _, path := range paths {
+			item, err := vfs.Lstat(ctx.Context, fsp.vfs, path)
 			if err != nil {
-				vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})
+				ctx.RunOnUI(func() {
+					vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})
+				})
 				return
 			}
-			ShowAttributesDialog(pf, fsp.vfs, fullPath, item)
+			targets = append(targets, attributesTarget{path: path, item: item})
+		}
+		ctx.RunOnUI(func() {
+			showAttributesDialogForTargets(pf, fsp.vfs, targets)
 		})
 	})
 }

--- a/cmd/f4/attributes_dialog.go
+++ b/cmd/f4/attributes_dialog.go
@@ -54,21 +54,70 @@ func isLocalOSVFS(v any) bool {
 	return false
 }
 
+type attributesTarget struct {
+	path string
+	item vfs.VFSItem
+}
+
 func ShowAttributesDialog(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSItem) {
 	if litem, err := vfs.Lstat(context.Background(), v, path); err == nil && litem.IsSymlink {
 		item = litem
 	}
+	showAttributesDialogForTargets(pf, v, []attributesTarget{{path: path, item: item}})
+}
+
+func showAttributesDialogForTargets(pf *PanelsFrame, v vfs.VFS, targets []attributesTarget) {
+	if v == nil || len(targets) == 0 {
+		return
+	}
 	caps := v.GetCapabilities()
 	if !caps.HasUnixPermissions {
-		showAttributesWindows(pf, v, path, item)
+		showAttributesWindowsForTargets(pf, v, targets)
 	} else {
-		showAttributesUnix(pf, v, path, item)
+		showAttributesUnixForTargets(pf, v, targets)
 	}
 }
 
+func setUnixAttributesForTargets(ctx context.Context, v vfs.VFS, targets []attributesTarget, edited vfs.VFSItem) error {
+	for _, target := range targets {
+		item := target.item
+		item.Uid = edited.Uid
+		item.Gid = edited.Gid
+		item.UnixMode = edited.UnixMode
+		item.MTime = edited.MTime
+		if err := v.SetAttributes(ctx, target.path, item); err != nil {
+			return fmt.Errorf("%s: %w", target.path, err)
+		}
+	}
+	return nil
+}
+
+func setWindowsAttributesForTargets(ctx context.Context, v vfs.VFS, targets []attributesTarget, edited vfs.VFSItem) error {
+	const editableWinAttrs = uint32(1 | 2 | 4 | 32)
+	for _, target := range targets {
+		item := target.item
+		item.MTime = edited.MTime
+		item.UnixMode = edited.UnixMode
+		// The dialog edits only the four ordinary Windows flags. Keep
+		// directory/reparse/compression and other provider-specific flags from
+		// each target instead of copying those of the first selected object.
+		item.WinAttrs = (item.WinAttrs &^ editableWinAttrs) | (edited.WinAttrs & editableWinAttrs)
+		if err := v.SetAttributes(ctx, target.path, item); err != nil {
+			return fmt.Errorf("%s: %w", target.path, err)
+		}
+	}
+	return nil
+}
+
 func showAttributesUnix(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSItem) {
+	showAttributesUnixForTargets(pf, v, []attributesTarget{{path: path, item: item}})
+}
+
+func showAttributesUnixForTargets(pf *PanelsFrame, v vfs.VFS, targets []attributesTarget) {
+	path := targets[0].path
+	item := targets[0].item
 	width, height := 70, 24
-	if item.IsSymlink {
+	if item.IsSymlink && len(targets) == 1 {
 		height = 26
 	}
 
@@ -91,7 +140,7 @@ func showAttributesUnix(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSIte
 	}
 
 	var editTarget *vtui.Edit
-	if item.IsSymlink {
+	if item.IsSymlink && len(targets) == 1 {
 		targetVal, _ := vfs.Readlink(context.Background(), v, path)
 		editTarget = vtui.NewEdit(0, 0, 35, targetVal)
 		lblTarget := vtui.NewLabel(0, 0, padLabel("T&arget:"), editTarget)
@@ -267,7 +316,7 @@ func showAttributesUnix(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSIte
 	}
 
 	btnSet.OnClick = func() {
-		if item.IsSymlink && editTarget != nil {
+		if item.IsSymlink && editTarget != nil && len(targets) == 1 {
 			newTarget := editTarget.GetText()
 			oldTarget, _ := vfs.Readlink(context.Background(), v, path)
 			if newTarget != "" && newTarget != oldTarget {
@@ -302,13 +351,15 @@ func showAttributesUnix(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSIte
 			item.MTime = t
 		}
 		vtui.RunAsync(func(ctx *vtui.TaskContext) {
-			err := v.SetAttributes(ctx.Context, path, item)
+			err := setUnixAttributesForTargets(ctx.Context, v, targets, item)
 			ctx.RunOnUI(func() {
 				if err != nil {
 					vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})
 				} else {
 					dlg.Close()
-					pf.RefreshAll()
+					if pf != nil {
+						pf.RefreshAll()
+					}
 				}
 			})
 		})
@@ -318,7 +369,11 @@ func showAttributesUnix(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSIte
 }
 
 func showAttributesWindows(pf *PanelsFrame, v vfs.VFS, path string, item vfs.VFSItem) {
-	showAttributesWindowsWithProperties(pf, v, path, item, defaultNativePropertiesOpener)
+	showAttributesWindowsForTargets(pf, v, []attributesTarget{{path: path, item: item}})
+}
+
+func showAttributesWindowsForTargets(pf *PanelsFrame, v vfs.VFS, targets []attributesTarget) {
+	showAttributesWindowsWithPropertiesForTargets(pf, v, targets, defaultNativePropertiesOpener)
 }
 
 var defaultNativePropertiesOpener = showNativePropertiesOS
@@ -334,6 +389,17 @@ func showAttributesWindowsWithProperties(
 	item vfs.VFSItem,
 	openProperties func(string) error,
 ) {
+	showAttributesWindowsWithPropertiesForTargets(pf, v, []attributesTarget{{path: path, item: item}}, openProperties)
+}
+
+func showAttributesWindowsWithPropertiesForTargets(
+	pf *PanelsFrame,
+	v vfs.VFS,
+	targets []attributesTarget,
+	openProperties func(string) error,
+) {
+	path := targets[0].path
+	item := targets[0].item
 	width, height := 60, 22
 	dlg := vtui.NewCenteredDialog(width, height, Msg("Attributes.Title"))
 	dlg.ShowClose = true
@@ -520,8 +586,17 @@ func showAttributesWindowsWithProperties(
 		}
 
 		vtui.RunAsync(func(ctx *vtui.TaskContext) {
-			v.SetAttributes(ctx.Context, path, item)
-			ctx.RunOnUI(func() { dlg.Close(); pf.RefreshAll() })
+			err := setWindowsAttributesForTargets(ctx.Context, v, targets, item)
+			ctx.RunOnUI(func() {
+				if err != nil {
+					vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})
+					return
+				}
+				dlg.Close()
+				if pf != nil {
+					pf.RefreshAll()
+				}
+			})
 		})
 	}
 	btnCancel.OnClick = func() { dlg.Close() }

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -396,7 +396,7 @@ func TestActionFileAttributesUsesAllSelectedEntries(t *testing.T) {
 
 	base := t.TempDir()
 	for _, name := range []string{"first.txt", "second.txt"} {
-		if err := os.WriteFile(filepath.Join(base, name), []byte(name), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(base, name), []byte(name), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -18,10 +18,11 @@ import (
 // mockMetadataVFS allows intercepting Stat and SetAttributes for testing.
 type mockMetadataVFS struct {
 	vfs.VFS
-	onSetAttr    func(vfs.VFSItem)
-	statErr      error
-	setAttrErr   error
-	statToReturn vfs.VFSItem
+	onSetAttr     func(vfs.VFSItem)
+	onSetAttrPath func(string, vfs.VFSItem)
+	statErr       error
+	setAttrErr    error
+	statToReturn  vfs.VFSItem
 }
 
 type lstatMetadataVFS struct {
@@ -49,6 +50,9 @@ func (m *mockMetadataVFS) SetAttributes(ctx context.Context, path string, item v
 	}
 	if m.onSetAttr != nil {
 		m.onSetAttr(item)
+	}
+	if m.onSetAttrPath != nil {
+		m.onSetAttrPath(path, item)
 	}
 	return nil
 }
@@ -319,6 +323,142 @@ func TestAttributesDialog_WindowsSetFlags(t *testing.T) {
 	// Verify the VFS call was made
 	if capturedItem.Name == "" {
 		t.Error("SetAttributes was not called after clicking Save in Windows attributes dialog")
+	}
+}
+
+func TestAttributesDialog_WindowsSetFlagsForSelectedTargets(t *testing.T) {
+	fm := vtui.FrameManager
+	fm.Init(vtui.NewSilentScreenBuf())
+
+	type attrCall struct {
+		path string
+		item vfs.VFSItem
+	}
+	var calls []attrCall
+	mockVFS := &mockMetadataVFS{
+		VFS: vfs.NewOSVFS(t.TempDir()),
+		onSetAttrPath: func(path string, item vfs.VFSItem) {
+			calls = append(calls, attrCall{path: path, item: item})
+		},
+	}
+	targets := []attributesTarget{
+		{path: "first.txt", item: vfs.VFSItem{Name: "first.txt", WinAttrs: 0x10 | 1, MTime: time.Now()}},
+		{path: "second.txt", item: vfs.VFSItem{Name: "second.txt", WinAttrs: 0x10 | 2, MTime: time.Now().Add(-time.Hour)}},
+	}
+
+	showAttributesWindowsForTargets(nil, mockVFS, targets)
+	dlg := fm.GetTopFrame().(vtui.Container)
+	var chkRO, chkHidden *vtui.Checkbox
+	var setButton *vtui.Button
+	walkUI(dlg.(vtui.UIElement), func(el vtui.UIElement) bool {
+		if c, ok := el.(*vtui.Checkbox); ok {
+			switch {
+			case strings.Contains(c.GetText(), "Read only"):
+				chkRO = c
+			case strings.Contains(c.GetText(), "Hidden"):
+				chkHidden = c
+			}
+		}
+		if b, ok := el.(*vtui.Button); ok && strings.Contains(b.GetText(), "Set") {
+			setButton = b
+		}
+		return true
+	})
+	if chkRO == nil || chkHidden == nil || setButton == nil {
+		t.Fatal("Windows multi-target dialog controls not found")
+	}
+	chkRO.State = 0
+	chkHidden.State = 1
+	setButton.OnClick()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for len(calls) < len(targets) && time.Now().Before(deadline) {
+		select {
+		case task := <-fm.TaskChan:
+			task()
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if len(calls) != 2 {
+		t.Fatalf("SetAttributes called %d times, want 2", len(calls))
+	}
+	for _, call := range calls {
+		if call.item.WinAttrs != 0x12 {
+			t.Errorf("%s attributes = %#x, want %#x", call.path, call.item.WinAttrs, uint32(0x12))
+		}
+	}
+}
+
+func TestActionFileAttributesUsesAllSelectedEntries(t *testing.T) {
+	fm := vtui.FrameManager
+	fm.Init(vtui.NewSilentScreenBuf())
+
+	base := t.TempDir()
+	for _, name := range []string{"first.txt", "second.txt"} {
+		if err := os.WriteFile(filepath.Join(base, name), []byte(name), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var calls []string
+	mockVFS := &mockMetadataVFS{
+		VFS:           vfs.NewOSVFS(base),
+		onSetAttrPath: func(path string, _ vfs.VFSItem) { calls = append(calls, path) },
+	}
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	fsp := pf.getActivePanel()
+	fsp.vfs = mockVFS
+	fsp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "first.txt"}},
+		{VFSItem: vfs.VFSItem{Name: "second.txt"}},
+	}
+	fsp.SetCursorIndex(0)
+	fsp.SetItemSelected(0, true)
+	fsp.SetItemSelected(1, true)
+
+	actionFileAttributes(pf)
+	var setButton *vtui.Button
+	deadline := time.Now().Add(2 * time.Second)
+	for setButton == nil && time.Now().Before(deadline) {
+		select {
+		case task := <-fm.TaskChan:
+			task()
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+		if top := fm.GetTopFrame(); top != nil {
+			if element, ok := top.(vtui.UIElement); ok {
+				walkUI(element, func(el vtui.UIElement) bool {
+					if b, ok := el.(*vtui.Button); ok && strings.Contains(b.GetText(), "Set") {
+						setButton = b
+					}
+					return true
+				})
+			}
+		}
+	}
+	if setButton == nil {
+		t.Fatal("attributes dialog did not open for selected entries")
+	}
+	setButton.OnClick()
+
+	deadline = time.Now().Add(2 * time.Second)
+	for len(calls) < 2 && time.Now().Before(deadline) {
+		select {
+		case task := <-fm.TaskChan:
+			task()
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if len(calls) != 2 {
+		t.Fatalf("SetAttributes called for %d selected entries, want 2: %v", len(calls), calls)
+	}
+	if !strings.HasSuffix(calls[0], "first.txt") || !strings.HasSuffix(calls[1], "second.txt") {
+		t.Errorf("SetAttributes paths = %v, want first.txt then second.txt", calls)
 	}
 }
 


### PR DESCRIPTION
Issue #266: Ctrl+A now snapshots every explicitly selected file or directory and applies the attributes dialog changes to all targets. Windows advanced per-object flags are preserved; the Files menu entry is covered by a regression test. Added multi-target/action tests and validated a native Windows TTY with two files plus a directory. go test ./cmd/f4 and native build pass. Full suite is green except the existing plugins/netfox known_hosts SSH-agent tests on this host.