### PR TITLE
fix: order vtvibe session resets against background directory reads

### DIFF
--- a/vtvibe/pack.go
+++ b/vtvibe/pack.go
@@ -16,6 +16,8 @@ import (
 // Two runs over the same tree produce byte identical output: there is no
 // timestamp in the header on purpose.
 func (s *Session) Pack() string {
+	s.treeMu.RLock()
+	defer s.treeMu.RUnlock()
 	files := s.tree.walkFiles(ctxDir)
 	var body bytes.Buffer
 	var tree bytes.Buffer

--- a/vtvibe/session.go
+++ b/vtvibe/session.go
@@ -49,6 +49,10 @@ type Status struct {
 // A single Session is shared by every ai:// panel, so both panes and both
 // panels of a split view look at the same conversation.
 type Session struct {
+	// treeMu protects only the identity of tree: Reset takes the write lock
+	// while AIVFS operations, Draft, ClearDraft and Pack take the read lock.
+	// memTree.mu separately protects the tree contents.
+	treeMu sync.RWMutex
 	mu     sync.Mutex
 	tree   *memTree
 	turns  []Turn
@@ -136,6 +140,8 @@ by typing "ai:" in the command line with nothing after the colon.
 func (s *Session) Reset(keepContext bool) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.treeMu.Lock()
+	defer s.treeMu.Unlock()
 	var keep map[string][]byte
 	if keepContext {
 		keep = map[string][]byte{}
@@ -190,6 +196,8 @@ func (s *Session) LastPatch() *Patch {
 }
 
 func (s *Session) Draft() string {
+	s.treeMu.RLock()
+	defer s.treeMu.RUnlock()
 	data, _ := s.tree.readFile(draftFile)
 	text := strings.TrimSpace(string(data))
 	if text == strings.TrimSpace(draftTemplate) {
@@ -200,6 +208,8 @@ func (s *Session) Draft() string {
 
 // ClearDraft empties the draft after it has been sent.
 func (s *Session) ClearDraft() {
+	s.treeMu.RLock()
+	defer s.treeMu.RUnlock()
 	_ = s.tree.writeFile(draftFile, []byte(draftTemplate))
 }
 

--- a/vtvibe/session_test.go
+++ b/vtvibe/session_test.go
@@ -2,6 +2,8 @@ package vtvibe
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -90,4 +92,43 @@ func TestAIVFS_CreateRedirectsToContextWhenCwdIsChat(t *testing.T) {
 		t.Fatalf("expected Open /chat/status.sh to find /ctx/status.sh, got %v", err)
 	}
 	_ = r.Close()
+}
+
+func TestAIVFS_ConcurrentReset(t *testing.T) {
+	s := NewSession()
+	v := NewVFS(s)
+	ctx := context.Background()
+
+	const iterations = 100
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			s.Reset(true)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		<-start
+		for range iterations {
+			if _, err := v.Stat(ctx, "/"); err != nil {
+				errs <- fmt.Errorf("Stat root: %w", err)
+				return
+			}
+			if err := v.ReadDir(ctx, "/", nil); err != nil {
+				errs <- fmt.Errorf("ReadDir root: %w", err)
+				return
+			}
+		}
+	}()
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
 }

--- a/vtvibe/vfs.go
+++ b/vtvibe/vfs.go
@@ -39,6 +39,8 @@ func (v *AIVFS) IsAbs(p string) bool {
 
 func (v *AIVFS) SetPath(p string) error {
 	target := v.normalize(p)
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	if n, ok := v.s.tree.stat(target); !ok || !n.isDir {
 		return os.ErrNotExist
 	}
@@ -65,14 +67,18 @@ func (v *AIVFS) normalize(p string) string {
 func (v *AIVFS) ReadDir(ctx context.Context, p string, onChunk func([]vfs.VFSItem)) error {
 	v.s.refresh()
 	target := v.normalize(p)
+	v.s.treeMu.RLock()
 	n, ok := v.s.tree.stat(target)
 	if !ok || !n.isDir {
+		v.s.treeMu.RUnlock()
 		return os.ErrNotExist
 	}
 	if onChunk == nil {
+		v.s.treeMu.RUnlock()
 		return nil
 	}
 	children := v.s.tree.list(target)
+	v.s.treeMu.RUnlock()
 	items := make([]vfs.VFSItem, 0, len(children))
 	for _, c := range children {
 		items = append(items, toItem(c))
@@ -86,6 +92,8 @@ func (v *AIVFS) ReadDir(ctx context.Context, p string, onChunk func([]vfs.VFSIte
 func (v *AIVFS) Stat(ctx context.Context, p string) (vfs.VFSItem, error) {
 	v.s.refresh()
 	target := v.normalize(p)
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	n, ok := v.s.tree.stat(target)
 	if !ok {
 		if altNode, altOk := v.s.tree.stat(path.Join(ctxDir, path.Base(target))); altOk {
@@ -156,6 +164,8 @@ func (v *AIVFS) MkDir(ctx context.Context, p string) error {
 	if !writable(target) {
 		return os.ErrPermission
 	}
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	return v.s.tree.mkdirAll(target)
 }
 
@@ -164,7 +174,9 @@ func (v *AIVFS) Remove(ctx context.Context, p string) error {
 	if !writable(target) || target == ctxDir || target == outDir {
 		return os.ErrPermission
 	}
+	v.s.treeMu.RLock()
 	err := v.s.tree.remove(target)
+	v.s.treeMu.RUnlock()
 	v.s.refresh()
 	return err
 }
@@ -174,6 +186,8 @@ func (v *AIVFS) Rename(ctx context.Context, oldPath, newPath string) error {
 	if !writable(from) || !writable(to) {
 		return os.ErrPermission
 	}
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	return v.s.tree.rename(from, to)
 }
 
@@ -192,6 +206,8 @@ func (v *AIVFS) Search(ctx context.Context, p string, pattern string) (chan int6
 func (v *AIVFS) Open(ctx context.Context, p string) (vfs.ReadAtCloser, error) {
 	v.s.refresh()
 	target := v.normalize(p)
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	data, ok := v.s.tree.readFile(target)
 	if !ok {
 		if altData, altOk := v.s.tree.readFile(path.Join(ctxDir, path.Base(target))); altOk {
@@ -219,6 +235,8 @@ func (v *AIVFS) Create(ctx context.Context, p string) (io.WriteCloser, error) {
 	if !writable(target) {
 		return nil, os.ErrPermission
 	}
+	v.s.treeMu.RLock()
+	defer v.s.treeMu.RUnlock()
 	if n, ok := v.s.tree.stat(target); ok && n.isDir {
 		return nil, os.ErrExist
 	}
@@ -288,7 +306,10 @@ func (w *memWriter) Close() error {
 	if w.failed != nil {
 		return w.failed
 	}
-	if err := w.v.s.tree.writeFile(w.path, w.buf); err != nil {
+	w.v.s.treeMu.RLock()
+	err := w.v.s.tree.writeFile(w.path, w.buf)
+	w.v.s.treeMu.RUnlock()
+	if err != nil {
 		return err
 	}
 	w.v.s.refresh()


### PR DESCRIPTION
Under the race detector, 23 of the 81 warnings in cmd/f4 were the same pair:
Session.reset replacing the session tree on the action goroutine while a
background directory read walked it through AIVFS.

    Write  vtvibe.(*Session).reset      session.go:116
      via  cmd/f4.aiAskAction, PanelsFrame.NavigateToPath
    Read   vtvibe.(*AIVFS).Stat         vfs.go:89
      via  cmd/f4.(*FileSystemPanel).readDirectoryEx.func1

memTree already had a mutex, so the contents of the tree were safe. What was
not was the pointer to it: Reset swaps in a whole new tree, and nothing ordered
that swap against readers still holding the old one. Both sides are production
code.

treeMu guards exactly that pointer and nothing else, which is why it is a
second lock rather than a wider use of the existing one. Reset takes it for
writing, everything reaching s.tree takes it for reading, and memTree.mu keeps
doing what it did.

Two things the layout depends on, worth stating because they are easy to undo:

ReadDir releases the lock before calling onChunk, and Remove and the writer's
Close release it before calling refresh. Neither may run under treeMu -- the
callback re-enters this VFS and refresh takes s.mu. Reset is the only place
that holds both, and it takes s.mu first, so that is the order.

An AIVFS handed out before a Reset keeps working afterwards; it simply sees the
new tree. That matches how the panels use it, since they hold one for the
lifetime of the panel and Reset is a user action underneath them.

Verified by reverting the change and watching the added test report the race
under -race, then passing five runs with it restored.