### PR TITLE
fix: SetSize does not return an error

### DIFF
--- a/cmd/f4/solaris_pty_backend_test.go
+++ b/cmd/f4/solaris_pty_backend_test.go
@@ -54,9 +54,7 @@ func TestSolarisPTY_IdleState_And_SetSize(t *testing.T) {
 	}
 
 	// 1. Тестируем вызов SetSize
-	if err := pty.SetSize(120, 43); err != nil {
-		t.Fatal(err)
-	}
+	pty.SetSize(120, 43)
 	if mock.lastCols != 120 || mock.lastRows != 43 {
 		t.Errorf("SetSize failed to forward parameters. Got cols=%d, rows=%d", mock.lastCols, mock.lastRows)
 	}


### PR DESCRIPTION
The errcheck pass over cmd/f4's tests wrapped

    pty.SetSize(120, 43)

in a check, but that method returns nothing, so cmd/f4 stopped compiling for
solaris and illumos and main went red.

Nothing local catches this: solaris_pty_backend_test.go sits behind a build tag
for those two, so it is never compiled on darwin or linux, and neither the go
build nor the tests run before merging touch it. The cross-platform vet matrix
did catch it, which is what it is for.

The lines after the call already assert on mock.lastCols and mock.lastRows, so
what the call did is still checked; only the error that never existed is gone.
Vet is clean again for solaris, illumos, windows, freebsd, netbsd, openbsd,
dragonfly, linux/arm and darwin/arm64.