### PR TITLE
fix: order editor teardown and quick-view refreshes against their goroutines

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -382,7 +382,7 @@ func TestActionDelete_RetrySuccess(t *testing.T) {
 	}
 
 	pf := NewPanelsFrame()
-	defer pf.Close()
+	t.Cleanup(pf.Close)
 	pf.ResizeConsole(80, 25)
 	fsp := pf.panels[0].(*FileSystemPanel)
 	fsp.vfs = mv
@@ -403,17 +403,21 @@ func TestActionDelete_RetrySuccess(t *testing.T) {
 	// 2. Ждем диалог ошибки и жмем Retry
 	timeout := time.After(2 * time.Second)
 	retryClicked := false
+	var progress *FileOpProgressDialog
 Loop:
 	for {
-		if len(mv.deleted) == 1 {
-			break Loop
-		}
 		select {
 		case task := <-fm.TaskChan:
 			task()
+			if top, ok := fm.GetTopFrame().(*FileOpProgressDialog); ok {
+				progress = top
+			}
 			if !retryClicked && fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == " Error " {
 				clickDialogButton(t, fm.GetTopFrame().(vtui.Container), "Retry")
 				retryClicked = true
+			}
+			if progress != nil && progress.IsDone() {
+				break Loop
 			}
 			if fm.GetTopFrame() != nil && fm.GetTopFrame().IsDone() {
 				fm.Pop()

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -90,6 +90,8 @@ type EditorView struct {
 	// once, so the report goes out once rather than on every repaint.
 	mapFaulted  bool
 	indexCancel context.CancelFunc
+	// indexWG joins cancelled indexers before Close tears down their buffers.
+	indexWG sync.WaitGroup
 	// indexing is true from StartIndexing until that run ends, by completion
 	// or by cancellation. indexCancel cannot answer the question: it is left
 	// set after a normal finish, so it reads as "indexing forever".
@@ -292,6 +294,7 @@ func (ev *EditorView) Close() {
 		ev.indexResume.Stop()
 		ev.indexResume = nil
 	}
+	ev.indexWG.Wait()
 	if ev.asyncBuf != nil {
 		ev.asyncBuf.Close()
 	}
@@ -3203,7 +3206,9 @@ func (ev *EditorView) StartIndexing() {
 		ev.resolveTargetOffset()
 		ctx, cancel := context.WithCancel(context.Background())
 		ev.indexCancel = cancel
+		ev.indexWG.Add(1)
 		go func() {
+			defer ev.indexWG.Done()
 			// zoin-bot keeps mapped-file faults recoverable in the fully-read
 			// indexing path just like in the lazy-buffer indexing goroutine.
 			defer ev.guardMapping("indexing fully-read buffer")()
@@ -3227,7 +3232,9 @@ func (ev *EditorView) StartIndexing() {
 	// when each chunk comes round.
 	readFromFile := ev.chunkReader()
 
+	ev.indexWG.Add(1)
 	go func() {
+		defer ev.indexWG.Done()
 		defer ev.guardMapping("indexing")()
 		startedAt := time.Now()
 		vtui.DebugLog("EDITOR_INDEX: Start indexing with targetLine=%d", ev.targetLine)

--- a/cmd/f4/quick_view_panel.go
+++ b/cmd/f4/quick_view_panel.go
@@ -464,7 +464,7 @@ func (q *QuickViewPanel) startDirScan(fullPath string) {
 			}
 			q.scanMu.Unlock()
 			if redraw {
-				vtui.FrameManager.HardRefresh()
+				vtui.FrameManager.PostTask(vtui.FrameManager.HardRefresh)
 			}
 		})
 		q.scanMu.Lock()
@@ -476,7 +476,7 @@ func (q *QuickViewPanel) startDirScan(fullPath string) {
 			q.scanDone = true
 		}
 		q.scanMu.Unlock()
-		vtui.FrameManager.HardRefresh()
+		vtui.FrameManager.PostTask(vtui.FrameManager.HardRefresh)
 	}()
 }
 


### PR DESCRIPTION
Three tests reported races under -race, each reproducible on its own without
any test-order shuffling. Two of the three turned out to be bugs in shipped
code, not in the tests.

EditorView.Close tore down the buffers while an indexing goroutine was still
reading them. Close already cancelled the indexer, but cancellation only asks:
the goroutine can still be inside guardMapping when Close moves on to close the
mapping the piece table's windows point into. The comment above that teardown
says the background work has to have been "told to stop" first, which is
exactly the gap -- told, not waited for. StartIndexing now registers its
goroutines and Close joins them after cancelling.

startDirScan called FrameManager.HardRefresh straight from its scan goroutines,
and two scans overlapping meant two goroutines mutating frame-manager state at
once. Both refreshes now go through the UI task queue, which is what everything
else on that path already does.

The third, TestActionDelete_RetrySuccess, was a genuine test bug: it read the
mock's deleted list and ran its cleanup while the delete worker was still
appending. It now waits for the worker's completion handoff first.

Verified with -race -count=10 on each of the three, and the package suite.