### PR TITLE
Fix remaining issue 651 menu behavior

### DIFF
--- a/ISSUE_651_SOLUTION_REVIEW.md
+++ b/ISSUE_651_SOLUTION_REVIEW.md
@@ -61,3 +61,30 @@ main rather than changed speculatively.
 Implement the common vtui fix plus the f4-side deterministic shortcut,
 archive, and autosave changes. Leave the disputed settings layout and already
 working GUI/Command-palette items unchanged.
+
+## Follow-up review after the reporter's retest
+
+The retest used a commit that already contained PR #740, so the remaining
+failures were checked against current `upstream/main` rather than assumed to be
+stale.
+
+1. **Generic plugin menus:** cap `PanelsFrame.Menu` by both its normal compact
+   limit and the actual screen height, then let `vtui.VMenu` scroll the rows.
+2. **Generic plugin menus:** keep the fixed 15-row height. Rejected because a
+   10-row terminal still receives a 15-row menu and loses its bottom rows.
+3. **Generic plugin menus:** paginate in every caller. Rejected because the
+   reusable `VMenu` already supplies the required viewport and scrollbar.
+
+1. **Archive shortcuts:** match far2l's Files menu with Shift+F1 for Add and
+   Shift+F2 for Extract; keep the legacy two-command menu on Shift+F3.
+2. **Archive shortcuts:** keep Alt+F5/Alt+F6 and only change the displayed
+   labels. Rejected because the actual keys would still differ from the
+   expected Files-menu behavior.
+3. **Archive shortcuts:** remove the legacy command menu. Rejected because it
+   would remove an existing entry point without helping the requested actions.
+
+The follow-up is covered by a small-screen `PanelsFrame.Menu` regression and
+updated archive registration/hotkey tests. The remaining startup-mode,
+deterministic drive-menu display, and Command-palette paths are already
+represented by current code and focused tests; the native Windows ANSI run
+also exercised the current menu and exit paths before reporting completion.

--- a/cmd/f4/panel_menu_test.go
+++ b/cmd/f4/panel_menu_test.go
@@ -2,9 +2,47 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/unxed/vtui"
 )
+
+func TestPanelsFrame_MenuFitsSmallScreenAndScrolls(t *testing.T) {
+	defer swapFrameManager(t)()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	vtui.FrameManager.Init(scr)
+
+	pf := &PanelsFrame{lastW: 80, lastH: 10}
+	items := make([]string, 30)
+	for i := range items {
+		items[i] = "Item"
+	}
+	pf.Menu("Long plugin menu", items, nil)
+
+	select {
+	case task := <-vtui.FrameManager.TaskChan:
+		task()
+	case <-time.After(time.Second):
+		t.Fatal("menu task was not posted")
+	}
+
+	menu, ok := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
+	if !ok {
+		t.Fatalf("top frame = %T, want *vtui.VMenu", vtui.FrameManager.GetTopFrame())
+	}
+	if menu.Y1 < 0 || menu.Y2 >= scr.Height() {
+		t.Fatalf("menu bounds = (%d,%d)-(%d,%d), screen height = %d", menu.X1, menu.Y1, menu.X2, menu.Y2, scr.Height())
+	}
+	if menu.ViewHeight >= len(items) || !menu.ShowScrollBar || menu.ScrollBar == nil {
+		t.Fatalf("menu viewport = %d items=%d scrollbar=%v bar=%v", menu.ViewHeight, len(items), menu.ShowScrollBar, menu.ScrollBar != nil)
+	}
+	menu.SetSelectPos(len(items) - 1)
+	if menu.TopPos == 0 {
+		t.Fatal("selecting the last item did not scroll the menu")
+	}
+	menu.Close()
+}
 
 func TestPanelsFrame_SideMenusExposeDriveHotkeys(t *testing.T) {
 	pf := &PanelsFrame{}

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -3660,9 +3660,16 @@ func (pf *PanelsFrame) Menu(title string, items []string, callback func(int)) {
 		}
 
 		h := len(items) + 2
-		if h > 15 {
-			h = 15
-		} // Max height limit
+		maxH := 15 // Keep generic plugin menus compact on normal screens.
+		if screenH := vtui.FrameManager.GetScreenHeight(); screenH > 0 && maxH > screenH {
+			maxH = screenH
+		}
+		if maxH < 3 {
+			maxH = 3
+		}
+		if h > maxH {
+			h = maxH
+		}
 
 		// Center relative to the PanelsFrame size
 		x := (pf.lastW - maxW) / 2

--- a/cmd/f4/ttyx_probe_parse.go
+++ b/cmd/f4/ttyx_probe_parse.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// parseXTWinOps decodes "<prefix>height;width t". The parser is shared by
+// Unix probing and its platform-independent regression tests; Windows uses
+// no ioctl/query implementation but still builds those tests.
+func parseXTWinOps(s, prefix string) (int, int, bool) {
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return 0, 0, false
+	}
+	rest := s[i+len(prefix):]
+	if j := strings.IndexByte(rest, 't'); j >= 0 {
+		rest = rest[:j]
+	}
+	parts := strings.Split(rest, ";")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	h, errH := strconv.Atoi(strings.TrimSpace(parts[0]))
+	w, errW := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if errH != nil || errW != nil || w <= 0 || h <= 0 {
+		return 0, 0, false
+	}
+	return w, h, true
+}
+
+func answerComplete(s, prefix string) bool {
+	return strings.HasSuffix(s, "t") && strings.Contains(s, prefix)
+}

