### PR TITLE
ci: execute luaplug under race detector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -803,11 +803,10 @@ jobs:
     - name: Run race detector
       shell: bash
       run: |
-        # luaplug's FFI tests call raw pointers, which Go's checkptr rejects
-        # under -race. Keep that package in the instrumented compile below,
-        # while running the complete cmd/f4 suite and all other packages under
-        # the detector.
-        mapfile -t packages < <(go list ./... | grep -Ev '^github.com/unxed/f4/(cmd/f4|luaplug)$')
+        # The FFI dependencies now keep Go-owned pointers typed and isolate
+        # the genuinely foreign-pointer conversions behind nocheckptr helpers,
+        # so luaplug can execute its FFI tests under the detector as well.
+        mapfile -t packages < <(go list ./... | grep -Ev '^github.com/unxed/f4/cmd/f4$')
         # The bare $packages this replaced failed the step when the list came
         # out empty, because set -e sees the assignment's exit status. mapfile
         # swallows it, and go test with no arguments would quietly fall back to
@@ -818,7 +817,6 @@ jobs:
         fi
         go test -race -shuffle=on -timeout 15m "${packages[@]}"
         go test -race -shuffle=on -timeout 15m ./cmd/f4
-        go test -race -run '^$' ./luaplug
 
   release:
     name: Create Official Release


### PR DESCRIPTION
Follow-up to issue #625. The FFI fixes merged in unxed/ffibridge#2, unxed/pureffi#1, and unxed/goffi#1 remove the checkptr failures that previously forced luaplug into compile-only mode. This changes the race job to execute luaplug's tests, while cmd/f4 remains a dedicated full race run. The Linux CI race job is the required validation because this Windows host has no cgo compiler.