### PR TITLE
gui: show font family names instead of file paths in the picker

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3917,9 +3917,9 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 			}
 		}
 	}
-	fontChoices := guiFontChoices(AppConfig.Language, AppConfig.GuiFont)
+	fontChoices := guiFontDisplayChoices(AppConfig.Language, AppConfig.GuiFont)
 	comboFont := vtui.NewComboBox(0, 0, 30, fontChoices)
-	comboFont.Edit.SetText(AppConfig.GuiFont)
+	comboFont.Edit.SetText(guiFontDisplayName(AppConfig.GuiFont))
 	lblFont := vtui.NewLabel(0, 0, Msg("AppearanceSettings.Font"), comboFont)
 	chkSystemMonospace := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.UseSystemMonospace"), false)
 	if AppConfig.GuiUseSystemMonospace {

--- a/cmd/f4/gui_font_catalog.go
+++ b/cmd/f4/gui_font_catalog.go
@@ -36,24 +36,30 @@ func guiFontChoices(language, current string) []string {
 	return choices
 }
 
+// platformGuiFontDisplayChoices and platformGuiFontDisplayName are indirection
+// variables so the non-Windows build never references the Windows-only font
+// name helpers: those live in the //go:build windows file and override these
+// from init there. The defaults keep the previous path-based behaviour.
+var platformGuiFontDisplayChoices = func(language, current string) []string {
+	return guiFontChoices(language, current)
+}
+
+var platformGuiFontDisplayName = func(value string) string {
+	return value
+}
+
 // guiFontDisplayChoices returns the strings shown in the font picker. On
 // Windows these are font family names (e.g. "Cascadia Mono") instead of file
 // paths; elsewhere the platform catalog has no name metadata, so the paths are
 // returned as before.
 func guiFontDisplayChoices(language, current string) []string {
-	if runtime.GOOS != "windows" {
-		return guiFontChoices(language, current)
-	}
-	return windowsGuiFontDisplayChoices(language, current)
+	return platformGuiFontDisplayChoices(language, current)
 }
 
 // guiFontDisplayName maps a stored font value to its picker label, resolving a
 // Windows font file path back to its family name when possible.
 func guiFontDisplayName(value string) string {
-	if runtime.GOOS != "windows" {
-		return value
-	}
-	return windowsGuiFontDisplayName(value)
+	return platformGuiFontDisplayName(value)
 }
 
 func sameGuiFontValue(left, right string) bool {

--- a/cmd/f4/gui_font_catalog.go
+++ b/cmd/f4/gui_font_catalog.go
@@ -36,6 +36,26 @@ func guiFontChoices(language, current string) []string {
 	return choices
 }
 
+// guiFontDisplayChoices returns the strings shown in the font picker. On
+// Windows these are font family names (e.g. "Cascadia Mono") instead of file
+// paths; elsewhere the platform catalog has no name metadata, so the paths are
+// returned as before.
+func guiFontDisplayChoices(language, current string) []string {
+	if runtime.GOOS != "windows" {
+		return guiFontChoices(language, current)
+	}
+	return windowsGuiFontDisplayChoices(language, current)
+}
+
+// guiFontDisplayName maps a stored font value to its picker label, resolving a
+// Windows font file path back to its family name when possible.
+func guiFontDisplayName(value string) string {
+	if runtime.GOOS != "windows" {
+		return value
+	}
+	return windowsGuiFontDisplayName(value)
+}
+
 func sameGuiFontValue(left, right string) bool {
 	if runtime.GOOS == "windows" {
 		return strings.EqualFold(filepath.Clean(left), filepath.Clean(right))

--- a/cmd/f4/gui_font_catalog_windows.go
+++ b/cmd/f4/gui_font_catalog_windows.go
@@ -9,6 +9,11 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+func init() {
+	platformGuiFontDisplayChoices = windowsGuiFontDisplayChoices
+	platformGuiFontDisplayName = windowsGuiFontDisplayName
+}
+
 func windowsFontEntries() []fontEntry {
 	var entries []fontEntry
 	for _, hive := range []registry.Key{registry.LOCAL_MACHINE, registry.CURRENT_USER} {

--- a/cmd/f4/gui_font_catalog_windows.go
+++ b/cmd/f4/gui_font_catalog_windows.go
@@ -59,3 +59,101 @@ func platformGuiFontFiles(language string) []string {
 	}
 	return paths
 }
+
+// windowsGuiFontDisplayChoices returns the font family names to show in the
+// picker (e.g. "Cascadia Mono") instead of file paths.
+func windowsGuiFontDisplayChoices(language, current string) []string {
+	entries := windowsFontEntries()
+	pathToName := make(map[string]string)
+	nameNormToName := make(map[string]string)
+	seenName := make(map[string]struct{})
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		pathToName[strings.ToLower(fontFilePath(e.file))] = e.base
+		nameNormToName[normalizeFontName(e.base)] = e.base
+		if _, ok := seenName[strings.ToLower(e.base)]; ok {
+			continue
+		}
+		seenName[strings.ToLower(e.base)] = struct{}{}
+		names = append(names, e.base)
+	}
+
+	choices := make([]string, 0, len(names)+1)
+	appendUnique := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range choices {
+			if strings.EqualFold(existing, value) {
+				return
+			}
+		}
+		choices = append(choices, value)
+	}
+
+	// Show the current value by its family name when it resolves, otherwise
+	// keep it verbatim (a manual path or custom family the catalog lacks).
+	if current != "" {
+		if name, ok := pathToName[strings.ToLower(fontFilePath(current))]; ok {
+			appendUnique(name)
+		} else if name, ok := nameNormToName[normalizeFontName(current)]; ok {
+			appendUnique(name)
+		} else {
+			appendUnique(current)
+		}
+	}
+	for _, name := range names {
+		appendUnique(name)
+	}
+
+	if isCJKLanguage(language) {
+		sort.SliceStable(choices, func(i, j int) bool {
+			iCJK := looksLikeCJKFontName(choices[i])
+			jCJK := looksLikeCJKFontName(choices[j])
+			if iCJK != jCJK {
+				return iCJK
+			}
+			return strings.ToLower(choices[i]) < strings.ToLower(choices[j])
+		})
+	} else {
+		sort.SliceStable(choices, func(i, j int) bool {
+			return strings.ToLower(choices[i]) < strings.ToLower(choices[j])
+		})
+	}
+	return choices
+}
+
+// windowsGuiFontDisplayName maps a stored font value to its family name label.
+func windowsGuiFontDisplayName(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return value
+	}
+	entries := windowsFontEntries()
+	for _, e := range entries {
+		if strings.EqualFold(fontFilePath(e.file), fontFilePath(value)) {
+			return e.base
+		}
+		if normalizeFontName(e.base) == normalizeFontName(value) {
+			return e.base
+		}
+	}
+	return value
+}
+
+func normalizeFontName(name string) string {
+	return strings.ToLower(strings.ReplaceAll(strings.TrimSpace(name), " ", ""))
+}
+
+func looksLikeCJKFontName(name string) bool {
+	name = strings.ToLower(strings.ReplaceAll(strings.TrimSpace(name), " ", ""))
+	for _, marker := range []string{
+		"cjk", "chinese", "droid", "gothic", "han", "japan", "jp", "korea", "ko", "ming", "noto", "simsun", "song", "wqy", "yahei",
+	} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/f4/gui_font_catalog_windows.go
+++ b/cmd/f4/gui_font_catalog_windows.go
@@ -97,6 +97,24 @@ func windowsGuiFontDisplayChoices(language, current string) []string {
 		choices = append(choices, value)
 	}
 
+	// Sort the catalog with CJK fonts first when relevant, but keep the
+	// current value pinned at the top so it stays selectable as the active
+	// choice (mirrors the old guiFontChoices ordering).
+	if isCJKLanguage(language) {
+		sort.SliceStable(names, func(i, j int) bool {
+			iCJK := looksLikeCJKFontName(names[i])
+			jCJK := looksLikeCJKFontName(names[j])
+			if iCJK != jCJK {
+				return iCJK
+			}
+			return strings.ToLower(names[i]) < strings.ToLower(names[j])
+		})
+	} else {
+		sort.SliceStable(names, func(i, j int) bool {
+			return strings.ToLower(names[i]) < strings.ToLower(names[j])
+		})
+	}
+
 	// Show the current value by its family name when it resolves, otherwise
 	// keep it verbatim (a manual path or custom family the catalog lacks).
 	if current != "" {
@@ -112,20 +130,6 @@ func windowsGuiFontDisplayChoices(language, current string) []string {
 		appendUnique(name)
 	}
 
-	if isCJKLanguage(language) {
-		sort.SliceStable(choices, func(i, j int) bool {
-			iCJK := looksLikeCJKFontName(choices[i])
-			jCJK := looksLikeCJKFontName(choices[j])
-			if iCJK != jCJK {
-				return iCJK
-			}
-			return strings.ToLower(choices[i]) < strings.ToLower(choices[j])
-		})
-	} else {
-		sort.SliceStable(choices, func(i, j int) bool {
-			return strings.ToLower(choices[i]) < strings.ToLower(choices[j])
-		})
-	}
 	return choices
 }
 


### PR DESCRIPTION
## Что сделано
В диалоге «Настройки оформления» (Appearance) под Windows список шрифтов показывал пути к файлам. Теперь показываются семейные имена шрифтов.

## Детали
- `guiFontDisplayChoices` / `guiFontDisplayName` (новые обёртки) на Windows возвращают имена, вне Windows — как раньше (пути).
- `windowsGuiFontDisplayChoices` строит список из `fontEntry.base` (имя), с дедупом и сортировкой, учитывающей CJK.
- Текущее значение, если это путь из старой конфигурации, отображается по имени; ручной ввод сохраняется как есть.
- Сохраняется имя, которое `windowsFontFile` корректно резолвит в путь при отрисовке GUI.

## Проверка
Открыть Appearance settings → поле Font: в списке имена, выбор применяется корректно.
