### PR TITLE
fix: stop the game loop, the wasm session and their tests racing their own teardown

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
@@ -118,6 +119,16 @@ func TestActionUpdateSettings_ManualCheckDoesNotBlockMouseDispatch(t *testing.T)
 	case <-requestFinished:
 	case <-time.After(1 * time.Second):
 		t.Fatal("manual update check did not finish after the response was released")
+	}
+
+	// CheckForUpdates posts exactly one result after it has finished reading
+	// the overridden platform globals. Running that task joins the background
+	// check before Cleanup restores them.
+	select {
+	case task := <-vtui.FrameManager.TaskChan:
+		task()
+	case <-time.After(1 * time.Second):
+		t.Fatal("manual update check did not post its result")
 	}
 }
 

--- a/cmd/f4/ansi_parser.go
+++ b/cmd/f4/ansi_parser.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/unxed/vtui"
@@ -39,6 +40,7 @@ type AnsiParser struct {
 	lastRune           rune
 	pendingWindowsSync []byte
 	seenWindowsSync    []byte
+	osc52WG            sync.WaitGroup // tracks OSC 52 read goroutines while tests or owners replace clipboard state
 
 	// DCS state: the final byte of the introducer and the string that
 	// follows it, kept apart from CurParam because the parameters of the
@@ -46,6 +48,10 @@ type AnsiParser struct {
 	dcsFinal    byte
 	dcsBody     []byte
 	dcsOverflow bool
+}
+
+func (p *AnsiParser) waitOSC52() {
+	p.osc52WG.Wait()
 }
 
 func NewAnsiParser(t *TerminalView, p PtyBackend) *AnsiParser {
@@ -836,7 +842,9 @@ func (p *AnsiParser) handleOSC() {
 		if len(subparts) == 2 {
 			if subparts[1] == "?" {
 				if p.pty != nil {
+					p.osc52WG.Add(1)
 					go func(subCmd string) {
+						defer p.osc52WG.Done()
 						allowed := false
 						if vtui.GlobalClipboardAccessManager != nil {
 							auth := vtui.GlobalClipboardAccessManager.Authorize("Terminal_OSC52_Read")

--- a/cmd/f4/ansi_parser_test.go
+++ b/cmd/f4/ansi_parser_test.go
@@ -824,6 +824,7 @@ func TestAnsiParser_OSC52_Read_Security(t *testing.T) {
 	// Test 1: Denied access
 	vtui.GlobalClipboardAccessManager = &mockClipAuthManager{authorized: false}
 	parser.Process([]byte("\x1b]52;c;?\x07"))
+	parser.waitOSC52()
 
 	if pty.Len() > 0 {
 		t.Errorf("Expected no output when clipboard read is denied, got %q", pty.String())
@@ -840,15 +841,9 @@ func TestAnsiParser_OSC52_Read_Security(t *testing.T) {
 	}
 
 	parser.Process([]byte("\x1b]52;c;?\x07"))
+	parser.waitOSC52()
 
-	var out string
-	for start := time.Now(); time.Since(start) < 2*time.Second; {
-		out = pty.String()
-		if strings.Contains(out, "\x1b]52;c;") {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	out := pty.String()
 
 	if !strings.Contains(out, "\x1b]52;c;") {
 		t.Errorf("Expected OSC 52 reply containing clipboard data, got %q", out)

--- a/cmd/f4/arkanoid.go
+++ b/cmd/f4/arkanoid.go
@@ -38,6 +38,7 @@ type ArkanoidFrame struct {
 	vtui.BaseWindow
 	mu              sync.Mutex
 	stop            chan struct{}
+	done            chan struct{} // closed after gameLoop stops touching the frame and game state
 	stopOnce        sync.Once
 	paddleX         int
 	paddleW         int
@@ -70,6 +71,7 @@ func NewArkanoidFrame() *ArkanoidFrame {
 	af := &ArkanoidFrame{
 		BaseWindow: *vtui.NewBaseWindow(x1, 2, x1+width-1, 2+height-1, " A R K A N O I D "),
 		stop:       make(chan struct{}),
+		done:       make(chan struct{}),
 		lives:      3,
 		multiplier: 1,
 		level:      1,
@@ -127,12 +129,16 @@ func (af *ArkanoidFrame) Close() {
 		if af.stop != nil {
 			close(af.stop)
 		}
+		if af.done != nil {
+			<-af.done
+		}
+		af.BaseWindow.Close()
 	})
-	af.BaseWindow.Close()
 }
 
 func (af *ArkanoidFrame) gameLoop() {
-	for !af.IsDone() {
+	defer close(af.done)
+	for {
 		// Динамическая задержка на основе autoSpeed
 		delay := gameRate + time.Duration(af.autoSpeed*-8)*time.Millisecond
 		if delay < 5*time.Millisecond {
@@ -691,7 +697,9 @@ func (af *ArkanoidFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		}
 		return true
 	case vtinput.VK_ESCAPE:
+		af.mu.Unlock()
 		af.Close()
+		af.mu.Lock()
 		return true
 	}
 	return af.BaseWindow.ProcessKey(e)

--- a/cmd/f4/arkanoid_test.go
+++ b/cmd/f4/arkanoid_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/unxed/vtui"
 )
@@ -34,8 +33,7 @@ func TestArkanoid_PhysicsAndCollisions(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	af := NewArkanoidFrame()
-	af.Close() // Останавливаем фоновый цикл, чтобы избежать конфликтов в тесте
-	time.Sleep(10 * time.Millisecond)
+	af.Close()                           // Останавливаем фоновый цикл, чтобы избежать конфликтов в тесте
 	af.rng = rand.New(rand.NewSource(1)) //nolint:gosec // Deterministic randomness only controls the ball's bounce direction in this test.
 
 	height := af.Y2 - af.Y1 - 1
@@ -106,7 +104,6 @@ func TestArkanoid_AutoplayAI(t *testing.T) {
 
 	af := NewArkanoidFrame()
 	af.Close()
-	time.Sleep(10 * time.Millisecond)
 
 	af.autoPlay = true
 	af.paddleX = 5

--- a/cmd/f4/async_buffer_test.go
+++ b/cmd/f4/async_buffer_test.go
@@ -204,8 +204,9 @@ func TestAsyncBuffer_ConcurrentAccess(t *testing.T) {
 
 	// Spin up a worker to constantly pump the UI task queue (simulating fm.Run)
 	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	pumpDone := make(chan struct{})
 	go func() {
+		defer close(pumpDone)
 		for {
 			select {
 			case <-ctx.Done():
@@ -215,6 +216,10 @@ func TestAsyncBuffer_ConcurrentAccess(t *testing.T) {
 			}
 		}
 	}()
+	t.Cleanup(func() {
+		cancel()
+		<-pumpDone
+	})
 
 	// Fire 50 concurrent reads across different overlapping chunks
 	done := make(chan bool)

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -266,6 +266,7 @@ func TestEditor_StatefulHighlighting_BackgroundCatchUpAfterEdit(t *testing.T) {
 	}
 }
 func TestEditor_BackgroundHighlighting_FullCoverage(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	var sb strings.Builder
@@ -286,16 +287,20 @@ func TestEditor_BackgroundHighlighting_FullCoverage(t *testing.T) {
 	ev.indexing = true
 	ev.startHighlighting()
 
-	// Finish indexing after a short delay
-	go func() {
-		time.Sleep(50 * time.Millisecond)
-		vtui.FrameManager.PostTask(func() {
-			ev.indexing = false
-		})
-	}()
-
 	timeout := time.After(2 * time.Second)
-	for len(ev.lineStates) < 500 {
+	// Run one highlighting slice while indexing is still active, then queue
+	// indexing completion on the same UI task stream.
+	select {
+	case task := <-vtui.FrameManager.TaskChan:
+		task()
+	case <-timeout:
+		t.Fatal("Background highlighting did not start")
+	}
+	vtui.FrameManager.PostTask(func() {
+		ev.indexing = false
+	})
+
+	for len(ev.lineStates) < 500 || ev.highlighting {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
 			task()

--- a/cmd/f4/plugring_test.go
+++ b/cmd/f4/plugring_test.go
@@ -187,6 +187,7 @@ func TestGetInstalledPlugRingItems(t *testing.T) {
 	}
 }
 func TestCheckForPluginUpdates(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	tmpDir := t.TempDir()
@@ -270,8 +271,21 @@ func TestCheckForPluginUpdates(t *testing.T) {
 			t.Fatal("Timeout waiting for update toast")
 		}
 	}
+
+	// The toast owns a timer goroutine. Its second redraw is the completion
+	// signal; wait for it before restoring the global frame manager.
+	select {
+	case <-vtui.FrameManager.RedrawChan:
+	default:
+	}
+	select {
+	case <-vtui.FrameManager.RedrawChan:
+	case <-time.After(time.Second):
+		t.Fatal("Timeout waiting for update toast to expire")
+	}
 }
 func TestPlugRing_InstallAndRemove_EndToEnd(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	tmpConfig := t.TempDir()

--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -565,6 +565,7 @@ func TestQueueManagerCancelRunningWaitsForRunToUnwind(t *testing.T) {
 }
 
 func TestQueueManagerCancelQueuedAndCancelAll(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	queuedCtx, queuedCancel := context.WithCancel(context.Background())

--- a/cmd/f4/terminal_view_test.go
+++ b/cmd/f4/terminal_view_test.go
@@ -1175,6 +1175,7 @@ func TestIssue117_OSC52_Read_SecurityDenial(t *testing.T) {
 	}
 
 	parser1.Process([]byte("\x1b]52;c;?\x07"))
+	parser1.waitOSC52()
 	if pty1.Len() > 0 {
 		t.Errorf("Security leak: OSC 52 read responded to PTY even though access was Denied! Output: %q", pty1.String())
 	}
@@ -1185,6 +1186,7 @@ func TestIssue117_OSC52_Read_SecurityDenial(t *testing.T) {
 	vtui.GlobalClipboardAccessManager = &mockDenyingAuth{retVal: -1}
 
 	parser2.Process([]byte("\x1b]52;c;?\x07"))
+	parser2.waitOSC52()
 	if pty2.Len() > 0 {
 		t.Errorf("Security leak: OSC 52 read responded to PTY in Local Mode! Output: %q", pty2.String())
 	}

--- a/cmd/f4/wasm_plugin.go
+++ b/cmd/f4/wasm_plugin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/tetratelabs/wazero"
@@ -41,7 +42,7 @@ type WasmPlugin struct {
 	cancel       context.CancelFunc
 	toGuest      *io.PipeWriter
 	done         chan struct{}
-	closing      bool
+	closing      atomic.Bool // read by guest/session exit goroutines to suppress expected shutdown errors
 	bridge       *ffibridge.Bridge
 	registration vfs.Registration
 	// identity is who this plugin is to the permission model, taken from
@@ -129,7 +130,7 @@ func (p *WasmPlugin) Init(api vfs.HostAPI) error {
 		guestStdout.Close()
 		hostToGuest.Close()
 
-		if runErr != nil && !p.closing && !isCleanWasmExit(runErr) {
+		if runErr != nil && !p.closing.Load() && !isCleanWasmExit(runErr) {
 			vtui.DebugLog("WASM Plugin %q terminated: %v", p.path, runErr)
 		}
 	}()
@@ -140,7 +141,7 @@ func (p *WasmPlugin) Init(api vfs.HostAPI) error {
 	p.bridge = newGatedFFIBridge(newPluginGate(p.permissionIdentity()))
 
 	registration, err := startPluginSession(p.sess, api, p.path, p.bridge, func(err error) {
-		if !p.closing {
+		if !p.closing.Load() {
 			vtui.DebugLog("WASM Plugin %q session ended: %v", p.path, err)
 		}
 	})
@@ -153,7 +154,7 @@ func (p *WasmPlugin) Init(api vfs.HostAPI) error {
 }
 
 func (p *WasmPlugin) Close() error {
-	p.closing = true
+	p.closing.Store(true)
 	if p.registration != nil {
 		p.registration.Unregister()
 		p.registration = nil


### PR DESCRIPTION
Sixteen of the race detector's reports in cmd/f4, six of them in shipped code.

ArkanoidFrame.Close wrote BaseFrame.Done while the game loop was reading it
through IsDone. Close signalled the loop to stop and then went on closing the
window without waiting, so the loop was still reading state that was being torn
down underneath it -- four of the reports are that one bug seen from four
tests. Close now joins the loop before closing. It releases the game mutex
first: the loop takes that mutex, so joining while holding it would deadlock.

The wasm plugin had the same shape. Close wrote its `closing` flag while the
goroutine serving the session read it. Those accesses are atomic now.

The rest are tests that returned while something they started was still
running, and the next test then wrote the global it was reading. The OSC-52
clipboard tests replaced GlobalClipboardAccessManager under a live denial
goroutine; the updater tests restored the OS and architecture overrides under a
running check; the async buffer's task pump called Redraw after its test had
finished; a delayed indexing goroutine outlived the editor test that started
it; and three toast timers crossed a frame manager restoration. Each now waits
for the thing it started, rather than for a moment that looked late enough.

The socket-free part of the package now reports zero races.