--- a/cmd/f4/ttyx_probe_unix.go
+++ b/cmd/f4/ttyx_probe_unix.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -132,30 +131,4 @@ func pollAnswer(in *os.File, budget time.Duration, prefix string) (string, bool)
 		return "", false
 	}
 	return sb.String(), answerComplete(sb.String(), prefix)
-}
-
-// parseXTWinOps decodes "<prefix>height;width t".
-func parseXTWinOps(s, prefix string) (int, int, bool) {
-	i := strings.Index(s, prefix)
-	if i < 0 {
-		return 0, 0, false
-	}
-	rest := s[i+len(prefix):]
-	if j := strings.IndexByte(rest, 't'); j >= 0 {
-		rest = rest[:j]
-	}
-	parts := strings.Split(rest, ";")
-	if len(parts) < 2 {
-		return 0, 0, false
-	}
-	h, errH := strconv.Atoi(strings.TrimSpace(parts[0]))
-	w, errW := strconv.Atoi(strings.TrimSpace(parts[1]))
-	if errH != nil || errW != nil || w <= 0 || h <= 0 {
-		return 0, 0, false
-	}
-	return w, h, true
-}
-
-func answerComplete(s, prefix string) bool {
-	return strings.HasSuffix(s, "t") && strings.Contains(s, prefix)
 }

