### PR TITLE
test: check the errors these tests were throwing away

### DIFF
--- a/fusefs/bridge_test.go
+++ b/fusefs/bridge_test.go
@@ -269,7 +269,7 @@ func TestReadRandomAccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer h.release()
+	defer func() { _ = h.release() }()
 
 	buf := make([]byte, 3)
 	n, err := h.readAt(context.Background(), buf, 2)
@@ -290,7 +290,7 @@ func TestSequentialBackendIsSpooled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer h.release()
+	defer func() { _ = h.release() }()
 
 	if h.tmp == nil {
 		t.Fatalf("a backend without random access must be spooled")
@@ -317,8 +317,12 @@ func TestReleaseIsIdempotent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	h.release()
-	h.release()
+	if err := h.release(); err != nil {
+		t.Fatalf("first release: %v", err)
+	}
+	if err := h.release(); err != nil {
+		t.Fatalf("second release: %v", err)
+	}
 	if _, err := h.readAt(context.Background(), make([]byte, 1), 0); !errors.Is(err, errClosed) {
 		t.Fatalf("read after release = %v, want errClosed", err)
 	}
@@ -484,7 +488,13 @@ func TestMountAndUnmount(t *testing.T) {
 		// FUSE mounts can fail in environments without /dev/fuse access (like CI)
 		t.Skipf("Mount failed (missing FUSE privileges?): %v", err)
 	}
-	defer m.Unmount()
+	t.Cleanup(func() {
+		if m.Active() {
+			if err := m.Unmount(); err != nil {
+				t.Errorf("cleanup unmount: %v", err)
+			}
+		}
+	})
 
 	if m.MountPoint != mountPoint {
 		t.Errorf("expected mount point %s, got %s", mountPoint, m.MountPoint)

--- a/fusefs/cli_test.go
+++ b/fusefs/cli_test.go
@@ -459,7 +459,7 @@ func TestAwaitReadySuccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	go reportReady(w, readyMessage{OK: true, MountPoint: "/mnt/x", PID: 42})
 
 	msg, err := awaitReady(r, 2*time.Second)
@@ -476,8 +476,10 @@ func TestAwaitReadyChildDiedSilently(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
-	w.Close() // the child exited without saying anything
+	defer func() { _ = r.Close() }()
+	if err := w.Close(); err != nil { // the child exited without saying anything
+		t.Fatalf("close readiness pipe: %v", err)
+	}
 
 	if _, err := awaitReady(r, 2*time.Second); err == nil {
 		t.Fatal("a silent child must be reported as a failure, not as success")
@@ -489,8 +491,12 @@ func TestAwaitReadyTimesOut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
-	defer w.Close() // held open: the child is up but wedged
+	defer func() { _ = r.Close() }()
+	t.Cleanup(func() {
+		if err := w.Close(); err != nil { // held open: the child is up but wedged
+			t.Errorf("close readiness pipe: %v", err)
+		}
+	})
 
 	start := time.Now()
 	_, err = awaitReady(r, 50*time.Millisecond)

--- a/fusefs/staged_test.go
+++ b/fusefs/staged_test.go
@@ -11,7 +11,11 @@ func TestStagedFileTakesWritesInAnyOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newStagedFile: %v", err)
 	}
-	defer sf.Close()
+	t.Cleanup(func() {
+		if err := sf.Close(); err != nil {
+			t.Errorf("close staged file: %v", err)
+		}
+	})
 
 	// The kernel does not promise to write a file front to back, which is
 	// the whole reason this staging file exists.
@@ -52,7 +56,11 @@ func TestStagedFileTruncateAndSecondCommit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer sf.Close()
+	t.Cleanup(func() {
+		if err := sf.Close(); err != nil {
+			t.Errorf("close staged file: %v", err)
+		}
+	})
 
 	if _, err := sf.WriteAt([]byte("0123456789"), 0); err != nil {
 		t.Fatal(err)
@@ -86,7 +94,11 @@ func TestStagedFileIsUnlinked(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer sf.Close()
+	t.Cleanup(func() {
+		if err := sf.Close(); err != nil {
+			t.Errorf("close staged file: %v", err)
+		}
+	})
 	// Unlinked at creation, so a crash cannot leave it behind: the name is
 	// already gone while the handle still works.
 	if _, err := sf.f.Stat(); err != nil {

--- a/internal/netproxy/netproxy_test.go
+++ b/internal/netproxy/netproxy_test.go
@@ -59,7 +59,9 @@ func TestHTTPClientGoesThroughTheProxyWithAuth(t *testing.T) {
 	proxySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		gotAuth = r.Header.Get("Proxy-Authorization")
 		gotHost = r.Host
-		w.Write([]byte("through the proxy"))
+		if _, err := w.Write([]byte("through the proxy")); err != nil {
+			t.Errorf("write proxy response: %v", err)
+		}
 	}))
 	defer proxySrv.Close()
 
@@ -71,7 +73,9 @@ func TestHTTPClientGoesThroughTheProxyWithAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request through the proxy failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close() // response body cleanup errors are uninteresting
+	}()
 	body, _ := io.ReadAll(resp.Body)
 
 	if string(body) != "through the proxy" {
@@ -92,7 +96,7 @@ func TestHTTPClientGoesThroughTheProxyWithAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("anonymous request through the proxy failed: %v", err)
 	}
-	resp2.Body.Close()
+	_ = resp2.Body.Close() // response body cleanup errors are uninteresting
 	if gotAuth != "" {
 		t.Errorf("unexpected Proxy-Authorization: %q", gotAuth)
 	}
@@ -103,7 +107,9 @@ func TestDirectModeIgnoresTheEnvironment(t *testing.T) {
 	t.Setenv("http_proxy", "http://127.0.0.1:1/")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("direct"))
+		if _, err := w.Write([]byte("direct")); err != nil {
+			t.Errorf("write direct response: %v", err)
+		}
 	}))
 	defer srv.Close()
 
@@ -111,7 +117,9 @@ func TestDirectModeIgnoresTheEnvironment(t *testing.T) {
 	if err != nil {
 		t.Fatalf("direct mode should have bypassed the env proxy: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close() // response body cleanup errors are uninteresting
+	}()
 	if body, _ := io.ReadAll(resp.Body); string(body) != "direct" {
 		t.Errorf("body: %q", body)
 	}
@@ -134,29 +142,43 @@ func fakeConnectProxy(t *testing.T, wantAuth string, target string) net.Listener
 				br := bufio.NewReader(c)
 				req, err := http.ReadRequest(br)
 				if err != nil {
-					c.Close()
+					_ = c.Close() // connection cleanup errors are uninteresting
 					return
 				}
 				if req.Method != http.MethodConnect || (wantAuth != "" && req.Header.Get("Proxy-Authorization") != wantAuth) {
-					io.WriteString(c, "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n")
-					c.Close()
+					if _, err := io.WriteString(c, "HTTP/1.1 407 Proxy Authentication Required\r\nContent-Length: 0\r\n\r\n"); err != nil {
+						_ = c.Close() // connection cleanup errors are uninteresting
+						return
+					}
+					_ = c.Close() // connection cleanup errors are uninteresting
 					return
 				}
 				up, err := net.Dial("tcp", target)
 				if err != nil {
-					io.WriteString(c, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n")
-					c.Close()
+					if _, err := io.WriteString(c, "HTTP/1.1 502 Bad Gateway\r\nContent-Length: 0\r\n\r\n"); err != nil {
+						_ = c.Close() // connection cleanup errors are uninteresting
+						return
+					}
+					_ = c.Close() // connection cleanup errors are uninteresting
 					return
 				}
-				io.WriteString(c, "HTTP/1.1 200 Connection established\r\n\r\n")
-				go io.Copy(up, c)
-				io.Copy(c, up)
-				up.Close()
-				c.Close()
+				if _, err := io.WriteString(c, "HTTP/1.1 200 Connection established\r\n\r\n"); err != nil {
+					_ = up.Close() // connection cleanup errors are uninteresting
+					_ = c.Close()  // connection cleanup errors are uninteresting
+					return
+				}
+				go func() {
+					_, _ = io.Copy(up, c) // tunnel shutdown errors are uninteresting
+				}()
+				_, _ = io.Copy(c, up) // tunnel shutdown errors are uninteresting
+				_ = up.Close()        // connection cleanup errors are uninteresting
+				_ = c.Close()         // connection cleanup errors are uninteresting
 			}(c)
 		}
 	}()
-	t.Cleanup(func() { ln.Close() })
+	t.Cleanup(func() {
+		_ = ln.Close() // listener cleanup errors are uninteresting
+	})
 	return ln
 }
 
@@ -167,15 +189,20 @@ func TestDialContextTunnelsRawTCPThroughCONNECT(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer site.Close()
+	defer func() {
+		_ = site.Close() // listener cleanup errors are uninteresting
+	}()
 	go func() {
 		for {
 			c, err := site.Accept()
 			if err != nil {
 				return
 			}
-			io.WriteString(c, "220 hello\r\n")
-			c.Close()
+			if _, err := io.WriteString(c, "220 hello\r\n"); err != nil {
+				_ = c.Close() // connection cleanup errors are uninteresting
+				continue
+			}
+			_ = c.Close() // connection cleanup errors are uninteresting
 		}
 	}()
 
@@ -191,7 +218,9 @@ func TestDialContextTunnelsRawTCPThroughCONNECT(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CONNECT tunnel failed: %v", err)
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close() // connection cleanup errors are uninteresting
+	}()
 	greeting, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil || !strings.HasPrefix(greeting, "220 hello") {
 		t.Errorf("greeting through the tunnel: %q, %v", greeting, err)

--- a/luaplug/ffi_test.go
+++ b/luaplug/ffi_test.go
@@ -16,18 +16,22 @@ func newFFIRuntime(t *testing.T) *Runtime {
 
 	bridge := ffibridge.New(ffibridge.Options{})
 	if _, err := bridge.OpenLibC(); err != nil {
-		bridge.Close()
+		_ = bridge.Close() // bridge cleanup cannot affect a skipped test
 		t.Skipf("no system C library available: %v", err)
 	}
 
 	r, err := New(Options{Name: "ffi test", FFI: bridge, CallTimeout: 5 * time.Second})
 	if err != nil {
-		bridge.Close()
+		_ = bridge.Close() // bridge cleanup cannot affect the primary failure
 		t.Fatalf("New: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = r.Close()
-		bridge.Close()
+		if err := r.Close(); err != nil {
+			t.Errorf("close runtime: %v", err)
+		}
+		if err := bridge.Close(); err != nil {
+			t.Errorf("close FFI bridge: %v", err)
+		}
 	})
 	return r
 }

--- a/luaplug/runtime_test.go
+++ b/luaplug/runtime_test.go
@@ -224,7 +224,11 @@ func TestUnsafeStdlibOptIn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer r.Close()
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("close runtime: %v", err)
+		}
+	})
 
 	if err := r.LoadString("plugin", "has_os = os ~= nil"); err != nil {
 		t.Fatalf("LoadString: %v", err)
@@ -244,7 +248,11 @@ func TestRuntimeTimeout(t *testing.T) {
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
-	defer r.Close()
+	t.Cleanup(func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("close runtime: %v", err)
+		}
+	})
 
 	start := time.Now()
 	err = r.LoadString("spin", "while true do end")

--- a/plugins/android/adb_integration_test.go
+++ b/plugins/android/adb_integration_test.go
@@ -155,7 +155,11 @@ func TestADBFishStartupTiming(t *testing.T) {
 	}
 
 	pool := newFishSessionPool()
-	defer pool.Close()
+	t.Cleanup(func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close FISH+ session pool: %v", err)
+		}
+	})
 	opener := &hybridDeviceOpener{
 		features: server.Features,
 		pool:     pool,
@@ -333,7 +337,11 @@ func TestADBDeviceIntegration(t *testing.T) {
 		}
 	}
 	pool := newFishSessionPool()
-	defer pool.Close()
+	t.Cleanup(func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close FISH+ session pool: %v", err)
+		}
+	})
 	opener := &hybridDeviceOpener{
 		features: func(context.Context, string) (map[string]bool, error) { return features, nil },
 		pool:     pool,
@@ -349,7 +357,11 @@ func TestADBDeviceIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open Android filesystem: %v", err)
 	}
