### PR TITLE
fix: keep nested remote paths out of local folder history

### DIFF
--- a/ISSUE_262_SOLUTION_REVIEW.md
+++ b/ISSUE_262_SOLUTION_REVIEW.md
@@ -1,0 +1,50 @@
+# Issue #262 solution review
+
+## Reproduction
+
+Opening a NetFox connection mounts a child VFS whose `GetPath()` is a remote
+POSIX path such as `/home/user`. `FileSystemPanel.readDirectoryEx` passed that
+path directly to `AddFolderHistory`. The global folder-history navigator later
+interpreted it as a local OS path, so remote navigation appeared as local
+folders.
+
+## Three candidate solutions
+
+1. Give NetFox a new persistent `netfox://connection/path` URI and implement
+   standalone restoration from saved connection settings. This would provide
+   the richest history, but requires URI design, config lookup, migration, and
+   restore tests across every NetFox protocol.
+2. Store the remote path together with the active provider instance and teach
+   history navigation to reuse that instance. This helps within one session,
+   but persisted history would still be ambiguous after restart and would
+   retain provider-specific state in the core.
+3. Record nested absolute paths only when the path is already a persistent URI
+   or is owned by a standalone provider; suppress unqualified nested absolute
+   paths. This fixes the reported misclassification for NetFox and protects
+   every provider that exposes an internal absolute path without claiming a
+   restore route.
+
+## Selected solution and three-pass review
+
+The third solution is selected. It is implemented in the common panel history
+boundary, so NetFox requires no transport changes and archive/URI providers
+keep their existing history behavior.
+
+### Pass 1: functional behavior
+
+The remote `/home/user` path is no longer saved as a local history entry.
+Standalone archive paths and persistent URI paths remain eligible, while local
+panels and relative nested paths keep their existing behavior.
+
+### Pass 2: safety and compatibility
+
+The change only removes entries that cannot be reopened by the host. It does
+not change VFS navigation, remote I/O, selection state, or path normalization.
+Slash-rooted POSIX paths are recognized even when f4 itself runs on Windows,
+which covers NetFox's cross-platform path format.
+
+### Pass 3: regression scope
+
+The regression test covers the reported unqualified nested absolute path,
+relative nested paths, and persistent URI paths. The full `cmd/f4` tests and a
+native Windows build will be run before the pull request is finalized.

--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -1769,6 +1769,27 @@ func (fp *FileSystemPanel) consumeFolderHistorySuppression(path string, token ui
 	return true
 }
 
+// shouldRecordFolderHistory prevents an internal path of a nested VFS from
+// leaking into the global OS-folder history. Some providers (notably NetFox)
+// expose an absolute remote path such as /home/user, but that path cannot be
+// reopened after the panel leaves the provider and would otherwise be treated
+// as a local directory. Keep URI and standalone-provider paths, which have a
+// host-level restore route (archives and other persistent virtual paths).
+func shouldRecordFolderHistory(fp *FileSystemPanel, path string) bool {
+	if fp == nil || fp.vfs == nil || path == "" {
+		return false
+	}
+	if fp.vfs.ParentVFS() == nil {
+		return true
+	}
+	if isPersistentURIPath(path) || vfs.FindStandaloneProvider(context.Background(), nil, path) != nil {
+		return true
+	}
+	// filepath.IsAbs does not treat a slash-rooted POSIX path as absolute on
+	// Windows, although a remote Unix VFS can legitimately return one there.
+	return !filepath.IsAbs(path) && !strings.HasPrefix(path, "/") && !strings.HasPrefix(path, "\\")
+}
+
 // showDirectoryError keeps asynchronous refresh failures from stacking modal
 // dialogs. A failed recovery may schedule another read before the user closes
 // the first message; only the first live dialog should remain actionable.
@@ -1837,7 +1858,7 @@ func (fp *FileSystemPanel) readDirectoryEx(keepEntries bool) {
 		fp.selectionEpoch = make(map[string]uint64)
 	}
 	fp.lastLoadedPath = path
-	if directoryChanged && !suppressFolderHistory {
+	if directoryChanged && !suppressFolderHistory && shouldRecordFolderHistory(fp, path) {
 		// Record accepted navigation in UI order, not in backend completion
 		// order. Otherwise an older slow cloud ReadDir can finish after a newer
 		// visit and move its path to the front of the global MRU history.

--- a/cmd/f4/folder_history_panel_test.go
+++ b/cmd/f4/folder_history_panel_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+type nestedFolderHistoryVFS struct {
+	*vfs.NullVFS
+	parent vfs.VFS
+	path   string
+}
+
+func (v *nestedFolderHistoryVFS) GetPath() string    { return v.path }
+func (v *nestedFolderHistoryVFS) ParentVFS() vfs.VFS { return v.parent }
+
+func TestShouldRecordFolderHistorySkipsUnqualifiedNestedAbsolutePath(t *testing.T) {
+	panel := &FileSystemPanel{vfs: &nestedFolderHistoryVFS{
+		NullVFS: vfs.NewNullVFS(0),
+		parent:  vfs.NewNullVFS(0),
+		path:    "/home/user",
+	}}
+
+	if shouldRecordFolderHistory(panel, panel.vfs.GetPath()) {
+		t.Fatal("unqualified absolute path from a nested VFS must not enter local folder history")
+	}
+	if !shouldRecordFolderHistory(panel, "remote-relative") {
+		t.Fatal("relative nested paths should retain the existing history behavior")
+	}
+	if !shouldRecordFolderHistory(panel, "netfox://site/home/user") {
+		t.Fatal("persistent URI paths must remain eligible for folder history")
+	}
+}


### PR DESCRIPTION
Issue #262: folder history now rejects unqualified absolute paths from nested VFS providers unless the path is a persistent URI or can be restored by a standalone provider. NetFox remote paths such as /home/user therefore cannot be mistaken for local folders, while archive and URI history remains supported. Added regression coverage and a three-pass solution review in ISSUE_262_SOLUTION_REVIEW.md. Validation: go test ./cmd/f4 -count=1, go test ./... -count=1, go vet ./..., native Windows build, and native binary --help smoke test. The full local suite passed; go vet reports only the repository's existing unsafe.Pointer warnings. A live NetFox remote navigation test was not possible because no remote test host/credentials are available on this Windows 10 x64 device. — zoin-bot