### PR TITLE
Fix Windows console resize input loss

### DIFF
--- a/ISSUE_397_SOLUTION_REVIEW.md
+++ b/ISSUE_397_SOLUTION_REVIEW.md
@@ -1,0 +1,48 @@
+# Issue 397 solution review
+
+The reporter still reproduced the crash from a Windows shortcut with a
+non-default console buffer/window layout. The attached logs show
+`ReadEvent error: No process is on the other end of the pipe`, followed by an
+80x25 fallback. In the current `vtinput v0.1.4`, that read error closes the
+event channel immediately; the f4 event loop then loses its input source while
+the console host is still applying the resize.
+
+## Three-pass comparison
+
+### Pass 1: ignore the error or change f4's resize handling
+
+This does not address the ownership of the event channel. `vtinput` still
+terminates its reader goroutine on the transient pipe error, so f4 can still
+leave its main loop. Rejected.
+
+### Pass 2: add a retry wrapper inside f4
+
+The failing read and event-channel lifecycle are private to `vtinput`; f4
+cannot reliably retry it without duplicating console-reader logic. This would
+also leave other `vtinput` consumers exposed to the same resize race. Rejected.
+
+### Pass 3: recover in vtinput and pin f4 to the reviewed revision
+
+The fix belongs in `vtinput`: classify only
+`ERROR_PIPE_NOT_CONNECTED` as transient on Windows, retry with a bounded delay,
+reset the retry counter after a successful read, and stop promptly when the
+reader closes. The Windows regression tests cover the error classification and
+event-channel recovery. Until the upstream PR is merged, f4 pins the upstream
+module path to the immutable `Zoinen/vtinput` commit containing that fix.
+This is the selected solution.
+
+## Safety review
+
+The retry is limited to the resize-specific Windows error; broken pipes and
+operation-aborted errors remain terminal. The retry count is bounded, the
+reader's close signal interrupts the delay, and successful reads clear the
+counter. The change therefore preserves shutdown behavior while preventing a
+single transient resize disconnect from ending f4's event stream.
+
+## Validation plan
+
+1. Run the related `vtinput` Windows tests from the PR revision.
+2. Run f4's full test suite and vet on Windows.
+3. Build a native Windows binary and repeat launches with the reported fixed
+   buffer/window layout and resize-related settings, checking that the process
+   stays alive and the event stream continues.

--- a/go.mod
+++ b/go.mod
@@ -180,4 +180,9 @@ replace github.com/ebitengine/hideconsole => ./internal/hideconsole
 
 // replace github.com/unxed/vtui => ../../../dev/vtui
 
+// Keep the upstream module path while the Windows console resize recovery is
+// reviewed upstream. This immutable fork revision contains the fix for the
+// transient ERROR_PIPE_NOT_CONNECTED input error.
+replace github.com/unxed/vtinput => github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f
+
 replace github.com/go-webgpu/goffi => github.com/unxed/goffi v0.1.4

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
+github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f h1:NcVygNwHXcVQUymsh6uvBXclEKFbPXHacQqlNXXGtOU=
+github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f/go.mod h1:ZOqbBmEzYb33FrwsJf0y1QSJLo378ciXEgZWD4cTqGU=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/akalin/gopar v0.0.0-20210524065929-a776223763d3 h1:riZbpH66GmEJzxox72D09gKw8YQ0DE5+GAYEtnGP1PM=


### PR DESCRIPTION
## Summary

Follow up on issue #397, where f4 launched from a shortcut with a custom Windows console buffer/window layout could disappear while the console host was resizing.

The supplied logs show ReadEvent error: No process is on the other end of the pipe followed by an 80x25 fallback. Current f4 was back on vtinput v0.1.4, which closes the input event channel on that transient ERROR_PIPE_NOT_CONNECTED error. This PR pins the upstream module path to immutable github.com/Zoinen/vtinput commit c39a9ab8, where the retry and Windows regression tests are implemented in vtinput PR #6.

The three-pass analysis is in ISSUE_397_SOLUTION_REVIEW.md.

## Validation

- go test ./... -count=1 in f4 on Windows x64
- go vet -unsafeptr=false ./... on Windows x64
- go test ./... -count=1 in vtinput PR #6 on Windows x64
- native Windows x64 builds and four attached runs at 150x50, 150x115/150x150 requested, and 120x30; all stayed responsive and exited cleanly
- native logs had no panic/fatal output or transient pipe error; only EOF during normal shutdown

Related upstream dependency PR: https://github.com/unxed/vtinput/pull/6

Fixes #397