### PR TITLE
test: stop the test fixtures being born group-readable

### DIFF
--- a/plugins/archive/archive_test.go
+++ b/plugins/archive/archive_test.go
@@ -50,7 +50,7 @@ func TestZipCompression_Deflate(t *testing.T) {
 
 	data := []byte(strings.Repeat("A", 1000))
 	filePath := filepath.Join(tmpDir, "data.txt")
-	if err := os.WriteFile(filePath, data, 0644); err != nil {
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -216,7 +216,7 @@ func TestActionAddArchive_ProgressUpdates(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	tmpDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("data"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "file1.txt"), []byte("data"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/provider_test.go
+++ b/plugins/archive/provider_test.go
@@ -27,7 +27,7 @@ func TestArchiveProvider_CanOpen(t *testing.T) {
 
 	// 1. Valid formats (e.g. .zip)
 	tmpZip := filepath.Join(t.TempDir(), "test.zip")
-	if err := os.WriteFile(tmpZip, []byte("PK\x03\x04..."), 0644); err != nil { // Zip magic bytes
+	if err := os.WriteFile(tmpZip, []byte("PK\x03\x04..."), 0600); err != nil { // Zip magic bytes
 		t.Fatal(err)
 	}
 	if !p.CanOpen(ctx, nil, tmpZip) {
@@ -36,7 +36,7 @@ func TestArchiveProvider_CanOpen(t *testing.T) {
 
 	// 2. Invalid formats (e.g. .txt)
 	tmpTxt := filepath.Join(t.TempDir(), "test.txt")
-	if err := os.WriteFile(tmpTxt, []byte("plain text"), 0644); err != nil {
+	if err := os.WriteFile(tmpTxt, []byte("plain text"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if p.CanOpen(ctx, nil, tmpTxt) {
@@ -51,7 +51,7 @@ func TestArchiveProvider_Open(t *testing.T) {
 	tmpDir := t.TempDir()
 	zipPath := filepath.Join(tmpDir, "empty.zip")
 	// Write empty zip structure (22 bytes EOCD)
-	if err := os.WriteFile(zipPath, []byte("\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644); err != nil {
+	if err := os.WriteFile(zipPath, []byte("\x50\x4b\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/repro_test.go
+++ b/plugins/archive/repro_test.go
@@ -108,13 +108,13 @@ func TestActionAddArchive_OverwriteWarning(t *testing.T) {
 	v := vfs.NewOSVFS(tmpDir)
 
 	dummyFile := v.Join(tmpDir, "file_to_archive.txt")
-	if err := os.WriteFile(dummyFile, []byte("some content"), 0644); err != nil {
+	if err := os.WriteFile(dummyFile, []byte("some content"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
 	archiveName := v.Base(tmpDir) + ".zip"
 	existingArchive := v.Join(tmpDir, archiveName)
-	if err := os.WriteFile(existingArchive, []byte("existing zip content"), 0644); err != nil {
+	if err := os.WriteFile(existingArchive, []byte("existing zip content"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -201,7 +201,7 @@ func TestArchivePlugin_ConcurrentOperationWarning(t *testing.T) {
 	v := vfs.NewOSVFS(tmpDir)
 
 	dummyFile := filepath.Join(tmpDir, "test.zip")
-	if err := os.WriteFile(dummyFile, []byte("dummy zip content"), 0644); err != nil {
+	if err := os.WriteFile(dummyFile, []byte("dummy zip content"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -235,10 +235,10 @@ func TestIssue150_Concurrent7zReadDir(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(srcDir, "dir1/dir2"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "dir1/file1.txt"), []byte("data1"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "dir1/file1.txt"), []byte("data1"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "dir1/dir2/file2.txt"), []byte("data2"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "dir1/dir2/file2.txt"), []byte("data2"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -305,10 +305,10 @@ func TestIssue150_7zDirectoryStructureAndSolid(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(srcDir, "empty_dir"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("solid content 1"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("solid content 1"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcDir, "file2.txt"), []byte("solid content 2"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcDir, "file2.txt"), []byte("solid content 2"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -156,7 +156,7 @@ func TestArchiveVFS_AtomicWrite(t *testing.T) {
 	tmp := t.TempDir()
 	arcPath := filepath.Join(tmp, "test.zip")
 
-	if err := os.WriteFile(arcPath, []byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0644); err != nil {
+	if err := os.WriteFile(arcPath, []byte("PK\x05\x06\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	origInfo, _ := os.Stat(arcPath)

--- a/plugins/netfox/netfox_test.go
+++ b/plugins/netfox/netfox_test.go
@@ -17,7 +17,7 @@ func TestNetFoxVFS_ConfigPersistence(t *testing.T) {
 	tmpDir := t.TempDir()
 	dbPath := filepath.Join(tmpDir, "test_net.json")
 	// Ensure the file is created for consistency in tests
-	if err := os.WriteFile(dbPath, []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(dbPath, []byte("{}"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	nf := NewNetFoxVFS(dbPath)

--- a/vfs/os_vfs_test.go
+++ b/vfs/os_vfs_test.go
@@ -135,7 +135,7 @@ func TestOSVFS_Lstat(t *testing.T) {
 	v := NewOSVFS(tmpDir)
 
 	targetFile := filepath.Join(tmpDir, "target.txt")
-	if err := os.WriteFile(targetFile, []byte("hello world"), 0644); err != nil {
+	if err := os.WriteFile(targetFile, []byte("hello world"), 0600); err != nil {
 		t.Fatalf("Failed to create target file: %v", err)
 	}
 
@@ -189,7 +189,7 @@ func TestOSVFS_ReadDir_Cancellation(t *testing.T) {
 	// Create 100 files to ensure multiple chunks/iterations
 	for i := 0; i < 100; i++ {
 		file := filepath.Join(tmpDir, fmt.Sprintf("file%d.txt", i))
-		if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+		if err := os.WriteFile(file, []byte("data"), 0600); err != nil {
 			t.Fatalf("Failed to create %s: %v", file, err)
 		}
 	}
@@ -232,7 +232,7 @@ func TestOSVFS_SetPath_Validation(t *testing.T) {
 
 	// 3. Path is a file -> Error
 	file := filepath.Join(tmpDir, "file.txt")
-	if err := os.WriteFile(file, []byte("data"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("data"), 0600); err != nil {
 		t.Fatalf("Failed to create test file: %v", err)
 	}
 	if err := v.SetPath(file); err == nil {

--- a/vfs/scanner_test.go
+++ b/vfs/scanner_test.go
@@ -46,10 +46,10 @@ func TestGenericScan_FlatFiles(t *testing.T) {
 	tmpDir := t.TempDir()
 	v := NewOSVFS(tmpDir)
 
-	if err := os.WriteFile(filepath.Join(tmpDir, "f1.txt"), []byte("abc"), 0644); err != nil { // 3 bytes
+	if err := os.WriteFile(filepath.Join(tmpDir, "f1.txt"), []byte("abc"), 0600); err != nil { // 3 bytes
 		t.Fatalf("Failed to create f1.txt: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(tmpDir, "f2.txt"), []byte("defg"), 0644); err != nil { // 4 bytes
+	if err := os.WriteFile(filepath.Join(tmpDir, "f2.txt"), []byte("defg"), 0600); err != nil { // 4 bytes
 		t.Fatalf("Failed to create f2.txt: %v", err)
 	}
 
@@ -85,10 +85,10 @@ func TestGenericScan_Recursive(t *testing.T) {
 		t.Fatalf("Failed to create scan directories: %v", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(rootDir, "file1.txt"), make([]byte, 5), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(rootDir, "file1.txt"), make([]byte, 5), 0600); err != nil {
 		t.Fatalf("Failed to create file1.txt: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(subDir, "file2.txt"), make([]byte, 10), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(subDir, "file2.txt"), make([]byte, 10), 0600); err != nil {
 		t.Fatalf("Failed to create file2.txt: %v", err)
 	}
 

--- a/vfs/utils_test.go
+++ b/vfs/utils_test.go
@@ -15,7 +15,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 1. Regular text file
 	txtFile := filepath.Join(tmpDir, "test.txt")
-	if err := os.WriteFile(txtFile, []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(txtFile, []byte("hello"), 0600); err != nil {
 		t.Fatalf("Failed to create text file: %v", err)
 	}
 	if IsTerminalRunnable(ctx, v, txtFile) {
@@ -24,7 +24,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 2. Shell script by extension
 	shFile := filepath.Join(tmpDir, "test.sh")
-	if err := os.WriteFile(shFile, []byte("echo hi"), 0644); err != nil {
+	if err := os.WriteFile(shFile, []byte("echo hi"), 0600); err != nil {
 		t.Fatalf("Failed to create shell script: %v", err)
 	}
 	if !IsTerminalRunnable(ctx, v, shFile) {
@@ -33,7 +33,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 3. File with shebang
 	sbFile := filepath.Join(tmpDir, "myscript")
-	if err := os.WriteFile(sbFile, []byte("#!/usr/bin/env python\nprint('hi')"), 0644); err != nil {
+	if err := os.WriteFile(sbFile, []byte("#!/usr/bin/env python\nprint('hi')"), 0600); err != nil {
 		t.Fatalf("Failed to create shebang script: %v", err)
 	}
 	if !IsTerminalRunnable(ctx, v, sbFile) {
@@ -81,7 +81,7 @@ func TestIsTerminalRunnable_ShebangVariations(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			path := filepath.Join(tmpDir, "script_"+tt.name)
-			if err := os.WriteFile(path, []byte(tt.content), 0644); err != nil {
+			if err := os.WriteFile(path, []byte(tt.content), 0600); err != nil {
 				t.Fatalf("Failed to create test script: %v", err)
 			}
 			if got := IsTerminalRunnable(ctx, v, path); got != tt.want {


### PR DESCRIPTION
23 gosec G306 findings, all the same: test fixtures written with os.WriteFile
at 0644. They have always been 0644. They only became visible because the
errcheck pass touched those lines, and CI reports findings only on lines a pull
request touches.

Nothing reads these fixtures as another user and nothing asserts on their mode,
so 0600 costs nothing and clears the class out of the test tree ahead of the
gosec pass proper.

Worth noting how easy this was to get wrong: golangci-lint prints at most three
identical messages by default, so a first attempt fixed three, watched three
more appear, and read that as the linter regenerating them. It was not; the
other twenty were simply not being printed. --max-same-issues=0 shows them.