### PR TITLE
fix: order the progress dialog's cancel against the task it cancels

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -3409,13 +3409,21 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 	vbox.Add(btnCancel, vtui.Margins{Top: 1}, vtui.AlignCenter)
 	vbox.Apply()
 
+	var taskCtxMu sync.Mutex // protects taskCtx and cancelPending
 	var taskCtx *vtui.TaskContext
+	cancelPending := false
 	btnCancel.OnClick = func() {
 		dlg.SetExitCode(1)
 	}
 	dlg.OnResult = func(code int) {
-		if taskCtx != nil {
-			taskCtx.Cancel()
+		taskCtxMu.Lock()
+		ctx := taskCtx
+		if ctx == nil {
+			cancelPending = true
+		}
+		taskCtxMu.Unlock()
+		if ctx != nil {
+			ctx.Cancel()
 		}
 	}
 
@@ -3450,7 +3458,7 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 		vtui.FrameManager.PostTask(showDialog)
 	}
 
-	taskCtx = vtui.RunAsync(func(ctx *vtui.TaskContext) {
+	ctx := vtui.RunAsync(func(ctx *vtui.TaskContext) {
 		update := func(msg string, percent int) {
 			ctx.RunOnUI(func() {
 				if msg != "" {
@@ -3478,6 +3486,13 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 			}
 		})
 	})
+	taskCtxMu.Lock()
+	taskCtx = ctx
+	cancel := cancelPending
+	taskCtxMu.Unlock()
+	if cancel {
+		ctx.Cancel()
+	}
 }
 func (pf *PanelsFrame) RunAdvancedProgressTask(title string, forked bool, worker func(ctx context.Context, reporter vfs.TaskReporter) error, onComplete func(err error)) {
 	dlg := NewFileOpProgressDialog(title)


### PR DESCRIPTION
Seven of the race detector's reports in cmd/f4 were the same pair:
runProgressTaskAfter assigning taskCtx while the dialog's OnResult callback
read it to decide whether to cancel.

Reading a pointer that is being written is the reported half. The interesting
half is what the code did when the read won: OnResult found taskCtx still nil,
concluded there was nothing to cancel, and returned. A cancel arriving in that
window was silently dropped, and the user watched a dialog they had just
dismissed keep working.

So this is not only a publication problem. taskCtx is now published under a
short lock covering the assignment and nothing else, and OnResult either
cancels or, if the task does not exist yet, records that a cancel is pending.
The publishing side delivers it. A cancel that arrives after the worker has
already finished is harmless and still delivered, which is simpler to reason
about than trying to detect that case.

The lock deliberately does not span the dialog setup. Nothing reachable from
there calls OnResult on the same goroutine today -- PostTask only queues,
RunAsync only starts a goroutine -- but a lock held across forty lines of UI
construction is a trap for whoever edits this next, and all it ever needed to
protect was one assignment.