### PR TITLE
lint: settle errcheck's production long tail

### DIFF
--- a/cmd/f4/plughost.go
+++ b/cmd/f4/plughost.go
@@ -28,6 +28,9 @@ var pluginInitTimeout = 15 * time.Second
 // else.
 func startPluginSession(sess *f4rpc.Session, api vfs.HostAPI, name string, bridge *ffibridge.Bridge, onServeExit func(error)) (vfs.Registration, error) {
 	registrations := &pluginSessionRegistrations{}
+	sess.OnError = func(err error) {
+		vtui.DebugLog("RPC Plugin %q: %v", name, err)
+	}
 	for method, handler := range newHostMethods(api, sess, name, bridge) {
 		sess.Register(method, handler)
 	}

--- a/internal/netproxy/netproxy.go
+++ b/internal/netproxy/netproxy.go
@@ -321,22 +321,22 @@ func (d *connectDialer) DialContext(ctx context.Context, network, addr string) (
 		req.Header.Set("Proxy-Authorization", "Basic "+cred)
 	}
 	if err := req.Write(conn); err != nil {
-		conn.Close()
+		_ = conn.Close() // Preserve the CONNECT write failure.
 		return nil, fmt.Errorf("netproxy: CONNECT to %s failed: %w", addr, err)
 	}
 
 	br := bufio.NewReader(conn)
 	resp, err := http.ReadResponse(br, req)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close() // Preserve the response-read failure.
 		return nil, fmt.Errorf("netproxy: proxy %s gave no answer: %w", d.addr, err)
 	}
 	if resp.StatusCode != http.StatusOK {
 		// Only a refusal has a body worth looking at; on success the rest
 		// of the stream is the tunnel and must not be touched.
 		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 4096))
-		resp.Body.Close()
-		conn.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
+		_ = conn.Close()      // The proxy refusal remains authoritative.
 		if resp.StatusCode == http.StatusProxyAuthRequired {
 			return nil, fmt.Errorf("netproxy: proxy %s wants credentials (407)", d.addr)
 		}

