### PR TITLE
test: stop these tests leaking state into whoever runs next

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -2572,16 +2572,19 @@ func TestActionEditFile_DirectoryRedirectsToAttributes(t *testing.T) {
 	}
 }
 func TestActionCreateLink_Flow(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
 	pf := NewPanelsFrame()
-	defer pf.Close()
+	t.Cleanup(pf.Close)
 	pf.ResizeConsole(80, 25)
 
 	tmpDir := t.TempDir()
 	fspSrc := pf.panels[0].(*FileSystemPanel)
 	fspDst := pf.panels[1].(*FileSystemPanel)
+	waitForLoad(t, fspSrc)
+	waitForLoad(t, fspDst)
 
 	srcDir := filepath.Join(tmpDir, "src")
 	dstDir := filepath.Join(tmpDir, "dst")
@@ -2630,6 +2633,8 @@ func TestActionCreateLink_Flow(t *testing.T) {
 	linkPath := filepath.Join(dstDir, "link.txt")
 	editDest.SetText(linkPath)
 
+	srcGeneration := fspSrc.loadingGeneration
+	dstGeneration := fspDst.loadingGeneration
 	clickDialogButton(t, dlg, "Create link")
 
 	// Drain task queue to execute async creation task
@@ -2651,6 +2656,18 @@ func TestActionCreateLink_Flow(t *testing.T) {
 	if _, err := os.Lstat(linkPath); err != nil {
 		t.Fatalf("Link was not created at %s: %v", linkPath, err)
 	}
+
+	timeout = time.After(2 * time.Second)
+	for fspSrc.loadingGeneration == srcGeneration || fspDst.loadingGeneration == dstGeneration {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			t.Fatal("Timeout waiting for link completion refresh")
+		}
+	}
+	waitForLoad(t, fspSrc)
+	waitForLoad(t, fspDst)
 }
 func TestActionSwitchEditorToViewerAndBack(t *testing.T) {
 	scr := vtui.NewSilentScreenBuf()

--- a/cmd/f4/arkanoid.go
+++ b/cmd/f4/arkanoid.go
@@ -37,6 +37,8 @@ type scorePopup struct {
 type ArkanoidFrame struct {
 	vtui.BaseWindow
 	mu              sync.Mutex
+	stop            chan struct{}
+	stopOnce        sync.Once
 	paddleX         int
 	paddleW         int
 	ballX, ballY    float64
@@ -67,6 +69,7 @@ func NewArkanoidFrame() *ArkanoidFrame {
 
 	af := &ArkanoidFrame{
 		BaseWindow: *vtui.NewBaseWindow(x1, 2, x1+width-1, 2+height-1, " A R K A N O I D "),
+		stop:       make(chan struct{}),
 		lives:      3,
 		multiplier: 1,
 		level:      1,
@@ -119,6 +122,15 @@ func (af *ArkanoidFrame) RunOnUI(fn func()) {
 	}
 }
 
+func (af *ArkanoidFrame) Close() {
+	af.stopOnce.Do(func() {
+		if af.stop != nil {
+			close(af.stop)
+		}
+	})
+	af.BaseWindow.Close()
+}
+
 func (af *ArkanoidFrame) gameLoop() {
 	for !af.IsDone() {
 		// Динамическая задержка на основе autoSpeed
@@ -127,7 +139,13 @@ func (af *ArkanoidFrame) gameLoop() {
 			delay = 5 * time.Millisecond
 		}
 
-		time.Sleep(delay)
+		timer := time.NewTimer(delay)
+		select {
+		case <-timer.C:
+		case <-af.stop:
+			timer.Stop()
+			return
+		}
 		// Авто-пауза при потере фокуса или Game Over
 		if af.gameOver || !af.IsFocused() {
 			continue

--- a/cmd/f4/command_palette_dynamic_test.go
+++ b/cmd/f4/command_palette_dynamic_test.go
@@ -520,6 +520,8 @@ func TestCommandPaletteIndexesPanelContextAndPlatformDriveCommands(t *testing.T)
 }
 
 func TestCommandPaletteBookmarksRejectPluginOnlyAndStalePanelTargets(t *testing.T) {
+	// Keep unrelated process-wide config users on the TestMain directory.
+	_ = GetF4ConfigDir()
 	configRoot := t.TempDir()
 	oldUserConfigDir := userConfigDir
 	userConfigDir = func() (string, error) { return configRoot, nil }

--- a/cmd/f4/editor_binary_open_test.go
+++ b/cmd/f4/editor_binary_open_test.go
@@ -56,6 +56,7 @@ func TestStartIndexingSkipsHexAndDecodeModes(t *testing.T) {
 // A binary file opened for editing goes straight into hex on the lazy chunked
 // path (codepage 65001) without a background scan.
 func TestShowEditorBinaryOpensInHex(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	drainPendingTasks()
 
@@ -68,8 +69,21 @@ func TestShowEditorBinaryOpensInHex(t *testing.T) {
 	localVFS := vfs.NewOSVFS(dir)
 	_ = localVFS.SetPath(dir)
 	pf := NewPanelsFrame()
-	pf.panels[0] = NewFileSystemPanel(0, 0, 40, 20, localVFS)
-	pf.panels[1] = NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+	t.Cleanup(pf.Close)
+	for _, panel := range pf.panels {
+		if fsp, ok := panel.(*FileSystemPanel); ok {
+			if fsp.cancelLoad != nil {
+				fsp.cancelLoad()
+			}
+			fsp.stopLoadingAnimation()
+		}
+	}
+	left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
+	right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+	pf.panels[0] = left
+	pf.panels[1] = right
+	waitForLoad(t, left)
+	waitForLoad(t, right)
 	pf.ResizeConsole(120, 60)
 	vtui.FrameManager.Push(pf)
 
@@ -83,7 +97,7 @@ func TestShowEditorBinaryOpensInHex(t *testing.T) {
 	if ev == nil {
 		t.Fatal("editor was not opened")
 	}
-	defer ev.Close()
+	t.Cleanup(ev.Close)
 	if !ev.HexMode || ev.Codepage != 65001 {
 		t.Errorf("binary file must open in hex with codepage 65001, got hex=%v cp=%d", ev.HexMode, ev.Codepage)
 	}

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -5269,11 +5269,29 @@ func TestEditorView_CursorScrollbarBoundary(t *testing.T) {
 }
 
 func TestEditorView_SearchPersistence(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	origPattern := LastEditorSearch
+	origCase := LastEditorSearchCase
+	origReverse := LastEditorSearchReverse
+	origRegexp := LastEditorSearchRegexp
+	origWholeWord := LastEditorSearchWholeWord
+	t.Cleanup(func() {
+		LastEditorSearch = origPattern
+		LastEditorSearchCase = origCase
+		LastEditorSearchReverse = origReverse
+		LastEditorSearchRegexp = origRegexp
+		LastEditorSearchWholeWord = origWholeWord
+	})
+	origSessionPath := getSessionIniPath
+	sessionDir := t.TempDir()
+	getSessionIniPath = func() string { return filepath.Join(sessionDir, "session.ini") }
+	t.Cleanup(func() { getSessionIniPath = origSessionPath })
 
 	// 1. Выполняем поиск
-	ev1 := NewEditorView(piecetable.New([]byte("data")), nil, "f1.txt")
-	defer ev1.Close()
+	ev1 := NewEditorView(piecetable.New([]byte("pattern")), nil, "f1.txt")
+	t.Cleanup(ev1.Close)
+	ev1.CursorPos = len("pattern")
 	ev1.Search("pattern", true, true, false, false, false)
 
 	// Дожидаемся завершения асинхронного поиска
@@ -5284,7 +5302,7 @@ func TestEditorView_SearchPersistence(t *testing.T) {
 			task()
 		case <-time.After(10 * time.Millisecond):
 		}
-		if LastEditorSearch == "pattern" {
+		if ev1.selActive {
 			break
 		}
 		select {

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -2230,8 +2230,16 @@ func TestFileSystemPanel_RightDoubleClickAppliesToWholePanel(t *testing.T) {
 }
 
 func TestFileSystemPanel_IncrementalInteraction(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(t.TempDir()))
+	t.Cleanup(func() {
+		if fp.cancelLoad != nil {
+			fp.cancelLoad()
+		}
+		fp.stopLoadingAnimation()
+	})
+	waitForLoad(t, fp)
 
 	// Ensure we have '..' as initial state
 	fp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
@@ -2862,6 +2870,12 @@ func TestFileSystemPanel_DirectoryCache(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 20, v)
+	t.Cleanup(func() {
+		if fp.cancelLoad != nil {
+			fp.cancelLoad()
+		}
+		fp.stopLoadingAnimation()
+	})
 
 	// 1. Manually populate cache
 	items := []vfs.VFSItem{
@@ -2889,6 +2903,7 @@ func TestFileSystemPanel_DirectoryCache(t *testing.T) {
 	if !found {
 		t.Error("Cached file not found in panel entries")
 	}
+	waitForLoad(t, fp)
 }
 
 func TestFileSystemPanel_DirectoryCacheIsScopedBySession(t *testing.T) {

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -3003,6 +3003,7 @@ func TestPanelsFrame_Clone_CachePreservation(t *testing.T) {
 }
 
 func TestExecuteFileOp_BackgroundButtonTrigger(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	// This test ensures that the logic inside Background button click works
 	fm := vtui.FrameManager
 	fm.Init(vtui.NewSilentScreenBuf())
@@ -3016,6 +3017,7 @@ func TestExecuteFileOp_BackgroundButtonTrigger(t *testing.T) {
 
 	// Simulate what Background button does:
 	fork := pf.Clone()
+	t.Cleanup(fork.Close)
 	fm.AddScreen(fork)
 
 	if len(fm.Screens) != initialScreens+1 {

--- a/cmd/f4/portable_test.go
+++ b/cmd/f4/portable_test.go
@@ -11,12 +11,20 @@ func TestConfig_PortableProfile(t *testing.T) {
 
 	// Имитируем путь исполняемого файла в тестовой директории
 	origExeFunc := osExecutable
+	origConfigDir := GetF4ConfigDir()
+	origPortable := cachedF4Portable
+	t.Cleanup(func() {
+		osExecutable = origExeFunc
+		resetConfigDirForTest()
+		cachedF4ConfigDir = origConfigDir
+		cachedF4Portable = origPortable
+		configDirOnce.Do(func() {})
+	})
 	mockExe := filepath.Join(tmpDir, "f4.exe")
 	os.WriteFile(mockExe, []byte(""), 0755)
 	osExecutable = func() (string, error) {
 		return mockExe, nil
 	}
-	defer func() { osExecutable = origExeFunc }()
 
 	// 1. Создаем f4.exe.ini с параметром UseSystemProfiles = 0
 	iniContent := `
@@ -34,7 +42,4 @@ UseSystemProfiles = 0
 	if filepath.Clean(gotDir) != filepath.Clean(wantDir) {
 		t.Errorf("Expected portable profile dir %q, got %q", wantDir, gotDir)
 	}
-
-	// Очищаем состояние для последующих тестов
-	resetConfigDirForTest()
 }

--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -566,7 +566,11 @@ func TestQueueManagerCancelQueuedAndCancelAll(t *testing.T) {
 	queuedCtx, queuedCancel := context.WithCancel(context.Background())
 	runningCtx, runningCancel := context.WithCancel(context.Background())
 	cancellingCtx, cancellingCancel := context.WithCancel(context.Background())
-	queued := &QueueTask{ID: 1, State: "Queued", ctx: queuedCtx, cancel: queuedCancel}
+	queuedComplete := make(chan struct{})
+	queued := &QueueTask{
+		ID: 1, State: "Queued", ctx: queuedCtx, cancel: queuedCancel,
+		OnComplete: func() { close(queuedComplete) },
+	}
 	running := &QueueTask{ID: 2, State: "Running", ctx: runningCtx, cancel: runningCancel}
 	cancelling := &QueueTask{ID: 3, State: "Cancelling", ctx: cancellingCtx, cancel: cancellingCancel}
 	done := &QueueTask{ID: 4, State: "Done"}
@@ -588,6 +592,17 @@ func TestQueueManagerCancelQueuedAndCancelAll(t *testing.T) {
 			t.Fatal("queued cancellation did not finish")
 		}
 		time.Sleep(time.Millisecond)
+	}
+pumpQueuedCompletion:
+	for {
+		select {
+		case <-queuedComplete:
+			break pumpQueuedCompletion
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-time.After(time.Second):
+			t.Fatal("queued cancellation completion callback did not run")
+		}
 	}
 
 	for _, tt := range []struct {

--- a/cmd/f4/rpc_plugin_test.go
+++ b/cmd/f4/rpc_plugin_test.go
@@ -198,9 +198,15 @@ func TestRPCPlugin_Progress_Cancellation(t *testing.T) {
 }
 func TestRPCPlugin_NativePermissionDenied(t *testing.T) {
 	tmpDir := t.TempDir()
+	_ = GetF4ConfigDir()
+	_ = PluginPermissions()
 	oldConfigDir := cachedF4ConfigDir
+	oldPermissionStore := pluginPermissionStore
 	cachedF4ConfigDir = tmpDir
-	defer func() { cachedF4ConfigDir = oldConfigDir }()
+	t.Cleanup(func() {
+		cachedF4ConfigDir = oldConfigDir
+		pluginPermissionStore = oldPermissionStore
+	})
 
 	pluginPermissionStore = LoadPermissionStore(DefaultPermissionStorePath())
 


### PR DESCRIPTION
Running the suite with -shuffle=on turned up a tail of failures that only
appear in particular orders. Each one is a test that returned while something
it started was still running, or that restored a global to the wrong value.
The victim is never where the problem is.

Most of it comes down to the same shape. cmd/f4 tests share vtui's
FrameManager and its task queue, so anything still queued when a test returns
gets run by the next test, inside its assertions.

  TestQueueManagerCancelQueuedAndCancelAll returned once it saw the state go
  to Cancelled, but the completion callback that reads FrameManager had not
  run yet. It landed in TestViewerView_MouseScrollbar.

  TestFileSystemPanel_DirectoryCache returned with its second directory read
  still in flight. t.TempDir then removed the directory, the read failed, and
  its failure queued an error dialog with a single Ok button.
  TestActionDelete_Abort picked that dialog up, took it for its own delete
  confirmation, and reported that it could not find the Abort button. That one
  took a while to see precisely because the two tests have nothing to do with
  each other.

  TestExecuteFileOp_BackgroundButtonTrigger and TestShowEditorBinaryOpensInHex
  each left a PanelsFrame in the shared manager for TestSession_DiskPersistence
  to snapshot.

  TestEditorView_SearchPersistence waited on globals that are written
  synchronously and returned with its dialog and task still pending.

The rest are globals restored carelessly. TestConfig_PortableProfile cleared
the cached config directory instead of putting back what was there.
TestRPCPlugin_NativePermissionDenied could leave configDirOnce completed with
the cached directory empty, which is a state production cannot reach, so the
next reader saw a sync.Once that had run and produced nothing.
TestCommandPaletteBookmarksRejectPluginOnlyAndStalePanelTargets could leave the
process-wide config cache pointing at its deleted temporary directory.

One of these is not a test bug. ArkanoidFrame's game loop had no way to be
stopped: Close could not tell it to exit, so it kept ticking and posting
redraws and high-score writes into whatever FrameManager existed by then. It
now has a stop channel, and the loop still checks IsDone as well, because Close
is not the only thing that marks a frame done.

-shuffle=on is deliberately not added to CI here. That is a follow-up, once
this has had time to prove quiet.