### PR TITLE
Fix Unicode cluster selection and bidi editing

### DIFF
--- a/ISSUE_546_FOLLOWUP_SOLUTION_REVIEW.md
+++ b/ISSUE_546_FOLLOWUP_SOLUTION_REVIEW.md
@@ -1,0 +1,76 @@
+# Issue 546 follow-up: solution review
+
+## Observed failure modes
+
+The supplied text files and screenshots show three related failures:
+
+1. Devanagari and Thaana clusters can be split at a virama or a terminal
+   mark, which makes dialogs and scrollbars disagree about the number of
+   cells occupied by the text.
+2. Shift-selection can begin inside a shaped Indic cluster in either
+   direction.
+3. A mixed left-to-right/right-to-left line can lose the relationship between
+   its visual clusters and logical rune offsets.
+
+The editor already had a local Indic-cluster extension, but its bidi path and
+the `vtui` dialog widgets still used the older segmentation independently.
+
+## Candidate solutions
+
+### A — selected: one terminal cluster model at every boundary
+
+Keep UAX grapheme segmentation as the base, then join an Indic virama with a
+following consonant for terminal editing and bidi mapping. Use that same model
+for `vtui.Edit`, `MultiLineEdit`, highlighted text, and caret maps. Keep the
+existing deletion-only rule for a final Indic/Thaana mark separate from cursor
+and Shift-selection movement.
+
+This fixes the common cause instead of adding a per-dialog exception. It also
+preserves the existing public cell-width path, while the editing path uses the
+same combined cluster width as `f4`.
+
+### B — rejected: byte/rune-only cursor corrections
+
+Moving the cursor by bytes or individual runes would avoid one observed split,
+but would still disagree with bidi visual order and would break combining
+marks, emoji sequences, and other scripts. It would also leave dialog drawing
+on the old cluster boundaries.
+
+### C — rejected: dialog-size or scrollbar padding hacks
+
+Adding columns or changing a particular dialog's width could hide one
+screenshot artifact, but it would not repair selection, bidi offsets, or other
+dialogs. It would also make layout depend on the specific sample string.
+
+## Three-pass review
+
+### Pass 1 — correctness
+
+The common `vtui` path now preserves the original logical rune positions while
+making Indic conjuncts atomic for editing and bidi. F4's editor keeps the
+terminal-compatible trailing-mark deletion rule only for Backspace; cursor and
+Shift-selection use complete clusters. RTL deletion follows logical text
+direction rather than treating the visual screen edge as an end-of-text no-op.
+
+### Pass 2 — regression and performance
+
+The existing UAX path and its width tests remain unchanged. The extra walk is
+used only for text that already requires full grapheme segmentation, and the
+ASCII fast path is untouched. Tests cover Devanagari, Thaana, mixed bidi text,
+selection, deletion, visual offsets, and rendered-cell preservation.
+
+### Pass 3 — portability
+
+The implementation uses Go Unicode tables and `golang.org/x/text/unicode/bidi`
+only; it does not depend on a particular font, window system, or terminal
+backend. Verification is being performed on Linux ARM64 with XWayland/X11,
+with the native Wayland startup panic tracked separately as an environment
+limitation.
+
+## Verification record
+
+- Focused F4 editor, text-layout, and viewer tests pass.
+- The new F4 mixed-bidi cluster-preservation and Shift-selection tests pass.
+- The new `vtui` terminal-cluster and bidi-map tests pass.
+- A native ARM64 build and X11 smoke test remain required before opening the
+  pull request.

--- a/cmd/f4/editor_grapheme.go
+++ b/cmd/f4/editor_grapheme.go
@@ -160,15 +160,32 @@ func (ev *EditorView) previousGraphemeBoundaryInLine(lineStart, pos int) int {
 			return pos - 1
 		}
 		if clusters[0].start > 0 || start == 0 {
-			last := clusters[len(clusters)-1]
-			if split := textlayout.TrailingModifierStart(last.text); split >= 0 {
-				return start + last.start + split
-			}
-			return start + last.start
+			return start + clusters[len(clusters)-1].start
 		}
 		take *= 2
 		if take > pos {
 			take = pos
 		}
 	}