--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -32,7 +32,7 @@ func (p *ArchivePlugin) Init(api vfs.HostAPI) error {
 			Label:          "Add to archive",
 			LabelKey:       "Archive.Command.Add",
 			MenuPath:       "Files",
-			Shortcut:       "Alt+F5",
+			Shortcut:       "Shift+F1",
 			Description:    "Create an archive from the selected files",
 			DescriptionKey: "Archive.Command.Add.Desc",
 			SearchKeys:     []string{"Attributes.Archive"},
@@ -48,7 +48,7 @@ func (p *ArchivePlugin) Init(api vfs.HostAPI) error {
 			Label:          "Extract files",
 			LabelKey:       "Archive.Command.Extract",
 			MenuPath:       "Files",
-			Shortcut:       "Alt+F6",
+			Shortcut:       "Shift+F2",
 			Description:    "Extract the selected archive to the passive panel",
 			DescriptionKey: "Archive.Command.Extract.Desc",
 			SearchKeys:     []string{"Attributes.Archive"},
@@ -63,11 +63,12 @@ func (p *ArchivePlugin) Init(api vfs.HostAPI) error {
 
 	api.RegisterVFSProvider(&ArchiveProvider{})
 
-	api.RegisterGlobalHotkey(vtinput.VK_F1, vtinput.ShiftPressed, func(app vfs.App) {
-		actionArchiveCommands(app)
-	})
-	api.RegisterGlobalHotkey(vtinput.VK_F5, vtinput.LeftAltPressed, actionAddArchive)
-	api.RegisterGlobalHotkey(vtinput.VK_F6, vtinput.LeftAltPressed, actionExtractArchive)
+	// Keep far2l's Files-menu shortcuts: direct archive operations are
+	// Shift+F1/Shift+F2, while the legacy two-item archive command menu stays
+	// available on Shift+F3.
+	api.RegisterGlobalHotkey(vtinput.VK_F1, vtinput.ShiftPressed, actionAddArchive)
+	api.RegisterGlobalHotkey(vtinput.VK_F2, vtinput.ShiftPressed, actionExtractArchive)
+	api.RegisterGlobalHotkey(vtinput.VK_F3, vtinput.ShiftPressed, actionArchiveCommands)
 
 	return nil
 }

--- a/plugins/archive/archive_plugin_test.go
+++ b/plugins/archive/archive_plugin_test.go
@@ -135,8 +135,8 @@ func TestArchivePluginRegistersDiscoverableCommands(t *testing.T) {
 		descriptionKey string
 		shortcut       string
 	}{
-		{id: archiveAddCommandID, label: "Add to archive", labelKey: "Archive.Command.Add", menuPath: "Files", descriptionKey: "Archive.Command.Add.Desc", shortcut: "Alt+F5"},
-		{id: archiveExtractCommandID, label: "Extract files", labelKey: "Archive.Command.Extract", menuPath: "Files", descriptionKey: "Archive.Command.Extract.Desc", shortcut: "Alt+F6"},
+		{id: archiveAddCommandID, label: "Add to archive", labelKey: "Archive.Command.Add", menuPath: "Files", descriptionKey: "Archive.Command.Add.Desc", shortcut: "Shift+F1"},
+		{id: archiveExtractCommandID, label: "Extract files", labelKey: "Archive.Command.Extract", menuPath: "Files", descriptionKey: "Archive.Command.Extract.Desc", shortcut: "Shift+F2"},
 	}
 	for index, expected := range want {
 		command := host.commands[index]
@@ -166,7 +166,7 @@ func TestArchivePluginRegistersDiscoverableCommands(t *testing.T) {
 	}
 }
 
-func TestArchivePluginKeepsShiftF1MenuWithoutContributionHost(t *testing.T) {
+func TestArchivePluginRegistersFar2lFileShortcutsWithoutContributionHost(t *testing.T) {
 	host := &archivePluginLegacyTestHost{}
 	plugin := &ArchivePlugin{}
 	if err := plugin.Init(host); err != nil {
@@ -184,13 +184,18 @@ func TestArchivePluginKeepsShiftF1MenuWithoutContributionHost(t *testing.T) {
 	if len(host.hotkeys) != 3 {
 		t.Fatalf("registered global hotkeys = %d, want 3", len(host.hotkeys))
 	}
-	hotkey := host.hotkeys[0]
-	if hotkey.vk != vtinput.VK_F1 || hotkey.mods != vtinput.ShiftPressed || hotkey.handler == nil {
-		t.Fatalf("legacy archive hotkey = %#v, want Shift+F1 with a handler", hotkey)
+	if host.hotkeys[0].vk != vtinput.VK_F1 || host.hotkeys[0].mods != vtinput.ShiftPressed || host.hotkeys[0].handler == nil {
+		t.Fatalf("add archive hotkey = %#v, want Shift+F1 with a handler", host.hotkeys[0])
+	}
+	if host.hotkeys[1].vk != vtinput.VK_F2 || host.hotkeys[1].mods != vtinput.ShiftPressed || host.hotkeys[1].handler == nil {
+		t.Fatalf("extract archive hotkey = %#v, want Shift+F2 with a handler", host.hotkeys[1])
+	}
+	if host.hotkeys[2].vk != vtinput.VK_F3 || host.hotkeys[2].mods != vtinput.ShiftPressed || host.hotkeys[2].handler == nil {
+		t.Fatalf("legacy archive hotkey = %#v, want Shift+F3 with a handler", host.hotkeys[2])
 	}
 
 	app := &archivePluginMenuTestApp{}
-	hotkey.handler(app)
+	host.hotkeys[2].handler(app)
 	if app.title != " Archive Commands " {
 		t.Errorf("legacy menu title = %q", app.title)
 	}
@@ -202,11 +207,5 @@ func TestArchivePluginKeepsShiftF1MenuWithoutContributionHost(t *testing.T) {
 		if app.items[index] != wantItems[index] {
 			t.Errorf("legacy menu item %d = %q, want %q", index, app.items[index], wantItems[index])
 		}
-	}
-	if host.hotkeys[1].vk != vtinput.VK_F5 || host.hotkeys[1].mods != vtinput.LeftAltPressed || host.hotkeys[1].handler == nil {
-		t.Fatalf("add archive hotkey = %#v, want Alt+F5", host.hotkeys[1])
-	}
-	if host.hotkeys[2].vk != vtinput.VK_F6 || host.hotkeys[2].mods != vtinput.LeftAltPressed || host.hotkeys[2].handler == nil {
-		t.Fatalf("extract archive hotkey = %#v, want Alt+F6", host.hotkeys[2])
 	}
 }


### PR DESCRIPTION
Summary: Clamp generic plugin callback menus to the actual terminal height so vtui can scroll long lists. Restore far2l-compatible archive menu shortcuts: Shift+F1 add, Shift+F2 extract, Shift+F3 legacy archive command menu. Keep the Windows test build compiling the shared terminal-response parser and add regressions for the menu viewport and archive registrations. Validation: go test ./... -count=1; go build ./cmd/f4; native Windows amd64 ANSI TTY launch opened the menu with F9 and the exit confirmation with F10, then saved the session. go test -race was not runnable because CGO_ENABLED=0 and gcc is unavailable. Existing GUI startup/window persistence, deterministic drive-menu display, and Command Palette paths were rechecked; disputed settings layout is unchanged.