### PR TITLE
lint: remove two functions nothing calls

### DIFF
--- a/internal/ttyx/watch.go
+++ b/internal/ttyx/watch.go
@@ -190,12 +190,6 @@ func (s *Session) Alive() bool {
 	return s.alive && s.conn != nil
 }
 
-func (s *Session) registerOverlay(o *Overlay) {
-	s.mu.Lock()
-	s.overlays = append(s.overlays, o)
-	s.mu.Unlock()
-}
-
 func (s *Session) unregisterOverlay(o *Overlay) {
 	s.mu.Lock()
 	kept := s.overlays[:0]

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -174,16 +174,6 @@ func VisualClustersInVisualOrder(text string) []VisualCluster {
 	return result
 }
 
-func byteOffsetAtRune(text string, runeIndex int) int {
-	if runeIndex <= 0 {
-		return 0
-	}
-	if runeIndex >= utf8.RuneCountInString(text) {
-		return len(text)
-	}
-	return len(string([]rune(text)[:runeIndex]))
-}
-
 // visualCaretMap is the caret equivalent of visualClusters. vtui's public
 // caret map is based on its UAX #29 clusters, while f4 extends those
 // boundaries for terminal-shaped Indic conjuncts; using the two maps


### PR DESCRIPTION
Строгий линтер на main красный из-за двух неиспользуемых функций. Обе — остатки, пропавших вызовов нет.

**`registerOverlay`** (`internal/ttyx/watch.go`) — добавляет наложение в список сессии. Рядом, в `NewOverlay`, то же самое уже делается напрямую и **под уже взятым замком**, так что вызов этой функции оттуда дал бы взаимоблокировку. Её не просто не вызывали — её нельзя было вызвать.

Это ещё и ловушка: называется «зарегистрировать наложение», выглядит ровно как то, что надо вызвать, и следующий, кто её найдёт, повесит программу.

**`byteOffsetAtRune`** (`textlayout/wrap.go`) — переводит номер символа в номер байта. Работала и использовалась, пока переделка под индийские письменности и двунаправленный текст не перевела всё на смещения по кластерам. Вызовы заменили, функцию убрать забыли.

Минус 16 строк.
