### PR TITLE
Fix gzip regular-file names in archive VFS

### DIFF
--- a/ISSUE_523_SOLUTION_REVIEW.md
+++ b/ISSUE_523_SOLUTION_REVIEW.md
@@ -1,0 +1,41 @@
+# Issue #523 follow-up solution review
+
+## Reproduction
+
+The maintainer-provided `history.log.1.gz` is a valid gzip stream. Its
+decompressed payload is 24,226 bytes and contains one apt history log.
+
+On the current f4/upstream dependency chain, the stream opens and reads
+successfully, but the root listing reports the physical name
+`history.log.1.gz` and the compressed size. The expected Far2l behavior is a
+single logical regular file named `history.log.1`, with the decompressed size
+and contents.
+
+## Three-pass comparison
+
+1. **Fix f4's archive VFS or special-case `.gz`.** Rejected. This would make
+   f4 compensate for metadata supplied by its dependency and would not fix
+   other consumers of `archives.FileSystem`.
+
+2. **Fix `zipper`'s fallback adapter.** Rejected. `zipper` delegates format
+   detection and the single-file filesystem to `unxed/archives`; adding a
+   presentation-only rename there would duplicate the responsible layer's
+   behavior.
+
+3. **Fix `archives.FileFS` for compressed regular files.** Selected. The
+   library already transparently decompresses reads, so `FileFS` should expose
+   the same logical view through `ReadDir`, `Stat`, and `Open`: strip the
+   compression suffix, accept the logical name, and report the decompressed
+   size. The physical basename remains accepted for compatibility.
+
+## Safety review
+
+The change is limited to the `FileSystem` branch that identifies a compressed
+regular file. Archive members and ordinary uncompressed files retain their
+existing behavior. Reads remain streaming and read-only. Metadata calculation
+counts the decompressed stream and propagates decoder errors instead of
+silently hiding corrupt input.
+
+Validation includes the generic gzip regression test and the exact attached
+`history.log.1.gz` sample: one entry named `history.log.1`, size 24,226 bytes,
+and a successful full read of the decompressed payload.

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,9 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
+// The upstream archives fix is under review in unxed/archives#1.
+replace github.com/unxed/archives => github.com/Zoinen/archives v0.0.0-20260823102249-509798dabcdc
+
 require (
 	cloud.google.com/go/auth v0.18.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/STARRY-S/zip v0.2.3 h1:luE4dMvRPDOWQdeDdUxUoZkzUIpTccdKdhHHsQJ1fm4=
 github.com/STARRY-S/zip v0.2.3/go.mod h1:lqJ9JdeRipyOQJrYSOtpNAiaesFO6zVDsE8GIGFaoSk=
 github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f h1:NcVygNwHXcVQUymsh6uvBXclEKFbPXHacQqlNXXGtOU=
 github.com/Zoinen/vtinput v0.1.5-0.20260822031659-c39a9ab8b09f/go.mod h1:ZOqbBmEzYb33FrwsJf0y1QSJLo378ciXEgZWD4cTqGU=
+github.com/Zoinen/archives v0.0.0-20260823102249-509798dabcdc h1:v5Ht9zBeAiqdUxyMq77CUcV0BAb/6XcFVgbL5HB8GEA=
+github.com/Zoinen/archives v0.0.0-20260823102249-509798dabcdc/go.mod h1:FzBQeo7yhgjwXvC2P02CDEy8D6yefSfQTkoATypr0Rk=
 github.com/abadojack/whatlanggo v1.0.1 h1:19N6YogDnf71CTHm3Mp2qhYfkRdyvbgwWdd2EPxJRG4=
 github.com/abadojack/whatlanggo v1.0.1/go.mod h1:66WiQbSbJBIlOZMsvbKe5m6pzQovxCH9B/K8tQB2uoc=
 github.com/akalin/gopar v0.0.0-20210524065929-a776223763d3 h1:riZbpH66GmEJzxox72D09gKw8YQ0DE5+GAYEtnGP1PM=
@@ -246,8 +248,6 @@ github.com/tetratelabs/wazero v1.12.0/go.mod h1:LvKtzl2RqO4gyF27BiXU+nKAjcV8f38U
 github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
-github.com/unxed/archives v0.0.0-20260822080017-884f4426de54 h1:0503Jbm4S/B0d+PhIvJJiJoAuCWtisio24vAMT8kalw=
-github.com/unxed/archives v0.0.0-20260822080017-884f4426de54/go.mod h1:FzBQeo7yhgjwXvC2P02CDEy8D6yefSfQTkoATypr0Rk=
 github.com/unxed/colorer4go v0.1.14 h1:7M+LXUwolR5zs+OgXSjSq29Wa1dGgmYHV8BywTN+Qs8=
 github.com/unxed/colorer4go v0.1.14/go.mod h1:3H2jIU3HsmlT7ChlpX+rnYrF2JM22ekgy/eyIBa7Cdo=
 github.com/unxed/ffibridge v0.1.2 h1:ej+L9MWIL6PIbW8dCagb4dv5IddaL5KN0F38ZBf/slc=

--- a/plugins/archive/compressed_regular_test.go
+++ b/plugins/archive/compressed_regular_test.go
@@ -1,0 +1,81 @@
+package archive
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestArchiveVFSCompressedRegularFileUsesLogicalEntry(t *testing.T) {
+	payload := bytes.Repeat([]byte("Start-Date: 2026-08-23  10:00:00\n"), 500)
+	root := t.TempDir()
+	filename := filepath.Join(root, "history.log.1.gz")
+
+	file, err := os.Create(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer := gzip.NewWriter(file)
+	if _, err := writer.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	archiveVFS, err := NewArchiveVFS(vfs.NewOSVFS(root), filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = archiveVFS.Close() })
+
+	var items []vfs.VFSItem
+	if err := archiveVFS.ReadDir(context.Background(), archiveVFS.GetPath(), func(chunk []vfs.VFSItem) {
+		items = append(items, chunk...)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("ReadDir returned %d entries, want one", len(items))
+	}
+	if items[0].Name != "history.log.1" {
+		t.Fatalf("entry name = %q, want history.log.1", items[0].Name)
+	}
+	if items[0].Size != int64(len(payload)) {
+		t.Fatalf("entry size = %d, want decompressed size %d", items[0].Size, len(payload))
+	}
+
+	opened, err := archiveVFS.Open(context.Background(), archiveVFS.Join(archiveVFS.GetPath(), items[0].Name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got bytes.Buffer
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := opened.Read(context.Background(), buf)
+		if n > 0 {
+			_, _ = got.Write(buf[:n])
+		}
+		if readErr != nil {
+			if readErr != io.EOF {
+				t.Fatal(readErr)
+			}
+			break
+		}
+	}
+	if err := opened.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got.Bytes(), payload) {
+		t.Fatalf("decompressed payload mismatch: got %d bytes, want %d", got.Len(), len(payload))
+	}
+}


### PR DESCRIPTION
Fixes #523. The maintainer-supplied history.log.1.gz is a valid single gzip-compressed regular file. The responsible behavior belongs in unxed/archives: FileFS now exposes the decompressed logical entry history.log.1 and its decompressed size; this f4 PR pins that immutable fix and adds a real ArchiveVFS regression test.

Validation on Windows 10 x64:
- go test ./... -count=1
- go vet -unsafeptr=false ./...
- native Win32 build
- real UI run with the attached sample: f4 listed one history.log.1 entry at 24,226 bytes and F3 opened the decompressed apt log successfully

Dependency PR: unxed/archives#1. GitHub Actions are currently queued; no queued check is claimed as passed.