### PR TITLE
test: join the directory-load worker before disturbing what it reads

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -466,6 +466,7 @@ type FileSystemPanel struct {
 
 	loadingGeneration          uint64
 	loadQueueMu                sync.Mutex
+	loadWorkerWG               sync.WaitGroup // joins the single directory-load queue worker
 	loadWorkerActive           bool
 	pendingDirectoryLoad       func()
 	providerOpenTask           *vtui.TaskContext
@@ -1597,9 +1598,11 @@ func (fp *FileSystemPanel) enqueueDirectoryLoad(load func()) {
 		return
 	}
 	fp.loadWorkerActive = true
+	fp.loadWorkerWG.Add(1)
 	fp.loadQueueMu.Unlock()
 
 	go func() {
+		defer fp.loadWorkerWG.Done()
 		next := load
 		for next != nil {
 			next()

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -523,6 +523,7 @@ func TestFileSystemPanel_UpdateTitle_WithProvider(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := &mockTitleVFS{OSVFS: *vfs.NewOSVFS("/tmp"), title: "user@host"}
 	fp := NewFileSystemPanel(0, 0, 40, 20, v)
+	waitForLoad(t, fp)
 
 	// Reset loading flag to avoid the spinner suffix.
 	fp.isLoading = false
@@ -669,9 +670,7 @@ func TestFileSystemPanel_SelectedInfo(t *testing.T) {
 	vtui.FrameManager.Init(scr)
 
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(t.TempDir()))
-	if fp.cancelLoad != nil {
-		fp.cancelLoad()
-	}
+	waitForLoad(t, fp)
 	fp.isLoading = false
 	if fp.loadingTimer != nil {
 		fp.loadingTimer.Stop()
@@ -824,6 +823,7 @@ func TestFileSystemPanel_Initialization(t *testing.T) {
 	// Verify that NewFileSystemPanel initializes with valid geometry to prevent collapsed panels
 	x, y, w, h := 10, 5, 40, 20
 	fp := NewFileSystemPanel(x, y, w, h, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 
 	if fp.X1 != x || fp.Y1 != y || fp.X2 != x+w-1 || fp.Y2 != y+h-1 {
 		t.Errorf("Panel coordinates not initialized correctly: got (%d,%d)-(%d,%d)", fp.X1, fp.Y1, fp.X2, fp.Y2)
@@ -1005,6 +1005,7 @@ func TestFileSystemPanel_InfoLineRendering(t *testing.T) {
 }
 func TestFileSystemPanel_CursorMapping(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 12, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 
 	// Simulate 20 items manually so Refresh() doesn't wipe them
 	fp.entries = make([]*fileEntry, 20)
@@ -1037,6 +1038,7 @@ func TestFileSystemPanel_CursorMapping(t *testing.T) {
 
 func TestFileSystemPanel_SelectName(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeDetailed)
 
 	// Mock entries
@@ -1067,6 +1069,7 @@ func TestFileSystemPanel_MultiSelect(t *testing.T) {
 	os.WriteFile(filepath.Join(tmp, "file3.txt"), []byte("3"), 0644)
 
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS(tmp))
+	waitForLoad(t, fp)
 	fp.viewMode = ViewModeDetailed
 
 	// Bypass async ReadDirectory for precise testing
@@ -1418,6 +1421,7 @@ drain:
 
 func TestFileSystemPanel_ProcessMouse(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeDetailed)
 
 	fp.entries = []*fileEntry{
@@ -2040,6 +2044,7 @@ func TestFileSystemPanel_CursorColorsColumnSeparators(t *testing.T) {
 
 func TestFileSystemPanel_MouseClick_Edges(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: ".."}}}
 	fp.SetCursorIndex(0)
 
@@ -2064,6 +2069,7 @@ func TestFileSystemPanel_MouseClick_Edges(t *testing.T) {
 
 func TestFileSystemPanel_RightClick_ResetOnRelease(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.viewMode = ViewModeDetailed
 	fp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "f1"}}}
 
@@ -2091,6 +2097,7 @@ func TestFileSystemPanel_RightClick_ResetOnRelease(t *testing.T) {
 
 func TestFileSystemPanel_RightDragAppliesToSkippedRows(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeDetailed)
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
@@ -2140,6 +2147,7 @@ func TestFileSystemPanel_RightDragAppliesToSkippedRows(t *testing.T) {
 
 func TestFileSystemPanel_RightDragTracksGridColumn(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeMedium)
 
 	height := fp.table.ViewHeight
@@ -2178,6 +2186,7 @@ func TestFileSystemPanel_RightDragTracksGridColumn(t *testing.T) {
 
 func TestFileSystemPanel_RightDoubleClickAppliesToWholePanel(t *testing.T) {
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewOSVFS("."))
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeDetailed)
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
@@ -3419,14 +3428,26 @@ func waitForLoad(t *testing.T, fp *FileSystemPanel) {
 		}
 	}
 	// Drain any final UI tasks after isLoading becomes false
+drain:
 	for i := 0; i < 5; i++ {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
 			task()
 		default:
-			return
+			break drain
 		}
 	}
+
+	// isLoading is cleared by the final UI task just before the directory
+	// worker returns to its queue loop. Enqueue a sentinel and join the worker
+	// so it cannot keep reading globals used by the next test.
+	fp.enqueueDirectoryLoad(func() {})
+	done := make(chan struct{})
+	go func() {
+		fp.loadWorkerWG.Wait()
+		close(done)
+	}()
+	waitForPanelSignal(t, done, "directory worker to stop")
 }
 
 func TestFileSystemPanel_PermissionFailureRestoresAbsoluteParentWithoutDialogLoop(t *testing.T) {


### PR DESCRIPTION
Fourteen of the race detector's reports in cmd/f4 came from the file panel's
directory-load worker, and all fourteen are the tests' fault rather than the
panel's.

The worker reads process-wide state while it runs -- AppConfig.SyncPanelLoad,
AppConfig.ShowHiddenFiles, vtui.FrameManager, and the frame manager's task
queue when it posts back. Tests that started a load and then returned left it
running, and the next test restored AppConfig or installed its own
FrameManager underneath it. The reports name the panel, but the write that
races is in whichever test ran next.

The panel now tracks the worker's lifetime with a WaitGroup, and the tests
enqueue a sentinel and join it before touching that state or returning. Twelve
short UI tests that started a load and immediately went on to poke at panel
state now let the initial load finish first.

Worth being explicit about one thing: production adds to that WaitGroup but
never waits on it. Today only tests do. If FileSystemPanel ever grows a real
shutdown path, that is where the matching Wait belongs, and the field is there
for it.

Targeted runs under -race went from six to ten warnings each to zero across
five runs.