### PR TITLE
ci: run the tests in a random order

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -713,7 +713,11 @@ jobs:
     - name: Run Tests
       shell: bash
       run: |
-        go test -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' ./...
+        # Shuffle tests and subtests to expose order dependencies. Go prints
+        # the seed on every run, so reproduce a failure with -shuffle=<seed>.
+        # The seed selects a permutation of the test set, so it only reproduces
+        # while that set remains unchanged.
+        go test -shuffle=on -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' ./...
         # Layout validation mutates shared UI registries from parallel
         # subtests. Go 1.26 schedules them aggressively enough to expose the
         # upstream race, so isolate that test in a single-threaded process.
@@ -814,7 +818,7 @@ jobs:
           echo "::error::no packages left to run under the race detector"
           exit 1
         fi
-        go test -race -timeout 15m "${packages[@]}"
+        go test -race -shuffle=on -timeout 15m "${packages[@]}"
         go test -race -run '^$' ./cmd/f4 ./luaplug
 
   release:

--- a/cmd/f4/issue561_test.go
+++ b/cmd/f4/issue561_test.go
@@ -18,7 +18,8 @@ func (*issue561ViewportRenderer) Flush()                                        
 
 func TestIssue561PanelSettingsRequestsViewportLargeEnoughForDialog(t *testing.T) {
 	oldConfig := AppConfig
-	defer func() { AppConfig = oldConfig }()
+	t.Cleanup(func() { AppConfig = oldConfig })
+	t.Cleanup(swapFrameManager(t))
 
 	scr := vtui.NewSilentScreenBuf()
 	scr.AllocBuf(100, 30)
@@ -27,6 +28,7 @@ func TestIssue561PanelSettingsRequestsViewportLargeEnoughForDialog(t *testing.T)
 	vtui.FrameManager.Init(scr)
 
 	pf := NewPanelsFrame()
+	t.Cleanup(pf.Close)
 	vtui.FrameManager.Push(pf)
 	actionPanelSettings(pf)
 

--- a/cmd/f4/navigation_mode_test.go
+++ b/cmd/f4/navigation_mode_test.go
@@ -428,10 +428,17 @@ func TestSearchFirstMouseFocusAndInactiveCursor(t *testing.T) {
 
 func TestDetailedHorizontalArrowsMatchPageNavigationExceptVim(t *testing.T) {
 	oldCfg := AppConfig
-	defer func() { AppConfig = oldCfg }()
+	t.Cleanup(func() { AppConfig = oldCfg })
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	fp := NewFileSystemPanel(0, 0, 50, 20, vfs.NewOSVFS(t.TempDir()))
+	t.Cleanup(func() {
+		if fp.cancelLoad != nil {
+			fp.cancelLoad()
+		}
+		fp.stopLoadingAnimation()
+	})
+	waitForLoad(t, fp)
 	fp.SetViewMode(ViewModeDetailed)
 	fp.entries = make([]*fileEntry, 60)
 	for i := range fp.entries {


### PR DESCRIPTION
Go runs tests in source order by default, which means a test that leaves state
behind and the test that trips over it stay paired forever, and neither looks
guilty. -shuffle=on breaks that pairing. It prints the seed on every run, so a
failure replays with -shuffle=<seed> -- with the caveat that a seed selects a
permutation of the test set, so it stops reproducing once that set changes,
which is worth knowing before concluding an old failing seed was imaginary.

It goes on the two invocations that actually run tests. The other two are left
alone: one runs a single named test, the other runs none and exists only to
compile those packages under the race detector.

This is switched on last rather than first. Turning it on before the existing
order dependencies were cleared would have produced a permanently flickering
pipeline that everyone learns to ignore, which is worse than not having it.
Four rounds of fixes came first, and the tail of them was found exactly this
way: a plugin catalog fetch outliving its dialog, a panel test returning before
its directory read, an attribute setter read before it had run.

Two more turned up while verifying this change, both fixed here.
TestDetailedHorizontalArrowsMatchPageNavigationExceptVim left an asynchronous
directory read running and it surfaced inside TestActionDelete_RetrySuccess.
TestIssue561PanelSettingsRequestsViewportLargeEnoughForDialog left a
PanelsFrame in the shared FrameManager for TestSession_DiskPersistence to
snapshot. Both are test bugs; production is untouched.

Twenty consecutive full shuffled runs are clean.

Being honest about the cost: this will occasionally go red on something nobody
changed. That is the point -- it is a real order dependency that was there all
along and simply had not been shuffled into view yet. It is work, not noise.