-	defer mounted.Close()
+	t.Cleanup(func() {
+		if err := mounted.Close(); err != nil {
+			t.Errorf("close Android filesystem: %v", err)
+		}
+	})
 	var fishMounted *netfox.FishVFS
 	if os.Getenv("F4_ADB_TEST_FISH") != "" {
 		var ok bool

--- a/plugins/android/adb_transport_test.go
+++ b/plugins/android/adb_transport_test.go
@@ -41,7 +41,9 @@ func (d *scriptedADBDialer) dial(ctx context.Context, network, address string) (
 	d.mu.Unlock()
 	client, server := net.Pipe()
 	go func() {
-		defer server.Close()
+		defer func() {
+			_ = server.Close() // connection cleanup only
+		}()
 		handler(server)
 	}()
 	return client, nil
@@ -186,7 +188,9 @@ func TestOpenServiceSelectsTransportThenService(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenService: %v", err)
 	}
-	defer stream.Close()
+	defer func() {
+		_ = stream.Close() // connection cleanup only
+	}()
 	got := make([]byte, len("service bytes"))
 	if _, err := io.ReadFull(stream, got); err != nil {
 		t.Fatalf("read service: %v", err)
@@ -519,7 +523,9 @@ func TestShellStreamFramesStdin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenShellRaw: %v", err)
 	}
-	defer raw.Close()
+	defer func() {
+		_ = raw.Close() // connection cleanup only
+	}()
 	if _, err := raw.Write([]byte("request")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -585,7 +591,9 @@ func TestFailedConnectStartsInstalledADBAndRetries(t *testing.T) {
 		}
 		client, peer := net.Pipe()
 		go func() {
-			defer peer.Close()
+			defer func() {
+				_ = peer.Close() // connection cleanup only
+			}()
 			expectTestRequest(t, peer, "host:devices-l")
 			writeTestHostReply(t, peer, "")
 		}()

--- a/plugins/android/fish_pool_test.go
+++ b/plugins/android/fish_pool_test.go
@@ -33,7 +33,9 @@ func newPoolTestFish(t *testing.T, parent vfs.VFS, blockNoop ...<-chan struct{})
 	}
 	go func() {
 		defer close(peer.closed)
-		defer peerConn.Close()
+		defer func() {
+			_ = peerConn.Close() // connection cleanup only
+		}()
 		scanner := bufio.NewScanner(peerConn)
 		scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
 		if !scanner.Scan() {
@@ -78,7 +80,7 @@ func newPoolTestFish(t *testing.T, parent vfs.VFS, blockNoop ...<-chan struct{})
 
 	fish, err := netfox.NewFishVFSOnStream(context.Background(), parent, clientConn, clientConn, clientConn, "pool-test")
 	if err != nil {
-		clientConn.Close()
+		_ = clientConn.Close() // connection cleanup only
 		t.Fatalf("create test FishVFS: %v", err)
 	}
 	return fish, peer
@@ -138,7 +140,11 @@ func TestFishSessionPoolReusesConnectionAndReparentsView(t *testing.T) {
 
 func TestFishSessionPoolDoesNotRetainNonFishVFS(t *testing.T) {
 	pool := newFishSessionPool()
-	defer pool.Close()
+	t.Cleanup(func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close FISH+ session pool: %v", err)
+		}
+	})
 	var opens atomic.Int64
 	open := func(context.Context, vfs.VFS, DeviceInfo) (vfs.VFS, error) {
 		opens.Add(1)
@@ -221,7 +227,11 @@ func TestFishSessionPoolDoesNotWaitBehindBusyConnection(t *testing.T) {
 
 func TestFishSessionPoolReopensClosingConnection(t *testing.T) {
 	pool := newFishSessionPool()
-	defer pool.Close()
+	t.Cleanup(func() {
+		if err := pool.Close(); err != nil {
+			t.Errorf("close FISH+ session pool: %v", err)
+		}
+	})
 	device := DeviceInfo{Serial: "serial", State: DeviceStateOnline}
 	var opens atomic.Int64
 	open := func(_ context.Context, parent vfs.VFS, _ DeviceInfo) (vfs.VFS, error) {
@@ -244,7 +254,11 @@ func TestFishSessionPoolReopensClosingConnection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reopen closing pooled session: %v", err)
 	}
-	defer second.Close()
+	t.Cleanup(func() {
+		if err := second.Close(); err != nil {
+			t.Errorf("close reopened pooled session: %v", err)
+		}
+	})
 	if got := opens.Load(); got != 2 {
 		t.Fatalf("backend opens = %d, want 2", got)
 	}

--- a/plugins/archive/archive_plugin_test.go
+++ b/plugins/archive/archive_plugin_test.go
@@ -172,7 +172,11 @@ func TestArchivePluginKeepsShiftF1MenuWithoutContributionHost(t *testing.T) {
 	if err := plugin.Init(host); err != nil {
 		t.Fatal(err)
 	}
-	defer plugin.Close()
+	t.Cleanup(func() {
+		if err := plugin.Close(); err != nil {
+			t.Errorf("close archive plugin: %v", err)
+		}
+	})
 
 	if host.providers != 1 {
 		t.Fatalf("registered archive providers = %d, want 1", host.providers)

--- a/plugins/archive/archive_test.go
+++ b/plugins/archive/archive_test.go
@@ -25,13 +25,23 @@ func TestActionExtractArchive_Integrity(t *testing.T) {
 	f, _ := os.Create(srcZip)
 	zw := zip.NewWriter(f)
 	fw, _ := zw.Create("extracted.txt")
-	fw.Write([]byte("content to extract"))
-	zw.Create("empty_dir/")
-	zw.Close()
-	f.Close()
+	if _, err := fw.Write([]byte("content to extract")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := zw.Create("empty_dir/"); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	destDir := filepath.Join(tmpDir, "output")
-	os.Mkdir(destDir, 0755)
+	if err := os.Mkdir(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestZipCompression_Deflate(t *testing.T) {
@@ -40,7 +50,9 @@ func TestZipCompression_Deflate(t *testing.T) {
 
 	data := []byte(strings.Repeat("A", 1000))
 	filePath := filepath.Join(tmpDir, "data.txt")
-	os.WriteFile(filePath, data, 0644)
+	if err := os.WriteFile(filePath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	out, err := os.Create(arcPath)
 	if err != nil {
@@ -57,7 +69,9 @@ func TestZipCompression_Deflate(t *testing.T) {
 	}
 
 	err = z.Archive(context.Background(), out, files)
-	out.Close()
+	if closeErr := out.Close(); closeErr != nil {
+		t.Fatalf("close output archive: %v", closeErr)
+	}
 
 	if err != nil {
 		t.Fatalf("Archiving failed: %v", err)
@@ -67,7 +81,7 @@ func TestZipCompression_Deflate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open resulting zip: %v", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 
 	if len(r.File) == 0 {
 		t.Fatal("Zip is empty")
@@ -150,12 +164,20 @@ func TestActionExtractArchive_ProgressUpdates(t *testing.T) {
 	f, _ := os.Create(srcZip)
 	zw := zip.NewWriter(f)
 	fw, _ := zw.Create("file.txt")
-	fw.Write([]byte("some data"))
-	zw.Close()
-	f.Close()
+	if _, err := fw.Write([]byte("some data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	destDir := filepath.Join(tmpDir, "output")
-	os.Mkdir(destDir, 0755)
+	if err := os.Mkdir(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	activeVfs := vfs.NewOSVFS(tmpDir)
 	passiveVfs := vfs.NewOSVFS(destDir)
@@ -194,7 +216,9 @@ func TestActionAddArchive_ProgressUpdates(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	tmpDir := t.TempDir()
-	os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("data"), 0644)
+	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	activeVfs := vfs.NewOSVFS(tmpDir)
 
@@ -288,13 +312,21 @@ func TestActionExtractArchive_Cancellation(t *testing.T) {
 	zw := zip.NewWriter(f)
 	for i := 0; i < 100; i++ {
 		fw, _ := zw.Create(fmt.Sprintf("file_%d.txt", i))
-		fw.Write([]byte("some data to simulate work"))
+		if _, err := fw.Write([]byte("some data to simulate work")); err != nil {
+			t.Fatal(err)
+		}
 	}
-	zw.Close()
-	f.Close()
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	destDir := filepath.Join(tmpDir, "output_cancel")
-	os.Mkdir(destDir, 0755)
+	if err := os.Mkdir(destDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	activeVfs := vfs.NewOSVFS(tmpDir)
 	passiveVfs := vfs.NewOSVFS(destDir)

--- a/plugins/archive/extraction_security_test.go
+++ b/plugins/archive/extraction_security_test.go
@@ -48,7 +48,11 @@ func TestArchiveVFSCopyBulkRejectsTraversal(t *testing.T) {
 			if err != nil {
 				t.Fatalf("open malicious fixture: %v", err)
 			}
-			defer archiveVFS.Close()
+			t.Cleanup(func() {
+				if err := archiveVFS.Close(); err != nil {
+					t.Errorf("close malicious archive fixture: %v", err)
+				}
+			})
 			if archiveVFS.format != test.wantFormat {
 				t.Fatalf("fixture dispatch format = %q, want %q", archiveVFS.format, test.wantFormat)
 			}

--- a/plugins/archive/provider_test.go
+++ b/plugins/archive/provider_test.go
@@ -27,14 +27,18 @@ func TestArchiveProvider_CanOpen(t *testing.T) {
 
 	// 1. Valid formats (e.g. .zip)
 	tmpZip := filepath.Join(t.TempDir(), "test.zip")
-	os.WriteFile(tmpZip, []byte("PK\x03\x04..."), 0644) // Zip magic bytes
+	if err := os.WriteFile(tmpZip, []byte("PK\x03\x04..."), 0644); err != nil { // Zip magic bytes
+		t.Fatal(err)
+	}
 	if !p.CanOpen(ctx, nil, tmpZip) {
 		t.Errorf("Expected CanOpen=true for %q", tmpZip)
 	}
 
 	// 2. Invalid formats (e.g. .txt)
 	tmpTxt := filepath.Join(t.TempDir(), "test.txt")
-	os.WriteFile(tmpTxt, []byte("plain text"), 0644)
+	if err := os.WriteFile(tmpTxt, []byte("plain text"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	if p.CanOpen(ctx, nil, tmpTxt) {
 		t.Errorf("Expected CanOpen=false for %q", tmpTxt)
 	}
@@ -47,7 +51,9 @@ func TestArchiveProvider_Open(t *testing.T) {
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "empty.zip")
 	// Write empty zip structure (22 bytes EOCD)
-	os.WriteFile(zipPath, []byte("\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644)
+	if err := os.WriteFile(zipPath, []byte("\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	parent := vfs.NewOSVFS(tmpDir)
 
@@ -55,7 +61,11 @@ func TestArchiveProvider_Open(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open failed: %v", err)
 	}
-	defer v.Close()
+	t.Cleanup(func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	if _, ok := v.(*ArchiveVFS); !ok {
 		t.Errorf("Expected Open to return *ArchiveVFS, got %T", v)

--- a/plugins/archive/repro_test.go
+++ b/plugins/archive/repro_test.go
@@ -85,9 +85,10 @@ func TestHangReproduction_RootChroot(t *testing.T) {
 			archiverErr = err
 			return
 		}
-		defer a.Close()
-
 		archiverErr = a.Archive(context.Background(), fileMap)
+		if closeErr := a.Close(); archiverErr == nil {
+			archiverErr = closeErr
+		}
 	}()
 
 	select {
@@ -107,11 +108,15 @@ func TestActionAddArchive_OverwriteWarning(t *testing.T) {
 	v := vfs.NewOSVFS(tmpDir)
 
 	dummyFile := v.Join(tmpDir, "file_to_archive.txt")
-	os.WriteFile(dummyFile, []byte("some content"), 0644)
+	if err := os.WriteFile(dummyFile, []byte("some content"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	archiveName := v.Base(tmpDir) + ".zip"
 	existingArchive := v.Join(tmpDir, archiveName)
-	os.WriteFile(existingArchive, []byte("existing zip content"), 0644)
+	if err := os.WriteFile(existingArchive, []byte("existing zip content"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	app := &mockOverwriteApp{
 		t:     t,
@@ -143,16 +148,26 @@ func TestIssue137_ArchiveOpenIsLazyAndContextAware(t *testing.T) {
 	w, _ := zw.Create("large.bin")
 	chunk := []byte(strings.Repeat("A", 1024*1024))
 	for i := 0; i < 5; i++ {
-		w.Write(chunk)
+		if _, err := w.Write(chunk); err != nil {
+			t.Fatal(err)
+		}
 	}
-	zw.Close()
-	f.Close()
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	vArc, err := NewArchiveVFS(&vfs.OSVFS{}, zipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vArc.Close()
+	t.Cleanup(func() {
+		if err := vArc.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	// Test 1: Open should be fast and not block
 	start := time.Now()
@@ -163,7 +178,7 @@ func TestIssue137_ArchiveOpenIsLazyAndContextAware(t *testing.T) {
 	if time.Since(start) > 500*time.Millisecond {
 		t.Fatalf("BUG REPRODUCED: Open took too long, likely synchronously extracting!")
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	// Test 2: ReadAt respects cancellation
 	ctx, cancel := context.WithCancel(context.Background())
@@ -186,7 +201,9 @@ func TestArchivePlugin_ConcurrentOperationWarning(t *testing.T) {
 	v := vfs.NewOSVFS(tmpDir)
 
 	dummyFile := filepath.Join(tmpDir, "test.zip")
-	os.WriteFile(dummyFile, []byte("dummy zip content"), 0644)
+	if err := os.WriteFile(dummyFile, []byte("dummy zip content"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Simulate an active operation already running for this archive
 	absPath, _ := v.Abs(dummyFile)
@@ -215,17 +232,25 @@ func TestIssue150_Concurrent7zReadDir(t *testing.T) {
 
 	// 1. Создаем тестовое дерево папок и файлов
 	srcDir := filepath.Join(tmpDir, "src")
-	os.MkdirAll(filepath.Join(srcDir, "dir1/dir2"), 0755)
-	os.WriteFile(filepath.Join(srcDir, "dir1/file1.txt"), []byte("data1"), 0644)
-	os.WriteFile(filepath.Join(srcDir, "dir1/dir2/file2.txt"), []byte("data2"), 0644)
+	if err := os.MkdirAll(filepath.Join(srcDir, "dir1/dir2"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "dir1/file1.txt"), []byte("data1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "dir1/dir2/file2.txt"), []byte("data2"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	fileMap := make(map[string]os.FileInfo)
-	filepath.Walk(srcDir, func(p string, fi os.FileInfo, err error) error {
+	if err := filepath.Walk(srcDir, func(p string, fi os.FileInfo, err error) error {
 		if err == nil && p != srcDir {
 			fileMap[p] = fi
 		}
 		return nil
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Сжимаем с флагом Solid
 	a, err := archive.NewArchiver(archivePath, srcDir, archive.Options{Solid: true})
@@ -233,7 +258,9 @@ func TestIssue150_Concurrent7zReadDir(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = a.Archive(context.Background(), fileMap)
-	a.Close()
+	if closeErr := a.Close(); closeErr != nil {
+		t.Fatalf("close concurrent archive fixture: %v", closeErr)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +270,11 @@ func TestIssue150_Concurrent7zReadDir(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer v.Close()
+	t.Cleanup(func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	// 3. Запускаем конкурентный обход дерева файлов
 	var wg sync.WaitGroup
@@ -271,17 +302,25 @@ func TestIssue150_7zDirectoryStructureAndSolid(t *testing.T) {
 	archivePath := filepath.Join(tmpDir, "test_structure.7z")
 
 	srcDir := filepath.Join(tmpDir, "src")
-	os.MkdirAll(filepath.Join(srcDir, "empty_dir"), 0755)
-	os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("solid content 1"), 0644)
-	os.WriteFile(filepath.Join(srcDir, "file2.txt"), []byte("solid content 2"), 0644)
+	if err := os.MkdirAll(filepath.Join(srcDir, "empty_dir"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("solid content 1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "file2.txt"), []byte("solid content 2"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	fileMap := make(map[string]os.FileInfo)
-	filepath.Walk(srcDir, func(p string, fi os.FileInfo, err error) error {
+	if err := filepath.Walk(srcDir, func(p string, fi os.FileInfo, err error) error {
 		if err == nil && p != srcDir {
 			fileMap[p] = fi
 		}
 		return nil
-	})
+	}); err != nil {
+		t.Fatal(err)
+	}
 
 	// Запаковываем в Solid-режиме
 	a, err := archive.NewArchiver(archivePath, srcDir, archive.Options{Solid: true})
@@ -289,7 +328,9 @@ func TestIssue150_7zDirectoryStructureAndSolid(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = a.Archive(context.Background(), fileMap)
-	a.Close()
+	if closeErr := a.Close(); closeErr != nil {
+		t.Fatalf("close solid archive fixture: %v", closeErr)
+	}
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +340,7 @@ func TestIssue150_7zDirectoryStructureAndSolid(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer zr.Close()
+	defer func() { _ = zr.Close() }()
 
 	// Проверяем, что директории помечены как IsDir() и имеют размер 0 (а не дублируются как файлы)
 	foundDir := false

--- a/plugins/archive/vfs_nested_test.go
+++ b/plugins/archive/vfs_nested_test.go
@@ -25,9 +25,15 @@ func TestArchiveVFS_NestedZip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	innerFile.Write([]byte("nested file content"))
-	innerZw.Close()
-	innerF.Close()
+	if _, err := innerFile.Write([]byte("nested file content")); err != nil {
+		t.Fatal(err)
+	}
+	if err := innerZw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := innerF.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	outerZipPath := filepath.Join(tmpDir, "outer.zip")
 	opts := archive.Options{
@@ -47,13 +53,19 @@ func TestArchiveVFS_NestedZip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	a.Close()
+	if err := a.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	vOuter, err := NewArchiveVFS(&vfs.OSVFS{}, outerZipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vOuter.Close()
+	t.Cleanup(func() {
+		if err := vOuter.Close(); err != nil {
+			t.Errorf("close outer archive VFS: %v", err)
+		}
+	})
 
 	solidPath := vOuter.Join(outerZipPath, "Solid.zip")
 	t.Logf("Opening Solid.zip: %q", solidPath)
@@ -61,7 +73,11 @@ func TestArchiveVFS_NestedZip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FAILED to open Solid.zip: %v", err)
 	}
-	defer vSolid.Close()
+	t.Cleanup(func() {
+		if err := vSolid.Close(); err != nil {
+			t.Errorf("close solid archive VFS: %v", err)
+		}
+	})
 
 	nestedPath := vSolid.Join(solidPath, "inner.zip")
 	t.Logf("Opening nested archive VFS: %q", nestedPath)
@@ -70,13 +86,17 @@ func TestArchiveVFS_NestedZip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FAILED to open nested ZIP (inner.zip): %v", err)
 	}
-	defer vInner.Close()
+	t.Cleanup(func() {
+		if err := vInner.Close(); err != nil {
+			t.Errorf("close nested archive VFS: %v", err)
+		}
+	})
 
 	rc, err := vInner.Open(context.Background(), vInner.Join(nestedPath, "test.txt"))
 	if err != nil {
 		t.Fatalf("FAILED to open file inside nested ZIP: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	data, err := io.ReadAll(ctxReader{rc, context.Background()})
 	if err != nil {

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -69,7 +69,11 @@ func TestArchiveVFS_SkipsExplicitRootEntryDuringScan(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer archiveVFS.Close()
+	t.Cleanup(func() {
+		if err := archiveVFS.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	var items []vfs.VFSItem
 	if err := archiveVFS.ReadDir(context.Background(), archiveVFS.GetPath(), func(chunk []vfs.VFSItem) {
@@ -152,21 +156,29 @@ func TestArchiveVFS_AtomicWrite(t *testing.T) {
 	tmp := t.TempDir()
 	arcPath := filepath.Join(tmp, "test.zip")
 
-	os.WriteFile(arcPath, []byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644)
+	if err := os.WriteFile(arcPath, []byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	origInfo, _ := os.Stat(arcPath)
 
 	v, err := NewArchiveVFS(&vfs.OSVFS{}, arcPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer v.Close()
+	t.Cleanup(func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	wc, err := v.Create(context.Background(), v.Join(arcPath, "newfile.txt"))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	wc.Write([]byte("some data"))
+	if _, err := wc.Write([]byte("some data")); err != nil {
+		t.Fatal(err)
+	}
 
 	currentInfo, _ := os.Stat(arcPath)
 	if currentInfo.Size() != origInfo.Size() {
@@ -190,15 +202,25 @@ func TestArchiveVFS_TempFileLeak(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w.Write([]byte("hello world"))
-	zw.Close()
-	f.Close()
+	if _, err := w.Write([]byte("hello world")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	vOuter, err := NewArchiveVFS(&vfs.OSVFS{}, zipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vOuter.Close()
+	t.Cleanup(func() {
+		if err := vOuter.Close(); err != nil {
+			t.Errorf("close outer archive VFS: %v", err)
+		}
+	})
 
 	rc, err := vOuter.Open(context.Background(), vOuter.Join(zipPath, "file.txt"))
 	if err != nil {
@@ -206,7 +228,9 @@ func TestArchiveVFS_TempFileLeak(t *testing.T) {
 	}
 
 	// Trigger lazy extraction which creates the temp file
-	rc.ReadAt(context.Background(), make([]byte, 1), 0)
+	if _, err := rc.ReadAt(context.Background(), make([]byte, 1), 0); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
 
 	var tempFilePath string
 	if wrapper, ok := rc.(*vfs.TempFileWrapper); ok {
@@ -222,10 +246,12 @@ func TestArchiveVFS_TempFileLeak(t *testing.T) {
 	}
 	t.Logf("Temp file created successfully at: %s", tempFilePath)
 
-	rc.Close()
+	if err := rc.Close(); err != nil {
+		t.Fatalf("close extracted temporary file: %v", err)
+	}
 
 	if _, err := os.Stat(tempFilePath); err == nil {
-		os.Remove(tempFilePath)
+		_ = os.Remove(tempFilePath) // t.TempDir cleanup will retry
 		t.Fatalf("TEST FAILED: Temp file %s was not deleted after Close()! Leak detected.", tempFilePath)
 	}
 
@@ -253,16 +279,24 @@ func TestArchiveVFS_DeferredClose(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w1.Write([]byte("content1"))
+	if _, err := w1.Write([]byte("content1")); err != nil {
+		t.Fatal(err)
+	}
 
 	w2, err := zw.Create("file2.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
-	w2.Write([]byte("content2"))
+	if _, err := w2.Write([]byte("content2")); err != nil {
+		t.Fatal(err)
+	}
 
-	zw.Close()
-	f.Close()
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	// 1. Open the archive VFS
 	vArc, err := NewArchiveVFS(&vfs.OSVFS{}, zipPath)
@@ -273,10 +307,12 @@ func TestArchiveVFS_DeferredClose(t *testing.T) {
 	// 2. Open the first file (simulates beginning of copy/extraction)
 	rc1, err := vArc.Open(context.Background(), vArc.Join(zipPath, "file1.txt"))
 	if err != nil {
-		vArc.Close()
+		_ = vArc.Close() // preserve the open failure
 		t.Fatal(err)
 	}
-	rc1.Close()
+	if err := rc1.Close(); err != nil {
+		t.Fatalf("close first archive reader: %v", err)
+	}
 
 	// 3. Simulate exiting the panel (closing the VFS) while extraction is active
 	errClose := vArc.Close()
@@ -289,7 +325,9 @@ func TestArchiveVFS_DeferredClose(t *testing.T) {
 	if errRead2 != nil {
 		t.Fatalf("BUG: Open file2 failed after VFS Close: %v. Expected to succeed due to active copy grace period.", errRead2)
 	}
-	rc2.Close()
+	if err := rc2.Close(); err != nil {
+		t.Fatalf("close second archive reader: %v", err)
+	}
 
 	// 5. Wait for the shortened test TTL to expire and perform cleanup.
 	time.Sleep(2 * archiveVFSIdleTTL)
@@ -346,15 +384,16 @@ func TestArchiveReadWrapper_CloseNonBlocking(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	closeDone := make(chan struct{})
+	closeDone := make(chan error, 1)
 	go func() {
-		w.Close()
-		close(closeDone)
+		closeDone <- w.Close()
 	}()
 
 	select {
-	case <-closeDone:
-		// Success
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("close archive read wrapper: %v", err)
+		}
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("archiveReadWrapper.Close() blocked because of active extraction holding the mutex!")
 	}
@@ -394,15 +433,16 @@ func TestArchiveVFS_OpenCloseNonBlocking(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	closeDone := make(chan struct{})
+	closeDone := make(chan error, 1)
 	go func() {
-		v.Close()
-		close(closeDone)
+		closeDone <- v.Close()
 	}()
 
 	select {
-	case <-closeDone:
-		// Success
+	case err := <-closeDone:
+		if err != nil {
+			t.Fatalf("close archive VFS: %v", err)
+		}
 	case <-time.After(10 * time.Second):
 		// Generous: on the happy path Close returns immediately, and a bound
 		// this loose still catches the regression — Close blocking forever.
@@ -514,15 +554,25 @@ func TestArchiveVFS_Open_ProgressReporting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w.Write([]byte("Progress test data"))
-	zw.Close()
-	f.Close()
+	if _, err := w.Write([]byte("Progress test data")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	vArc, err := NewArchiveVFS(&vfs.OSVFS{}, zipPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vArc.Close()
+	t.Cleanup(func() {
+		if err := vArc.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	callbackCalled := false
 	var lastCallbackPct int
@@ -541,7 +591,7 @@ func TestArchiveVFS_Open_ProgressReporting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open failed: %v", err)
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }()
 
 	if !callbackCalled {
 		t.Error("ProgressCallback was not invoked during Open")
@@ -584,23 +634,35 @@ func TestArchiveVFSCopyBulk(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	w1.Write([]byte("content1"))
+	if _, err := w1.Write([]byte("content1")); err != nil {
+		t.Fatal(err)
+	}
 
 	w2, err := zw.Create("folder/file2.txt")
 	if err != nil {
 		t.Fatal(err)
 	}
-	w2.Write([]byte("content2"))
+	if _, err := w2.Write([]byte("content2")); err != nil {
+		t.Fatal(err)
+	}
 
-	zw.Close()
-	f.Close()
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	parentVFS := vfs.NewOSVFS(tmpDir)
 	archiveVFS, err := NewArchiveVFS(parentVFS, "test.zip")
 	if err != nil {
 		t.Fatalf("failed to create ArchiveVFS: %v", err)
 	}
-	defer archiveVFS.Close()
+	t.Cleanup(func() {
+		if err := archiveVFS.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	dstDir := filepath.Join(tmpDir, "extracted")
 	dstVFS := vfs.NewOSVFS(dstDir)
@@ -623,7 +685,7 @@ func TestArchiveVFSCopyBulk(t *testing.T) {
 	if err != nil {
 		t.Fatal("file1.txt was not extracted")
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 	data1, _ := io.ReadAll(ctxReader{r: f1, ctx: context.Background()})
 	if string(data1) != "content1" {
 		t.Errorf("expected content1, got %q", string(data1))
@@ -633,7 +695,7 @@ func TestArchiveVFSCopyBulk(t *testing.T) {
 	if err != nil {
 		t.Fatal("folder/file2.txt was not extracted")
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 	data2, _ := io.ReadAll(ctxReader{r: f2, ctx: context.Background()})
 	if string(data2) != "content2" {
 		t.Errorf("expected content2, got %q", string(data2))
@@ -657,7 +719,9 @@ func TestArchiveVFSCopyBulk_Tar(t *testing.T) {
 	if err := tw.WriteHeader(hdr1); err != nil {
 		t.Fatal(err)
 	}
-	tw.Write([]byte("content1"))
+	if _, err := tw.Write([]byte("content1")); err != nil {
+		t.Fatal(err)
+	}
 
 	hdr2 := &tar.Header{
 		Name: "folder/file2.txt",
@@ -667,17 +731,27 @@ func TestArchiveVFSCopyBulk_Tar(t *testing.T) {
 	if err := tw.WriteHeader(hdr2); err != nil {
 		t.Fatal(err)
 	}
-	tw.Write([]byte("content2"))
+	if _, err := tw.Write([]byte("content2")); err != nil {
+		t.Fatal(err)
+	}
 
-	tw.Close()
-	f.Close()
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	parentVFS := vfs.NewOSVFS(tmpDir)
 	archiveVFS, err := NewArchiveVFS(parentVFS, "test.tar")
 	if err != nil {
 		t.Fatalf("failed to create ArchiveVFS: %v", err)
 	}
-	defer archiveVFS.Close()
+	t.Cleanup(func() {
+		if err := archiveVFS.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	dstDir := filepath.Join(tmpDir, "extracted")
 	dstVFS := vfs.NewOSVFS(dstDir)
@@ -700,7 +774,7 @@ func TestArchiveVFSCopyBulk_Tar(t *testing.T) {
 	if err != nil {
 		t.Fatal("file1.txt was not extracted")
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 	data1, _ := io.ReadAll(ctxReader{r: f1, ctx: context.Background()})
 	if string(data1) != "content1" {
 		t.Errorf("expected content1, got %q", string(data1))
@@ -710,7 +784,7 @@ func TestArchiveVFSCopyBulk_Tar(t *testing.T) {
 	if err != nil {
 		t.Fatal("folder/file2.txt was not extracted")
 	}
-	defer f2.Close()
+	defer func() { _ = f2.Close() }()
 	data2, _ := io.ReadAll(ctxReader{r: f2, ctx: context.Background()})
 	if string(data2) != "content2" {
 		t.Errorf("expected content2, got %q", string(data2))
@@ -727,16 +801,26 @@ func TestArchiveVFSCopyBulk_ConcurrentQueue(t *testing.T) {
 	}
 	zw := zip.NewWriter(f)
 	w1, _ := zw.Create("file1.txt")
-	w1.Write([]byte("content1"))
-	zw.Close()
-	f.Close()
+	if _, err := w1.Write([]byte("content1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
 
 	parentVFS := vfs.NewOSVFS(tmpDir)
 	archiveVFS, err := NewArchiveVFS(parentVFS, "test.zip")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer archiveVFS.Close()
+	t.Cleanup(func() {
+		if err := archiveVFS.Close(); err != nil {
+			t.Errorf("close archive VFS: %v", err)
+		}
+	})
 
 	absPath := archiveVFS.activePath()
 
@@ -747,7 +831,9 @@ func TestArchiveVFSCopyBulk_ConcurrentQueue(t *testing.T) {
 
 	dstDir := filepath.Join(tmpDir, "extracted")
 	dstVFS := vfs.NewOSVFS(dstDir)
-	dstVFS.MkDir(context.Background(), dstDir)
+	if err := dstVFS.MkDir(context.Background(), dstDir); err != nil {
+		t.Fatal(err)
+	}
 
 	copier := interface{}(archiveVFS).(vfs.BulkCopier)
 
@@ -787,7 +873,7 @@ func TestArchiveVFSCopyBulk_ConcurrentQueue(t *testing.T) {
 	if err != nil {
 		t.Fatal("file1.txt was not extracted")
 	}
-	defer f1.Close()
+	defer func() { _ = f1.Close() }()
 	data1, _ := io.ReadAll(ctxReader{r: f1, ctx: context.Background()})
 	if string(data1) != "content1" {
 		t.Errorf("expected content1, got %q", string(data1))

--- a/plugins/cloudfox/cloud_vfs_share_test.go
+++ b/plugins/cloudfox/cloud_vfs_share_test.go
@@ -49,7 +49,11 @@ func TestCloudVFSShareLinkAdapterResolvesAliasesAndCopiesCapabilities(t *testing
 		created: vfs.ShareLink{URL: "https://share.example/new?token=opaque", Role: vfs.ShareRoleViewer, ExpiresAt: time.Now().Add(time.Hour)},
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := cloud.ReadDir(context.Background(), cloud.GetPath(), func([]vfs.VFSItem) {}); err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +106,11 @@ func TestCloudVFSShareLinkAdapterRejectsUnsafeURLs(t *testing.T) {
 				created:     vfs.ShareLink{URL: raw},
 			}
 			cloud := testCloudVFS(t, backend)
-			defer cloud.Close()
+			t.Cleanup(func() {
+				if err := cloud.Close(); err != nil {
+					t.Errorf("close test resource: %v", err)
+				}
+			})
 			if _, err := cloud.ShareLinkInfo(context.Background(), cloud.GetPath()); err == nil {
 				t.Fatal("unsafe info URL was accepted")
 			}
@@ -130,7 +138,11 @@ func TestCloudVFSShareLinkAdapterRejectsMismatchedMutationResultsAsUnknown(t *te
 		t.Run(name, func(t *testing.T) {
 			backend := &fakeShareBackend{fakeBackend: &fakeBackend{}, created: created}
 			cloud := testCloudVFS(t, backend)
-			defer cloud.Close()
+			t.Cleanup(func() {
+				if err := cloud.Close(); err != nil {
+					t.Errorf("close test resource: %v", err)
+				}
+			})
 			_, err := cloud.CreateShareLink(context.Background(), cloud.GetPath(), request)
 			if !errors.Is(err, vfs.ErrOperationStateUnknown) {
 				t.Fatalf("CreateShareLink error = %v", err)
@@ -141,7 +153,11 @@ func TestCloudVFSShareLinkAdapterRejectsMismatchedMutationResultsAsUnknown(t *te
 
 func TestCloudVFSShareLinkAdapterReportsUnsupportedBackend(t *testing.T) {
 	cloud := testCloudVFS(t, &fakeBackend{})
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if _, err := cloud.ShareLinkInfo(context.Background(), cloud.GetPath()); !errors.Is(err, ErrShareLinksUnsupported) {
 		t.Fatalf("ShareLinkInfo error = %v", err)
 	}

--- a/plugins/cloudfox/cloud_vfs_test.go
+++ b/plugins/cloudfox/cloud_vfs_test.go
@@ -299,13 +299,17 @@ func TestSessionPoolCloseCancelsInFlightBackendOperation(t *testing.T) {
 
 func TestCloudReadHandleOutlivesOpenCallContext(t *testing.T) {
 	cloud := testCloudVFS(t, &readableFakeBackend{fakeBackend: &fakeBackend{}})
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	openCtx, cancelOpen := context.WithCancel(context.Background())
 	handle, err := cloud.Open(openCtx, cloud.GetPath())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer handle.Close()
+	defer func() { _ = handle.Close() }()
 
 	// Viewer opening runs inside a progress task. Completion cancels that
 	// task, but the returned handle must remain usable by subsequent paints.
@@ -318,7 +322,11 @@ func TestCloudReadHandleOutlivesOpenCallContext(t *testing.T) {
 
 func TestCloudVFSResolvesF5DestinationWithTrailingSlash(t *testing.T) {
 	cloud := testCloudVFS(t, &fakeBackend{})
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	directoryTarget := cloud.GetPath() + "/"
 	if !cloud.IsAbs(directoryTarget) {
 		t.Fatalf("F5 destination %q is not recognized as absolute", directoryTarget)
@@ -335,7 +343,11 @@ func TestCloudVFSResolvesF5DestinationWithTrailingSlash(t *testing.T) {
 
 func TestCloudVFSPanelTitleShowsFullPlatformPath(t *testing.T) {
 	cloud := testCloudVFS(t, &fakeBackend{})
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	separator := string(os.PathSeparator)
 	if got, want := cloud.PanelTitle(cloud.GetPath()), "Test:"+separator; got != want {
 		t.Fatalf("root PanelTitle = %q, want %q", got, want)
@@ -360,7 +372,11 @@ func TestCloudVFSPublicContractUsesOnlyVisualPaths(t *testing.T) {
 		},
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	separator := string(os.PathSeparator)
 	root := "Test:" + separator
 	if got := cloud.GetPath(); got != root {
@@ -423,7 +439,11 @@ func TestCloudVFSRestoresVisualPathByResolvingEachDirectory(t *testing.T) {
 		},
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := cloud.restoreVisualPath(context.Background(), []string{"First", "Second"}); err != nil {
 		t.Fatal(err)
 	}
@@ -454,7 +474,11 @@ func TestGooglePanelTitleUsesCachedDisplayHierarchy(t *testing.T) {
 		transferNames: make(map[string]string),
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := cloud.SetPath(cloud.publicPath(second)); err != nil {
 		t.Fatal(err)
 	}
@@ -471,7 +495,11 @@ func TestCloudVFSDisambiguatesAcrossPagesAndResolvesOpaqueLocations(t *testing.T
 		{{VFSItem: vfs.VFSItem{Name: "report.txt"}, Location: "/ids/object-b"}},
 	}}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	var names []string
 	if err := cloud.ReadDir(context.Background(), cloud.GetPath(), func(items []vfs.VFSItem) {
 		for _, item := range items {
@@ -527,7 +555,11 @@ func TestCloudVFSSanitizesPathLikeProviderLabelsButKeepsOpaqueIdentity(t *testin
 		{VFSItem: vfs.VFSItem{Name: "a/b\\c"}, Location: "/ids/separator-label"},
 	}}}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	var names []string
 	if err := cloud.ReadDir(context.Background(), cloud.GetPath(), func(items []vfs.VFSItem) {
 		for _, item := range items {
@@ -584,7 +616,11 @@ func TestCloudVFSTransferNameIsDestinationAware(t *testing.T) {
 		VFSItem: vfs.VFSItem{Name: "document.docx"}, Location: "/ids/native", TransferName: "document.docx",
 	}}}}}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := cloud.ReadDir(context.Background(), cloud.GetPath(), func([]vfs.VFSItem) {}); err != nil {
 		t.Fatal(err)
 	}
@@ -593,7 +629,11 @@ func TestCloudVFSTransferNameIsDestinationAware(t *testing.T) {
 		t.Fatalf("external transfer name = %q", got)
 	}
 	clone := cloud.Clone().(*CloudVFS)
-	defer clone.Close()
+	t.Cleanup(func() {
+		if err := clone.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if got := cloud.TransferName(source, clone); got != "document" {
 		t.Fatalf("same-session transfer name = %q", got)
 	}
@@ -601,12 +641,20 @@ func TestCloudVFSTransferNameIsDestinationAware(t *testing.T) {
 
 func TestTrashCapabilityIsExposedOnlyByTrashBackends(t *testing.T) {
 	plain := testCloudVFS(t, &fakeBackend{})
-	defer plain.Close()
+	t.Cleanup(func() {
+		if err := plain.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if _, ok := wrapCloudVFS(plain).(vfs.TrashVFS); ok {
 		t.Fatal("plain backend unexpectedly exposes TrashVFS")
 	}
 	trash := testCloudVFS(t, &fakeTrashBackend{fakeBackend: &fakeBackend{}})
-	defer trash.Close()
+	t.Cleanup(func() {
+		if err := trash.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if _, ok := wrapCloudVFS(trash).(vfs.TrashVFS); !ok {
 		t.Fatal("trash backend does not expose TrashVFS")
 	}

--- a/plugins/cloudfox/plugin_test.go
+++ b/plugins/cloudfox/plugin_test.go
@@ -21,8 +21,16 @@ func TestNewPluginDoesNotMutateOrShareGoogleFactory(t *testing.T) {
 	shared := &GoogleDriveFactory{}
 	first := NewPlugin(Options{ConfigDir: t.TempDir(), Portable: true, Factories: []BackendFactory{shared}})
 	second := NewPlugin(Options{ConfigDir: t.TempDir(), Portable: true, Factories: []BackendFactory{shared}})
-	defer first.Close()
-	defer second.Close()
+	t.Cleanup(func() {
+		if err := first.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
+	t.Cleanup(func() {
+		if err := second.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	if shared.TokenUpdate != nil {
 		t.Fatal("NewPlugin mutated the caller-owned Google factory")
@@ -47,7 +55,11 @@ func TestNewPluginDoesNotMutateOrShareGoogleFactory(t *testing.T) {
 
 func TestPortablePluginKeepsExistingKeyringReferencesReadable(t *testing.T) {
 	plugin := NewPlugin(Options{ConfigDir: t.TempDir(), Portable: true})
-	defer plugin.Close()
+	t.Cleanup(func() {
+		if err := plugin.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	if plugin.repo == nil || plugin.repo.Secrets.Keyring == nil {
 		t.Fatal("portable plugin disabled the keyring needed by an existing keyring:v1 reference")
@@ -71,7 +83,11 @@ func TestConnectionProviderReopensStandaloneVisualBookmark(t *testing.T) {
 		ConfigDir: t.TempDir(),
 		Factories: []BackendFactory{&visualPathTestFactory{backend: backend}},
 	})
-	defer plugin.Close()
+	t.Cleanup(func() {
+		if err := plugin.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	connection, err := plugin.repo.Save(context.Background(), Connection{
 		Name: "My cloud", Provider: ProviderWebDAV,
 		Settings: []byte(`{"base_url":"https://example.invalid/dav","auth":"anonymous"}`),
@@ -92,7 +108,11 @@ func TestConnectionProviderReopensStandaloneVisualBookmark(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer opened.Close()
+	t.Cleanup(func() {
+		if err := opened.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if got := opened.GetPath(); got != bookmark {
 		t.Fatalf("reopened bookmark path = %q, want %q", got, bookmark)
 	}
@@ -115,7 +135,11 @@ func TestConnectionProviderReopensNestedVisualHistoryFromManager(t *testing.T) {
 		ConfigDir: t.TempDir(),
 		Factories: []BackendFactory{&visualPathTestFactory{backend: backend}},
 	})
-	defer plugin.Close()
+	t.Cleanup(func() {
+		if err := plugin.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	connection, err := plugin.repo.Save(context.Background(), Connection{
 		Name: "My cloud", Provider: ProviderWebDAV,
 		Settings: []byte(`{"base_url":"https://example.invalid/dav","auth":"anonymous"}`),
@@ -135,7 +159,11 @@ func TestConnectionProviderReopensNestedVisualHistoryFromManager(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer opened.Close()
+	t.Cleanup(func() {
+		if err := opened.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if got := opened.GetPath(); got != historyPath {
 		t.Fatalf("reopened manager history path = %q, want %q", got, historyPath)
 	}
@@ -151,7 +179,11 @@ func TestConnectionProviderDoesNotRemountPathOwnedByCurrentCloudVFS(t *testing.T
 		names:       map[string]string{"/opaque/albums": "Albums", "/opaque/year": "2026"},
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	current := cloud.publicPath("/opaque/year")
 	if err := cloud.SetPath(current); err != nil {
 		t.Fatal(err)

--- a/plugins/cloudfox/provider_google_production_test.go
+++ b/plugins/cloudfox/provider_google_production_test.go
@@ -112,7 +112,11 @@ func TestGoogleFreshCanonicalStatHydratesFullPanelTitle(t *testing.T) {
 		}
 	})
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	location := googleItemLocation("", "second-id")
 	if err := cloud.SetPath(cloud.canonicalURI(location)); err != nil {
 		t.Fatal(err)
@@ -333,7 +337,11 @@ func TestGoogleIdentityPreservingWriteUpdatesExistingIDInPlace(t *testing.T) {
 		transferNames: map[string]string{location: "editable.bin"}, resolved: make(map[string]string), downloads: newGoogleDownloadCache(),
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if !cloud.GetCapabilities().HasIdentityPreservingWrite {
 		t.Fatal("Google CloudVFS did not advertise identity-preserving writes")
 	}
@@ -436,7 +444,11 @@ func TestGoogleIdentityPreservingWriteUpdatesShortcutTargetNotShortcut(t *testin
 		transferNames: map[string]string{shortcutLocation: "editable-link.bin"}, resolved: make(map[string]string), downloads: newGoogleDownloadCache(),
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	file, err := cloud.Create(vfs.WithDestinationOverwrite(context.Background(), true), cloud.canonicalURI(shortcutLocation))
 	if err != nil {
 		t.Fatal(err)
@@ -545,7 +557,11 @@ func TestGoogleRenameReplacementRemapsDeletedDestinationIdentity(t *testing.T) {
 		t.Fatalf("reopen replaced destination = %#v, %v", file, err)
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	resolved, err := cloud.resolvePath(cloud.canonicalURI(destination))
 	if err != nil || resolved != source {
 		t.Fatalf("CloudVFS replacement remap = %q, %v; want %q", resolved, err, source)
@@ -626,7 +642,7 @@ func TestGoogleNativeExportRefreshesRevisionBeforeUsingSessionCache(t *testing.T
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer r.Close()
+		defer func() { _ = r.Close() }()
 		data := make([]byte, r.Size())
 		n, err := r.ReadAt(context.Background(), data, 0)
 		if err != nil && !errors.Is(err, io.EOF) {
@@ -793,7 +809,11 @@ func TestCloudVFSReadDirReplacesStaleAliasSnapshot(t *testing.T) {
 		VFSItem: vfs.VFSItem{Name: "gone.txt"}, Location: "/ids/gone",
 	}}}}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := cloud.ReadDir(context.Background(), cloud.GetPath(), func([]vfs.VFSItem) {}); err != nil {
 		t.Fatal(err)
 	}

--- a/plugins/cloudfox/provider_google_real_native_integration_test.go
+++ b/plugins/cloudfox/provider_google_real_native_integration_test.go
@@ -532,7 +532,7 @@ func assertRealGoogleBytes(t *testing.T, ctx context.Context, backend Backend, l
 	if err != nil {
 		t.Fatalf("reopen Google Drive shortcut target: %v", err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if len(expected) != 0 {
 		buffer := make([]byte, min(17, len(expected)))
 		n, readErr := reader.ReadAt(ctx, buffer, int64(len(expected)-len(buffer)))

--- a/plugins/cloudfox/provider_google_test.go
+++ b/plugins/cloudfox/provider_google_test.go
@@ -132,7 +132,11 @@ func TestGoogleMyDriveListingNeverExposesOpaqueRootID(t *testing.T) {
 		names: make(map[string]string), transferNames: make(map[string]string),
 	}
 	cloud := testCloudVFS(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	root := cloud.GetPath()
 	if err := cloud.ReadDir(context.Background(), root, func([]vfs.VFSItem) {}); err != nil {
@@ -189,7 +193,7 @@ func TestGoogleRangeReaderPinsETagAndValidatesContentRange(t *testing.T) {
 	}
 	lifetime, cancel := context.WithCancel(context.Background())
 	reader := &googleRangeReader{service: service, fileID: "file-id", size: 6, etag: `"generation-one"`, ctx: lifetime, cancel: cancel}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	buffer := make([]byte, 3)
 	if n, err := reader.ReadAt(context.Background(), buffer, 2); err != nil || n != 3 || string(buffer) != "cde" {
 		t.Fatalf("ReadAt = %d, %v, %q", n, err, buffer)
@@ -226,7 +230,7 @@ func TestGoogleRangeReaderFallsBackWhenRangeIsIgnored(t *testing.T) {
 	}
 	lifetime, cancel := context.WithCancel(context.Background())
 	reader := &googleRangeReader{service: service, fileID: "file-id", size: int64(len(content)), etag: `"generation-one"`, ctx: lifetime, cancel: cancel}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 
 	buffer := make([]byte, 4)
 	readCtx := context.WithValue(context.Background(), vfs.ProgressKey, vfs.ProgressCallback(func(_ string, percent int) {
@@ -255,13 +259,21 @@ func TestGoogleSessionDownloadCacheReusesOnlyMatchingRevision(t *testing.T) {
 	}
 	path := f.Name()
 	if _, err := io.WriteString(f, "cached payload"); err != nil {
-		f.Close()
-		os.Remove(path)
+		if closeErr := f.Close(); closeErr != nil {
+			t.Errorf("close failed cache fixture: %v", closeErr)
+		}
+		if removeErr := os.Remove(path); removeErr != nil {
+			t.Errorf("remove failed cache fixture: %v", removeErr)
+		}
 		t.Fatal(err)
 	}
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		f.Close()
-		os.Remove(path)
+		if closeErr := f.Close(); closeErr != nil {
+			t.Errorf("close failed cache fixture: %v", closeErr)
+		}
+		if removeErr := os.Remove(path); removeErr != nil {
+			t.Errorf("remove failed cache fixture: %v", removeErr)
+		}
 		t.Fatal(err)
 	}
 	handle, err := cache.install("file-id", "revision-1", newProviderTempReader(f, path, int64(len("cached payload"))))
@@ -554,7 +566,9 @@ func TestAuthorizeGoogleDesktopCompletesLoopbackWithoutExternalNetwork(t *testin
 		if err != nil {
 			return err
 		}
-		defer response.Body.Close()
+		defer func() {
+			_ = response.Body.Close() // response body cleanup only
+		}()
 		if response.StatusCode != http.StatusOK {
 			t.Errorf("callback status = %s", response.Status)
 		}

--- a/plugins/cloudfox/provider_real_diagnostics_test.go
+++ b/plugins/cloudfox/provider_real_diagnostics_test.go
@@ -151,7 +151,7 @@ func TestRealSavedCloudConnectionDiagnostics(t *testing.T) {
 			cancelResult <- openErr
 			return
 		}
-		defer reader.Close()
+		defer func() { _ = reader.Close() }()
 		buffer := make([]byte, 1<<20)
 		for {
 			_, readErr := reader.Read(cancelCtx, buffer)
@@ -241,7 +241,7 @@ func measureRealDiagnosticDownload(ctx context.Context, backend Backend, locatio
 		result.totalDuration = time.Since(started)
 		return result
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	h := sha256.New()
 	buffer := make([]byte, 1<<20)
 	for {

--- a/plugins/cloudfox/provider_real_saved_integration_test.go
+++ b/plugins/cloudfox/provider_real_saved_integration_test.go
@@ -490,8 +490,12 @@ func TestRealRetryTCPDialContextRetriesOnlyUnestablishedTCPConnections(t *testin
 
 	calls = 0
 	connected, peer := net.Pipe()
-	defer connected.Close()
-	defer peer.Close()
+	defer func() {
+		_ = connected.Close() // connection cleanup only
+	}()
+	defer func() {
+		_ = peer.Close() // connection cleanup only
+	}()
 	dial = realRetryTCPDialContext(func(context.Context, string, string) (net.Conn, error) {
 		calls++
 		return connected, wantErr

--- a/plugins/cloudfox/provider_real_semantics_test.go
+++ b/plugins/cloudfox/provider_real_semantics_test.go
@@ -162,7 +162,11 @@ func runRealSavedSemantics(t *testing.T, plugin *Plugin, connection Connection) 
 	}
 
 	root, writeRoot := openRealSemanticsRoot(t, ctx, plugin, connection)
-	defer root.Close()
+	t.Cleanup(func() {
+		if err := root.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	removeRealSemanticsNormalFolder(t, ctx, root, writeRoot, titleName)
 
 	trashPath := createRealSemanticsDirectory(t, ctx, root, writeRoot, trashName)
@@ -345,7 +349,7 @@ func assertRealSemanticsFile(t *testing.T, ctx context.Context, filesystem vfs.V
 	if err != nil {
 		t.Fatalf("open recovered marker: %s", redactRealProviderError(err))
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	got := make([]byte, len(expected))
 	n, err := r.ReadAt(ctx, got, 0)
 	if n != len(expected) || (err != nil && !errors.Is(err, io.EOF)) || string(got) != string(expected) {
@@ -461,7 +465,9 @@ func realYandexAboutShape(ctx context.Context, backend *yandexDiskBackend) (bool
 	if err != nil {
 		return false, false, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close() // response body cleanup only
+	}()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return false, false, mapProviderHTTPError(resp, readSmallResponse(resp))
 	}
@@ -544,12 +550,12 @@ func realYandexTrashEntries(ctx context.Context, backend *yandexDiskBackend) ([]
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			message := readSmallResponse(resp)
-			resp.Body.Close()
+			_ = resp.Body.Close() // response body cleanup only
 			return nil, mapProviderHTTPError(resp, message)
 		}
 		var resource yandexResource
 		err = json.NewDecoder(resp.Body).Decode(&resource)
-		resp.Body.Close()
+		_ = resp.Body.Close() // response body cleanup only
 		if err != nil {
 			return nil, err
 		}
@@ -702,7 +708,11 @@ func cleanupRealSemanticsArtifacts(t *testing.T, plugin *Plugin, connectionID st
 		return
 	}
 	filesystem, writeRoot := openRealSemanticsRoot(t, ctx, plugin, connection)
-	defer filesystem.Close()
+	t.Cleanup(func() {
+		if err := filesystem.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	for _, name := range names {
 		if !strings.HasPrefix(name, realSemanticsPrefix) || strings.ContainsAny(name, "/\\") {
 			t.Errorf("refusing unsafe real semantics cleanup name")

--- a/plugins/cloudfox/provider_real_sharing_integration_test.go
+++ b/plugins/cloudfox/provider_real_sharing_integration_test.go
@@ -545,7 +545,9 @@ func probeRealAnonymousShare(ctx context.Context, client *http.Client, rawURL st
 		}
 		return false, errRealAnonymousShareProbe
 	}
-	defer response.Body.Close()
+	defer func() {
+		_ = response.Body.Close() // response body cleanup only
+	}()
 	body, err := io.ReadAll(io.LimitReader(response.Body, 512<<10))
 	if err != nil {
 		return false, errRealAnonymousShareProbe

--- a/plugins/cloudfox/provider_s3_discovery_core_test.go
+++ b/plugins/cloudfox/provider_s3_discovery_core_test.go
@@ -298,7 +298,7 @@ func TestS3DiscoveryRoutesCRUDCopyAndRangeByLocationRegion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	buffer := make([]byte, 4)
 	if n, err := reader.ReadAt(context.Background(), buffer, 0); n != 4 || err != nil || !bytes.Equal(buffer, []byte("data")) {
 		t.Fatalf("ReadAt = %d, %v, %q", n, err, buffer)

--- a/plugins/cloudfox/provider_s3_discovery_regression_test.go
+++ b/plugins/cloudfox/provider_s3_discovery_regression_test.go
@@ -370,7 +370,11 @@ func TestS3ExplicitBucketNeverRequiresListBuckets(t *testing.T) {
 	defer server.Close()
 
 	backend := openS3DiscoveryRegressionBackend(t, server, "manual")
-	defer backend.Close()
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if entries := readS3DiscoveryEntries(t, backend, backend.Root()); len(entries) != 0 {
 		t.Fatalf("manual bucket root entries = %#v, want empty", entries)
 	}
@@ -391,7 +395,11 @@ func TestS3DiscoveryCloudVFSUsesVisualNativePathsAndRestoresThem(t *testing.T) {
 
 	backend := openS3DiscoveryRegressionBackend(t, server, "")
 	cloud := newS3DiscoveryRegressionCloud(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	separator := string(os.PathSeparator)
 	root := "S3 test:" + separator
@@ -434,7 +442,11 @@ func TestS3DiscoveryCloudVFSUsesVisualNativePathsAndRestoresThem(t *testing.T) {
 
 	freshBackend := openS3DiscoveryRegressionBackend(t, server, "")
 	fresh := newS3DiscoveryRegressionCloud(t, freshBackend)
-	defer fresh.Close()
+	t.Cleanup(func() {
+		if err := fresh.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	if err := fresh.restoreVisualPath(context.Background(), []string{"alpha", "folder"}); err != nil {
 		t.Fatal(err)
 	}
@@ -448,7 +460,11 @@ func TestS3DiscoveryGuardsAccountAndBucketRootsWithoutAPIRequests(t *testing.T) 
 	server := httptest.NewServer(fixture)
 	defer server.Close()
 	backend := openS3DiscoveryRegressionBackend(t, server, "")
-	defer backend.Close()
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	bucket := findS3DiscoveryEntry(t, readS3DiscoveryEntries(t, backend, backend.Root()), "alpha")
 	newBucket := backend.Join(backend.Root(), "new-bucket")
@@ -508,11 +524,19 @@ func TestS3ExplicitBucketRejectsDiscoveryLocationForAnotherBucket(t *testing.T) 
 	server := httptest.NewServer(fixture)
 	defer server.Close()
 	discovery := openS3DiscoveryRegressionBackend(t, server, "")
-	defer discovery.Close()
+	t.Cleanup(func() {
+		if err := discovery.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	alpha := findS3DiscoveryEntry(t, readS3DiscoveryEntries(t, discovery, discovery.Root()), "alpha")
 
 	explicit := openS3DiscoveryRegressionBackend(t, server, "beta")
-	defer explicit.Close()
+	t.Cleanup(func() {
+		if err := explicit.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 	before := fixture.requestCount()
 	if normalized, err := explicit.Normalize(alpha.Location); err == nil {
 		t.Fatalf("manual beta backend accepted alpha discovery location as %q", normalized)
@@ -541,7 +565,11 @@ func TestS3DiscoverySameSessionVisualHistoryUsesCachedBucketRegionOnFirstRequest
 	defer server.Close()
 	backend := openS3SignedDiscoveryRegressionBackend(t, server)
 	cloud := newS3DiscoveryRegressionCloud(t, backend)
-	defer cloud.Close()
+	t.Cleanup(func() {
+		if err := cloud.Close(); err != nil {
+			t.Errorf("close test resource: %v", err)
+		}
+	})
 
 	separator := string(os.PathSeparator)
 	root := "S3 test:" + separator
@@ -597,7 +625,9 @@ func TestS3DiscoveryFreshSessionRestoresVisualHistoryBeforeRegionalObjectList(t 
 		Region: "us-east-1", Endpoint: server.URL, UsePathStyle: true, Auth: "static", AllowInsecure: true,
 	})
 	if err != nil {
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after settings failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	credentials := SecretValues{"access_key_id": "test-access", "secret_access_key": "test-secret"}
@@ -605,32 +635,44 @@ func TestS3DiscoveryFreshSessionRestoresVisualHistoryBeforeRegionalObjectList(t 
 		Name: "History S3", Provider: ProviderS3, Settings: settings,
 	}, &credentials, SecretStorageVault)
 	if err != nil {
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after save failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	historyPath := connection.Name + ":" + separator + "history-eu" + separator + "folder"
 	provider := &connectionProvider{plugin: plugin}
 	if !provider.CanOpen(context.Background(), vfs.NewOSVFS(t.TempDir()), historyPath) {
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after rejected path: %v", closeErr)
+		}
 		t.Fatalf("provider rejected S3 visual history path %q", historyPath)
 	}
 	opened, err := provider.Open(context.Background(), vfs.NewOSVFS(t.TempDir()), historyPath)
 	if err != nil {
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after open failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	if got := opened.GetPath(); got != historyPath {
 		_ = opened.Close()
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after path mismatch: %v", closeErr)
+		}
 		t.Fatalf("fresh-session restored path = %q, want %q", got, historyPath)
 	}
 	if err := opened.ReadDir(context.Background(), historyPath, func([]vfs.VFSItem) {}); err != nil {
 		_ = opened.Close()
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after read failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	if err := opened.Close(); err != nil {
-		plugin.Close()
+		if closeErr := plugin.Close(); closeErr != nil {
+			t.Errorf("close plugin after VFS close failure: %v", closeErr)
+		}
 		t.Fatal(err)
 	}
 	if err := plugin.Close(); err != nil {

--- a/plugins/cloudfox/provider_s3_test.go
+++ b/plugins/cloudfox/provider_s3_test.go
@@ -533,7 +533,7 @@ func TestS3HTTPClientNeverFollowsRedirects(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			resp.Body.Close()
+			_ = resp.Body.Close() // response body cleanup only
 			if resp.StatusCode != status {
 				t.Fatalf("status = %d, want redirect %d", resp.StatusCode, status)
 			}
@@ -1058,7 +1058,7 @@ func TestS3RangeReaderRejectsInvalidInputsAndContentRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if n, err := reader.ReadAt(context.Background(), nil, 0); n != 0 || err != nil {
 		t.Fatalf("zero-length ReadAt = %d, %v", n, err)
 	}
@@ -1078,7 +1078,7 @@ func TestS3SequentialReadReportsSourceDownloadThroughTaskReporter(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	capture := &productionProgressCapture{}
 	ctx := context.WithValue(context.Background(), vfs.ReporterKey, capture)
 	buffer := make([]byte, len(key))
@@ -1102,7 +1102,7 @@ func TestS3OpenWithoutValidatorUsesSingleSnapshotDownload(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	buf := make([]byte, 5)
 	if n, err := reader.ReadAt(context.Background(), buf, 5); n != len(buf) || err != nil {
 		t.Fatalf("snapshot ReadAt = %d, %v", n, err)
@@ -1123,7 +1123,7 @@ func TestS3RangeReaderRejectsChangedResponseGeneration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if n, err := reader.ReadAt(context.Background(), make([]byte, 2), 0); n != 0 || !errors.Is(err, ErrRemoteObjectChanged) {
 		t.Fatalf("changed-generation ReadAt = %d, %v", n, err)
 	}

--- a/plugins/cloudfox/provider_webdav_edge_test.go
+++ b/plugins/cloudfox/provider_webdav_edge_test.go
@@ -82,7 +82,7 @@ func edgeReadWebDAVFile(t *testing.T, backend *webDAVBackend, location string) [
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	data := make([]byte, r.Size())
 	if len(data) == 0 {
 		return data
@@ -188,7 +188,11 @@ func TestWebDAVEdgeSettingsAndAuthenticationMatrix(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			defer opened.Close()
+			t.Cleanup(func() {
+				if err := opened.Close(); err != nil {
+					t.Errorf("close test resource: %v", err)
+				}
+			})
 			backend := opened.(*webDAVBackend)
 			switch test.transport.(type) {
 			case *webDAVStaticAuthTransport:
@@ -588,7 +592,7 @@ func TestWebDAVEdgeMissingPROPFINDLengthUsesActualFullSize(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if reader.Size() != int64(len(content)) {
 		t.Fatalf("reader size=%d, want %d", reader.Size(), len(content))
 	}
@@ -664,7 +668,7 @@ func TestWebDAVEdgeWildcardETagDoesNotEnableRangeReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if n, err := reader.ReadAt(context.Background(), buffer, 0); err != nil || n != 5 || string(buffer) != "world" {
 		t.Fatalf("second wildcard response=%d, %v, %q", n, err, buffer)
 	}

--- a/plugins/cloudfox/provider_webdav_integration_test.go
+++ b/plugins/cloudfox/provider_webdav_integration_test.go
@@ -79,7 +79,7 @@ func readWebDAVFile(t *testing.T, backend *webDAVBackend, location string) strin
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	data := make([]byte, r.Size())
 	if len(data) == 0 {
 		return ""
@@ -1163,7 +1163,7 @@ func TestWebDAVRangeReaderContinuesShortPartialResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	buffer := make([]byte, 6)
 	if n, err := r.ReadAt(context.Background(), buffer, 2); err != nil || n != 6 || string(buffer) != "234567" {
 		t.Fatalf("short-part continuation = %d, %v, %q", n, err, buffer)
@@ -1186,7 +1186,7 @@ func TestWebDAVRangeReaderDetectsChangedSizeFrom416(t *testing.T) {
 	defer server.Close()
 	readerCtx, cancel := context.WithCancel(context.Background())
 	reader := &webDAVRangeReader{client: server.Client(), url: server.URL, size: 5, etag: `"one"`, ctx: readerCtx, cancel: cancel}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if _, err := reader.ReadAt(context.Background(), make([]byte, 1), 0); !errors.Is(err, ErrRemoteObjectChanged) {
 		t.Fatalf("416 after size change = %v", err)
 	}

--- a/plugins/cloudfox/provider_webdav_test.go
+++ b/plugins/cloudfox/provider_webdav_test.go
@@ -140,7 +140,7 @@ func TestWebDAVOpenUsesByteRangeReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	if reader.Size() != 6 {
 		t.Fatalf("Size = %d", reader.Size())
 	}
@@ -181,7 +181,7 @@ func TestWebDAVOpenFallsBackWhenRangesAreIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	buffer := make([]byte, 3)
 	n, err := reader.ReadAt(context.Background(), buffer, 1)
 	if err != nil || n != 3 || string(buffer) != "bcd" {

--- a/plugins/cloudfox/provider_yandex_production_test.go
+++ b/plugins/cloudfox/provider_yandex_production_test.go
@@ -69,7 +69,7 @@ func yandexHasIntermediateProgress(samples []int) bool {
 
 func yandexReadAll(t *testing.T, reader vfs.ReadAtCloser) string {
 	t.Helper()
-	defer reader.Close()
+	defer func() { _ = reader.Close() }()
 	data, err := io.ReadAll(vfsReaderAdapter{ctx: context.Background(), reader: reader})
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/id3editor/plugin_test.go
+++ b/plugins/id3editor/plugin_test.go
@@ -22,8 +22,11 @@ func TestID3Editor_Roundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(tempFile.Name())
-	defer tempFile.Close()
+	t.Cleanup(func() {
+		if err := os.Remove(tempFile.Name()); err != nil {
+			t.Errorf("remove temporary MP3: %v", err)
+		}
+	})
 
 	dummyAudio := make([]byte, 100)
 	if _, err := tempFile.Write(dummyAudio); err != nil {
@@ -41,6 +44,9 @@ func TestID3Editor_Roundtrip(t *testing.T) {
 	if _, err := tempFile.Write(tag.Bytes()); err != nil {
 		t.Fatal(err)
 	}
+	if err := tempFile.Close(); err != nil {
+		t.Fatalf("close temporary MP3: %v", err)
+	}
 
 	file, err := id3.Open(tempFile.Name())
 	if err != nil {
@@ -50,7 +56,9 @@ func TestID3Editor_Roundtrip(t *testing.T) {
 	if strings.TrimRight(file.Title(), "\x00") != "Initial Title" {
 		t.Errorf("expected initial title, got %q", file.Title())
 	}
-	file.Close()
+	if err := file.Close(); err != nil {
+		t.Fatalf("close initial tag: %v", err)
+	}
 
 	file2, err := id3.Open(tempFile.Name())
 	if err != nil {
@@ -69,7 +77,7 @@ func TestID3Editor_Roundtrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer file3.Close()
+	defer func() { _ = file3.Close() }()
 
 	title := strings.TrimSpace(strings.TrimRight(file3.Title(), "\x00"))
 	artist := strings.TrimSpace(strings.TrimRight(file3.Artist(), "\x00"))

--- a/plugins/ios/afc_vfs_test.go
+++ b/plugins/ios/afc_vfs_test.go
@@ -25,7 +25,11 @@ func TestAFCTransferWaiterWakesWhenLostClientReleasesCapacity(t *testing.T) {
 		dials.Add(1)
 		return &poolTestConnection{}, nil
 	})
-	defer session.Close()
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Errorf("close AFC session: %v", err)
+		}
+	})
 
 	first, err := session.leaseTransfer(context.Background())
 	if err != nil {
@@ -79,7 +83,11 @@ func TestAFCTransferDialStartedBeforeResetIsDiscarded(t *testing.T) {
 		}
 		return &poolTestConnection{}, nil
 	})
-	defer session.Close()
+	t.Cleanup(func() {
+		if err := session.Close(); err != nil {
+			t.Errorf("close AFC session: %v", err)
+		}
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()

--- a/plugins/ios/internal/afcproto/client_test.go
+++ b/plugins/ios/internal/afcproto/client_test.go
@@ -36,7 +36,9 @@ func openResponse(handle uint64) packet {
 func runServer(conn net.Conn, steps []serverStep) <-chan error {
 	done := make(chan error, 1)
 	go func() {
-		defer conn.Close()
+		defer func() {
+			_ = conn.Close() // connection cleanup only
+		}()
 		for i, step := range steps {
 			number := uint64(i + 1)
 			req, err := readPacket(conn, number)
@@ -300,7 +302,9 @@ func TestMalformedResponsesPoisonConnection(t *testing.T) {
 			client := New(clientConn)
 			done := make(chan error, 1)
 			go func() {
-				defer serverConn.Close()
+				defer func() {
+					_ = serverConn.Close() // connection cleanup only
+				}()
 				if _, err := readPacket(serverConn, 1); err != nil {
 					done <- err
 					return
@@ -327,8 +331,12 @@ func TestMalformedResponsesPoisonConnection(t *testing.T) {
 func TestUnsafePathsAndDirectoryEntries(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 	client := New(clientConn)
-	defer client.Close()
-	defer serverConn.Close()
+	defer func(c *Client) {
+		_ = c.Close() // connection cleanup only
+	}(client)
+	defer func() {
+		_ = serverConn.Close() // connection cleanup only
+	}()
 	for _, call := range []func() error{
 		func() error { _, err := client.List(context.Background(), "/safe/../secret"); return err },
 		func() error { return client.Remove(context.Background(), "/") },
@@ -344,7 +352,9 @@ func TestUnsafePathsAndDirectoryEntries(t *testing.T) {
 		t.Fatalf("out-of-range mtime error = %v", err)
 	}
 
-	client.Close()
+	if err := client.Close(); err != nil {
+		t.Fatalf("close validation client: %v", err)
+	}
 	client, done := newScriptedClient(t, []serverStep{{op: opReadDir, response: dataResponse(nulDict("safe", "nested/name"))}})
 	_, err := client.List(context.Background(), "/")
 	if !IsConnectionLost(err) || !errors.Is(err, ErrProtocol) {
@@ -383,7 +393,9 @@ func TestCancellationClosesAndPoisonsConnection(t *testing.T) {
 	client := New(clientConn)
 	requestRead := make(chan error, 1)
 	go func() {
-		defer serverConn.Close()
+		defer func() {
+			_ = serverConn.Close() // connection cleanup only
+		}()
 		_, err := readPacket(serverConn, 1)
 		requestRead <- err
 		if err == nil {
@@ -415,7 +427,9 @@ func TestClientSerializesWholeExchange(t *testing.T) {
 	client := New(clientConn)
 	serverDone := make(chan error, 1)
 	go func() {
-		defer serverConn.Close()
+		defer func() {
+			_ = serverConn.Close() // connection cleanup only
+		}()
 		if _, err := readPacket(serverConn, 1); err != nil {
 			serverDone <- err
 			return

--- a/plugins/ios/ios_integration_test.go
+++ b/plugins/ios/ios_integration_test.go
@@ -55,7 +55,11 @@ func TestIOSDeviceIntegration(t *testing.T) {
 	if !ok {
 		t.Fatalf("Media backend = %T, want *AFCVFS", mounted)
 	}
-	defer media.Close()
+	t.Cleanup(func() {
+		if err := media.Close(); err != nil {
+			t.Errorf("close Media filesystem: %v", err)
+		}
+	})
 
 	repeated, err := backend.openMedia(ctx, nil, selected)
 	if err != nil {
@@ -221,7 +225,11 @@ func TestIOSDeviceIntegration(t *testing.T) {
 		if err != nil {
 			t.Fatalf("open application %q: %v", testBundle, err)
 		}
-		defer appVFS.Close()
+		t.Cleanup(func() {
+			if err := appVFS.Close(); err != nil {
+				t.Errorf("close application filesystem: %v", err)
+			}
+		})
 		var appEntries []vfs.VFSItem
 		if err := appVFS.ReadDir(ctx, appVFS.GetPath(), func(chunk []vfs.VFSItem) {
 			appEntries = append(appEntries, chunk...)
@@ -260,7 +268,11 @@ func TestIOSDeviceIntegration(t *testing.T) {
 		t.Fatalf("open CoreDevice %s: %v", label, err)
 	}
 	coreVFS := newCoreVFS(media, selected, domain, identifier, label+" (CoreDevice)", service, backend.core)
-	defer coreVFS.Close()
+	t.Cleanup(func() {
+		if err := coreVFS.Close(); err != nil {
+			t.Errorf("close CoreDevice filesystem: %v", err)
+		}
+	})
 	corePath := strings.TrimSpace(os.Getenv("F4_IOS_TEST_CORE_PATH"))
 	if corePath == "" {
 		corePath = coreVFS.GetPath()

--- a/plugins/netfox/fish_clone_session_test.go
+++ b/plugins/netfox/fish_clone_session_test.go
@@ -18,7 +18,11 @@ func TestFishCloneStartsOnTheLiveSession(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer v.Close()
+	defer func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	// One view reconnects; every other view of the connection follows, which
 	// is what the clone then has to be born on too.
@@ -26,7 +30,11 @@ func TestFishCloneStartsOnTheLiveSession(t *testing.T) {
 	if !ok {
 		t.Fatal("Clone did not hand back a FishVFS")
 	}
-	defer reconnecting.Close()
+	defer func() {
+		if err := reconnecting.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	dead := v.Client()
 	dead.Session().MarkBroken()
@@ -41,7 +49,11 @@ func TestFishCloneStartsOnTheLiveSession(t *testing.T) {
 	if !ok {
 		t.Fatal("Clone did not hand back a FishVFS")
 	}
-	defer fresh.Close()
+	defer func() {
+		if err := fresh.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	if fresh.Client() == dead {
 		t.Fatal("the clone was born holding the session that had died")

--- a/plugins/netfox/fish_dialer_test.go
+++ b/plugins/netfox/fish_dialer_test.go
@@ -24,13 +24,21 @@ func TestFishReconnectRepointsEveryView(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer v.Close()
+	defer func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	other, ok := v.Clone().(*FishVFS)
 	if !ok {
 		t.Fatal("Clone did not hand back a FishVFS")
 	}
-	defer other.Close()
+	defer func() {
+		if err := other.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	dead := v.Client()
 	dead.Session().MarkBroken()
@@ -63,7 +71,9 @@ func deadTCPPort(t *testing.T) string {
 		t.Skipf("no loopback listener available: %v", err)
 	}
 	port := ln.Addr().(*net.TCPAddr).Port
-	ln.Close()
+	if err := ln.Close(); err != nil {
+		t.Fatalf("close port probe listener: %v", err)
+	}
 	return strconv.Itoa(port)
 }
 
@@ -75,7 +85,7 @@ func TestSSHFishDialerReportsAFailedDial(t *testing.T) {
 	stdin, stdout, closer, err := dial(context.Background())
 	if err == nil {
 		if closer != nil {
-			closer.Close()
+			_ = closer.Close() // unexpected dial cleanup only
 		}
 		t.Fatal("dialling a dead port succeeded")
 	}
@@ -94,7 +104,7 @@ func TestSSHFishDialerHonoursACancelledContext(t *testing.T) {
 	_, _, closer, err := dial(ctx)
 	if !errors.Is(err, context.Canceled) {
 		if closer != nil {
-			closer.Close()
+			_ = closer.Close() // unexpected dial cleanup only
 		}
 		t.Fatalf("dialler answered %v, want context.Canceled", err)
 	}
@@ -109,7 +119,7 @@ func TestSSHFishDialerHonoursACancelledContext(t *testing.T) {
 func TestNewFishVFSReportsAFailedDial(t *testing.T) {
 	v, err := NewFishVFS(nil, "127.0.0.1", deadTCPPort(t), "nobody", "", 1, netproxy.Settings{})
 	if err == nil {
-		v.Close()
+		_ = v.Close() // unexpected open cleanup only
 		t.Fatal("opening a site on a dead port succeeded")
 	}
 	if v != nil {

--- a/plugins/netfox/fish_reconnect_entry_test.go
+++ b/plugins/netfox/fish_reconnect_entry_test.go
@@ -20,7 +20,11 @@ func TestFishReconnectRepointsTheView(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer v.Close()
+	defer func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	was := v.GetPath()
 	dead := v.Client()
@@ -60,7 +64,9 @@ func TestFishCanReconnectFollowsTheDialer(t *testing.T) {
 	if !withDialer.CanReconnect() {
 		t.Error("a site opened through a dialer says it cannot reconnect")
 	}
-	withDialer.Close()
+	if err := withDialer.Close(); err != nil {
+		t.Fatalf("close reconnectable filesystem: %v", err)
+	}
 	if withDialer.CanReconnect() {
 		t.Error("a closed connection still offers a reconnect")
 	}
@@ -85,13 +91,21 @@ func TestFishReconnectTwiceSharesOneSession(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer first.Close()
+	defer func() {
+		if err := first.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	second, ok := first.Clone().(*FishVFS)
 	if !ok {
 		t.Fatal("Clone did not hand back a FishVFS")
 	}
-	defer second.Close()
+	defer func() {
+		if err := second.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	first.Client().Session().MarkBroken()
 

--- a/plugins/netfox/fish_reconnect_test.go
+++ b/plugins/netfox/fish_reconnect_test.go
@@ -39,13 +39,16 @@ func localShellDialer(t *testing.T) FishDialer {
 			return nil, nil, nil, err
 		}
 		t.Cleanup(func() {
-			stdin.Close()
+			_ = stdin.Close() // process cleanup only
 			done := make(chan struct{})
-			go func() { cmd.Wait(); close(done) }()
+			go func() {
+				_ = cmd.Wait() // process cleanup only
+				close(done)
+			}()
 			select {
 			case <-done:
 			case <-time.After(5 * time.Second):
-				cmd.Process.Kill()
+				_ = cmd.Process.Kill() // process cleanup only
 			}
 		})
 		return stdin, stdout, stdin, nil
@@ -65,7 +68,11 @@ func TestFishReconnectReplacesADeadSession(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer v.Close()
+	defer func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	was := v.GetPath()
 	dead := v.conn.current()
@@ -104,7 +111,11 @@ func TestFishReconnectYieldsToOneThatAlreadyHappened(t *testing.T) {
 		}
 		t.Fatalf("open: %v", err)
 	}
-	defer v.Close()
+	defer func() {
+		if err := v.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	dead := v.conn.current()
 	dead.Session().MarkBroken()
@@ -150,7 +161,9 @@ func TestFishReconnectAfterCloseRefuses(t *testing.T) {
 		t.Fatalf("open: %v", err)
 	}
 	dead := v.conn.current()
-	v.Close()
+	if err := v.Close(); err != nil {
+		t.Fatalf("close filesystem before reconnect: %v", err)
+	}
 
 	if _, err := v.conn.reconnect(context.Background(), dead); !errors.Is(err, fishplus.ErrBroken) {
 		t.Fatalf("reconnect after close answered %v, want ErrBroken", err)

--- a/plugins/netfox/fish_vfs_test.go
+++ b/plugins/netfox/fish_vfs_test.go
@@ -95,8 +95,8 @@ func TestFishVFSReadDirResolvesAllSymlinksInOneRequest(t *testing.T) {
 	clientR, peerW := io.Pipe()
 	sess := fishplus.NewSession(clientW, clientR, nil)
 	t.Cleanup(func() {
-		clientW.Close()
-		peerW.Close()
+		_ = clientW.Close() // pipe cleanup only
+		_ = peerW.Close()   // pipe cleanup only
 	})
 
 	done := make(chan error, 1)
@@ -115,11 +115,26 @@ func TestFishVFSReadDirResolvesAllSymlinksInOneRequest(t *testing.T) {
 			done <- fmt.Errorf("enum path = %q, want /", scanner.Text())
 			return
 		}
-		fmt.Fprintln(peerW, "M stat")
-		fmt.Fprintln(peerW, "a1ff 8 1 1 1 0 0 /directory-link")
-		fmt.Fprintln(peerW, "a1ff 8 1 1 1 0 0 /file-link")
-		fmt.Fprintln(peerW, "81a4 1 1 1 1 0 0 /ordinary")
-		fmt.Fprintf(peerW, ".%s %s ok\n", sess.Token(), enumHeader[0])
+		if _, err := fmt.Fprintln(peerW, "M stat"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintln(peerW, "a1ff 8 1 1 1 0 0 /directory-link"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintln(peerW, "a1ff 8 1 1 1 0 0 /file-link"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintln(peerW, "81a4 1 1 1 1 0 0 /ordinary"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintf(peerW, ".%s %s ok\n", sess.Token(), enumHeader[0]); err != nil {
+			done <- err
+			return
+		}
 
 		if !scanner.Scan() {
 			done <- fmt.Errorf("missing isdirs header: %v", scanner.Err())
@@ -137,9 +152,18 @@ func TestFishVFSReadDirResolvesAllSymlinksInOneRequest(t *testing.T) {
 				return
 			}
 		}
-		fmt.Fprintln(peerW, "1")
-		fmt.Fprintln(peerW, "0")
-		fmt.Fprintf(peerW, ".%s %s ok\n", sess.Token(), batchHeader[0])
+		if _, err := fmt.Fprintln(peerW, "1"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintln(peerW, "0"); err != nil {
+			done <- err
+			return
+		}
+		if _, err := fmt.Fprintf(peerW, ".%s %s ok\n", sess.Token(), batchHeader[0]); err != nil {
+			done <- err
+			return
+		}
 		done <- nil
 	}()
 
@@ -200,23 +224,25 @@ func newLocalFishVFSWithTitle(t *testing.T, title string) *FishVFS {
 	}
 	v, err := NewFishVFSOnStream(context.Background(), nil, stdin, stdout, stdin, title)
 	if err != nil {
-		cmd.Process.Kill()
+		_ = cmd.Process.Kill() // process cleanup only
 		if strings.Contains(err.Error(), "base64") {
 			t.Skipf("no base64 on this host: %v", err)
 		}
 		t.Fatalf("handshake: %v", err)
 	}
 	t.Cleanup(func() {
-		v.Close()
+		if err := v.Close(); err != nil {
+			t.Errorf("close local FISH+ filesystem: %v", err)
+		}
 		done := make(chan struct{})
 		go func() {
-			cmd.Wait()
+			_ = cmd.Wait() // process cleanup only
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 	return v
@@ -344,7 +370,7 @@ func TestFishVFSStatAndOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if f.Size() != int64(len(body)) {
 		t.Errorf("Size = %d, want %d", f.Size(), len(body))
 	}
@@ -647,7 +673,7 @@ func TestSSHTimeoutDefaults(t *testing.T) {
 func TestDialSSHFailsOnAClosedPort(t *testing.T) {
 	client, err := DialSSH("127.0.0.1", "1", "nobody", "", 2, netproxy.Settings{})
 	if err == nil {
-		client.Close()
+		_ = client.Close() // unexpected dial cleanup only
 		t.Fatal("dialing a closed port succeeded")
 	}
 }
@@ -924,7 +950,11 @@ func TestFishVFSServerSideCopyAndMove(t *testing.T) {
 
 	// Test SameSession helper
 	v2 := v1.Clone()
-	defer v2.Close()
+	defer func() {
+		if err := v2.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	if !vfs.SameSession(v1, v2) {
 		t.Error("expected SameSession to be true for clones")
@@ -932,7 +962,11 @@ func TestFishVFSServerSideCopyAndMove(t *testing.T) {
 
 	// Test different session (with different titles)
 	v3 := newLocalFishVFSWithTitle(t, "local-diff")
-	defer v3.Close()
+	defer func() {
+		if err := v3.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	if vfs.SameSession(v1, v3) {
 		t.Error("expected SameSession to be false for distinct sessions with different titles")
@@ -941,7 +975,11 @@ func TestFishVFSServerSideCopyAndMove(t *testing.T) {
 
 func TestFishVFSServerToServerInfo(t *testing.T) {
 	v1 := newLocalFishVFS(t)
-	defer v1.Close()
+	defer func() {
+		if err := v1.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	v1.host = "runcity.org"
 	v1.port = "22"
@@ -958,7 +996,11 @@ func TestFishVFSServerToServerInfo(t *testing.T) {
 	}
 
 	v2 := v1.Clone().(*FishVFS)
-	defer v2.Close()
+	defer func() {
+		if err := v2.Close(); err != nil {
+			t.Errorf("close FISH+ filesystem: %v", err)
+		}
+	}()
 
 	h2, p2, u2, ok2 := interface{}(v2).(vfs.ConnectionInfoProvider).ConnectionInfo()
 	if !ok2 || h2 != h || p2 != p || u2 != u {

--- a/plugins/netfox/fishplus/cancel_test.go
+++ b/plugins/netfox/fishplus/cancel_test.go
@@ -14,8 +14,13 @@ import (
 // next one began. The terminator is that way.
 func TestCancelledRequestKeepsTheSession(t *testing.T) {
 	sess := newMockPeer(t, "ok FISHPLUS 1 dd base64", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, "one line of an answer nobody is waiting for any more\n")
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "one line of an answer nobody is waiting for any more\n"); err != nil {
+			t.Errorf("write canceled response: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write canceled response terminator: %v", err)
+		}
 	}, 0)
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -53,9 +58,17 @@ func TestCancelledRequestDrainsItsFrames(t *testing.T) {
 		payload[i] = '\n' // the worst possible payload for a line reader
 	}
 	sess := newMockPeer(t, "ok FISHPLUS 1 dd base64", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, "S 300\n#%d\n", len(payload))
-		w.Write(payload)
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "S 300\n#%d\n", len(payload)); err != nil {
+			t.Errorf("write canceled frame header: %v", err)
+			return
+		}
+		if _, err := w.Write(payload); err != nil {
+			t.Errorf("write canceled frame payload: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write canceled frame terminator: %v", err)
+		}
 	}, 1)
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -104,8 +117,11 @@ func TestDrainGivesUpEventually(t *testing.T) {
 	}()
 
 	err := sess.drainToTerminator(".sometoken 1 ", false)
-	pw.Close()
+	closeErr := pw.Close()
 	<-done
+	if closeErr != nil {
+		t.Fatalf("close endless response pipe: %v", closeErr)
+	}
 	if err == nil {
 		t.Fatal("draining an answer that never ends reported success")
 	}

--- a/plugins/netfox/fishplus/fs_test.go
+++ b/plugins/netfox/fishplus/fs_test.go
@@ -193,10 +193,21 @@ func TestTargetDirsUsesOneRequestAndPreservesPathEncoding(t *testing.T) {
 	seen := make(chan mockRequest, 1)
 	sess := newMockPeer(t, "ok FISHPLUS 1 stat", func(w io.Writer, token string, req mockRequest) {
 		seen <- req
-		fmt.Fprintln(w, "1")
-		fmt.Fprintln(w, "0")
-		fmt.Fprintln(w, "0")
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintln(w, "1"); err != nil {
+			t.Errorf("write target-dir response: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintln(w, "0"); err != nil {
+			t.Errorf("write target-dir response: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintln(w, "0"); err != nil {
+			t.Errorf("write target-dir response: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write target-dir terminator: %v", err)
+		}
 	}, len(paths))
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -236,9 +247,14 @@ func TestTargetDirsRejectsMalformedAnswers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			sess := newMockPeer(t, "ok FISHPLUS 1 stat", func(w io.Writer, token string, req mockRequest) {
 				for _, line := range tc.lines {
-					fmt.Fprintln(w, line)
+					if _, err := fmt.Fprintln(w, line); err != nil {
+						t.Errorf("write malformed target-dir response: %v", err)
+						return
+					}
 				}
-				fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+				if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+					t.Errorf("write malformed target-dir terminator: %v", err)
+				}
 			}, 2)
 			if err := sess.Handshake(context.Background()); err != nil {
 				t.Fatalf("handshake: %v", err)
@@ -287,16 +303,18 @@ func newLocalShellClientEnv(t *testing.T, extraEnv ...string) *Client {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
 		go func() {
-			cmd.Wait()
+			_ = cmd.Wait() // process cleanup only
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 	if err := sess.Handshake(context.Background()); err != nil {

--- a/plugins/netfox/fishplus/read_test.go
+++ b/plugins/netfox/fishplus/read_test.go
@@ -3,6 +3,7 @@ package fishplus
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -44,8 +45,13 @@ func TestFeaturesReadMode(t *testing.T) {
 // size cannot make the client allocate it.
 func TestReadRejectsOversizedFrame(t *testing.T) {
 	sess := newMockPeer(t, "ok FISHPLUS 1 dd base64 read:dd", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, "S 10\n#%d\n", int64(MaxFrameLen)+1)
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "S 10\n#%d\n", int64(MaxFrameLen)+1); err != nil {
+			t.Errorf("write oversized frame header: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+			t.Errorf("write oversized frame terminator: %v", err)
+		}
 	}, 1)
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -189,7 +195,7 @@ func TestFileReadAtAndCache(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	f.SetChunkSize(4096)
 	if f.Size() != int64(len(blob)) {
 		t.Errorf("Size = %d, want %d", f.Size(), len(blob))
@@ -246,7 +252,9 @@ func TestFileReadAtAndCache(t *testing.T) {
 		t.Errorf("ReadFile returned %d bytes, want %d", len(all), len(blob))
 	}
 
-	f.Close()
+	if err := f.Close(); err != nil {
+		t.Fatalf("close file before closed-state check: %v", err)
+	}
 	if _, err := f.ReadAt(ctx, buf, 0); err != ErrClosed {
 		t.Errorf("ReadAt after Close = %v, want ErrClosed", err)
 	}

--- a/plugins/netfox/fishplus/session_pwsh_test.go
+++ b/plugins/netfox/fishplus/session_pwsh_test.go
@@ -57,16 +57,18 @@ func TestHelperAgainstLocalPwsh(t *testing.T) {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
 		go func() {
-			cmd.Wait()
+			_ = cmd.Wait() // process cleanup only
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 
@@ -196,13 +198,18 @@ func TestHelperAgainstLocalPwshEnumAndRead(t *testing.T) {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
-		go func() { cmd.Wait(); close(done) }()
+		go func() {
+			_ = cmd.Wait() // process cleanup only
+			close(done)
+		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
@@ -314,13 +321,18 @@ func TestHelperAgainstLocalPwshFind(t *testing.T) {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
-		go func() { cmd.Wait(); close(done) }()
+		go func() {
+			_ = cmd.Wait() // process cleanup only
+			close(done)
+		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/plugins/netfox/fishplus/session_test.go
+++ b/plugins/netfox/fishplus/session_test.go
@@ -101,14 +101,25 @@ func newMockPeer(t *testing.T, banner string, handle func(w io.Writer, token str
 			reqs <- req
 		}
 	}()
+	peerDone := make(chan struct{})
 	go func() {
+		defer close(peerDone)
 		if banner != "" {
-			fmt.Fprintf(peerW, "Last login: never, this host is a fake\n")
+			if _, err := fmt.Fprintf(peerW, "Last login: never, this host is a fake\n"); err != nil {
+				t.Errorf("write mock login banner: %v", err)
+				return
+			}
 			// The bootstrap announces itself, takes the script, and only
 			// then does the helper get to speak.
-			fmt.Fprintf(peerW, "%s\n", ReadyMarker(sess.Token()))
+			if _, err := fmt.Fprintf(peerW, "%s\n", ReadyMarker(sess.Token())); err != nil {
+				t.Errorf("write mock ready marker: %v", err)
+				return
+			}
 			<-uploaded
-			fmt.Fprintf(peerW, ".%s 0 %s\n", sess.Token(), banner)
+			if _, err := fmt.Fprintf(peerW, ".%s 0 %s\n", sess.Token(), banner); err != nil {
+				t.Errorf("write mock handshake response: %v", err)
+				return
+			}
 		}
 		for req := range reqs {
 			if handle != nil {
@@ -117,8 +128,9 @@ func newMockPeer(t *testing.T, banner string, handle func(w io.Writer, token str
 		}
 	}()
 	t.Cleanup(func() {
-		cliW.Close()
-		peerW.Close()
+		_ = cliW.Close()  // pipe cleanup only
+		_ = peerW.Close() // pipe cleanup only
+		<-peerDone
 	})
 	return sess
 }
@@ -445,7 +457,9 @@ func TestCloseWakesRequestWaitingForGate(t *testing.T) {
 
 func TestTryNoopTimeoutInterruptsSilentTransport(t *testing.T) {
 	clientConn, peerConn := net.Pipe()
-	defer peerConn.Close()
+	defer func() {
+		_ = peerConn.Close() // connection cleanup only
+	}()
 	sess := NewSession(clientConn, clientConn, clientConn)
 	requestSeen := make(chan struct{})
 	go func() {
@@ -486,8 +500,12 @@ func TestTryNoopTimeoutInterruptsSilentTransport(t *testing.T) {
 
 func TestTryNoopReleasesSessionBeforeReturning(t *testing.T) {
 	clientConn, peerConn := net.Pipe()
-	defer clientConn.Close()
-	defer peerConn.Close()
+	defer func() {
+		_ = clientConn.Close() // connection cleanup only
+	}()
+	defer func() {
+		_ = peerConn.Close() // connection cleanup only
+	}()
 	sess := NewSession(clientConn, clientConn, clientConn)
 	go func() {
 		reader := bufio.NewReader(peerConn)
@@ -564,10 +582,21 @@ func TestHandshakeReportsRemoteFailure(t *testing.T) {
 
 func TestExecCollectsTextLines(t *testing.T) {
 	sess := newMockPeer(t, "ok FISHPLUS 1 stat", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, "first\n")
-		fmt.Fprintf(w, "#not a data frame in text mode\n")
-		fmt.Fprintf(w, "last\n")
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "first\n"); err != nil {
+			t.Errorf("write first response line: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, "#not a data frame in text mode\n"); err != nil {
+			t.Errorf("write hash-prefixed response line: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, "last\n"); err != nil {
+			t.Errorf("write last response line: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write text response terminator: %v", err)
+		}
 	})
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -596,7 +625,10 @@ func TestExecPathEscapesOnlyWhenNecessary(t *testing.T) {
 		mu.Lock()
 		seen = append(seen, req)
 		mu.Unlock()
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write path response terminator: %v", err)
+			return
+		}
 		done <- struct{}{}
 	}, 1)
 	if err := sess.Handshake(context.Background()); err != nil {
@@ -649,11 +681,25 @@ func TestExecRejectsWhitespaceArguments(t *testing.T) {
 func TestExecDataReadsBinaryFrames(t *testing.T) {
 	payload := []byte{0x00, 0x01, '\n', 0xff, '.', '#', 'x'}
 	sess := newMockPeer(t, "ok FISHPLUS 1 dd", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, "#%d\n", len(payload))
-		w.Write(payload)
-		fmt.Fprintf(w, "#%d\n", 3)
-		w.Write([]byte("abc"))
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "#%d\n", len(payload)); err != nil {
+			t.Errorf("write binary frame header: %v", err)
+			return
+		}
+		if _, err := w.Write(payload); err != nil {
+			t.Errorf("write binary frame payload: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, "#%d\n", 3); err != nil {
+			t.Errorf("write second binary frame header: %v", err)
+			return
+		}
+		if _, err := w.Write([]byte("abc")); err != nil {
+			t.Errorf("write second binary frame payload: %v", err)
+			return
+		}
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write binary response terminator: %v", err)
+		}
 	})
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -673,7 +719,9 @@ func TestExecDataReadsBinaryFrames(t *testing.T) {
 
 func TestRemoteErrorIsReported(t *testing.T) {
 	sess := newMockPeer(t, "ok FISHPLUS 1", func(w io.Writer, token string, req mockRequest) {
-		fmt.Fprintf(w, ".%s %s err No such file or directory\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, ".%s %s err No such file or directory\n", token, req.ID); err != nil {
+			t.Errorf("write remote error response: %v", err)
+		}
 	})
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -771,16 +819,18 @@ func TestBase64BootstrapAgainstLocalShell(t *testing.T) {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
 		go func() {
-			cmd.Wait()
+			_ = cmd.Wait() // process cleanup only
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 
@@ -829,16 +879,18 @@ func TestHelperAgainstLocalShell(t *testing.T) {
 	}
 	sess := NewSession(stdin, stdout, stdin)
 	t.Cleanup(func() {
-		sess.Close()
+		if err := sess.Close(); err != nil {
+			t.Errorf("close shell session: %v", err)
+		}
 		done := make(chan struct{})
 		go func() {
-			cmd.Wait()
+			_ = cmd.Wait() // process cleanup only
 			close(done)
 		}()
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			cmd.Process.Kill()
+			_ = cmd.Process.Kill() // process cleanup only
 		}
 	})
 

--- a/plugins/netfox/fishplus/write_test.go
+++ b/plugins/netfox/fishplus/write_test.go
@@ -67,7 +67,9 @@ func TestWriteEncodedRequest(t *testing.T) {
 			t.Errorf("payload line is not base64: %v", err)
 		}
 		gotPayload = string(raw)
-		fmt.Fprintf(w, "D\n.%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, "D\n.%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write base64 response: %v", err)
+		}
 	}, 2)
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)
@@ -108,7 +110,9 @@ func TestWriteBreaksSessionWithoutDrainMarker(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sess := newMockPeer(t, "ok FISHPLUS 1 dd base64 write:b64", func(w io.Writer, token string, req mockRequest) {
-				fmt.Fprintf(w, "%s.%s %s err disk on fire\n", tc.lines, token, req.ID)
+				if _, err := fmt.Fprintf(w, "%s.%s %s err disk on fire\n", tc.lines, token, req.ID); err != nil {
+					t.Errorf("write failure response: %v", err)
+				}
 			}, 2)
 			if err := sess.Handshake(context.Background()); err != nil {
 				t.Fatalf("handshake: %v", err)

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -17,12 +17,16 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test_net.json")
 	// Ensure the file is created for consistency in tests
-	os.WriteFile(dbPath, []byte("{}"), 0644)
+	if err := os.WriteFile(dbPath, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
 	nf := NewNetFoxVFS(dbPath)
 
 	// 1. Test Saving
 	cfg := NetFoxConfig{Type: "sftp", Host: "1.2.3.4", User: "root", Pass: "plaintext_secret", Timeout: "15"}
-	nf.SaveConfig("My Server", cfg)
+	if err := nf.SaveConfig("My Server", cfg); err != nil {
+		t.Fatal(err)
+	}
 
 	// Check if password was actually encrypted on disk
 	rawJSON, _ := os.ReadFile(dbPath)
@@ -119,7 +123,9 @@ func TestNetFox_TimeoutAndDial(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to start mock TCP server: %v", err)
 	}
-	defer l.Close()
+	defer func() {
+		_ = l.Close() // listener cleanup only
+	}()
 
 	addr := l.Addr().String()
 	host, port, _ := net.SplitHostPort(addr)
@@ -128,7 +134,9 @@ func TestNetFox_TimeoutAndDial(t *testing.T) {
 	go func() {
 		conn, err := l.Accept()
 		if err == nil {
-			defer conn.Close()
+			defer func() {
+				_ = conn.Close() // connection cleanup only
+			}()
 			time.Sleep(2 * time.Second)
 		}
 	}()

--- a/plugins/netfox/sftp_dial_test.go
+++ b/plugins/netfox/sftp_dial_test.go
@@ -27,7 +27,7 @@ func TestNetFoxProvidersFailedDialReturnPlainNil(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			manager := NewNetFoxVFS(filepath.Join(t.TempDir(), "NetFox.json"))
-			manager.SaveConfig("unreachable", NetFoxConfig{
+			if err := manager.SaveConfig("unreachable", NetFoxConfig{
 				Type:      tt.typeName,
 				Host:      "127.0.0.1",
 				Port:      deadTCPPort(t),
@@ -35,7 +35,9 @@ func TestNetFoxProvidersFailedDialReturnPlainNil(t *testing.T) {
 				Pass:      "",
 				Timeout:   "1",
 				ProxyMode: netproxy.ModeDirect,
-			})
+			}); err != nil {
+				t.Fatal(err)
+			}
 
 			parent := &netFoxVFSWrapper{NetFoxVFS: manager}
 			opened, err := tt.provider.Open(context.Background(), parent, "unreachable")

--- a/sdk/f4rpc/mux_test.go
+++ b/sdk/f4rpc/mux_test.go
@@ -27,8 +27,24 @@ func TestSession_CallAndServe(t *testing.T) {
 	})
 
 	// Запускаем слушателей в фоне
-	go server.Serve()
-	go client.Serve()
+	serverErr := make(chan error, 1)
+	clientErr := make(chan error, 1)
+	go func() { serverErr <- server.Serve() }()
+	go func() { clientErr <- client.Serve() }()
+	t.Cleanup(func() {
+		if err := c2sW.Close(); err != nil {
+			t.Errorf("close client pipe: %v", err)
+		}
+		if err := s2cW.Close(); err != nil {
+			t.Errorf("close server pipe: %v", err)
+		}
+		if err := <-serverErr; err != nil {
+			t.Errorf("server Serve: %v", err)
+		}
+		if err := <-clientErr; err != nil {
+			t.Errorf("client Serve: %v", err)
+		}
+	})
 
 	// Выполняем синхронный вызов с клиента на сервер
 	var res string
@@ -49,8 +65,24 @@ func TestSession_MethodNotFound(t *testing.T) {
 	client := NewSession(s2cR, c2sW)
 	server := NewSession(c2sR, s2cW)
 
-	go server.Serve()
-	go client.Serve()
+	serverErr := make(chan error, 1)
+	clientErr := make(chan error, 1)
+	go func() { serverErr <- server.Serve() }()
+	go func() { clientErr <- client.Serve() }()
+	t.Cleanup(func() {
+		if err := c2sW.Close(); err != nil {
+			t.Errorf("close client pipe: %v", err)
+		}
+		if err := s2cW.Close(); err != nil {
+			t.Errorf("close server pipe: %v", err)
+		}
+		if err := <-serverErr; err != nil {
+			t.Errorf("server Serve: %v", err)
+		}
+		if err := <-clientErr; err != nil {
+			t.Errorf("client Serve: %v", err)
+		}
+	})
 
 	err := client.Call("Unknown.Method", nil, nil)
 	if err == nil {
@@ -73,8 +105,24 @@ func TestSession_Concurrency(t *testing.T) {
 		return "Pong", nil
 	})
 
-	go server.Serve()
-	go client.Serve()
+	serverErr := make(chan error, 1)
+	clientErr := make(chan error, 1)
+	go func() { serverErr <- server.Serve() }()
+	go func() { clientErr <- client.Serve() }()
+	t.Cleanup(func() {
+		if err := c2sW.Close(); err != nil {
+			t.Errorf("close client pipe: %v", err)
+		}
+		if err := s2cW.Close(); err != nil {
+			t.Errorf("close server pipe: %v", err)
+		}
+		if err := <-serverErr; err != nil {
+			t.Errorf("server Serve: %v", err)
+		}
+		if err := <-clientErr; err != nil {
+			t.Errorf("client Serve: %v", err)
+		}
+	})
 
 	done := make(chan bool)
 	for i := 0; i < 50; i++ {

--- a/vfs/null_vfs_test.go
+++ b/vfs/null_vfs_test.go
@@ -13,11 +13,13 @@ func TestNullVFS_DirectoryListing(t *testing.T) {
 	ctx := context.Background()
 
 	var files []string
-	v.ReadDir(ctx, "/", func(items []VFSItem) {
+	if err := v.ReadDir(ctx, "/", func(items []VFSItem) {
 		for _, item := range items {
 			files = append(files, item.Name)
 		}
-	})
+	}); err != nil {
+		t.Fatalf("ReadDir failed: %v", err)
+	}
 
 	// 6 static files + 'upload' + 'scenarios' = 8
 	if len(files) != 8 {
@@ -102,7 +104,9 @@ func TestNullVFS_Writer(t *testing.T) {
 	if err != nil || n != 9 {
 		t.Errorf("Write failed: n=%d, err=%v", n, err)
 	}
-	w.Close()
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
 }
 
 func TestNullVFS_ReadZeroes(t *testing.T) {
@@ -175,7 +179,9 @@ func TestNullVFS_BasicMethods(t *testing.T) {
 		t.Errorf("Expected path /, got %s", v.GetPath())
 	}
 
-	v.SetPath("/upload")
+	if err := v.SetPath("/upload"); err != nil {
+		t.Fatalf("SetPath(/upload) failed: %v", err)
+	}
 	if v.IsAtRoot() {
 		t.Error("Should not be at root after SetPath(/upload)")
 	}
@@ -204,7 +210,9 @@ func TestNullVFS_BasicMethods(t *testing.T) {
 
 func TestNullVFS_NativeSlashes(t *testing.T) {
 	v := NewNullVFS(0)
-	v.SetPath("/test/path")
+	if err := v.SetPath("/test/path"); err != nil {
+		t.Fatalf("SetPath(/test/path) failed: %v", err)
+	}
 
 	path := v.GetPath()
 	expected := filepath.FromSlash("/test/path")
@@ -219,9 +227,11 @@ func TestNullVFS_Scenarios(t *testing.T) {
 
 	t.Run("IOPS Scenario", func(t *testing.T) {
 		var items []VFSItem
-		v.ReadDir(ctx, "/scenarios/iops", func(chunk []VFSItem) {
+		if err := v.ReadDir(ctx, "/scenarios/iops", func(chunk []VFSItem) {
 			items = append(items, chunk...)
-		})
+		}); err != nil {
+			t.Fatalf("ReadDir failed: %v", err)
+		}
 		if len(items) != 10000 {
 			t.Errorf("Expected 10000 files in IOPS scenario, got %d", len(items))
 		}
@@ -323,7 +333,7 @@ func TestNullVFS_OpenCreateMetadataLatency(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		dur := time.Since(start)
 		if dur < 90*time.Millisecond {
@@ -338,7 +348,11 @@ func TestNullVFS_OpenCreateMetadataLatency(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		defer w.Close()
+		t.Cleanup(func() {
+			if err := w.Close(); err != nil {
+				t.Errorf("close writer: %v", err)
+			}
+		})
 
 		dur := time.Since(start)
 		if dur < 90*time.Millisecond {

--- a/vfs/os_vfs_dot_test.go
+++ b/vfs/os_vfs_dot_test.go
@@ -56,8 +56,12 @@ func TestTrailingDotsSupport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to Create file with trailing dot: %v", err)
 	}
-	f.Write([]byte("test"))
-	f.Close()
+	if _, err := f.Write([]byte("test")); err != nil {
+		t.Fatalf("Failed to write file with trailing dot: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Failed to close file with trailing dot: %v", err)
+	}
 
 	// 3. Test ReadDir and Stat
 	stat, err := vfs.Stat(ctx, dotFilePath)

--- a/vfs/os_vfs_symlink_test.go
+++ b/vfs/os_vfs_symlink_test.go
@@ -9,7 +9,9 @@ import (
 func TestOSVFS_SymlinkPreservation(t *testing.T) {
 	tmpDir := t.TempDir()
 	realDir := filepath.Join(tmpDir, "real_dir")
-	os.MkdirAll(realDir, 0755)
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatalf("Failed to create real directory: %v", err)
+	}
 
 	linkDir := filepath.Join(tmpDir, "link_dir")
 	err := os.Symlink(realDir, linkDir)

--- a/vfs/os_vfs_test.go
+++ b/vfs/os_vfs_test.go
@@ -31,8 +31,12 @@ func TestOSVFS_Mutations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
-	wc.Write([]byte("VFS Test Data"))
-	wc.Close()
+	if _, err := wc.Write([]byte("VFS Test Data")); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+	if err := wc.Close(); err != nil {
+		t.Fatalf("Close writer failed: %v", err)
+	}
 
 	rc, err := vfs.Open(context.Background(), filePath)
 	if err != nil {
@@ -45,7 +49,9 @@ func TestOSVFS_Mutations(t *testing.T) {
 
 	buf := make([]byte, 4)
 	n, err := rc.ReadAt(context.Background(), buf, 4)
-	rc.Close()
+	if closeErr := rc.Close(); closeErr != nil {
+		t.Fatalf("Close reader failed: %v", closeErr)
+	}
 	if err != nil || string(buf[:n]) != "Test" {
 		t.Errorf("ReadAt failed. Expected 'Test', got %q", string(buf[:n]))
 	}
@@ -89,7 +95,9 @@ func TestOSVFS_Symlinks(t *testing.T) {
 
 	// 1. Create a real directory
 	targetDir := filepath.Join(tmpDir, "real_folder")
-	os.Mkdir(targetDir, 0755)
+	if err := os.Mkdir(targetDir, 0755); err != nil {
+		t.Fatalf("Failed to create target directory: %v", err)
+	}
 
 	// 2. Create a symlink to that directory
 	linkPath := filepath.Join(tmpDir, "link_folder")
@@ -127,10 +135,14 @@ func TestOSVFS_Lstat(t *testing.T) {
 	v := NewOSVFS(tmpDir)
 
 	targetFile := filepath.Join(tmpDir, "target.txt")
-	os.WriteFile(targetFile, []byte("hello world"), 0644)
+	if err := os.WriteFile(targetFile, []byte("hello world"), 0644); err != nil {
+		t.Fatalf("Failed to create target file: %v", err)
+	}
 
 	linkFile := filepath.Join(tmpDir, "link.txt")
-	os.Symlink(targetFile, linkFile)
+	if err := os.Symlink(targetFile, linkFile); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
 
 	statItem, err := v.Stat(context.Background(), linkFile)
 	if err != nil {
@@ -176,7 +188,10 @@ func TestOSVFS_ReadDir_Cancellation(t *testing.T) {
 	tmpDir := t.TempDir()
 	// Create 100 files to ensure multiple chunks/iterations
 	for i := 0; i < 100; i++ {
-		os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("file%d.txt", i)), []byte("data"), 0644)
+		file := filepath.Join(tmpDir, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+			t.Fatalf("Failed to create %s: %v", file, err)
+		}
 	}
 
 	v := NewOSVFS(tmpDir)
@@ -203,7 +218,9 @@ func TestOSVFS_SetPath_Validation(t *testing.T) {
 
 	// 1. Existing dir -> Success
 	sub := filepath.Join(tmpDir, "exist")
-	os.Mkdir(sub, 0755)
+	if err := os.Mkdir(sub, 0755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
 	if err := v.SetPath(sub); err != nil {
 		t.Errorf("SetPath failed for existing dir: %v", err)
 	}
@@ -215,7 +232,9 @@ func TestOSVFS_SetPath_Validation(t *testing.T) {
 
 	// 3. Path is a file -> Error
 	file := filepath.Join(tmpDir, "file.txt")
-	os.WriteFile(file, []byte("data"), 0644)
+	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
 	if err := v.SetPath(file); err == nil {
 		t.Error("SetPath should fail if path is a file")
 	}
@@ -224,7 +243,9 @@ func TestOSVFS_Abs_Consistency(t *testing.T) {
 	// Test that Abs is relative to the VFS path, not process CWD
 	tmp := t.TempDir()
 	vfsPath := filepath.Join(tmp, "vfs_root")
-	os.Mkdir(vfsPath, 0755)
+	if err := os.Mkdir(vfsPath, 0755); err != nil {
+		t.Fatalf("Failed to create VFS root: %v", err)
+	}
 
 	v := NewOSVFS(vfsPath)
 
@@ -243,7 +264,9 @@ func TestOSVFS_Abs_CWD_Independence(t *testing.T) {
 	// Create a folder structure: /tmp/root/subdir
 	tmp := t.TempDir()
 	vfsRoot := filepath.Join(tmp, "vfs_root")
-	os.MkdirAll(vfsRoot, 0755)
+	if err := os.MkdirAll(vfsRoot, 0755); err != nil {
+		t.Fatalf("Failed to create VFS root: %v", err)
+	}
 
 	v := NewOSVFS(vfsRoot)
 
@@ -266,7 +289,9 @@ func TestOSVFS_Abs_CWD_Independence(t *testing.T) {
 func TestOSVFS_SetPath_Relative(t *testing.T) {
 	tmpDir := t.TempDir()
 	subDir := "my_sub_folder"
-	os.Mkdir(filepath.Join(tmpDir, subDir), 0755)
+	if err := os.Mkdir(filepath.Join(tmpDir, subDir), 0755); err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
 
 	v := NewOSVFS(tmpDir)
 

--- a/vfs/scanner_test.go
+++ b/vfs/scanner_test.go
@@ -46,8 +46,12 @@ func TestGenericScan_FlatFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	v := NewOSVFS(tmpDir)
 
-	os.WriteFile(filepath.Join(tmpDir, "f1.txt"), []byte("abc"), 0644)  // 3 bytes
-	os.WriteFile(filepath.Join(tmpDir, "f2.txt"), []byte("defg"), 0644) // 4 bytes
+	if err := os.WriteFile(filepath.Join(tmpDir, "f1.txt"), []byte("abc"), 0644); err != nil { // 3 bytes
+		t.Fatalf("Failed to create f1.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "f2.txt"), []byte("defg"), 0644); err != nil { // 4 bytes
+		t.Fatalf("Failed to create f2.txt: %v", err)
+	}
 
 	stats, err := GenericScan(context.Background(), v, tmpDir, []string{"f1.txt", "f2.txt"}, nil)
 	if err != nil {
@@ -77,10 +81,16 @@ func TestGenericScan_Recursive(t *testing.T) {
 
 	rootDir := filepath.Join(tmpDir, "root_dir")
 	subDir := filepath.Join(rootDir, "sub_dir")
-	os.MkdirAll(subDir, 0755)
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatalf("Failed to create scan directories: %v", err)
+	}
 
-	os.WriteFile(filepath.Join(rootDir, "file1.txt"), make([]byte, 5), 0644)
-	os.WriteFile(filepath.Join(subDir, "file2.txt"), make([]byte, 10), 0644)
+	if err := os.WriteFile(filepath.Join(rootDir, "file1.txt"), make([]byte, 5), 0644); err != nil {
+		t.Fatalf("Failed to create file1.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "file2.txt"), make([]byte, 10), 0644); err != nil {
+		t.Fatalf("Failed to create file2.txt: %v", err)
+	}
 
 	var lastReportedPath string
 	callCount := 0
@@ -121,7 +131,9 @@ func TestGenericScan_Cancellation(t *testing.T) {
 	tmpDir := t.TempDir()
 	v := NewOSVFS(tmpDir)
 
-	os.MkdirAll(filepath.Join(tmpDir, "dir1", "dir2", "dir3"), 0755)
+	if err := os.MkdirAll(filepath.Join(tmpDir, "dir1", "dir2", "dir3"), 0755); err != nil {
+		t.Fatalf("Failed to create scan tree: %v", err)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 

--- a/vfs/sudo_test.go
+++ b/vfs/sudo_test.go
@@ -16,7 +16,9 @@ func mockSudoDispatcher(t *testing.T, l *net.UnixListener, stop chan struct{}) {
 	if err != nil {
 		return
 	}
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close() // connection cleanup errors are uninteresting
+	}()
 
 	for {
 		select {
@@ -66,10 +68,18 @@ func mockSudoDispatcher(t *testing.T, l *net.UnixListener, stop chan struct{}) {
 			if req.Path == "/protected/file.txt" {
 				tmp, err := os.CreateTemp("", "sudo-test-open-*")
 				if err == nil {
-					tmp.Write([]byte("elevated content"))
-					tmp.Seek(0, 0)
-					fdToSend = int(tmp.Fd())
 					tmpFileToClean = tmp
+					if _, err := tmp.Write([]byte("elevated content")); err != nil {
+						t.Errorf("write temporary response file: %v", err)
+						resp.Error = err.Error()
+						break
+					}
+					if _, err := tmp.Seek(0, 0); err != nil {
+						t.Errorf("rewind temporary response file: %v", err)
+						resp.Error = err.Error()
+						break
+					}
+					fdToSend = int(tmp.Fd())
 				} else {
 					resp.Error = err.Error()
 				}
@@ -109,14 +119,22 @@ func mockSudoDispatcher(t *testing.T, l *net.UnixListener, stop chan struct{}) {
 		if err := sendMsg(conn, resp, fdToSend); err != nil {
 			t.Logf("mockSudoDispatcher sendMsg error: %v", err)
 			if tmpFileToClean != nil {
-				tmpFileToClean.Close()
-				os.Remove(tmpFileToClean.Name())
+				if err := tmpFileToClean.Close(); err != nil {
+					t.Errorf("close temporary response file: %v", err)
+				}
+				if err := os.Remove(tmpFileToClean.Name()); err != nil {
+					t.Errorf("remove temporary response file: %v", err)
+				}
 			}
 			return
 		}
 		if tmpFileToClean != nil {
-			tmpFileToClean.Close()
-			os.Remove(tmpFileToClean.Name())
+			if err := tmpFileToClean.Close(); err != nil {
+				t.Errorf("close temporary response file: %v", err)
+			}
+			if err := os.Remove(tmpFileToClean.Name()); err != nil {
+				t.Errorf("remove temporary response file: %v", err)
+			}
 		}
 	}
 }
@@ -136,7 +154,9 @@ func TestSudoClient_IPCProtocol(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListenUnix failed: %v", err)
 	}
-	defer l.Close()
+	defer func() {
+		_ = l.Close() // listener cleanup errors are uninteresting
+	}()
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
@@ -157,7 +177,9 @@ func TestSudoClient_IPCProtocol(t *testing.T) {
 		t.Fatalf("Failed to connect to mock dispatcher: %v", err)
 	}
 	client.conn = conn
-	defer client.conn.Close()
+	defer func() {
+		_ = client.conn.Close() // connection cleanup errors are uninteresting
+	}()
 
 	// 1. Тест Stat
 	t.Run("Stat Success", func(t *testing.T) {
@@ -194,7 +216,7 @@ func TestSudoClient_IPCProtocol(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Open failed: %v", err)
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		content, err := io.ReadAll(f)
 		if err != nil {
@@ -249,7 +271,9 @@ func TestSudoClient_DisconnectRecovery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListenUnix failed: %v", err)
 	}
-	defer l.Close()
+	defer func() {
+		_ = l.Close() // listener cleanup errors are uninteresting
+	}()
 
 	stopChan := make(chan struct{})
 	defer close(stopChan)
@@ -271,7 +295,9 @@ func TestSudoClient_DisconnectRecovery(t *testing.T) {
 	client.conn = conn
 
 	// Закрываем соединение, имитируя неожиданный обрыв связи
-	client.conn.Close()
+	if err := client.conn.Close(); err != nil {
+		t.Fatalf("Close connection failed: %v", err)
+	}
 
 	// Первый вызов на закрытом сокете должен завершиться ошибкой и сбросить c.conn
 	_, _, err = client.SendRequest(SudoRequest{Cmd: CmdPing})
@@ -294,6 +320,10 @@ func shortSocketDir(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() { os.RemoveAll(dir) })
+	t.Cleanup(func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Errorf("remove short socket directory: %v", err)
+		}
+	})
 	return dir
 }

--- a/vfs/utils_test.go
+++ b/vfs/utils_test.go
@@ -15,28 +15,36 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 1. Regular text file
 	txtFile := filepath.Join(tmpDir, "test.txt")
-	os.WriteFile(txtFile, []byte("hello"), 0644)
+	if err := os.WriteFile(txtFile, []byte("hello"), 0644); err != nil {
+		t.Fatalf("Failed to create text file: %v", err)
+	}
 	if IsTerminalRunnable(ctx, v, txtFile) {
 		t.Error("Text file should not be terminal-runnable")
 	}
 
 	// 2. Shell script by extension
 	shFile := filepath.Join(tmpDir, "test.sh")
-	os.WriteFile(shFile, []byte("echo hi"), 0644)
+	if err := os.WriteFile(shFile, []byte("echo hi"), 0644); err != nil {
+		t.Fatalf("Failed to create shell script: %v", err)
+	}
 	if !IsTerminalRunnable(ctx, v, shFile) {
 		t.Error(".sh file should be terminal-runnable")
 	}
 
 	// 3. File with shebang
 	sbFile := filepath.Join(tmpDir, "myscript")
-	os.WriteFile(sbFile, []byte("#!/usr/bin/env python\nprint('hi')"), 0644)
+	if err := os.WriteFile(sbFile, []byte("#!/usr/bin/env python\nprint('hi')"), 0644); err != nil {
+		t.Fatalf("Failed to create shebang script: %v", err)
+	}
 	if !IsTerminalRunnable(ctx, v, sbFile) {
 		t.Error("File with shebang should be terminal-runnable")
 	}
 
 	// 4. Directory should not be runnable
 	subDir := filepath.Join(tmpDir, "folder")
-	os.Mkdir(subDir, 0755)
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatalf("Failed to create directory: %v", err)
+	}
 	if IsTerminalRunnable(ctx, v, subDir) {
 		t.Error("Directory should not be terminal-runnable")
 	}
@@ -44,7 +52,9 @@ func TestIsTerminalRunnable(t *testing.T) {
 	// 5. Unix Executable Bit
 	if runtime.GOOS != "windows" {
 		binFile := filepath.Join(tmpDir, "mybin")
-		os.WriteFile(binFile, []byte{0x7f, 'E', 'L', 'F'}, 0755)
+		if err := os.WriteFile(binFile, []byte{0x7f, 'E', 'L', 'F'}, 0755); err != nil {
+			t.Fatalf("Failed to create executable: %v", err)
+		}
 		if !IsTerminalRunnable(ctx, v, binFile) {
 			t.Error("Executable bit should make file runnable on Unix")
 		}
@@ -71,7 +81,9 @@ func TestIsTerminalRunnable_ShebangVariations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := filepath.Join(tmpDir, "script_"+tt.name)
-			os.WriteFile(path, []byte(tt.content), 0644)
+			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+				t.Fatalf("Failed to create test script: %v", err)
+			}
 			if got := IsTerminalRunnable(ctx, v, path); got != tt.want {
 				t.Errorf("IsTerminalRunnable() for content %q = %v, want %v", tt.content, got, tt.want)
 			}

--- a/vtvibe/session_test.go
+++ b/vtvibe/session_test.go
@@ -11,7 +11,9 @@ func TestSession_Draft(t *testing.T) {
 	if s.Draft() != "" {
 		t.Errorf("expected empty draft, got %q", s.Draft())
 	}
-	s.tree.writeFile("/draft.md", []byte("hello model"))
+	if err := s.tree.writeFile("/draft.md", []byte("hello model")); err != nil {
+		t.Fatalf("write draft: %v", err)
+	}
 	if s.Draft() != "hello model" {
 		t.Errorf("expected draft to be read")
 	}
@@ -23,7 +25,9 @@ func TestSession_Draft(t *testing.T) {
 
 func TestSession_Reset(t *testing.T) {
 	s := NewSession()
-	s.tree.writeFile("/ctx/test.go", []byte("package main"))
+	if err := s.tree.writeFile("/ctx/test.go", []byte("package main")); err != nil {
+		t.Fatalf("write context: %v", err)
+	}
 	s.appendTurn(Turn{Role: "user", Text: "hello"})
 
 	s.Reset(true)


### PR DESCRIPTION
errcheck's whole-tree backlog is 1432, and 900 of those sit in test files rather
than in shipped code. This clears the test half everywhere except cmd/f4, which
is 502 findings on its own and is where everything else in this repository is
landing right now, so it goes separately rather than spending its life in
conflict. Production code is untouched here and still has 532 findings; that is
its own pass, and the interesting ones are in it.

The default treatment is to check the error and fail. A test whose setup
silently failed does not report the setup: it reports whichever assertion falls
over later, somewhere unrelated, and whoever reads the failure starts in the
wrong place.

Three exceptions, and only these three.

A handle opened for reading gets `_ =` on Close. A handle opened for writing
does not, because there the Close error is the only word on whether what was
written actually reached the disk. errcheck cannot tell those apart, which is
why this had to be read rather than rewritten in bulk.

Cleanup whose failure genuinely says nothing -- response bodies, connections,
listeners, an os.Remove of a path t.TempDir will take anyway -- gets `_ =` and a
clause saying why.

Goroutines other than the test's own report through t.Errorf, because t.Fatal is
only valid on the test goroutine and quietly does the wrong thing elsewhere.

Lines whose whole point is that the call fails were left asserting on the error.
Turning those into t.Fatal would have inverted the test.

Two things came out of checking rather than discarding, both in the plugin half.
The mock FISH+ peer could outlive the test that started it; its cleanup now
joins that goroutine, which is a leak the discarded errors were hiding rather
than something the change introduced. And closing the reconnect handles in
checked form initially reordered them, which that path depends on, so the
deferred closes keep the original order.

Nothing else started failing, so outside those two there was no silently failed
setup propping a test up.