### PR TITLE
lint: decide what the network plugins do when a call fails

### DIFF
--- a/plugins/cloudfox/oauth.go
+++ b/plugins/cloudfox/oauth.go
@@ -63,7 +63,7 @@ func AuthorizeGoogleDesktop(ctx context.Context, connection Connection, secrets 
 	if err != nil {
 		return nil, fmt.Errorf("cloudfox: start Google OAuth callback: %w", err)
 	}
-	defer listener.Close()
+	defer func() { _ = listener.Close() }() // Listener teardown is best effort.
 
 	state, err := randomOAuthState()
 	if err != nil {
@@ -251,7 +251,7 @@ func ExchangeYandexAuthorizationCode(ctx context.Context, client *http.Client, o
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
+	defer func() { _ = response.Body.Close() }() // Response-body cleanup is best effort.
 	data, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
 	if err != nil {
 		return nil, err

--- a/plugins/cloudfox/provider_google.go
+++ b/plugins/cloudfox/provider_google.go
@@ -1630,7 +1630,7 @@ func (r *googleRangeReader) ReadAt(ctx context.Context, p []byte, off int64) (in
 		}
 		return local.ReadAt(ctx, p, off)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode != http.StatusPartialContent {
 		return 0, errors.New("cloudfox: Google Drive stopped honoring byte ranges")
 	}
@@ -1659,28 +1659,24 @@ func (r *googleRangeReader) Read(ctx context.Context, p []byte) (int, error) {
 }
 
 func googleResponseToTemp(ctx context.Context, resp *http.Response, displayName string) (*providerTempReader, error) {
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	f, err := os.CreateTemp("", "f4-cloudfox-google-export-*")
 	if err != nil {
 		return nil, err
 	}
 	name := f.Name()
-	cleanup := func() {
-		f.Close()
-		os.Remove(name)
+	cleanup := func() error {
+		return errors.Join(f.Close(), os.Remove(name))
 	}
 	if err := f.Chmod(0o600); err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	written, err := copyGoogleResponse(ctx, f, resp.Body, resp.ContentLength, displayName)
 	if err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	return newProviderTempReader(f, name, written), nil
 }

--- a/plugins/cloudfox/provider_s3.go
+++ b/plugins/cloudfox/provider_s3.go
@@ -1600,7 +1600,7 @@ func (r *s3RangeReader) ReadAt(ctx context.Context, p []byte, off int64) (int, e
 	if output == nil || output.Body == nil {
 		return 0, errors.New("cloudfox: S3 GetObject returned no response body")
 	}
-	defer output.Body.Close()
+	defer func() { _ = output.Body.Close() }() // Response-body cleanup is best effort.
 	if r.etag != "" && strings.TrimSpace(aws.ToString(output.ETag)) != r.etag {
 		return 0, ErrRemoteObjectChanged
 	}
@@ -1689,7 +1689,7 @@ func (b *s3Backend) openS3Snapshot(ctx context.Context, target s3Target) (_ vfs.
 	if output == nil || output.Body == nil {
 		return nil, errors.New("cloudfox: S3 GetObject returned no response body")
 	}
-	defer output.Body.Close()
+	defer func() { _ = output.Body.Close() }() // Response-body cleanup is best effort.
 
 	file, err := os.CreateTemp("", "f4-cloudfox-s3-read-*")
 	if err != nil {

--- a/plugins/cloudfox/provider_webdav.go
+++ b/plugins/cloudfox/provider_webdav.go
@@ -308,10 +308,10 @@ func (t *webDAVDigestTransport) RoundTrip(req *http.Request) (*http.Response, er
 	}
 	parsed, parseErr := parseDigestChallenge(resp.Header.Values("WWW-Authenticate"))
 	if parseErr != nil {
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		return nil, parseErr
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close() // Response-body cleanup is best effort.
 	t.setChallenge(parsed)
 	challenge, nonceCount = t.cachedChallenge()
 	return t.roundTrip(req, challenge, nonceCount, !hadChallenge)
@@ -1282,7 +1282,7 @@ func (b *webDAVBackend) propfind(ctx context.Context, location, depth string, ac
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode != http.StatusMultiStatus {
 		return mapWebDAVHTTPError(resp, readSmallResponse(resp))
 	}
@@ -1438,7 +1438,7 @@ func (b *webDAVBackend) MkDir(ctx context.Context, location string) error {
 		}
 		_, canonicalCollection := webDAVTrailingSlashRedirect(resp)
 		if resp.StatusCode == http.StatusMethodNotAllowed || canonicalCollection {
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			entry, statErr := b.Stat(ctx, current)
 			if statErr != nil {
 				if canonicalCollection {
@@ -1453,10 +1453,10 @@ func (b *webDAVBackend) MkDir(ctx context.Context, location string) error {
 		}
 		if resp.StatusCode != http.StatusCreated {
 			message := readSmallResponse(resp)
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			return failure(current, webDAVHTTPMutationError("WebDAV MKCOL", resp, message))
 		}
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		created = append(created, current)
 	}
 	return nil
@@ -1478,7 +1478,7 @@ func (b *webDAVBackend) mutation(ctx context.Context, method, location string, h
 	if err != nil {
 		return &vfs.UnknownOperationStateError{Operation: "WebDAV " + method, Err: safeWebDAVMutationTransportError(err)}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.Request != nil && resp.Request.Method != method {
 		return &vfs.UnknownOperationStateError{
 			Operation: "WebDAV " + method,
@@ -1744,7 +1744,7 @@ func (r *webDAVRangeReader) readRange(ctx context.Context, p []byte, start, requ
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode == http.StatusPreconditionFailed {
 		return 0, ErrRemoteObjectChanged
 	}
@@ -1897,13 +1897,11 @@ func responseToTempReader(ctx context.Context, resp *http.Response, displayName 
 		return nil, err
 	}
 	tempPath := f.Name()
-	cleanup := func() {
-		f.Close()
-		os.Remove(tempPath)
+	cleanup := func() error {
+		return errors.Join(f.Close(), os.Remove(tempPath))
 	}
 	if err := f.Chmod(0o600); err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	total := resp.ContentLength
 	if total < 0 {
@@ -1921,16 +1919,13 @@ func responseToTempReader(ctx context.Context, resp *http.Response, displayName 
 	}
 	written, err := copyWebDAVResponse(ctx, f, &contextReader{ctx: ctx, r: body}, total, displayName)
 	if err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	if requireExpectedSize && written != expectedSize {
-		cleanup()
-		return nil, fmt.Errorf("%w: WebDAV response size changed from %d to %d bytes", ErrRemoteObjectChanged, expectedSize, written)
+		return nil, errors.Join(fmt.Errorf("%w: WebDAV response size changed from %d to %d bytes", ErrRemoteObjectChanged, expectedSize, written), cleanup())
 	}
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		cleanup()
-		return nil, err
+		return nil, errors.Join(err, cleanup())
 	}
 	if reporter, ok := ctx.Value(vfs.ReporterKey).(vfs.TaskReporter); ok {
 		reporter.UpdateTransfer("Downloading", displayName, 100, "", 100, "")
@@ -1972,7 +1967,7 @@ func (b *webDAVBackend) Open(ctx context.Context, location string) (vfs.ReadAtCl
 		return nil, err
 	}
 	if resp.StatusCode == http.StatusPreconditionFailed {
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		return nil, ErrRemoteObjectChanged
 	}
 	if resp.StatusCode == http.StatusRequestedRangeNotSatisfiable {
@@ -1980,7 +1975,7 @@ func (b *webDAVBackend) Open(ctx context.Context, location string) (vfs.ReadAtCl
 		if strings.HasPrefix(strings.ToLower(contentRange), "bytes */") {
 			actualSize, sizeErr := strconv.ParseInt(strings.TrimSpace(contentRange[len("bytes */"):]), 10, 64)
 			if sizeErr == nil && entry.SizeKnown && actualSize != entry.Size {
-				resp.Body.Close()
+				_ = resp.Body.Close() // Response-body cleanup is best effort.
 				return nil, ErrRemoteObjectChanged
 			}
 		}
@@ -1988,15 +1983,15 @@ func (b *webDAVBackend) Open(ctx context.Context, location string) (vfs.ReadAtCl
 	if resp.StatusCode == http.StatusPartialContent {
 		probeStart, probeEnd, probeTotal, rangeErr := parseContentRange(resp.Header.Get("Content-Range"))
 		if rangeErr == nil && probeTotal != entry.Size {
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			return nil, ErrRemoteObjectChanged
 		}
 		if rangeErr != nil || probeStart != 0 || probeEnd != 0 {
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			return nil, fmt.Errorf("cloudfox: Content-Range %q does not match WebDAV range probe bytes 0-0/%d", resp.Header.Get("Content-Range"), entry.Size)
 		}
 		probe, readErr := io.ReadAll(io.LimitReader(resp.Body, 2))
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		if readErr != nil || len(probe) != 1 {
 			if readErr == nil {
 				readErr = fmt.Errorf("received %d bytes, want 1", len(probe))
@@ -2031,7 +2026,7 @@ func (b *webDAVBackend) Open(ctx context.Context, location string) (vfs.ReadAtCl
 		if err != nil {
 			return nil, err
 		}
-		defer fullResp.Body.Close()
+		defer func() { _ = fullResp.Body.Close() }() // Response-body cleanup is best effort.
 		if fullResp.StatusCode != http.StatusOK {
 			return nil, mapWebDAVHTTPError(fullResp, readSmallResponse(fullResp))
 		}
@@ -2046,10 +2041,10 @@ func (b *webDAVBackend) Open(ctx context.Context, location string) (vfs.ReadAtCl
 		return b.downloads.install(entry.Location, cacheFingerprint, temp)
 	}
 	if resp.StatusCode != http.StatusOK {
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 		return nil, mapWebDAVHTTPError(resp, readSmallResponse(resp))
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	cacheFingerprint, fingerprintErr := webDAVFullResponseFingerprint(entry.Revision, fingerprint, resp.Header.Get("ETag"))
 	if fingerprintErr != nil {
 		return nil, fingerprintErr
@@ -2108,7 +2103,7 @@ func (b *webDAVBackend) Create(ctx context.Context, location string) (io.WriteCl
 		if err != nil {
 			return &vfs.UnknownOperationStateError{Operation: "WebDAV PUT", Err: safeWebDAVMutationTransportError(err)}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 		if resp.Request != nil && resp.Request.Method != http.MethodPut {
 			return &vfs.UnknownOperationStateError{
 				Operation: "WebDAV PUT",

--- a/plugins/cloudfox/provider_yandex.go
+++ b/plugins/cloudfox/provider_yandex.go
@@ -315,7 +315,7 @@ func (b *yandexDiskBackend) apiRequest(ctx context.Context, method, endpoint str
 		return nil, err
 	}
 	if resp.Request != nil && resp.Request.Method != method {
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		return nil, fmt.Errorf("cloudfox: Yandex.Disk %s completed as %s after a redirect", method, resp.Request.Method)
 	}
 	return resp, nil
@@ -339,7 +339,7 @@ func (b *yandexDiskBackend) getResource(ctx context.Context, location string, li
 	if err != nil {
 		return yandexResource{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return yandexResource{}, mapProviderHTTPError(resp, readSmallResponse(resp))
 	}
@@ -442,7 +442,7 @@ func (b *yandexDiskBackend) MkDir(ctx context.Context, location string) error {
 		// retry could race or turn a committed create into a misleading conflict.
 		return &vfs.UnknownOperationStateError{Operation: "Yandex.Disk create directory", Err: err}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusNoContent {
 		return providerHTTPMutationError("Yandex.Disk create directory", resp, readSmallResponse(resp))
 	}
@@ -454,7 +454,7 @@ func (b *yandexDiskBackend) mutation(ctx context.Context, method, endpoint strin
 	if err != nil {
 		return &vfs.UnknownOperationStateError{Operation: "Yandex.Disk " + method, Err: err}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 && resp.StatusCode != http.StatusAccepted {
 		return nil
 	}
@@ -511,19 +511,19 @@ func (b *yandexDiskBackend) waitOperation(ctx context.Context, href string) erro
 			return err
 		}
 		if resp.Request != nil && resp.Request.Method != http.MethodGet {
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			return fmt.Errorf("cloudfox: Yandex.Disk status GET completed as %s after a redirect", resp.Request.Method)
 		}
 		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 			message := readSmallResponse(resp)
-			resp.Body.Close()
+			_ = resp.Body.Close() // Response-body cleanup is best effort.
 			return mapProviderHTTPError(resp, message)
 		}
 		var status struct {
 			Status string `json:"status"`
 		}
 		err = json.NewDecoder(resp.Body).Decode(&status)
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		if err != nil {
 			return fmt.Errorf("cloudfox: decode Yandex.Disk operation status: %w", err)
 		}
@@ -625,7 +625,7 @@ func (b *yandexDiskBackend) getLink(ctx context.Context, endpoint, location, ove
 	if err != nil {
 		return yandexLink{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return yandexLink{}, mapProviderHTTPError(resp, readSmallResponse(resp))
 	}
@@ -674,7 +674,7 @@ func (b *yandexDiskBackend) Open(ctx context.Context, location string) (vfs.Read
 	if err != nil {
 		return nil, sanitizeYandexTransferError(err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.Request != nil && resp.Request.Method != http.MethodGet {
 		return nil, fmt.Errorf("cloudfox: Yandex.Disk download GET completed as %s after a redirect", resp.Request.Method)
 	}
@@ -745,7 +745,7 @@ func (b *yandexDiskBackend) Create(ctx context.Context, location string) (io.Wri
 		if err != nil {
 			return &vfs.UnknownOperationStateError{Operation: "Yandex.Disk upload", Err: sanitizeYandexTransferError(err)}
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 		if resp.Request != nil && resp.Request.Method != http.MethodPut {
 			return &vfs.UnknownOperationStateError{
 				Operation: "Yandex.Disk upload",

--- a/plugins/cloudfox/provider_yandex_info.go
+++ b/plugins/cloudfox/provider_yandex_info.go
@@ -15,7 +15,7 @@ func (b *yandexDiskBackend) refreshAbout(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return mapProviderHTTPError(resp, readSmallResponse(resp))
 	}

--- a/plugins/cloudfox/provider_yandex_share.go
+++ b/plugins/cloudfox/provider_yandex_share.go
@@ -71,7 +71,7 @@ func (b *yandexDiskBackend) shareResource(ctx context.Context, location string) 
 	if err != nil {
 		return yandexShareResource{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		// A public URL is a bearer-like credential. Do not include an arbitrary
 		// provider response body in an error which can reach logs or history.
@@ -94,7 +94,7 @@ func (b *yandexDiskBackend) shareMutation(ctx context.Context, location, endpoin
 	if err != nil {
 		return &vfs.UnknownOperationStateError{Operation: operation, Err: err}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }() // Response-body cleanup is best effort.
 	// Yandex documents publish and unpublish as synchronous operations which
 	// return 200 and a metadata Link. The Link is deliberately ignored: it is
 	// not the public URL, and following an API-provided URL would add an SSRF and

--- a/plugins/netfox/dialog.go
+++ b/plugins/netfox/dialog.go
@@ -259,10 +259,16 @@ func showConnectionDialog(app vfs.App, nf *NetFoxVFS, oldName string) {
 			save()
 		}
 
-		if oldName != "" && oldName != newName {
-			nf.Remove(context.Background(), oldName)
+		if err := nf.SaveConfig(newName, cfg); err != nil {
+			vtui.ShowMessageOn(dlg, vtui.Msg("Error.Title"), "Could not save connection:\n"+err.Error(), []string{vtui.Msg("vtui.Ok")})
+			return
 		}
-		nf.SaveConfig(newName, cfg)
+		if oldName != "" && oldName != newName {
+			if err := nf.Remove(context.Background(), oldName); err != nil {
+				vtui.ShowMessageOn(dlg, vtui.Msg("Error.Title"), "The renamed connection was saved, but the old connection could not be removed:\n"+err.Error(), []string{vtui.Msg("vtui.Ok")})
+				return
+			}
+		}
 
 		dlg.Close()
 		app.RefreshAll()

--- a/plugins/netfox/fish_pool.go
+++ b/plugins/netfox/fish_pool.go
@@ -84,7 +84,7 @@ func (p *fishPool) take(key fishPoolKey) *fishConn {
 		// The idle timer had not fired yet, but the far side is already
 		// gone — a keepalive failure, the remote host rebooting. Finish
 		// tearing it down rather than leaving it half closed.
-		e.conn.shutdown()
+		_ = e.conn.shutdown() // Dead pooled-session teardown is best effort.
 		return nil
 	}
 	return e.conn
@@ -102,7 +102,7 @@ func (p *fishPool) park(conn *fishConn, key fishPoolKey) {
 		}
 		p.mu.Unlock()
 		if ok {
-			conn.shutdown()
+			_ = conn.shutdown() // Idle-session teardown is best effort.
 		}
 	})
 
@@ -117,7 +117,7 @@ func (p *fishPool) park(conn *fishConn, key fishPoolKey) {
 		// that connection can exist — but a session left behind by this
 		// race is worth closing rather than leaking.
 		old.timer.Stop()
-		old.conn.shutdown()
+		_ = old.conn.shutdown() // Superseded-session teardown is best effort.
 	}
 }
 
@@ -131,7 +131,7 @@ func (p *fishPool) closeAll() {
 	p.mu.Unlock()
 	for _, e := range entries {
 		e.timer.Stop()
-		e.conn.shutdown()
+		_ = e.conn.shutdown() // Process-exit session teardown is best effort.
 	}
 }
 

--- a/plugins/netfox/fish_vfs.go
+++ b/plugins/netfox/fish_vfs.go
@@ -148,14 +148,14 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 	// One round trip before anything is promised: a handshake that answered
 	// says the helper is there, and a noop says the request loop is running.
 	if err := sess.Noop(ctx); err != nil {
-		sess.Close()
+		_ = sess.Close() // Preserve the failed readiness check.
 		return nil, err
 	}
 
 	c.mu.Lock()
 	if c.closed {
 		c.mu.Unlock()
-		sess.Close()
+		_ = sess.Close() // Preserve the connection-closed result.
 		return nil, fishplus.ErrBroken
 	}
 	if dead != nil && c.client != dead {
@@ -163,7 +163,7 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 		// good as this one and is already in use, so this one is dropped.
 		fresh := c.client
 		c.mu.Unlock()
-		sess.Close()
+		_ = sess.Close() // The concurrently installed session remains authoritative.
 		return fresh, nil
 	}
 	old, oldKA := c.client, c.ka
@@ -180,7 +180,7 @@ func (c *fishConn) reconnect(ctx context.Context, dead *fishplus.Client) (*fishp
 
 	oldKA.Stop()
 	if old != nil {
-		old.Session().Close() // This also closes its session's closer automatically
+		_ = old.Session().Close() // The replaced broken session is best-effort cleanup.
 	}
 	return client, nil
 }
@@ -260,7 +260,7 @@ func NewFishVFSOnDialers(ctx context.Context, parent vfs.VFS, dial FishDialer, o
 func newFishVFSOnStream(ctx context.Context, parent vfs.VFS, stdin io.Writer, stdout io.Reader, closer io.Closer, title string, dial FishDialer, opts fishplus.HandshakeOptions) (*FishVFS, error) {
 	sess := fishplus.NewSession(stdin, stdout, closer)
 	if err := sess.HandshakeWithOptions(ctx, opts); err != nil {
-		sess.Close()
+		_ = sess.Close() // Preserve the handshake failure.
 		return nil, err
 	}
 	return newFishVFSFromSession(parent, sess, closer, title, dial, opts, nil, fishplus.HandshakeOptions{}), nil
@@ -302,7 +302,7 @@ func establishSession(ctx context.Context, dial FishDialer, opts fishplus.Handsh
 	}
 	sess := fishplus.NewSession(stdin, stdout, closer)
 	if err := sess.HandshakeWithOptions(ctx, opts); err != nil {
-		sess.Close()
+		_ = sess.Close() // Preserve the handshake failure.
 		return nil, nil, err
 	}
 	return sess, closer, nil
@@ -378,8 +378,7 @@ type sshShell struct {
 }
 
 func (s *sshShell) Close() error {
-	s.sess.Close()
-	return s.client.Close()
+	return errors.Join(s.sess.Close(), s.client.Close())
 }
 
 func (s *sshShell) OpenPty(cols, rows int) (any, error) {
@@ -388,7 +387,9 @@ func (s *sshShell) OpenPty(cols, rows int) (any, error) {
 		return nil, err
 	}
 	pty.SetSize(cols, rows)
-	pty.Run("")
+	if err := pty.Run(""); err != nil {
+		return nil, fmt.Errorf("fishplus: start SSH PTY: %w", errors.Join(err, pty.Close()))
+	}
 	return pty, nil
 }
 
@@ -449,27 +450,27 @@ func sshFishDialerWith(host, port, user, pass string, timeout int, px netproxy.S
 		}
 		sess, err := client.NewSession()
 		if err != nil {
-			client.Close()
+			_ = client.Close() // Preserve the session-creation failure.
 			return nil, nil, nil, err
 		}
 		shell := &sshShell{sess: sess, client: client}
 		stdin, err := sess.StdinPipe()
 		if err != nil {
-			shell.Close()
+			_ = shell.Close() // Preserve the pipe-creation failure.
 			return nil, nil, nil, err
 		}
 		stdout, err := sess.StdoutPipe()
 		if err != nil {
-			shell.Close()
+			_ = shell.Close() // Preserve the pipe-creation failure.
 			return nil, nil, nil, err
 		}
 		sess.Stderr = io.Discard
 		if err := startShell(sess); err != nil {
-			shell.Close()
+			_ = shell.Close() // Preserve the remote-shell startup failure.
 			return nil, nil, nil, err
 		}
 		if err := ctx.Err(); err != nil {
-			shell.Close()
+			_ = shell.Close() // Preserve cancellation as the primary error.
 			return nil, nil, nil, err
 		}
 		return stdin, stdout, shell, nil
@@ -1312,7 +1313,7 @@ func netFoxConfigAt(ctx context.Context, parent vfs.VFS, pth string) (NetFoxConf
 	if err != nil {
 		return NetFoxConfig{}, false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The configuration file is read-only.
 	var cfg NetFoxConfig
 	if err := json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg); err != nil {
 		return NetFoxConfig{}, false

--- a/plugins/netfox/fishplus/job.go
+++ b/plugins/netfox/fishplus/job.go
@@ -349,7 +349,7 @@ func (c *Client) dropJobQuietly(id int) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), jobDropTimeout)
 	defer cancel()
-	c.DropJob(ctx, id)
+	_ = c.DropJob(ctx, id) // Session teardown removes any job left behind.
 }
 
 // parseScanLine reads one line of scan output: "P <bytes> <dirbytes>

--- a/plugins/netfox/fishplus/write.go
+++ b/plugins/netfox/fishplus/write.go
@@ -150,8 +150,7 @@ func (c *Client) WriteFile(ctx context.Context, p string, data []byte) error {
 		return err
 	}
 	if _, err := w.Write(data); err != nil {
-		w.Close()
-		return err
+		return errors.Join(err, w.Close())
 	}
 	return w.Close()
 }

--- a/plugins/netfox/ftp_vfs.go
+++ b/plugins/netfox/ftp_vfs.go
@@ -3,6 +3,7 @@ package netfox
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -93,7 +94,7 @@ func NewFTPVFS(parent vfs.VFS, host, port, user, pass string, timeout int, optio
 
 	err = c.Login(user, pass)
 	if err != nil {
-		c.Quit()
+		_ = c.Quit() // Preserve the authentication failure.
 		return nil, err
 	}
 	vtui.DebugLog("NET: FTP logged in successfully")
@@ -271,12 +272,22 @@ func (v *FTPVFS) Open(ctx context.Context, p string) (vfs.ReadAtCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	tmp, _ := os.CreateTemp("", "f4ftp-*")
-	io.Copy(tmp, &ioCtxReader{r: resp, ctx: ctx})
-	resp.Close()
-	tmp.Seek(0, 0)
-	stat, _ := tmp.Stat()
-	return &ftpFileWrapper{File: tmp, size: stat.Size(), path: tmp.Name()}, nil
+	tmp, err := os.CreateTemp("", "f4ftp-*")
+	if err != nil {
+		_ = resp.Close() // Preserve the temp-file creation failure.
+		return nil, err
+	}
+	cleanup := func() error {
+		return errors.Join(tmp.Close(), os.Remove(tmp.Name()))
+	}
+	size, copyErr := io.Copy(tmp, &ioCtxReader{r: resp, ctx: ctx})
+	if err := errors.Join(copyErr, resp.Close()); err != nil {
+		return nil, errors.Join(err, cleanup())
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return nil, errors.Join(err, cleanup())
+	}
+	return &ftpFileWrapper{File: tmp, size: size, path: tmp.Name()}, nil
 }
 
 func (v *FTPVFS) Create(ctx context.Context, p string) (io.WriteCloser, error) {
@@ -316,9 +327,11 @@ func (p *ftpProvider) CanOpen(ctx context.Context, parent vfs.VFS, pth string) b
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The configuration file is read-only.
 	var cfg NetFoxConfig
-	json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg)
+	if err := json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg); err != nil {
+		return false
+	}
 	return cfg.Type == "ftp"
 }
 func (p *ftpProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vfs.VFS, error) {
@@ -327,9 +340,11 @@ func (p *ftpProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vfs
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The configuration file is read-only.
 	var cfg NetFoxConfig
-	json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg)
+	if err := json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("netfox: decode FTP connection: %w", err)
+	}
 	port := cfg.Port
 	if port == "" {
 		port = "21"
@@ -393,4 +408,4 @@ func (w *ftpFileWrapper) ReadAt(ctx context.Context, p []byte, off int64) (int, 
 	return w.File.ReadAt(p, off)
 }
 func (w *ftpFileWrapper) Read(ctx context.Context, p []byte) (int, error) { return w.File.Read(p) }
-func (w *ftpFileWrapper) Close() error                                    { w.File.Close(); return os.Remove(w.path) }
+func (w *ftpFileWrapper) Close() error                                    { return errors.Join(w.File.Close(), os.Remove(w.path)) }

--- a/plugins/netfox/sftp_uri.go
+++ b/plugins/netfox/sftp_uri.go
@@ -59,7 +59,7 @@ func (p *sftpURIProvider) OpenURI(ctx context.Context, current vfs.VFS, raw stri
 	}
 	if p := strings.TrimSpace(u.Path); p != "" && p != "/" {
 		if err := v.SetPath(p); err != nil {
-			v.Close()
+			_ = v.Close() // Preserve the invalid-path error.
 			return nil, err
 		}
 	}

--- a/plugins/netfox/sftp_vfs.go
+++ b/plugins/netfox/sftp_vfs.go
@@ -100,7 +100,7 @@ func NewSFTPVFS(parent vfs.VFS, host, port, user, pass string, timeout int, cp s
 
 	sftpClient, err := sftp.NewClient(sshClient)
 	if err != nil {
-		sshClient.Close()
+		_ = sshClient.Close() // Preserve the SFTP startup failure.
 		return nil, err
 	}
 	vtui.DebugLog("NET: SFTP session established successfully")
@@ -363,7 +363,7 @@ func (v *SFTPVFS) Open(ctx context.Context, p string) (vfs.ReadAtCloser, error) 
 	}
 	info, err := f.Stat()
 	if err != nil {
-		f.Close()
+		_ = f.Close() // Preserve the remote stat failure.
 		return nil, err
 	}
 	return &sftpFileWrapper{File: f, size: info.Size()}, nil
@@ -410,7 +410,9 @@ func (v *SFTPVFS) OpenPty(cols, rows int) (any, error) {
 		return nil, err
 	}
 	pty.SetSize(cols, rows)
-	pty.Run("")
+	if err := pty.Run(""); err != nil {
+		return nil, fmt.Errorf("sftp: start SSH PTY: %w", errors.Join(err, pty.Close()))
+	}
 	return pty, nil
 }
 
@@ -530,7 +532,7 @@ func runSFTPCommandSessionWithCodec(
 	cb func(line string),
 	codec sftpCommandCodec,
 ) (int, error) {
-	defer session.Close()
+	defer func() { _ = session.Close() }() // Command status comes from Wait.
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
@@ -695,9 +697,11 @@ func (p *sftpProvider) CanOpen(ctx context.Context, parent vfs.VFS, pth string) 
 	if err != nil {
 		return false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The configuration file is read-only.
 	var cfg NetFoxConfig
-	json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg)
+	if err := json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg); err != nil {
+		return false
+	}
 	return cfg.Type == "sftp" || cfg.Type == ""
 }
 func (p *sftpProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vfs.VFS, error) {
@@ -706,9 +710,11 @@ func (p *sftpProvider) Open(ctx context.Context, parent vfs.VFS, pth string) (vf
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The configuration file is read-only.
 	var cfg NetFoxConfig
-	json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg)
+	if err := json.NewDecoder(ctxReader{f, ctx}).Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("netfox: decode SFTP connection: %w", err)
+	}
 	port := cfg.Port
 	if port == "" {
 		port = "22"

--- a/plugins/netfox/ssh_dial.go
+++ b/plugins/netfox/ssh_dial.go
@@ -73,7 +73,7 @@ func DialSSH(host, port, user, pass string, timeout int, px netproxy.Settings) (
 	client, err := dialSSHVia(px, host+":"+port, config)
 	if err != nil {
 		if agentConn != nil {
-			agentConn.Close()
+			_ = agentConn.Close() // Preserve the SSH dial failure.
 		}
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func dialSSHVia(px netproxy.Settings, addr string, config *ssh.ClientConfig) (*s
 	}
 	c, chans, reqs, err := ssh.NewClientConn(conn, addr, config)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close() // Preserve the SSH handshake failure.
 		return nil, err
 	}
 	_ = conn.SetDeadline(time.Time{})

--- a/plugins/netfox/ssh_pty.go
+++ b/plugins/netfox/ssh_pty.go
@@ -1,8 +1,10 @@
 package netfox
 
 import (
-	"golang.org/x/crypto/ssh"
 	"io"
+
+	"github.com/unxed/vtui"
+	"golang.org/x/crypto/ssh"
 )
 
 type SSHPty struct {
@@ -25,7 +27,7 @@ func NewSSHPty(client *ssh.Client) (*SSHPty, error) {
 		ssh.IUTF8:         1,
 	}
 	if err := sess.RequestPty("xterm-256color", 24, 80, modes); err != nil {
-		sess.Close()
+		_ = sess.Close() // Preserve the PTY request failure.
 		return nil, err
 	}
 	in, _ := sess.StdinPipe()
@@ -36,9 +38,13 @@ func NewSSHPty(client *ssh.Client) (*SSHPty, error) {
 func (p *SSHPty) Read(b []byte) (int, error)  { return p.stdout.Read(b) }
 func (p *SSHPty) Write(b []byte) (int, error) { return p.stdin.Write(b) }
 func (p *SSHPty) Close() error                { return p.session.Close() }
-func (p *SSHPty) SetSize(cols, rows int)      { p.session.WindowChange(rows, cols) }
-func (p *SSHPty) IsBusy() bool                { return false }
-func (p *SSHPty) Wait() error                 { return p.session.Wait() }
+func (p *SSHPty) SetSize(cols, rows int) {
+	if err := p.session.WindowChange(rows, cols); err != nil {
+		vtui.DebugLog("NET: failed to resize SSH PTY: %v", err)
+	}
+}
+func (p *SSHPty) IsBusy() bool { return false }
+func (p *SSHPty) Wait() error  { return p.session.Wait() }
 func (p *SSHPty) Run(name string, args ...string) error {
 	if name == "" {
 		return p.session.Shell()


### PR DESCRIPTION
82 errcheck findings in the production code of plugins/netfox and
plugins/cloudfox. Unlike the test cleanup that preceded it, there is no default
answer here: a test can always call t.Fatal, but production code has to decide
whether the error goes up, gets handled, or is genuinely uninteresting. Most of
these are the third kind -- an HTTP response body is closed to release the
connection and has nothing to say -- and those get `_ =` with a clause saying so.

The rest were not, and three of them were bugs.

FTP downloads reported success regardless. ftp_vfs.go created a temp file,
copied into it, closed the transfer, seeked, closed the file and removed it,
and looked at none of those. A transfer that failed halfway through handed the
caller a truncated file and told them it had worked. All six now propagate.

Renaming a saved connection could lose it. dialog.go wrote the new profile and
deleted the old one without checking the write, so a failed save left the user
with neither. It now saves first, checks, and only then removes.

Malformed connection settings were being used. The FTP and SFTP config
decoders ignored what json.Decode said and carried on with a zero-valued
struct, so a corrupt entry became a connection attempt to nowhere. CanOpen now
says no and Open returns the decode error with context.

Smaller ones: FISH+ and SFTP now notice when pty.Run fails to start the process
and close the pty rather than leaking it; the Google and WebDAV temp-file
cleanups join their close and remove failures into the returned error, which is
the same shape as the Windows spool bug fixed earlier; fishplus/write.go joins
the buffered close with the write; fish_vfs.go returns both the session and
client close errors instead of the first.

One is only logged: ssh_pty.go's resize failure has nowhere to go, because the
SetSize interface it implements does not return an error. Changing that
interface is a bigger decision than this change should make.

No exported signature changed -- everything that propagates does so through an
API that already returned an error. No missing Close turned up while reading.