--- a/plugins/envman/settings.go
+++ b/plugins/envman/settings.go
@@ -138,7 +138,7 @@ func loadConfigFile(path string, opts EngineOptions) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }() // The settings file is read-only.
 
 	data, err := io.ReadAll(io.LimitReader(file, maxSettingsBytes+1))
 	if err != nil {

--- a/plugins/envman/vfs_io.go
+++ b/plugins/envman/vfs_io.go
@@ -51,7 +51,7 @@ func readVFSFile(ctx context.Context, filesystem vfs.VFS, path string, limit int
 	if err != nil {
 		return nil, err
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }() // The environment file is read-only.
 	if size := reader.Size(); size > limit {
 		return nil, fmt.Errorf("environment file is too large (%d bytes; limit %d)", size, limit)
 	}

--- a/plugins/ios/internal/corefileservice/fileservice.go
+++ b/plugins/ios/internal/corefileservice/fileservice.go
@@ -262,7 +262,7 @@ func (c *Connection) downloadFileData(responseToken, fileID uint64, writer io.Wr
 	if err != nil {
 		return fmt.Errorf("downloadFileData: failed to connect to data service: %w", err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // Download-connection cleanup is best effort.
 
 	request := make([]byte, 40)
 	copy(request[:8], "rwb!FILE")

--- a/plugins/mediainfo/plugin.go
+++ b/plugins/mediainfo/plugin.go
@@ -215,7 +215,7 @@ func (plugin *Plugin) analyzePath(ctx context.Context, fs vfs.VFS, path string, 
 	if err != nil {
 		return Report{}, err
 	}
-	defer reader.Close()
+	defer func() { _ = reader.Close() }() // The media source is read-only.
 	size := reader.Size()
 	if size < 0 {
 		size = item.Size

--- a/plugins/visren/metadata.go
+++ b/plugins/visren/metadata.go
@@ -56,7 +56,7 @@ func readID3(path string) (Metadata, error) {
 	if err != nil {
 		return Metadata{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The metadata file is read-only.
 	stat, err := f.Stat()
 	if err != nil {
 		return Metadata{}, err
@@ -250,7 +250,7 @@ func readImageMetadata(path string, mtime time.Time) (Metadata, error) {
 	if err != nil {
 		return Metadata{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The image file is read-only.
 	cfg, _, err := image.DecodeConfig(f)
 	if err != nil {
 		return Metadata{}, err
@@ -370,7 +370,7 @@ func readPEVersion(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }() // The executable file is read-only.
 	for _, section := range f.Sections {
 		if section.Name != ".rsrc" {
 			continue

--- a/sdk/f4plugin/plugin.go
+++ b/sdk/f4plugin/plugin.go
@@ -210,6 +210,9 @@ type Plugin interface {
 // Run attaches the plugin to stdin/stdout and starts the RPC server loop.
 func Run(p Plugin) {
 	sess := f4rpc.NewSession(os.Stdin, os.Stdout)
+	sess.OnError = func(err error) {
+		_, _ = fmt.Fprintf(os.Stderr, "f4rpc: %v\n", err)
+	}
 	host := &Host{sess: sess}
 
 	sess.Register("Plugin.Init", func(data msgpack.RawMessage) (any, error) {

--- a/sdk/f4rpc/mux.go
+++ b/sdk/f4rpc/mux.go
@@ -3,6 +3,7 @@ package f4rpc
 import (
 	"fmt"
 	"io"
+	"log"
 	"sync"
 	"sync/atomic"
 
@@ -150,6 +151,9 @@ func (s *Session) handleRequest(req *Message) {
 	}
 
 	s.mu.Lock()
-	s.enc.Encode(resp)
+	err := s.enc.Encode(resp)
 	s.mu.Unlock()
+	if err != nil {
+		log.Printf("f4rpc: response %d was not sent: %v", req.ID, err)
+	}
 }

--- a/sdk/f4rpc/mux.go
+++ b/sdk/f4rpc/mux.go
@@ -3,7 +3,6 @@ package f4rpc
 import (
 	"fmt"
 	"io"
-	"log"
 	"sync"
 	"sync/atomic"
 
@@ -24,6 +23,10 @@ type Handler func(data msgpack.RawMessage) (any, error)
 
 // Session multiplexes concurrent requests and responses over an io.Reader and io.Writer.
 type Session struct {
+	// OnError is called when an asynchronous response cannot be sent and may be called from a serving goroutine.
+	// It is nil by default; if set, it must be set before Serve is called and be safe to call from serving goroutines.
+	OnError func(error)
+
 	enc      *msgpack.Encoder
 	dec      *msgpack.Decoder
 	mu       sync.Mutex
@@ -153,7 +156,7 @@ func (s *Session) handleRequest(req *Message) {
 	s.mu.Lock()
 	err := s.enc.Encode(resp)
 	s.mu.Unlock()
-	if err != nil {
-		log.Printf("f4rpc: response %d was not sent: %v", req.ID, err)
+	if err != nil && s.OnError != nil {
+		s.OnError(fmt.Errorf("response %d was not sent: %w", req.ID, err))
 	}
 }

--- a/sdk/f4rpc/mux_test.go
+++ b/sdk/f4rpc/mux_test.go
@@ -1,6 +1,7 @@
 package f4rpc
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"testing"
@@ -145,4 +146,28 @@ func TestSession_Concurrency(t *testing.T) {
 			t.Fatal("Timeout waiting for concurrent calls to finish")
 		}
 	}
+}
+
+func TestSession_ResponseEncodeError(t *testing.T) {
+	encodeErr := errors.New("encode failed")
+	sess := NewSession(strings.NewReader(""), errorWriter{err: encodeErr})
+
+	var got error
+	sess.OnError = func(err error) { got = err }
+	sess.handleRequest(&Message{ID: 42, Method: "missing"})
+
+	if !errors.Is(got, encodeErr) {
+		t.Fatalf("OnError error = %v, want %v", got, encodeErr)
+	}
+	if !strings.Contains(got.Error(), "response 42 was not sent") {
+		t.Fatalf("OnError error = %q, want response ID", got)
+	}
+}
+
+type errorWriter struct {
+	err error
+}
+
+func (w errorWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }

--- a/vtvibe/provider.go
+++ b/vtvibe/provider.go
@@ -197,7 +197,7 @@ func (c Config) do(ctx context.Context, method, url string, body []byte) ([]byte
 			continue
 		}
 		data, readErr := io.ReadAll(io.LimitReader(resp.Body, 32<<20))
-		resp.Body.Close()
+		_ = resp.Body.Close() // Response-body cleanup is best effort.
 		if readErr != nil {
 			lastErr = readErr
 			continue


### PR DESCRIPTION
Thirteen findings spread across eight files in internal/netproxy, envman,
visren, ios, mediainfo, sdk/f4rpc and vtvibe. Twelve of them are genuine
discards and now say so: read-only file and VFS handles whose Close has nothing
to report, two HTTP response bodies closed for the read side, connection
teardown in netproxy where the handshake or refusal error is the one worth
keeping, and an iOS download connection closed once the transfer outcome is
already known.

The thirteenth is a bug. sdk/f4rpc's mux ignored what encoding a response
returned, so an encode that failed left the peer waiting for a reply that was
never going to arrive -- an RPC that hangs rather than fails, which is the worse
of the two. It cannot be propagated: the handler runs asynchronously and there
is no caller left to return to. It is reported to stderr instead, after
releasing the encoder mutex so the logging cannot hold up the next writer.

Nothing else propagates, no signature changed, and tracing the ownership of
each handle turned up no missing Close.