### PR TITLE
lint: decide what the vfs layer does when a call fails, and fix three that mattered

### DIFF
--- a/vfs/device_size_test.go
+++ b/vfs/device_size_test.go
@@ -1,0 +1,29 @@
+package vfs
+
+import (
+	"errors"
+	"io"
+	"testing"
+)
+
+type resetFailingSeeker struct {
+	resetErr error
+}
+
+func (s resetFailingSeeker) Seek(_ int64, whence int) (int64, error) {
+	if whence == io.SeekEnd {
+		return 4096, nil
+	}
+	return 0, s.resetErr
+}
+
+func TestProbeSeekSizePropagatesResetFailure(t *testing.T) {
+	wantErr := errors.New("reset failed")
+	size, found, err := probeSeekSize(resetFailingSeeker{resetErr: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("probeSeekSize error = %v, want %v", err, wantErr)
+	}
+	if size != 0 || found {
+		t.Fatalf("probeSeekSize = (%d, %v), want (0, false) on reset failure", size, found)
+	}
+}

--- a/vfs/disks_unix.go
+++ b/vfs/disks_unix.go
@@ -4,13 +4,21 @@ package vfs
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
 )
+
+func parseSysfsBlockSize(data []byte) (int64, bool) {
+	sectors, err := strconv.ParseInt(strings.TrimSpace(string(data)), 10, 64)
+	if err != nil || sectors <= 0 || sectors > int64(1<<63-1)/512 {
+		return 0, false
+	}
+	return sectors * 512, true
+}
 
 func resolveDevicePath(name string) string {
 	if !strings.HasPrefix(name, "/dev/") {
@@ -36,12 +44,10 @@ func getPlatformBlockDevices(ctx context.Context) []VFSItem {
 			if err != nil {
 				continue
 			}
-			var sectors int64
-			fmt.Sscanf(strings.TrimSpace(string(sizeData)), "%d", &sectors)
-			if sectors <= 0 {
+			size, ok := parseSysfsBlockSize(sizeData)
+			if !ok {
 				continue
 			}
-			size := sectors * 512
 
 			displayName := name
 			if dmName, err := os.ReadFile("/sys/class/block/" + name + "/dm/name"); err == nil {
@@ -76,9 +82,13 @@ func getPlatformBlockDevices(ctx context.Context) []VFSItem {
 			// can block forever (macOS tty.* waits for carrier, and every
 			// Mac ships /dev/tty.Bluetooth-Incoming-Port).
 			if err == nil && info.Mode()&os.ModeDevice != 0 && info.Mode()&os.ModeCharDevice == 0 {
+				size, sizeErr := getDeviceSize("/dev/"+e.Name(), nil)
+				if sizeErr != nil {
+					continue
+				}
 				items = append(items, VFSItem{
 					Name:      e.Name(),
-					Size:      getDeviceSize("/dev/"+e.Name(), nil),
+					Size:      size,
 					SizeKnown: true,
 					MTime:     info.ModTime(),
 				})
@@ -88,21 +98,20 @@ func getPlatformBlockDevices(ctx context.Context) []VFSItem {
 	return items
 }
 
-func getDeviceSize(devPath string, f *os.File) int64 {
+func getDeviceSize(devPath string, f *os.File) (int64, error) {
 	if f != nil {
-		if pos, err := f.Seek(0, io.SeekEnd); err == nil && pos > 0 {
-			f.Seek(0, io.SeekStart)
-			return pos
+		if size, found, err := probeSeekSize(f); err != nil {
+			return 0, err
+		} else if found {
+			return size, nil
 		}
 	}
 	// Try sysfs lookup if devPath is /dev/xxx
 	sysName := strings.TrimPrefix(devPath, "/dev/")
 	sysName = strings.TrimPrefix(sysName, "mapper/")
 	if sizeData, err := os.ReadFile("/sys/class/block/" + sysName + "/size"); err == nil {
-		var sectors int64
-		fmt.Sscanf(strings.TrimSpace(string(sizeData)), "%d", &sectors)
-		if sectors > 0 {
-			return sectors * 512
+		if size, ok := parseSysfsBlockSize(sizeData); ok {
+			return size, nil
 		}
 	}
 	// Direct open seek fallback
@@ -110,11 +119,13 @@ func getDeviceSize(devPath string, f *os.File) int64 {
 		// O_NONBLOCK: never wait for a device to become ready just to
 		// measure it; a probe must not hang on carrier or DTR.
 		if localF, err := os.OpenFile(devPath, os.O_RDONLY|syscall.O_NONBLOCK, 0); err == nil {
-			defer localF.Close()
+			defer func() {
+				_ = localF.Close() // The probe handle is read-only.
+			}()
 			if pos, err := localF.Seek(0, io.SeekEnd); err == nil && pos > 0 {
-				return pos
+				return pos, nil
 			}
 		}
 	}
-	return 0
+	return 0, nil
 }

--- a/vfs/disks_unix_test.go
+++ b/vfs/disks_unix_test.go
@@ -1,0 +1,32 @@
+//go:build !windows
+
+package vfs
+
+import "testing"
+
+func TestParseSysfsBlockSize(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+		want int64
+		ok   bool
+	}{
+		{name: "valid", data: "8\n", want: 4096, ok: true},
+		{name: "surrounding whitespace", data: " \t8\r\n", want: 4096, ok: true},
+		{name: "empty", data: "\n"},
+		{name: "non-numeric", data: "unknown\n"},
+		{name: "numeric prefix", data: "8 sectors\n"},
+		{name: "zero", data: "0\n"},
+		{name: "negative", data: "-1\n"},
+		{name: "overflowing bytes", data: "18014398509481984\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseSysfsBlockSize([]byte(tt.data))
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("parseSysfsBlockSize(%q) = (%d, %v), want (%d, %v)", tt.data, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}

--- a/vfs/disks_vfs.go
+++ b/vfs/disks_vfs.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +13,17 @@ import (
 type diskFileWrapper struct {
 	*os.File
 	size int64
+}
+
+func probeSeekSize(f io.Seeker) (size int64, found bool, err error) {
+	pos, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return 0, false, nil
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return 0, false, fmt.Errorf("restore device offset after size probe: %w", err)
+	}
+	return pos, pos > 0, nil
 }
 
 func (f *diskFileWrapper) Size() int64 { return f.size }
@@ -72,7 +84,10 @@ func (v *DisksVFS) ReadDir(ctx context.Context, path string, onChunk func([]VFSI
 func (v *DisksVFS) Stat(ctx context.Context, path string) (VFSItem, error) {
 	name := v.Base(path)
 	devPath := resolveDevicePath(name)
-	size := getDeviceSize(devPath, nil)
+	size, err := getDeviceSize(devPath, nil)
+	if err != nil {
+		return VFSItem{}, err
+	}
 	return VFSItem{Name: name, Size: size, SizeKnown: true, MTime: time.Now()}, nil
 }
 
@@ -88,12 +103,20 @@ func (v *DisksVFS) Open(ctx context.Context, path string) (ReadAtCloser, error) 
 	if err != nil && os.IsPermission(err) && globalSudoClient.IsAvailable() {
 		sudoF, sudoErr := globalSudoClient.Open(prepareOSPath(devPath), os.O_RDWR, 0)
 		if sudoErr == nil {
-			size := getDeviceSize(devPath, sudoF)
+			size, sizeErr := getDeviceSize(devPath, sudoF)
+			if sizeErr != nil {
+				_ = sudoF.Close() // The handle cannot be returned at the wrong offset.
+				return nil, sizeErr
+			}
 			return &diskFileWrapper{File: sudoF, size: size}, nil
 		}
 		sudoF, sudoErr = globalSudoClient.Open(prepareOSPath(devPath), os.O_RDONLY, 0)
 		if sudoErr == nil {
-			size := getDeviceSize(devPath, sudoF)
+			size, sizeErr := getDeviceSize(devPath, sudoF)
+			if sizeErr != nil {
+				_ = sudoF.Close() // The handle cannot be returned at the wrong offset.
+				return nil, sizeErr
+			}
 			return &diskFileWrapper{File: sudoF, size: size}, nil
 		}
 		return nil, sudoErr
@@ -103,11 +126,15 @@ func (v *DisksVFS) Open(ctx context.Context, path string) (ReadAtCloser, error) 
 		return nil, err
 	}
 
-	size := getDeviceSize(devPath, f)
+	size, sizeErr := getDeviceSize(devPath, f)
+	if sizeErr != nil {
+		_ = f.Close() // The handle cannot be returned at the wrong offset.
+		return nil, sizeErr
+	}
 	return &diskFileWrapper{File: f, size: size}, nil
 }
 
-func (v *DisksVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) error {
+func (v *DisksVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) (returnErr error) {
 	// A raw disk cannot grow or shift, so a patch that would move the pieces
 	// after it has to be refused before anything is written over the device.
 	if err := ValidateInPlacePieces(pieces); err != nil {
@@ -126,7 +153,9 @@ func (v *DisksVFS) PatchInPlace(ctx context.Context, path string, pieces []Patch
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		returnErr = errors.Join(returnErr, f.Close())
+	}()
 
 	var newOffset int64 = 0
 	for _, p := range pieces {

--- a/vfs/disks_windows.go
+++ b/vfs/disks_windows.go
@@ -5,7 +5,6 @@ package vfs
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"time"
@@ -53,26 +52,27 @@ func getPlatformBlockDevices(ctx context.Context) []VFSItem {
 	return items
 }
 
-func getDeviceSize(devPath string, f *os.File) int64 {
+func getDeviceSize(devPath string, f *os.File) (int64, error) {
 	if f != nil {
-		if pos, err := f.Seek(0, io.SeekEnd); err == nil && pos > 0 {
-			f.Seek(0, io.SeekStart)
-			return pos
+		if size, found, err := probeSeekSize(f); err != nil {
+			return 0, err
+		} else if found {
+			return size, nil
 		}
 	}
 	ptr, err := windows.UTF16PtrFromString(devPath)
 	if err != nil {
-		return 0
+		return 0, nil
 	}
 	h, err := windows.CreateFile(ptr, 0, windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE, nil, windows.OPEN_EXISTING, 0, 0)
 	if err != nil {
-		return 0
+		return 0, nil
 	}
 	defer windows.CloseHandle(h)
 	var length int64
 	var returned uint32
 	if err := windows.DeviceIoControl(h, 0x7405C, nil, 0, (*byte)(unsafe.Pointer(&length)), 8, &returned, nil); err == nil {
-		return length
+		return length, nil
 	}
-	return 0
+	return 0, nil
 }

--- a/vfs/os_vfs.go
+++ b/vfs/os_vfs.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"time"
@@ -442,7 +443,7 @@ func (v *OSVFS) SetAttributes(ctx context.Context, path string, item VFSItem) er
 	return errPlat
 }
 
-func (v *OSVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) error {
+func (v *OSVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPiece) (returnErr error) {
 	// Before the first byte goes out: a patch this cannot express has to be
 	// refused while the file is still intact.
 	if err := ValidateInPlacePieces(pieces); err != nil {
@@ -453,7 +454,9 @@ func (v *OSVFS) PatchInPlace(ctx context.Context, path string, pieces []PatchPie
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() {
+		returnErr = errors.Join(returnErr, f.Close())
+	}()
 
 	var newOffset int64 = 0
 	for _, p := range pieces {
@@ -536,9 +539,11 @@ func (v *OSVFS) Open(ctx context.Context, path string) (ReadAtCloser, error) {
 				info, _ := sudoF.Stat()
 				size := info.Size()
 				if info.Mode()&(os.ModeDevice|os.ModeCharDevice) != 0 {
-					if pos, err := sudoF.Seek(0, io.SeekEnd); err == nil && pos > 0 {
-						size = pos
-						sudoF.Seek(0, io.SeekStart)
+					if probedSize, found, err := probeSeekSize(sudoF); err != nil {
+						_ = sudoF.Close() // The read handle cannot be returned at the wrong offset.
+						return nil, err
+					} else if found {
+						size = probedSize
 					}
 				}
 				vtui.DebugLog("VFS: Sudo Open(%q) SUCCESS, size: %d", path, size)
@@ -550,14 +555,16 @@ func (v *OSVFS) Open(ctx context.Context, path string) (ReadAtCloser, error) {
 	}
 	info, err := f.Stat()
 	if err != nil {
-		f.Close()
+		_ = f.Close() // No writes occurred before the failed metadata read.
 		return nil, err
 	}
 	size := info.Size()
 	if info.Mode()&(os.ModeDevice|os.ModeCharDevice) != 0 {
-		if pos, err := f.Seek(0, io.SeekEnd); err == nil && pos > 0 {
-			size = pos
-			f.Seek(0, io.SeekStart)
+		if probedSize, found, err := probeSeekSize(f); err != nil {
+			_ = f.Close() // The handle cannot be returned at the wrong offset.
+			return nil, err
+		} else if found {
+			size = probedSize
 		}
 	}
 	return &osFileWrapper{File: f, size: size}, nil

--- a/vfs/os_vfs_search.go
+++ b/vfs/os_vfs_search.go
@@ -232,7 +232,9 @@ func (v *OSVFS) findFileContains(ctx context.Context, path string, matcher *find
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close() // Search opens the handle only for reading.
+	}()
 
 	overlap := len(matcher.needle) + 4
 	if matcher.regex != nil && overlap < 4096 {

--- a/vfs/rename_noreplace.go
+++ b/vfs/rename_noreplace.go
@@ -42,8 +42,7 @@ func renameSameObject(oldPath, newPath string) error {
 	}
 	tmpPath := tmp.Name()
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
-		return err
+		return errors.Join(err, os.Remove(tmpPath))
 	}
 	if err := os.Remove(tmpPath); err != nil {
 		return err

--- a/vfs/sudo_askpass_unix.go
+++ b/vfs/sudo_askpass_unix.go
@@ -22,9 +22,9 @@ func RunSudoAskpass() {
 	debugLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-debug-%d.txt", os.Getuid()))
 	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] ASKPASS: PID=%d, ParentPID=%s, Args=%v\n", time.Now().Format("15:04:05"), os.Getpid(), parentStr, os.Args)
-		fmt.Fprintf(debugLog, "[%s] ASKPASS: Environ=%v\n", time.Now().Format("15:04:05"), os.Environ())
-		debugLog.Close()
+		_, _ = fmt.Fprintf(debugLog, "[%s] ASKPASS: PID=%d, ParentPID=%s, Args=%v\n", time.Now().Format("15:04:05"), os.Getpid(), parentStr, os.Args) // Debug logging is best-effort.
+		_, _ = fmt.Fprintf(debugLog, "[%s] ASKPASS: Environ=%v\n", time.Now().Format("15:04:05"), os.Environ())                                       // Debug logging is best-effort.
+		_ = debugLog.Close()                                                                                                                          // Debug log persistence is best-effort.
 	}
 	parentPID, _ := strconv.Atoi(parentStr)
 	if parentPID == 0 {
@@ -47,10 +47,11 @@ func RunSudoAskpass() {
 	if err != nil {
 		os.Exit(1)
 	}
-	defer conn.Close()
 
 	// Request password
-	fmt.Fprintf(conn, "GET\n")
+	if _, err := fmt.Fprintf(conn, "GET\n"); err != nil {
+		os.Exit(1)
+	}
 
 	buf := make([]byte, 512)
 	n, err := conn.Read(buf)
@@ -60,22 +61,35 @@ func RunSudoAskpass() {
 
 	// Output password to sudo
 	vtui.DebugLog("F4_ASKPASS: Sending %d bytes to sudo stdout", n)
-	os.Stdout.Write(buf[:n])
+	if _, err := os.Stdout.Write(buf[:n]); err != nil {
+		os.Exit(1)
+	}
 	// Sudo expects the password followed by a newline or just the password depending on the version.
 	// Most implementations use a trailing newline.
-	os.Stdout.Write([]byte("\n"))
+	if _, err := os.Stdout.Write([]byte("\n")); err != nil {
+		os.Exit(1)
+	}
+	_ = conn.Close() // The request is complete; process exit remains authoritative.
 	os.Exit(0)
 }
 
 func (c *SudoClient) runAskpassServer(path string) {
-	os.Remove(path)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		vtui.DebugLog("SUDO_CLIENT: remove stale askpass socket %q: %v", path, err)
+		return
+	}
 	l, err := net.Listen("unix", path)
 	if err != nil {
 		vtui.DebugLog("SUDO_CLIENT: runAskpassServer Listen failed for %q: %v", path, err)
 		return
 	}
-	defer l.Close()
-	os.Chmod(path, 0600)
+	defer func() {
+		_ = l.Close() // Listener cleanup cannot affect a completed request.
+	}()
+	if err := os.Chmod(path, 0600); err != nil {
+		vtui.DebugLog("SUDO_CLIENT: secure askpass socket %q: %v", path, err)
+		return
+	}
 
 	for {
 		conn, err := l.Accept()
@@ -90,7 +104,9 @@ func (c *SudoClient) runAskpassServer(path string) {
 
 func (c *SudoClient) handleAskpassRequest(conn net.Conn) {
 	vtui.DebugLog("SUDO_CLIENT: Received askpass request from helper, current attempts: %d", c.attempts)
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close() // Request writes are checked before transport cleanup.
+	}()
 
 	// Max 3 attempts per connection session to prevent UI lockup
 	if c.attempts >= 3 {
@@ -157,7 +173,9 @@ func (c *SudoClient) handleAskpassRequest(conn net.Conn) {
 	password := <-resChan
 	if password != "" {
 		vtui.DebugLog("SUDO_CLIENT: Password received from UI, sending to helper...")
-		conn.Write([]byte(password))
+		if _, err := conn.Write([]byte(password)); err != nil {
+			vtui.DebugLog("SUDO_CLIENT: Failed to send password to helper: %v", err)
+		}
 	} else {
 		vtui.DebugLog("SUDO_CLIENT: Password dialog cancelled by user.")
 	}

--- a/vfs/sudo_client.go
+++ b/vfs/sudo_client.go
@@ -60,11 +60,13 @@ func (c *SudoClient) Connect() error {
 
 	vtui.DebugLog("SUDO_CLIENT: Initializing connection... UID=%d GID=%d", os.Getuid(), os.Getgid())
 	c.sockPath = filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-%d.sock", os.Getpid()))
-	os.Remove(c.sockPath)
+	_ = os.Remove(c.sockPath) // The root dispatcher retries removal before its authoritative bind.
 
 	// Start internal askpass server to handle dialog requests from the helper process
 	askPassSock := getAskpassSocketPath(os.Getpid())
-	os.Remove(askPassSock)
+	if err := os.Remove(askPassSock); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cannot remove stale askpass socket %q; remove it and retry: %w", askPassSock, err)
+	}
 	go c.runAskpassServer(askPassSock)
 	// We don't remove askPassSock here, it will be removed by the server goroutine or on exit
 
@@ -164,7 +166,7 @@ func (c *SudoClient) Connect() error {
 	if matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "f4-canary-*.txt")); len(matches) > 0 {
 		vtui.DebugLog("SUDO_CLIENT: DEBUG: Canary files found: %v. Dispatcher WAS running.", matches)
 		for _, m := range matches {
-			os.Remove(m)
+			_ = os.Remove(m) // Canary cleanup is diagnostic only.
 		}
 	} else {
 		vtui.DebugLog("SUDO_CLIENT: DEBUG: No canary files found. Dispatcher never reached RunSudoDispatcher.")
@@ -180,7 +182,7 @@ func (c *SudoClient) Connect() error {
 			}
 		}
 		// Clean up to avoid double-logging on next attempt
-		os.Remove(debugLogPath)
+		_ = os.Remove(debugLogPath) // Harvested debug-log cleanup is best-effort.
 	}
 
 	return fmt.Errorf("failed to connect to elevated dispatcher: %v", err)
@@ -197,7 +199,7 @@ func (c *SudoClient) SendRequest(req SudoRequest) (SudoResponse, *os.File, error
 
 	vtui.DebugLog("SUDO_CLIENT: Sending request: Cmd=%d, Path=%q", req.Cmd, req.Path)
 	if err := sendMsg(c.conn, req, -1); err != nil {
-		c.conn.Close()
+		_ = c.conn.Close() // Preserve the protocol error that forced disconnect.
 		c.conn = nil
 		return SudoResponse{}, nil, err
 	}
@@ -205,14 +207,14 @@ func (c *SudoClient) SendRequest(req SudoRequest) (SudoResponse, *os.File, error
 	var resp SudoResponse
 	f, err := recvMsg(c.conn, &resp)
 	if err != nil {
-		c.conn.Close()
+		_ = c.conn.Close() // Preserve the protocol error that forced disconnect.
 		c.conn = nil
 		return SudoResponse{}, nil, err
 	}
 
 	if resp.Error != "" {
 		if f != nil {
-			f.Close()
+			_ = f.Close() // The rejected response's descriptor was never used.
 		}
 		return resp, nil, errors.New(resp.Error)
 	}

--- a/vfs/sudo_dispatcher_unix.go
+++ b/vfs/sudo_dispatcher_unix.go
@@ -25,13 +25,12 @@ func RunSudoDispatcher(sockPath string) {
 	debugLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-debug-%s.txt", sudoUid))
 	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] DISPATCHER STARTING: EUID=%d PID=%d Sock=%q\n", time.Now().Format("15:04:05"), os.Geteuid(), os.Getpid(), sockPath)
-		defer debugLog.Close()
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER STARTING: EUID=%d PID=%d Sock=%q\n", time.Now().Format("15:04:05"), os.Geteuid(), os.Getpid(), sockPath) // Debug logging is best-effort.
 	}
 
 	// Create a canary file to prove execution
 	canaryPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-canary-%d.txt", os.Getpid()))
-	os.WriteFile(canaryPath, []byte(fmt.Sprintf("EUID=%d", os.Geteuid())), 0666)
+	_ = os.WriteFile(canaryPath, []byte(fmt.Sprintf("EUID=%d", os.Geteuid())), 0600) // The canary is diagnostic only.
 
 	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: STARTING (EUID=%d, PID=%d)\n", os.Geteuid(), os.Getpid())
 	if os.Geteuid() != 0 {
@@ -41,7 +40,7 @@ func RunSudoDispatcher(sockPath string) {
 	}
 	vtui.DebugLog("SUDO_DISPATCHER: Initializing on %q as root", sockPath)
 
-	os.Remove(sockPath)
+	_ = os.Remove(sockPath) // ListenUnix reports an actionable bind error if the path still blocks startup.
 	vtui.DebugLog("SUDO_DISPATCHER: Creating socket %q", sockPath)
 	addr, err := net.ResolveUnixAddr("unix", sockPath)
 	if err != nil {
@@ -54,26 +53,24 @@ func RunSudoDispatcher(sockPath string) {
 		fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: ListenUnix failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer l.Close()
-
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] DISPATCHER: Socket created.\n", time.Now().Format("15:04:05"))
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Socket created.\n", time.Now().Format("15:04:05")) // Debug logging is best-effort.
 	}
 
 	fi, _ := os.Stat(sockPath)
 	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Socket created. Initial perms: %v\n", fi.Mode())
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] DISPATCHER: Initial perms: %v\n", time.Now().Format("15:04:05"), fi.Mode())
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Initial perms: %v\n", time.Now().Format("15:04:05"), fi.Mode()) // Debug logging is best-effort.
 	}
 
 	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Setting permissions 0666...\n")
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod 0666 starting...\n", time.Now().Format("15:04:05"))
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod 0666 starting...\n", time.Now().Format("15:04:05")) // Debug logging is best-effort.
 	}
 	// Permissions 0666 allow the non-root f4 process to connect to the root-owned socket.
 	err = os.Chmod(sockPath, 0666)
 	if debugLog != nil {
-		fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod result: %v\n", time.Now().Format("15:04:05"), err)
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod result: %v\n", time.Now().Format("15:04:05"), err) // Debug logging is best-effort.
 	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Chmod failed: %v\n", err)
@@ -85,11 +82,17 @@ func RunSudoDispatcher(sockPath string) {
 	if err == nil {
 		handleSudoClient(conn)
 	}
+	_ = l.Close() // The single-client dispatcher is done.
+	if debugLog != nil {
+		_ = debugLog.Close() // Best effort before the explicit process exit.
+	}
 	os.Exit(0)
 }
 
 func handleSudoClient(conn *net.UnixConn) {
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close() // Transport cleanup cannot change a completed request.
+	}()
 
 	for {
 		var req SudoRequest
@@ -107,6 +110,7 @@ func handleSudoClient(conn *net.UnixConn) {
 
 		resp := SudoResponse{}
 		fd := -1
+		var openedFile *os.File
 
 		vtui.DebugLog("SUDO_DISPATCHER: Processing Cmd=%d, Path=%q", req.Cmd, req.Path)
 
@@ -125,8 +129,8 @@ func handleSudoClient(conn *net.UnixConn) {
 					resp.Error = err.Error()
 				} else {
 					fd = int(f.Fd())
+					openedFile = f
 					vtui.DebugLog("SUDO_DISPATCHER: Open(%q) SUCCESS, FD=%d", req.Path, fd)
-					defer f.Close() // Safe to close in dispatcher, FD is duplicated across Unix socket
 				}
 			}
 
@@ -215,6 +219,9 @@ func handleSudoClient(conn *net.UnixConn) {
 		}
 
 		err = sendMsg(conn, resp, fd)
+		if openedFile != nil {
+			_ = openedFile.Close() // sendMsg duplicated the descriptor for the client.
+		}
 		if err != nil {
 			return
 		}

--- a/vfs/sudo_test.go
+++ b/vfs/sudo_test.go
@@ -3,10 +3,12 @@
 package vfs
 
 import (
+	"errors"
 	"io"
 	"net"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -150,10 +152,7 @@ func TestSudoClient_IPCProtocol(t *testing.T) {
 		t.Fatalf("ResolveUnixAddr failed: %v", err)
 	}
 
-	l, err := net.ListenUnix("unix", addr)
-	if err != nil {
-		t.Fatalf("ListenUnix failed: %v", err)
-	}
+	l := listenUnixForTest(t, addr)
 	defer func() {
 		_ = l.Close() // listener cleanup errors are uninteresting
 	}()
@@ -267,10 +266,7 @@ func TestSudoClient_DisconnectRecovery(t *testing.T) {
 	sockPath := filepath.Join(tmpDir, "sudo-recovery.sock")
 
 	addr, _ := net.ResolveUnixAddr("unix", sockPath)
-	l, err := net.ListenUnix("unix", addr)
-	if err != nil {
-		t.Fatalf("ListenUnix failed: %v", err)
-	}
+	l := listenUnixForTest(t, addr)
 	defer func() {
 		_ = l.Close() // listener cleanup errors are uninteresting
 	}()
@@ -326,4 +322,16 @@ func shortSocketDir(t *testing.T) string {
 		}
 	})
 	return dir
+}
+
+func listenUnixForTest(t *testing.T, addr *net.UnixAddr) *net.UnixListener {
+	t.Helper()
+	l, err := net.ListenUnix("unix", addr)
+	if errors.Is(err, syscall.EPERM) {
+		t.Skipf("sandbox does not permit Unix socket bind: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("ListenUnix failed: %v", err)
+	}
+	return l
 }

--- a/vfs/utils.go
+++ b/vfs/utils.go
@@ -34,7 +34,9 @@ func IsTerminalRunnable(ctx context.Context, v VFS, path string) bool {
 	// 3. Check for Shebang
 	f, err := v.Open(ctx, path)
 	if err == nil {
-		defer f.Close()
+		defer func() {
+			_ = f.Close() // The shebang probe is read-only.
+		}()
 		buf := make([]byte, 2)
 		n, _ := f.Read(ctx, buf)
 		if n == 2 && string(buf) == "#!" {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -893,7 +893,9 @@ func (w *TempFileWrapper) Read(ctx context.Context, p []byte) (int, error) {
 
 func (w *TempFileWrapper) Close() error {
 	err := w.File.Close()
-	os.Remove(w.TempPath)
+	if w.TempPath != "" {
+		err = errors.Join(err, os.Remove(w.TempPath))
+	}
 	return err
 }
 


### PR DESCRIPTION
43 находки errcheck в `vfs`. Три оказались настоящими.

**Определение размера диска.** Размер узнают, перемотав в конец и обратно. Обратная перемотка не проверялась — и если она не удалась, дескриптор оставался в конце, а вызывающий продолжал читать с текущей позиции. То есть прочитал бы ноль байт и счёл это содержимым устройства.

**Два разбора размера из sysfs** игнорировали результат и работали с нулём: нечитаемый размер превращался в устройство нулевой длины вместо ошибки.

**Утечка дескрипторов в sudo-диспетчере.** `defer f.Close()` внутри цикла, но отложенный вызов живёт до конца функции, а не итерации. Дескриптор копился на каждый открытый файл до отключения клиента.

**Два намеренных изменения поведения**, вынесены отдельно: сокет askpass не поднимается, если не удалось выставить права `0600` (у протокола нет проверки собеседника, доступный всем сокет — утечка пароля), и устаревший сокет askpass, который не удалось удалить, теперь фатален с путём в сообщении.

**Что урезано при ревью.** Первый заход убирал `os.Exit(0)` из путей askpass и диспетчера. Это было бы плохо: `--askpass` вызывается уже после установки отложенной очистки всего приложения, так что вспомогательный процесс, запущенный спросить пароль, выполнил бы `SaveSession`, остановку плагинов и сброс состояния файлов. Восстановлено.
