### PR TITLE
fix: stop the plugin catalog fetch outliving the dialog that started it

### DIFF
--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -1426,17 +1426,28 @@ func getCleanText(item vtui.UIElement) string {
 
 func clickDialogButton(t *testing.T, dlg vtui.Container, btnText string) {
 	t.Helper()
+	var buttons []string
+	var message []string
 	for _, itm := range dlg.GetChildren() {
 		if b, ok := itm.(*vtui.Button); ok {
-			if getCleanText(b) == btnText {
+			text := getCleanText(b)
+			buttons = append(buttons, text)
+			if text == btnText {
 				if b.OnClick != nil {
 					b.OnClick()
 					return
 				}
 			}
 		}
+		if line, ok := itm.(*vtui.Text); ok {
+			message = append(message, line.GetText())
+		}
 	}
-	t.Fatalf("Button %q not found in dialog", btnText)
+	title := ""
+	if titled, ok := dlg.(interface{ GetTitle() string }); ok {
+		title = titled.GetTitle()
+	}
+	t.Fatalf("Button %q not found in dialog %q; message: %q; buttons: %q", btnText, title, message, buttons)
 }
 
 func setDialogCheckbox(t *testing.T, dlg vtui.Container, chkText string, state int) {

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -4542,6 +4542,13 @@ func TestFileSystemPanel_LiveSelectionPreservation(t *testing.T) {
 
 	// 1. Setup: Panel with cached data
 	fp := NewFileSystemPanel(0, 0, 40, 20, v)
+	t.Cleanup(func() {
+		if fp.cancelLoad != nil {
+			fp.cancelLoad()
+		}
+		fp.stopLoadingAnimation()
+	})
+	waitForLoad(t, fp)
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
 		{VFSItem: vfs.VFSItem{Name: "item1"}, IsCached: true, Selected: true}, // Selected initially

--- a/cmd/f4/plugring_ui.go
+++ b/cmd/f4/plugring_ui.go
@@ -136,14 +136,29 @@ func actionPlugRing(pf *PanelsFrame) {
 	// shown[i] is the plugin on row i, or nil when row i is a category
 	// heading.
 	var shown []*PlugRingItem
+	var refreshTask *vtui.TaskContext
+	dlg.OnResult = func(int) {
+		if refreshTask != nil {
+			refreshTask.Cancel()
+		}
+	}
 
 	refresh := func() {
+		if refreshTask != nil {
+			refreshTask.Cancel()
+		}
 		table.SetRows(nil)
 		vtui.FrameManager.Redraw()
 
-		vtui.RunAsync(func(ctx *vtui.TaskContext) {
+		refreshTask = vtui.RunAsync(func(ctx *vtui.TaskContext) {
 			fetched, err := FetchCatalog(ctx.Context)
+			if ctx.Err() != nil {
+				return
+			}
 			ctx.RunOnUI(func() {
+				if ctx.Err() != nil || dlg.IsDone() {
+					return
+				}
 				if err != nil {
 					vtui.ShowMessageOn(dlg, " Error ", fmt.Sprintf("Failed to fetch catalog:\n%v", err), []string{"&Ok"})
 					return

--- a/cmd/f4/plugring_ui_test.go
+++ b/cmd/f4/plugring_ui_test.go
@@ -7,25 +7,28 @@ import (
 )
 
 func TestPlugRingDialog_Layout(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.SetDefaultPalette()
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	pf := NewPanelsFrame()
-	defer pf.Close()
+	t.Cleanup(pf.Close)
 
 	actionPlugRing(pf)
 
 	top := vtui.FrameManager.GetTopFrame()
+	t.Cleanup(func() {
+		if top != nil {
+			top.Close()
+			vtui.FrameManager.RemoveFrame(top)
+		}
+	})
 	dlg, ok := top.(vtui.Container)
 	if !ok {
 		t.Fatalf("Expected vtui.Container, got %T", top)
 	}
 
 	vtui.AssertLayout(t, dlg)
-
-	// Clean up
-	top.SetExitCode(-1)
-	vtui.FrameManager.Pop()
 }
 
 func TestPlugRingRowColorsFollowDialogTheme(t *testing.T) {


### PR DESCRIPTION
TestActionDelete_Abort kept failing with "Button Abort not found in dialog",
roughly once in five shuffled runs. It is never this test's fault: something
earlier leaves a dialog in the shared task queue and this one picks it up,
looks at it, and does not find its own button.

Two sources this time, one of them in shipped code.

PlugRingDialog started a catalog fetch and had no way to stop it. Closing the
dialog, or reopening it and starting another fetch, left the old one running,
and when it eventually failed it queued a one-button "Failed to fetch catalog"
error into whatever was on screen by then -- in CI, an unrelated test.
Refreshes are now cancelled when the dialog closes or restarts, and a
completion that arrives after the close is dropped.

TestFileSystemPanel_LiveSelectionPreservation returned before its initial
directory read had finished. t.TempDir then removed the directory, the read
failed, and its failure queued a directory error dialog. Same shape as the
DirectoryCache leak fixed earlier, in a different test.

clickDialogButton now prints the title, message and available buttons of the
dialog it actually found. That is what identifies the culprit: the failure
above says only that a button is missing, while the dialog's own text names the
test that left it. Worth keeping regardless of this bug.

Both failing seeds replay clean, followed by twenty fresh shuffled runs of the
whole tree.