+}
+
+// previousDeletionBoundaryInLine preserves the editor's established
+// backspace behavior for a trailing Indic virama or Thaana mark. Cursor
+// movement and Shift+Left must use the complete grapheme cluster, however:
+// splitting a modifier there makes a reverse selection start in the middle of
+// the visible symbol (for example, Shift+Left on the final म् selected only
+// the virama). Keep the deletion-only compatibility rule separate.
+func (ev *EditorView) previousDeletionBoundaryInLine(lineStart, pos int) int {
+	boundary := ev.previousGraphemeBoundaryInLine(lineStart, pos)
+	if boundary >= pos {
+		return boundary
+	}
+	data, err := ev.pt.GetRange(lineStart+boundary, pos-boundary)
+	if err != nil || len(data) == 0 {
+		return boundary
+	}
+	if split := textlayout.TrailingModifierStart(string(data)); split >= 0 {
+		return boundary + split
+	}
+	return boundary
 }

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -2272,10 +2272,11 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 					ev.CursorLine--
 					ev.CursorPos = prevLen
 				} else {
-					deleteStart := ev.li.GetLineOffset(ev.CursorLine) + ev.previousGraphemeBoundaryInLine(ev.li.GetLineOffset(ev.CursorLine), ev.CursorPos)
-					if ev.lineUsesVisualBidi() {
-						deleteStart = ev.engine.MoveVisual(offset, -1)
-					}
+					deleteStart := ev.li.GetLineOffset(ev.CursorLine) + ev.previousDeletionBoundaryInLine(ev.li.GetLineOffset(ev.CursorLine), ev.CursorPos)
+					// Backspace deletes the preceding logical text, even when the
+					// line is painted right-to-left. A visual-left move from the
+					// logical end of an RTL line is already at the screen edge and
+					// therefore cannot identify the character Backspace must remove.
 					ev.pt.Delete(deleteStart, offset-deleteStart)
 					ev.li.UpdateAfterDelete(deleteStart, offset-deleteStart)
 					ev.CursorLine = ev.li.GetLineAtOffset(deleteStart)
@@ -2324,13 +2325,12 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 				ev.modified = true
 				deleteEnd := offset + 1
 				if ev.CursorPos < ev.getLineLength(ev.CursorLine) {
-					if ev.lineUsesVisualBidi() {
-						deleteEnd = ev.engine.MoveVisual(offset, 1)
-					} else {
-						lineStart := ev.li.GetLineOffset(ev.CursorLine)
-						next := ev.nextGraphemeBoundaryInLine(lineStart, ev.getLineLength(ev.CursorLine), ev.CursorPos)
-						deleteEnd = lineStart + next
-					}
+					// Delete follows the logical text direction. A visual-right
+					// move from the logical start of an RTL line is already at the
+					// screen edge and would turn this into a no-op.
+					lineStart := ev.li.GetLineOffset(ev.CursorLine)
+					next := ev.nextGraphemeBoundaryInLine(lineStart, ev.getLineLength(ev.CursorLine), ev.CursorPos)
+					deleteEnd = lineStart + next
 				}
 				ev.pt.Delete(offset, deleteEnd-offset)
 				ev.li.UpdateAfterDelete(offset, deleteEnd-offset)

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -898,6 +898,34 @@ func TestEditorMouseOffsetSnapsToClusterBoundary(t *testing.T) {
 	}
 }
 
+func TestEditorShiftLeftKeepsIndicConjunctsAtomic(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	vtui.DefaultBidiMode = vtui.BidiFull
+	t.Cleanup(func() { vtui.DefaultBidiMode = oldMode })
+
+	text := "संस्कृतम्"
+	pt := piecetable.New([]byte(text))
+	ev := NewEditorView(pt, nil, "")
+	defer ev.Close()
+	ev.SetPosition(0, 0, 79, 24)
+	ev.CursorPos = len([]byte(text))
+
+	want := []string{"म्", "तम्", "स्कृतम्", "संस्कृतम्"}
+	for i, expected := range want {
+		ev.ProcessKey(&vtinput.InputEvent{
+			Type:            vtinput.KeyEventType,
+			KeyDown:         true,
+			VirtualKeyCode:  vtinput.VK_LEFT,
+			ControlKeyState: vtinput.ShiftPressed,
+		})
+		min, max := ev.getSelectionRange()
+		got := pt.String()[min:max]
+		if got != expected {
+			t.Fatalf("shift-left %d selected %q, want %q (range %d:%d)", i, got, expected, min, max)
+		}
+	}
+}
+
 func TestEditorView_BracketedPaste(t *testing.T) {
 	pt := piecetable.New([]byte("Start-"))
 	ev := NewEditorView(pt, nil, "")

--- a/cmd/f4/unicode_input_test.go
+++ b/cmd/f4/unicode_input_test.go
@@ -83,3 +83,39 @@ func TestEditorUnicodeInputBackspaceRemovesGraphemeCluster(t *testing.T) {
 		t.Fatalf("second backspace left the combining cluster: %q", got)
 	}
 }
