### PR TITLE
lint: say why the android plugin discards what it discards

### DIFF
--- a/plugins/android/adb_sync.go
+++ b/plugins/android/adb_sync.go
@@ -195,7 +195,7 @@ func (c *SyncClient) List(ctx context.Context, path string) ([]SyncEntry, error)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // The protocol response determines metadata success.
 
 	v2 := c.hasFeature("ls_v2")
 	requestID := syncIDListV1
@@ -265,7 +265,7 @@ func (c *SyncClient) stat(ctx context.Context, path, requestID string) (SyncEntr
 	if err != nil {
 		return SyncEntry{}, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // The protocol response determines metadata success.
 
 	if err := writeSyncRequest(conn, requestID, path); err != nil {
 		return SyncEntry{}, syncContextError(ctx, fmt.Errorf("adb sync stat request: %w", err))
@@ -325,7 +325,7 @@ func (c *SyncClient) Receive(ctx context.Context, path string) (*SyncReceiveRead
 		requestID = syncIDRecvV2
 	}
 	if err := writeSyncRequest(conn, requestID, path); err != nil {
-		conn.Close()
+		_ = conn.Close() // Preserve the receive-request failure.
 		return nil, syncContextError(ctx, fmt.Errorf("adb sync receive request: %w", err))
 	}
 	if v2 {
@@ -333,7 +333,7 @@ func (c *SyncClient) Receive(ctx context.Context, path string) (*SyncReceiveRead
 		copy(setup[:4], syncIDRecvV2)
 		// flags remains zero: no compression is requested.
 		if err := writeSyncFull(conn, setup[:]); err != nil {
-			conn.Close()
+			_ = conn.Close() // Preserve the receive-setup failure.
 			return nil, syncContextError(ctx, fmt.Errorf("adb sync receive setup: %w", err))
 		}
 	}
@@ -381,7 +381,7 @@ func (c *SyncClient) Send(ctx context.Context, path string, mode uint32, mtime t
 		return nil, err
 	}
 	if err := writeSyncRequest(conn, requestID, payload); err != nil {
-		conn.Close()
+		_ = conn.Close() // Preserve the send-request failure.
 		return nil, syncContextError(ctx, fmt.Errorf("adb sync send request: %w", err))
 	}
 	if v2 {
@@ -390,7 +390,7 @@ func (c *SyncClient) Send(ctx context.Context, path string, mode uint32, mtime t
 		binary.LittleEndian.PutUint32(setup[4:8], mode)
 		// flags remains zero: no compression and no dry-run.
 		if err := writeSyncFull(conn, setup[:]); err != nil {
-			conn.Close()
+			_ = conn.Close() // Preserve the send-setup failure.
 			return nil, syncContextError(ctx, fmt.Errorf("adb sync send setup: %w", err))
 		}
 	}

--- a/plugins/android/adb_transport.go
+++ b/plugins/android/adb_transport.go
@@ -203,7 +203,7 @@ func (s *Server) openServiceConn(ctx context.Context, serial, service string) (n
 	defer func() {
 		stop()
 		if !ok {
-			conn.Close()
+			_ = conn.Close() // Preserve the service-selection error.
 		}
 	}()
 	if err := requestService(conn, "host:transport:"+serial); err != nil {
@@ -286,7 +286,7 @@ func (s *Server) runLegacyShellStream(ctx context.Context, serial, command strin
 	if err != nil {
 		return -1, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // The shell connection is read-only here.
 	stop := interruptConnOnCancel(ctx, conn)
 	defer stop()
 
@@ -376,7 +376,7 @@ func (s *Server) runShellV2Stream(ctx context.Context, serial, command string, c
 	if err != nil {
 		return -1, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // The shell connection is read-only here.
 	stop := interruptConnOnCancel(ctx, conn)
 	defer stop()
 
@@ -448,7 +448,7 @@ func (s *Server) runShell(ctx context.Context, serial, command string, maxStdout
 		if openErr != nil {
 			return nil, nil, -1, openErr
 		}
-		defer conn.Close()
+		defer func() { _ = conn.Close() }() // The shell connection is read-only here.
 		stop := interruptConnOnCancel(ctx, conn)
 		defer stop()
 		out, readErr := readAllWithLimit(conn, maxStdout)
@@ -464,7 +464,7 @@ func (s *Server) runShell(ctx context.Context, serial, command string, maxStdout
 	if openErr != nil {
 		return nil, nil, -1, openErr
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }() // The shell stream is read-only here.
 	stop := stream.InterruptOnCancel(ctx)
 	defer stop()
 	out, readErr := readAllWithLimit(stream, maxStdout)
@@ -500,7 +500,7 @@ func (s *Server) hostQuery(ctx context.Context, service string) ([]byte, error) 
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // The query result determines success.
 	stop := interruptConnOnCancel(ctx, conn)
 	defer stop()
 	if err := requestService(conn, service); err != nil {

--- a/plugins/android/sync_vfs.go
+++ b/plugins/android/sync_vfs.go
@@ -645,7 +645,7 @@ func (f *syncReadFile) materialize(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	defer stream.Close()
+	defer func() { _ = stream.Close() }() // The receive stream is read-only.
 
 	tmp, err := os.CreateTemp("", "f4-android-*")
 	if err != nil {
@@ -655,8 +655,8 @@ func (f *syncReadFile) materialize(ctx context.Context) error {
 	keep := false
 	defer func() {
 		if !keep {
-			tmp.Close()
-			os.Remove(name)
+			_ = tmp.Close()     // The incomplete cache is discarded below.
+			_ = os.Remove(name) // Internal temporary-file cleanup is best effort.
 		}
 	}()
 	n, err := io.Copy(tmp, stream)


### PR DESCRIPTION
Fifteen errcheck findings in plugins/android's production code, and all fifteen
turn out to be the benign kind. The value of the pass is not the diff; it is
having read them and being able to say so.

Eleven are connection closes after the protocol result is already in hand, or
in a setup failure path where the close error would replace something more
useful. Two are stream closes on the read direction -- shell output and the
sync RECV -- so neither finalises anything written. The one writable temp file
is closed and removed only after a failed materialisation, so both are
best-effort cleanup of a cache entry that is already known to be junk.

The case worth ruling out was an upload whose Close error is dropped, since
that is how a truncated file reaches a device and nobody hears about it.
SyncSendWriter.Close already propagates, including the remote OKAY/FAIL, so
that path was never in danger.

Nothing propagates, no signature changed, and no missing Close turned up while
reading.