### PR TITLE
lint: hold staticcheck at zero across the whole tree

### DIFF
--- a/.golangci-strict.yml
+++ b/.golangci-strict.yml
@@ -21,7 +21,12 @@ linters:
   default: none
   enable:
     - ineffassign
+    - staticcheck
     - unused
+
+  settings:
+    staticcheck:
+      checks: ["all", "-ST1000", "-ST1003", "-ST1005", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
 
   exclusions:
     generated: lax

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,13 @@ linters:
     - unused
     - gosec
 
+  settings:
+    staticcheck:
+      # ST1005 is cosmetic: it keeps wrapped errors from reading with a capital
+      # mid-sentence. Both findings are the product name "Far Manager 3", and
+      # error strings here routinely become dialog text the user reads.
+      checks: ["all", "-ST1000", "-ST1003", "-ST1005", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+
   exclusions:
     generated: lax
     presets:

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -2187,12 +2187,13 @@ func TestPanelsFrame_Clone_SelectionPreservation(t *testing.T) {
 		t.Fatal("Timeout waiting for initial load")
 	}
 	// Drain remaining tasks
+drainTasks:
 	for i := 0; i < 10; i++ {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
 			task()
 		default:
-			break
+			break drainTasks
 		}
 	}
 


### PR DESCRIPTION
The main config is paired with --new-from-rev, so it only reports findings on
lines a pull request touched and stays silent about everything else. The strict
config is the subset whose backlog is actually zero: those run over the whole
tree, so their debt cannot quietly regrow. staticcheck's backlog went from 319
to zero over the last few changes, so it joins ineffassign and unused there.

One check is dropped on the way in. ST1005 says an error string should not start
with a capital. It is cosmetic -- the point is that a wrapped error should not
read with a capital in the middle of a sentence -- and both findings it had left
were the phrase "Far Manager 3", which is the name of a different product that
the envman plugin imports settings out of. Lowercasing a proper noun is wrong,
and in this codebase these strings are not log lines: they go to the user
through showFar3ImportError and are read on screen. The rest of the check
selection is golangci-lint's own default, spelled out because naming any check
means naming all of them.

Moving staticcheck to the whole tree immediately found one thing that had landed
since the backlog was last measured, which is the point of doing it. In
TestPanelsFrame_Clone_SelectionPreservation a break meant to stop draining the
task queue was inside a select, so it left the select rather than the loop and
the loop went on spinning through its remaining iterations hitting the empty
default. Harmless here because the count was bounded and the default does
nothing, but it is not what the code says it does. Labelled.