+
+func TestEditorUnicodeInputBackspaceKeepsTerminalModifierRuleInBidiMode(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	vtui.DefaultBidiMode = vtui.BidiFull
+	t.Cleanup(func() { vtui.DefaultBidiMode = oldMode })
+
+	text := "ދިވެހިބަސް"
+	ev := NewEditorView(piecetable.New([]byte(text)), nil, "divehi.txt")
+	defer ev.Close()
+	ev.SetPosition(0, 0, 80, 12)
+	ev.CursorPos = len([]byte(text))
+	ev.SetFocus(true)
+	ev.ProcessKey(unicodeKey(vtinput.VK_BACK, 0))
+	data, _ := ev.pt.Bytes()
+	if got, want := string(data), "ދިވެހިބަސ"; got != want {
+		t.Fatalf("backspace in BidiFull mode = %q, want %q", got, want)
+	}
+}
+
+func TestEditorUnicodeInputDeleteKeepsLogicalDirectionInBidiMode(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	vtui.DefaultBidiMode = vtui.BidiFull
+	t.Cleanup(func() { vtui.DefaultBidiMode = oldMode })
+
+	text := "ދިވެހިބަސް"
+	ev := NewEditorView(piecetable.New([]byte(text)), nil, "divehi.txt")
+	defer ev.Close()
+	ev.SetPosition(0, 0, 80, 12)
+	ev.CursorPos = 0
+	ev.SetFocus(true)
+	ev.ProcessKey(unicodeKey(vtinput.VK_DELETE, 0))
+	data, _ := ev.pt.Bytes()
+	if got, want := string(data), "ވެހިބަސް"; got != want {
+		t.Fatalf("delete in BidiFull mode = %q, want %q", got, want)
+	}
+}

--- a/cmd/f4/viewer_text_test.go
+++ b/cmd/f4/viewer_text_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/unxed/f4/textlayout"
 	"github.com/unxed/vtui"
 )
 
@@ -43,6 +44,26 @@ func TestViewerTextCellsKeepsRTLClustersAndOffsets(t *testing.T) {
 		if offsets[i] != want[i] {
 			t.Fatalf("visual cell %d offset = %d, want %d", i, offsets[i], want[i])
 		}
+	}
+}
+
+func TestViewerTextCellsKeepsIndicClustersInsideBidiParagraph(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	t.Cleanup(func() { vtui.DefaultBidiMode = oldMode })
+	vtui.DefaultBidiMode = vtui.BidiFull
+
+	text := "संस्कृतम् ދިވެހިބަސް"
+	clusters := textlayout.VisualClustersInVisualOrder(text)
+	cells, offsets := viewerTextCells(text, 0, 8, 100)
+	if len(cells) != len(clusters) || len(offsets) != len(clusters) {
+		t.Fatalf("rendered %d cells/%d offsets for %d clusters", len(cells), len(offsets), len(clusters))
+	}
+	seen := make(map[int]bool, len(offsets))
+	for _, offset := range offsets {
+		seen[offset] = true
+	}
+	if len(seen) != len(clusters) {
+		t.Fatalf("rendered offsets covered %d clusters, want %d", len(seen), len(clusters))
 	}
 }
 

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/unxed/f4/piecetable"
 	"github.com/unxed/vtui"
+	"golang.org/x/text/unicode/bidi"
 )
 
 // LineFragment описывает один визуальный кусок логической строки после свертки.
@@ -102,27 +103,56 @@ func visualClusters(text string) []visualCluster {
 		return logical
 	}
 
-	byLogical := make(map[int]visualCluster, len(logical))
-	for _, cluster := range logical {
-		byLogical[cluster.logicalPos] = cluster
-	}
-	visualText, logicalPositions := vtui.VisualStringWithRuneMap(text)
 	visual := make([]visualCluster, 0, len(logical))
-	index := 0
-	vtui.ForEachClusterAt(visualText, func(cluster string, width, _, _ int) {
-		if index >= len(logicalPositions) {
-			return
+
+	// vtui.VisualStringWithRuneMap performs bidi reordering over the UAX #29
+	// clusters supplied by uniseg. VisualClusters deliberately has one extra
+	// terminal-facing rule for Indic conjuncts (for example, it joins the
+	// virama in स् to the following क), so consuming vtui's reordered string
+	// here loses or duplicates clusters when the two segmentations differ.
+	// Reorder the already-normalized clusters directly instead. This keeps the
+	// byte/rune boundaries used by wrapping, painting, hit testing, and caret
+	// movement identical.
+	p := bidi.Paragraph{}
+	if _, err := p.SetString(text); err != nil {
+		return logical
+	}
+	order, err := p.Order()
+	if err != nil {
+		return logical
+	}
+
+	for runIndex := 0; runIndex < order.NumRuns(); runIndex++ {
+		run := order.Run(runIndex)
+		start, end := run.Pos()
+		runClusters := make([]visualCluster, 0, len(logical))
+		for _, cluster := range logical {
+			if cluster.logicalPos >= start && cluster.logicalPos <= end {
+				runClusters = append(runClusters, cluster)
+			}
 		}
-		original, ok := byLogical[logicalPositions[index]]
-		if !ok {
-			index++
-			return
+		if len(runClusters) == 0 {
+			continue
 		}
-		original.text = cluster
-		original.width = width
-		visual = append(visual, original)
-		index++
-	})
+
+		if run.Direction() == bidi.RightToLeft {
+			for i, j := 0, len(runClusters)-1; i < j; i, j = i+1, j-1 {
+				runClusters[i], runClusters[j] = runClusters[j], runClusters[i]
+			}
+			for i := range runClusters {
+				if utf8.RuneCountInString(runClusters[i].text) == 1 {
+					runClusters[i].text = bidi.ReverseString(runClusters[i].text)
+				}
+			}
+		}
+		visual = append(visual, runClusters...)
+	}
+	if len(visual) != len(logical) {
+		// A bidi implementation must not make a text cluster disappear. Keep
+		// the safe logical layout if a future Unicode table creates a run
+		// boundary inside one of our extended clusters.
+		return logical
+	}
 	return visual
 }
 
@@ -154,6 +184,92 @@ func byteOffsetAtRune(text string, runeIndex int) int {
 	return len(string([]rune(text)[:runeIndex]))
 }
 
+// visualCaretMap is the caret equivalent of visualClusters. vtui's public
+// caret map is based on its UAX #29 clusters, while f4 extends those
+// boundaries for terminal-shaped Indic conjuncts; using the two maps
+// together lets a caret land at a different logical boundary than the one
+// that was painted.
+type visualCaretMap struct {
+	VisualToLogical []int
+	LogicalToVisual []int
+}
+
+func buildVisualCaretMap(text string) visualCaretMap {
+	logical := logicalTextClusters(text)
+	n := len(logical)
+	identity := func() visualCaretMap {
+		visualToLogical := make([]int, n+1)
+		logicalToVisual := make([]int, n+1)
+		for i := 0; i <= n; i++ {
+			visualToLogical[i] = i
+			logicalToVisual[i] = i
+		}
+		return visualCaretMap{VisualToLogical: visualToLogical, LogicalToVisual: logicalToVisual}
+	}
+	if vtui.DefaultBidiMode != vtui.BidiFull || !vtui.HasRTL(text) || n == 0 {
+		return identity()
+	}
+
+	p := bidi.Paragraph{}
+	if _, err := p.SetString(text); err != nil {
+		return identity()
+	}
+	order, err := p.Order()
+	if err != nil {
+		return identity()
+	}
+
+	logicalToVisual := make([]int, n+1)
+	visualClusterIndex := 0
+	for runIndex := 0; runIndex < order.NumRuns(); runIndex++ {
+		run := order.Run(runIndex)
+		start, end := run.Pos()
+		runIndices := make([]int, 0, n)
+		for logicalIndex, cluster := range logical {
+			if cluster.logicalPos >= start && cluster.logicalPos <= end {
+				runIndices = append(runIndices, logicalIndex)
+			}
+		}
+		if len(runIndices) == 0 {
+			continue
+		}
+		runEnd := runIndices[len(runIndices)-1]
+		if run.Direction() == bidi.RightToLeft {
+			for i, logicalIndex := range runIndices {
+				logicalToVisual[logicalIndex] = visualClusterIndex + len(runIndices) - i
+			}
+			logicalToVisual[runEnd+1] = visualClusterIndex
+		} else {
+			for i, logicalIndex := range runIndices {
+				logicalToVisual[logicalIndex] = visualClusterIndex + i
+			}
+			logicalToVisual[runEnd+1] = visualClusterIndex + len(runIndices)
+		}
+		visualClusterIndex += len(runIndices)
+	}
+	if visualClusterIndex != n {
+		return identity()
+	}
+
+	visualToLogical := make([]int, n+1)
+	for logicalIndex, visualIndex := range logicalToVisual {
+		if visualIndex < 0 || visualIndex > n {
+			return identity()
+		}
+		visualToLogical[visualIndex] = logicalIndex
+	}
+	return visualCaretMap{VisualToLogical: visualToLogical, LogicalToVisual: logicalToVisual}
+}
+
+func logicalClusterIndexAtByte(clusters []visualCluster, byteOffset int) int {
+	for index, cluster := range clusters {
+		if byteOffset <= cluster.byteStart || byteOffset < cluster.byteEnd {
+			return index
+		}
+	}
+	return len(clusters)
+}
+
 func visualClusterWidths(clusters []visualCluster, tabSize int) []int {
 	if tabSize <= 0 {
 		tabSize = 8
@@ -181,20 +297,13 @@ func fragmentLogicalToVisual(text string, byteOffset, tabSize int) int {
 	if byteOffset > len(text) {
 		byteOffset = len(text)
 	}
-	runeIndex := utf8.RuneCountInString(text[:byteOffset])
-	logical := logicalTextClusters(text)
 	clusters := visualClusters(text)
 	visualPos := 0
 	if vtui.DefaultBidiMode == vtui.BidiFull && vtui.HasRTL(text) {
-		for _, cluster := range logical {
-			if byteOffset < cluster.byteEnd {
-				runeIndex = cluster.logicalPos
-				break
-			}
-		}
-		caret := vtui.BuildCaretMap(text)
-		if runeIndex < len(caret.LogicalToVisual) {
-			visualPos = caret.LogicalToVisual[runeIndex]
+		logicalIndex := logicalClusterIndexAtByte(logicalTextClusters(text), byteOffset)
+		caret := buildVisualCaretMap(text)
+		if logicalIndex < len(caret.LogicalToVisual) {
+			visualPos = caret.LogicalToVisual[logicalIndex]
 		}
 	} else {
 		for _, cluster := range clusters {
@@ -226,20 +335,22 @@ func fragmentVisualToLogical(text string, visualCol, tabSize int) int {
 			visualPos++
 		}
 	}
-	runeIndex := 0
 	if vtui.DefaultBidiMode == vtui.BidiFull && vtui.HasRTL(text) {
-		caret := vtui.BuildCaretMap(text)
+		logical := logicalTextClusters(text)
+		caret := buildVisualCaretMap(text)
+		logicalIndex := len(logical)
 		if visualPos < len(caret.VisualToLogical) {
-			runeIndex = caret.VisualToLogical[visualPos]
-		} else {
-			runeIndex = utf8.RuneCountInString(text)
+			logicalIndex = caret.VisualToLogical[visualPos]
 		}
+		if logicalIndex < len(logical) {
+			return logical[logicalIndex].byteStart
+		}
+		return len(text)
 	} else if visualPos < len(clusters) {
-		runeIndex = clusters[visualPos].logicalPos
+		return clusters[visualPos].byteStart
 	} else {
-		runeIndex = utf8.RuneCountInString(text)
+		return len(text)
 	}
-	return byteOffsetAtRune(text, runeIndex)
 }
 
 func fragmentVisualMove(text string, byteOffset, direction int) (int, bool) {
@@ -247,18 +358,12 @@ func fragmentVisualMove(text string, byteOffset, direction int) (int, bool) {
 	if len(clusters) == 0 {
 		return byteOffset, false
 	}
-	runeIndex := utf8.RuneCountInString(text[:byteOffset])
 	visualPos := 0
 	if vtui.DefaultBidiMode == vtui.BidiFull && vtui.HasRTL(text) {
-		for _, cluster := range logicalTextClusters(text) {
-			if byteOffset < cluster.byteEnd {
-				runeIndex = cluster.logicalPos
-				break
-			}
-		}
-		caret := vtui.BuildCaretMap(text)
-		if runeIndex < len(caret.LogicalToVisual) {
-			visualPos = caret.LogicalToVisual[runeIndex]
+		logicalIndex := logicalClusterIndexAtByte(logicalTextClusters(text), byteOffset)
+		caret := buildVisualCaretMap(text)
+		if logicalIndex < len(caret.LogicalToVisual) {
+			visualPos = caret.LogicalToVisual[logicalIndex]
 		}
 	} else {
 		for _, cluster := range clusters {
@@ -273,18 +378,21 @@ func fragmentVisualMove(text string, byteOffset, direction int) (int, bool) {
 		return byteOffset, false
 	}
 	if vtui.DefaultBidiMode == vtui.BidiFull && vtui.HasRTL(text) {
-		caret := vtui.BuildCaretMap(text)
+		logical := logicalTextClusters(text)
+		caret := buildVisualCaretMap(text)
+		logicalIndex := len(logical)
 		if target < len(caret.VisualToLogical) {
-			runeIndex = caret.VisualToLogical[target]
-		} else {
-			runeIndex = utf8.RuneCountInString(text)
+			logicalIndex = caret.VisualToLogical[target]
 		}
+		if logicalIndex < len(logical) {
+			return logical[logicalIndex].byteStart, true
+		}
+		return len(text), true
 	} else if target < len(clusters) {
-		runeIndex = clusters[target].logicalPos
+		return clusters[target].byteStart, true
 	} else {
-		runeIndex = utf8.RuneCountInString(text)
+		return len(text), true
 	}
-	return byteOffsetAtRune(text, runeIndex), true
 }
 
 // MoveVisual moves one grapheme cluster in the direction shown on screen.

--- a/textlayout/wrap_test.go
+++ b/textlayout/wrap_test.go
@@ -578,6 +578,37 @@ func TestWrapEngine_BoundarySafety(t *testing.T) {
 		}
 	})
 }
+
+func TestVisualClustersInVisualOrderPreservesTerminalClustersInBidiParagraph(t *testing.T) {
+	oldMode := vtui.DefaultBidiMode
+	vtui.DefaultBidiMode = vtui.BidiFull
+	defer func() { vtui.DefaultBidiMode = oldMode }()
+
+	text := "संस्कृतम् ދިވެހިބަސް"
+	logical := VisualClusters(text)
+	visual := VisualClustersInVisualOrder(text)
+	if len(visual) != len(logical) {
+		t.Fatalf("visual cluster count = %d, want %d", len(visual), len(logical))
+	}
+
+	wantStarts := make(map[int]bool, len(logical))
+	for _, cluster := range logical {
+		wantStarts[cluster.Start] = true
+	}
+	seen := make(map[int]bool, len(visual))
+	for _, cluster := range visual {
+		if !wantStarts[cluster.Start] {
+			t.Fatalf("visual cluster starts at unexpected byte %d", cluster.Start)
+		}
+		if seen[cluster.Start] {
+			t.Fatalf("visual cluster start %d was emitted twice", cluster.Start)
+		}
+		seen[cluster.Start] = true
+	}
+	if len(seen) != len(wantStarts) {
+		t.Fatalf("visual clusters covered %d logical starts, want %d", len(seen), len(wantStarts))
+	}
+}
 func TestWrapEngine_LogicalToVisual_CappedLine(t *testing.T) {
 	// Tests safety when a logical line is massive (binary) and indexing is capped at 64KB.
 	// Create 100KB of data with NO newlines.


### PR DESCRIPTION
## Summary

Follow-up for #546.

- keep Indic conjuncts atomic for cursor movement and Shift+Left selection
- preserve the established terminal-only trailing-mark Backspace behavior
- make Delete and Backspace follow logical text direction in `BidiFull`
- reorder F4's already-normalized clusters directly so mixed Indic/RTL lines keep every cluster and byte boundary
- add regression tests for Sanskrit, Thaana, mixed bidi layout, selection, deletion, and viewer cells
- document the three-pass solution review in `ISSUE_546_FOLLOWUP_SOLUTION_REVIEW.md`

The shared dialog/input widget fix is in [vtui#87](https://github.com/unxed/vtui/pull/87), which updates `Edit`, `MultiLineEdit`, highlighting, and bidi maps to use the same terminal cluster boundaries.

## Verification

- `GOTMPDIR=/home/zoin/.cache/f4-546-go-tmp GOMAXPROCS=2 go test -p 1 ./textlayout ./cmd/f4`
- `GOTMPDIR=/home/zoin/.cache/f4-546-go-tmp GOMAXPROCS=2 go vet ./textlayout ./cmd/f4`
- native Linux ARM64 build completed
- X11 opened the supplied `F4_Unicode_Bugs.txt` in the editor and the captured frame stayed aligned
- ANSI PTY exercised Find invocation, Unicode input, Backspace, and cleanup; automated F10 did not close under this PTY harness

The Wayland backend remains unavailable for device verification on this host because the current upstream startup path panics before rendering.
