### PR TITLE
fix: report a failed fusefs write to whoever wrote the file

### DIFF
--- a/fusefs/bridge.go
+++ b/fusefs/bridge.go
@@ -35,9 +35,10 @@ var errClosed = errors.New("mount is closed")
 // implement vfs.ConcurrentVFS may overlap independent read-side calls; all
 // mutations and bridge shutdown remain exclusive.
 type bridge struct {
-	mu     sync.RWMutex
-	v      vfs.VFS
-	closed bool
+	mu       sync.RWMutex
+	v        vfs.VFS
+	closed   bool
+	closeErr error
 	// A backend must opt in before read-side calls can overlap. Writes and
 	// close remain exclusive even for concurrent backends.
 	parallel bool
@@ -140,6 +141,7 @@ func (b *bridge) statsReport() string {
 type writeHandle struct {
 	path string
 	refs int
+	ioMu sync.Mutex
 
 	// staged is where the writes land when the backend can only be handed a
 	// whole file. Exactly one of staged and direct is set.
@@ -147,31 +149,131 @@ type writeHandle struct {
 	// direct is the backend's own file, written at the offset the kernel
 	// asked for. No staging, no download on open, no commit on close.
 	direct vfs.WriterAtCloser
+
+	// A direct writer is closed by Flush so that close errors reach the
+	// caller. A later write through a dup'd descriptor reopens it. Staged
+	// files stay open until Release and can be committed more than once.
+	closed    bool
+	finished  bool
+	committed bool
 }
 
 // needsCommit says whether closing this handle still has to send anything.
 // A directly written file is already in the backend; a staged one is not.
-func (h *writeHandle) needsCommit() bool { return h.direct == nil }
+func (h *writeHandle) needsCommit() bool { return h.staged != nil }
 
-func (h *writeHandle) writeAt(p []byte, off int64) (int, error) {
+func (h *writeHandle) writeAt(ctx context.Context, b *bridge, p []byte, off int64) (int, error) {
+	h.ioMu.Lock()
+	defer h.ioMu.Unlock()
+	if h.finished {
+		return 0, os.ErrClosed
+	}
 	if h.direct != nil {
+		if h.closed {
+			direct, err := b.openDirectWriter(ctx, h.path)
+			if err != nil {
+				return 0, err
+			}
+			h.direct = direct
+			h.closed = false
+		}
 		return h.direct.WriteAt(p, off)
 	}
-	return h.staged.WriteAt(p, off)
+	n, err := h.staged.WriteAt(p, off)
+	if n > 0 {
+		h.committed = false
+	}
+	return n, err
 }
 
-func (h *writeHandle) truncate(size int64) error {
+func (h *writeHandle) truncate(ctx context.Context, b *bridge, size int64) error {
+	h.ioMu.Lock()
+	defer h.ioMu.Unlock()
+	if h.finished {
+		return os.ErrClosed
+	}
 	if h.direct != nil {
+		if h.closed {
+			direct, err := b.openDirectWriter(ctx, h.path)
+			if err != nil {
+				return err
+			}
+			h.direct = direct
+			h.closed = false
+		}
 		return h.direct.Truncate(size)
 	}
-	return h.staged.Truncate(size)
+	if err := h.staged.Truncate(size); err != nil {
+		return err
+	}
+	h.committed = false
+	return nil
 }
 
 func (h *writeHandle) close() error {
+	h.ioMu.Lock()
+	defer h.ioMu.Unlock()
+	if h.finished {
+		return nil
+	}
+	h.finished = true
+	if h.closed {
+		return nil
+	}
+	h.closed = true
 	if h.direct != nil {
 		return h.direct.Close()
 	}
 	return h.staged.Close()
+}
+
+func (h *writeHandle) flushLocked(ctx context.Context, b *bridge) error {
+	if h.finished || h.closed {
+		return nil
+	}
+	if h.staged != nil {
+		if h.committed {
+			return nil
+		}
+		return h.commitLocked(ctx, b)
+	}
+	err := h.direct.Close()
+	h.closed = true
+	b.invalidate(b.parentOf(h.path))
+	return err
+}
+
+func (h *writeHandle) finishLocked(ctx context.Context, b *bridge) error {
+	if h.finished {
+		return nil
+	}
+	var err error
+	if h.staged != nil && !h.committed {
+		err = h.commitLocked(ctx, b)
+	}
+	if !h.closed {
+		if h.direct != nil {
+			err = errors.Join(err, h.direct.Close())
+			b.invalidate(b.parentOf(h.path))
+		} else {
+			err = errors.Join(err, h.staged.Close())
+		}
+		h.closed = true
+	}
+	h.finished = true
+	return err
+}
+
+func (h *writeHandle) commitLocked(ctx context.Context, b *bridge) error {
+	r, err := h.staged.Reader()
+	if err != nil {
+		return err
+	}
+	if err := b.commit(ctx, h.path, r); err != nil {
+		return err
+	}
+	h.committed = true
+	return nil
 }
 
 // stagedFile is a file being assembled on local disk before it is handed to
@@ -183,9 +285,9 @@ func (h *writeHandle) close() error {
 // failed transfer leaves the backend's copy untouched rather than half
 // rewritten.
 //
-// The file is unlinked immediately after creation, exactly like the read-side
-// spool, so it disappears with the process even on a crash and never shows up
-// in anybody's temp directory listing.
+// The file is unlinked immediately after creation when the host permits it,
+// exactly like the read-side spool. Failure is survivable: the open file still
+// works, so inability to hide its name must not make a mount unusable.
 type stagedFile struct {
 	f *os.File
 }
@@ -195,7 +297,7 @@ func newStagedFile() (*stagedFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	os.Remove(f.Name())
+	_ = os.Remove(f.Name()) // Best effort: the open file remains usable if unlink is unavailable.
 	return &stagedFile{f: f}, nil
 }
 
@@ -333,12 +435,22 @@ func (b *bridge) close() {
 	v := b.v
 	b.mu.Unlock()
 
+	var closeErr error
 	if v != nil {
-		v.Close()
+		closeErr = v.Close()
 	}
+	b.mu.Lock()
+	b.closeErr = closeErr
+	b.mu.Unlock()
 	b.cacheMu.Lock()
 	b.dirCache = make(map[string]dirCacheEntry)
 	b.cacheMu.Unlock()
+}
+
+func (b *bridge) closeError() error {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.closeErr
 }
 
 // join maps a name inside dirPath to a VFS-native path. Paths are whatever
@@ -545,8 +657,7 @@ func (b *bridge) open(ctx context.Context, itemPath string, size int64) (*handle
 	}
 
 	if err := h.spool(ctx); err != nil {
-		h.release()
-		return nil, err
+		return nil, errors.Join(err, h.release())
 	}
 	return h, nil
 }
@@ -559,14 +670,13 @@ func (h *handle) spool(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	os.Remove(tmp.Name())
+	_ = os.Remove(tmp.Name()) // Best effort: spooling still works while the file remains open.
 
 	buf := make([]byte, spoolChunk)
 	var total int64
 	for {
 		if err := ctx.Err(); err != nil {
-			tmp.Close()
-			return err
+			return errors.Join(err, tmp.Close())
 		}
 		// The lock is taken per chunk rather than held for the whole
 		// transfer. Backends are still one conversation at a time, but a
@@ -575,8 +685,7 @@ func (h *handle) spool(ctx context.Context) error {
 		// chunks. Writing to the local spool needs no lock at all.
 		_, unlock, err := h.b.beginReadCall()
 		if err != nil {
-			tmp.Close()
-			return err
+			return errors.Join(err, tmp.Close())
 		}
 		doneChunk := h.b.track("Read(spool)")
 		n, readErr := h.r.Read(ctx, buf)
@@ -584,8 +693,7 @@ func (h *handle) spool(ctx context.Context) error {
 		unlock()
 		if n > 0 {
 			if _, err := tmp.Write(buf[:n]); err != nil {
-				tmp.Close()
-				return err
+				return errors.Join(err, tmp.Close())
 			}
 			total += int64(n)
 		}
@@ -593,8 +701,7 @@ func (h *handle) spool(ctx context.Context) error {
 			break
 		}
 		if readErr != nil {
-			tmp.Close()
-			return readErr
+			return errors.Join(readErr, tmp.Close())
 		}
 		if n == 0 {
 			break
@@ -607,7 +714,7 @@ func (h *handle) spool(ctx context.Context) error {
 	// The source has been consumed to the end; releasing it now lets the
 	// backend drop its own temporary state while the mount keeps serving.
 	if h.r != nil {
-		h.r.Close()
+		_ = h.r.Close() // This handle was opened only for reading; its data is already spooled.
 		h.r = nil
 	}
 	return nil
@@ -661,21 +768,22 @@ func (h *handle) release() error {
 	h.r, h.tmp = nil, nil
 	h.mu.Unlock()
 
+	var closeErr error
 	if tmp != nil {
 		h.ioMu.Lock()
-		tmp.Close()
+		closeErr = tmp.Close()
 		h.ioMu.Unlock()
 	}
 	if reader != nil {
 		h.ioMu.Lock()
 		_, unlock, err := h.b.beginReadCall()
 		if err == nil {
-			reader.Close()
+			_ = reader.Close() // This backend handle was opened only for reading.
 			unlock()
 		}
 		h.ioMu.Unlock()
 	}
-	return nil
+	return closeErr
 }
 
 // inodeOf derives a stable inode number from a path. Real inode numbers are
@@ -766,17 +874,8 @@ func (b *bridge) acquireWriteHandle(ctx context.Context, itemPath string) (h *wr
 
 	// A backend that can write at an offset gets written at an offset. The
 	// staging file is the fallback, not the design.
-	if rw, ok := b.v.(vfs.RandomWriteVFS); ok {
-		b.mu.Lock()
-		closed := b.closed
-		var f vfs.WriterAtCloser
-		if !closed {
-			f, err = rw.OpenWriteAt(ctx, itemPath)
-		}
-		b.mu.Unlock()
-		if closed {
-			return nil, false, errClosed
-		}
+	if _, ok := b.v.(vfs.RandomWriteVFS); ok {
+		f, err := b.openDirectWriter(ctx, itemPath)
 		if err != nil {
 			// Staging would not rescue this: committing goes through
 			// Create on the same backend and would fail the same way,
@@ -797,6 +896,19 @@ func (b *bridge) acquireWriteHandle(ctx context.Context, itemPath string) (h *wr
 	return h, true, nil
 }
 
+func (b *bridge) openDirectWriter(ctx context.Context, itemPath string) (vfs.WriterAtCloser, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		return nil, errClosed
+	}
+	rw, ok := b.v.(vfs.RandomWriteVFS)
+	if !ok {
+		return nil, errors.New("backend no longer supports positional writes")
+	}
+	return rw.OpenWriteAt(ctx, itemPath)
+}
+
 // loadStaged fills a staging file with what the backend already holds. This
 // is the read-modify-write an editor's save needs: FUSE may write two bytes
 // in the middle of a file, and the commit sends the whole thing back, so what
@@ -814,22 +926,51 @@ func (b *bridge) loadStaged(ctx context.Context, itemPath string, s *stagedFile)
 	if err != nil {
 		return err
 	}
-	defer rc.Close()
+	defer func() { _ = rc.Close() }() // This backend handle was opened only for reading.
 	// Like the read spool: the lock is taken per chunk, so opening a large
 	// file for writing does not stall every other request for the length of
 	// the download.
 	return s.LoadFrom(ctx, b, rc)
 }
 
-// isLastWriter reports whether h is the only handle left on its file, which
-// is how a close knows it is the one that has to commit.
-func (b *bridge) isLastWriter(h *writeHandle) bool {
+// flushWriter keeps the last-writer check and the handle state transition in
+// one critical section. An open racing with Flush either becomes visible to
+// the check or waits for the flush and then uses the resulting handle state.
+func (b *bridge) flushWriter(ctx context.Context, h *writeHandle) error {
 	if h == nil {
-		return false
+		return nil
 	}
 	b.writeMu.Lock()
-	defer b.writeMu.Unlock()
-	return h.refs <= 1
+	h.ioMu.Lock()
+	if h.refs > 1 {
+		h.ioMu.Unlock()
+		b.writeMu.Unlock()
+		return nil
+	}
+	b.writeMu.Unlock()
+	err := h.flushLocked(ctx, b)
+	h.ioMu.Unlock()
+	return err
+}
+
+// finishWriter drops a FUSE open reference and, for the final one, commits
+// and closes the shared writer. Release is the fallback when Flush never ran.
+func (b *bridge) finishWriter(ctx context.Context, h *writeHandle) error {
+	if h == nil {
+		return nil
+	}
+	b.writeMu.Lock()
+	h.refs--
+	if h.refs > 0 {
+		b.writeMu.Unlock()
+		return nil
+	}
+	h.ioMu.Lock()
+	delete(b.writers, h.path)
+	b.writeMu.Unlock()
+	err := h.finishLocked(ctx, b)
+	h.ioMu.Unlock()
+	return err
 }
 
 // commit hands the staged file to the backend in one sequential pass, which
@@ -844,9 +985,7 @@ func (b *bridge) commit(ctx context.Context, itemPath string, r io.Reader) error
 	w, err := b.v.Create(ctx, itemPath)
 	if err == nil {
 		_, err = io.Copy(w, r)
-		if cerr := w.Close(); err == nil {
-			err = cerr
-		}
+		err = errors.Join(err, w.Close())
 	}
 	b.mu.Unlock()
 	b.invalidate(path.Dir(itemPath))

--- a/fusefs/bridge_test.go
+++ b/fusefs/bridge_test.go
@@ -34,6 +34,23 @@ type concurrentStatVFS struct {
 	release chan struct{}
 }
 
+type closeErrorVFS struct {
+	*fakeVFS
+	err    error
+	closes int
+}
+
+func (v *closeErrorVFS) Close() error {
+	v.closed = true
+	v.closes++
+	return v.err
+}
+
+type immediateMountServer struct{}
+
+func (immediateMountServer) Unmount() error { return nil }
+func (immediateMountServer) Wait()          {}
+
 func (*concurrentStatVFS) SupportsConcurrentCalls() bool { return true }
 
 func (f *concurrentStatVFS) Stat(ctx context.Context, p string) (vfs.VFSItem, error) {
@@ -338,6 +355,40 @@ func TestCloseReleasesTheBackend(t *testing.T) {
 	}
 	if _, err := b.readDir(context.Background(), "/root"); !errors.Is(err, errClosed) {
 		t.Fatalf("readDir after close = %v, want errClosed", err)
+	}
+}
+
+func TestMountVFSEarlyFailureClosesVFSOnce(t *testing.T) {
+	v := &closeErrorVFS{fakeVFS: newFakeVFS(true)}
+	if _, err := MountVFS(context.Background(), v, Options{}); err == nil {
+		t.Fatal("MountVFS without a mount point succeeded")
+	}
+	if v.closes != 1 {
+		t.Fatalf("early MountVFS failure closed the VFS %d times, want once", v.closes)
+	}
+}
+
+func TestCleanupErrorReachesOnExitButNotUnmount(t *testing.T) {
+	want := errors.New("backend close failed")
+	v := &closeErrorVFS{fakeVFS: newFakeVFS(true), err: want}
+	var exitErr error
+	m := &Mount{
+		ID:     "cleanup-error-test",
+		server: immediateMountServer{},
+		bridge: newBridge(v, "/root", Options{}),
+		done:   make(chan struct{}),
+		onExit: func(_ *Mount, err error) { exitErr = err },
+	}
+
+	m.watch()
+	if !errors.Is(exitErr, want) {
+		t.Fatalf("OnExit error = %v, want backend close error", exitErr)
+	}
+	if err := m.Unmount(); err != nil {
+		t.Fatalf("Unmount after successful detach = %v, want nil", err)
+	}
+	if v.closes != 1 {
+		t.Fatalf("watch closed the VFS %d times, want once", v.closes)
 	}
 }
 

--- a/fusefs/cli.go
+++ b/fusefs/cli.go
@@ -88,14 +88,14 @@ func RunCLI(argv []string) (code int, handled bool) {
 
 func runMount(spec *Spec, stdout, stderr io.Writer) int {
 	if err := spec.Validate(); err != nil {
-		fmt.Fprintf(stderr, "f4: %v\n", err)
+		diagnose(stderr, "f4: %v\n", err)
 		if errors.Is(err, ErrWriteNotImplemented) {
 			return ExitUnsupported
 		}
 		return ExitUsage
 	}
 	if !Supported() {
-		fmt.Fprintf(stderr, "f4: mounting is not supported on this platform\n")
+		diagnose(stderr, "f4: mounting is not supported on this platform\n")
 		return ExitUnsupported
 	}
 	if spec.Daemon {
@@ -112,7 +112,7 @@ func mountAndServe(spec *Spec, stdout, stderr io.Writer) int {
 	mountPoint, wait, err := mountOnce(*spec)
 	if err != nil {
 		reportReady(ready, readyMessage{OK: false, Error: err.Error()})
-		emit(stderr, spec.JSON, readyMessage{OK: false, Error: err.Error()},
+		_ = emit(stderr, spec.JSON, readyMessage{OK: false, Error: err.Error()}, // The exit status already reports this failure.
 			fmt.Sprintf("f4: mount %s: %v\n", spec.Source, err))
 		return ExitFailed
 	}
@@ -125,13 +125,21 @@ func mountAndServe(spec *Spec, stdout, stderr io.Writer) int {
 	})
 	if regErr != nil {
 		// A mount that works but is not listed is still a working mount.
-		fmt.Fprintf(stderr, "f4: warning: could not record the mount: %v\n", regErr)
+		diagnose(stderr, "f4: warning: could not record the mount: %v\n", regErr)
 	}
-	defer Deregister(rec.ID)
+	defer func() {
+		if err := Deregister(rec.ID); err != nil {
+			diagnose(stderr, "f4: warning: could not remove the mount record: %v\n", err)
+		}
+	}()
 
 	reportReady(ready, readyMessage{OK: true, MountPoint: mountPoint, PID: os.Getpid()})
-	emit(stdout, spec.JSON, readyMessage{OK: true, MountPoint: mountPoint, PID: os.Getpid()},
-		mountPoint+"\n")
+	if err := emit(stdout, spec.JSON, readyMessage{OK: true, MountPoint: mountPoint, PID: os.Getpid()},
+		mountPoint+"\n"); err != nil {
+		diagnose(stderr, "f4: report mounted path: %v\n", err)
+		_ = unmountOwn(mountPoint) // A failed mount command must not leave its mount behind.
+		return ExitFailed
+	}
 
 	// Held from here rather than looked up afterwards: by the time the wait
 	// returns the mount is gone from the registry, which is exactly when
@@ -141,7 +149,7 @@ func mountAndServe(spec *Spec, stdout, stderr io.Writer) int {
 	waitOrSignal(wait, mountPoint)
 	if mounted != nil {
 		if report := mounted.Stats(); report != "" {
-			fmt.Fprint(stderr, report)
+			diagnose(stderr, "%s", report)
 		}
 	}
 	return ExitOK
@@ -182,15 +190,15 @@ func waitOrSignal(wait func(), mountPoint string) {
 func spawnDaemon(spec *Spec, stdout, stderr io.Writer) int {
 	exe, err := os.Executable()
 	if err != nil {
-		fmt.Fprintf(stderr, "f4: cannot locate the f4 binary: %v\n", err)
+		diagnose(stderr, "f4: cannot locate the f4 binary: %v\n", err)
 		return ExitFailed
 	}
 	r, w, err := os.Pipe()
 	if err != nil {
-		fmt.Fprintf(stderr, "f4: %v\n", err)
+		diagnose(stderr, "f4: %v\n", err)
 		return ExitFailed
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }() // Read-side close errors cannot affect the readiness result.
 
 	cmd := exec.Command(exe, spec.ChildArgs()...)
 	cmd.Env = append(os.Environ(), daemonReadyFDEnv+"=3")
@@ -201,26 +209,33 @@ func spawnDaemon(spec *Spec, stdout, stderr io.Writer) int {
 	cmd.SysProcAttr = detachAttr()
 
 	if err := cmd.Start(); err != nil {
-		w.Close()
-		fmt.Fprintf(stderr, "f4: cannot start the mount process: %v\n", err)
+		_ = w.Close() // The child never started, so this pipe carried no data.
+		diagnose(stderr, "f4: cannot start the mount process: %v\n", err)
 		return ExitFailed
 	}
 	// The parent must drop its copy, or the read below never sees EOF.
-	w.Close()
+	if err := w.Close(); err != nil {
+		_ = cmd.Process.Kill()
+		diagnose(stderr, "f4: close readiness pipe: %v\n", err)
+		return ExitFailed
+	}
 
 	msg, err := awaitReady(r, spec.Timeout)
 	if err != nil {
 		_ = cmd.Process.Kill()
-		fmt.Fprintf(stderr, "f4: mount %s: %v (try --foreground to see what happens)\n", spec.Source, err)
+		diagnose(stderr, "f4: mount %s: %v (try --foreground to see what happens)\n", spec.Source, err)
 		return ExitFailed
 	}
 	if !msg.OK {
-		emit(stderr, spec.JSON, msg, fmt.Sprintf("f4: mount %s: %s\n", spec.Source, msg.Error))
+		_ = emit(stderr, spec.JSON, msg, fmt.Sprintf("f4: mount %s: %s\n", spec.Source, msg.Error)) // The exit status already reports this failure.
 		return ExitFailed
 	}
 	// Let the child outlive us.
 	_ = cmd.Process.Release()
-	emit(stdout, spec.JSON, msg, msg.MountPoint+"\n")
+	if err := emit(stdout, spec.JSON, msg, msg.MountPoint+"\n"); err != nil {
+		diagnose(stderr, "f4: report mounted path: %v (mount remains active at %s)\n", err, msg.MountPoint)
+		return ExitFailed
+	}
 	return ExitOK
 }
 
@@ -279,13 +294,13 @@ func reportReady(w *os.File, msg readyMessage) {
 	if err == nil {
 		_, _ = w.Write(append(blob, '\n'))
 	}
-	w.Close()
+	_ = w.Close() // The parent observes a failed readiness write as EOF or a timeout.
 }
 
 func runUmount(spec *Spec, stdout, stderr io.Writer) int {
 	target := spec.Source
 	if strings.TrimSpace(target) == "" {
-		fmt.Fprintf(stderr, "f4: --umount needs a mount point\n")
+		diagnose(stderr, "f4: --umount needs a mount point\n")
 		return ExitUsage
 	}
 
@@ -294,7 +309,7 @@ func runUmount(spec *Spec, stdout, stderr io.Writer) int {
 	if !found {
 		abs, err := filepath.Abs(target)
 		if err != nil {
-			fmt.Fprintf(stderr, "f4: %v\n", err)
+			diagnose(stderr, "f4: %v\n", err)
 			return ExitUsage
 		}
 		mountPoint = filepath.Clean(abs)
@@ -312,16 +327,16 @@ func runUmount(spec *Spec, stdout, stderr io.Writer) int {
 
 	if err != nil {
 		if isBusy(err) {
-			emit(stderr, spec.JSON, readyMessage{Error: "busy", MountPoint: mountPoint},
+			_ = emit(stderr, spec.JSON, readyMessage{Error: "busy", MountPoint: mountPoint}, // The exit status already reports this failure.
 				fmt.Sprintf("f4: %s is busy — something is still inside it\n", mountPoint))
 			return ExitBusy
 		}
 		if !found {
-			emit(stderr, spec.JSON, readyMessage{Error: err.Error(), MountPoint: mountPoint},
+			_ = emit(stderr, spec.JSON, readyMessage{Error: err.Error(), MountPoint: mountPoint}, // The exit status already reports this failure.
 				fmt.Sprintf("f4: no mount at %s (%v)\n", mountPoint, err))
 			return ExitNoSuchMount
 		}
-		emit(stderr, spec.JSON, readyMessage{Error: err.Error(), MountPoint: mountPoint},
+		_ = emit(stderr, spec.JSON, readyMessage{Error: err.Error(), MountPoint: mountPoint}, // The exit status already reports this failure.
 			fmt.Sprintf("f4: unmount %s: %v\n", mountPoint, err))
 		return ExitFailed
 	}
@@ -329,7 +344,10 @@ func runUmount(spec *Spec, stdout, stderr io.Writer) int {
 	if found {
 		_ = Deregister(rec.ID)
 	}
-	emit(stdout, spec.JSON, readyMessage{OK: true, MountPoint: mountPoint}, "")
+	if err := emit(stdout, spec.JSON, readyMessage{OK: true, MountPoint: mountPoint}, ""); err != nil {
+		diagnose(stderr, "f4: report unmount result: %v\n", err)
+		return ExitFailed
+	}
 	return ExitOK
 }
 
@@ -345,7 +363,7 @@ func isBusy(err error) bool {
 func runList(spec *Spec, stdout, stderr io.Writer) int {
 	recs, err := Mounts()
 	if err != nil {
-		fmt.Fprintf(stderr, "f4: %v\n", err)
+		diagnose(stderr, "f4: %v\n", err)
 		return ExitFailed
 	}
 	if spec.JSON {
@@ -355,7 +373,7 @@ func runList(spec *Spec, stdout, stderr io.Writer) int {
 			recs = []Record{}
 		}
 		if err := enc.Encode(recs); err != nil {
-			fmt.Fprintf(stderr, "f4: %v\n", err)
+			diagnose(stderr, "f4: %v\n", err)
 			return ExitFailed
 		}
 		return ExitOK
@@ -364,25 +382,41 @@ func runList(spec *Spec, stdout, stderr io.Writer) int {
 		return ExitOK
 	}
 	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "MOUNT POINT\tMODE\tPID\tAGE\tSOURCE")
-	for _, r := range recs {
-		fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
-			r.MountPoint, r.Mode(), r.PID, r.Age().Truncate(time.Second), r.Source)
+	if _, err := fmt.Fprintln(tw, "MOUNT POINT\tMODE\tPID\tAGE\tSOURCE"); err != nil {
+		diagnose(stderr, "f4: write mount list: %v\n", err)
+		return ExitFailed
 	}
-	tw.Flush()
+	for _, r := range recs {
+		if _, err := fmt.Fprintf(tw, "%s\t%s\t%d\t%s\t%s\n",
+			r.MountPoint, r.Mode(), r.PID, r.Age().Truncate(time.Second), r.Source); err != nil {
+			diagnose(stderr, "f4: write mount list: %v\n", err)
+			return ExitFailed
+		}
+	}
+	if err := tw.Flush(); err != nil {
+		diagnose(stderr, "f4: write mount list: %v\n", err)
+		return ExitFailed
+	}
 	return ExitOK
 }
 
 // emit writes either the JSON object or the human line, never both.
-func emit(w io.Writer, asJSON bool, msg readyMessage, human string) {
+func emit(w io.Writer, asJSON bool, msg readyMessage, human string) error {
 	if asJSON {
 		blob, err := json.Marshal(msg)
-		if err == nil {
-			fmt.Fprintf(w, "%s\n", blob)
+		if err != nil {
+			return err
 		}
-		return
+		_, err = fmt.Fprintf(w, "%s\n", blob)
+		return err
 	}
 	if human != "" {
-		fmt.Fprint(w, human)
+		_, err := fmt.Fprint(w, human)
+		return err
 	}
+	return nil
+}
+
+func diagnose(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...) // A failed diagnostic has nowhere else to be reported.
 }

--- a/fusefs/fusefs.go
+++ b/fusefs/fusefs.go
@@ -112,7 +112,14 @@ func Supported() bool { return supported }
 // MountVFS takes ownership of v unconditionally: it is closed when the mount
 // ends, and also when mounting fails. Callers pass a VFS opened for this
 // mount alone and never one a panel is browsing.
-func MountVFS(ctx context.Context, v vfs.VFS, opts Options) (*Mount, error) {
+func MountVFS(ctx context.Context, v vfs.VFS, opts Options) (mount *Mount, err error) {
+	if v != nil {
+		defer func() {
+			if mount == nil {
+				err = errors.Join(err, v.Close())
+			}
+		}()
+	}
 	if !supported {
 		return nil, ErrUnsupported
 	}
@@ -120,14 +127,13 @@ func MountVFS(ctx context.Context, v vfs.VFS, opts Options) (*Mount, error) {
 		return nil, errors.New("mount: no file system given")
 	}
 	if !opts.ReadOnly && !v.GetCapabilities().HasWrite {
-		v.Close()
 		return nil, errors.New("mount: this file system cannot be written through")
 	}
 	point := strings.TrimSpace(opts.MountPoint)
 	if point == "" {
 		return nil, errors.New("mount: no mount point given")
 	}
-	point, err := filepath.Abs(point)
+	point, err = filepath.Abs(point)
 	if err != nil {
 		return nil, err
 	}
@@ -162,11 +168,11 @@ func MountVFS(ctx context.Context, v vfs.VFS, opts Options) (*Mount, error) {
 	registry.Unlock()
 
 	if err := startServer(ctx, m, opts); err != nil {
-		m.bridge.close()
+		var removeErr error
 		if created {
-			os.Remove(point)
+			removeErr = os.Remove(point)
 		}
-		return nil, err
+		return nil, errors.Join(err, removeErr)
 	}
 
 	registry.Lock()
@@ -267,13 +273,14 @@ func (m *Mount) watch() {
 	registry.Unlock()
 
 	m.bridge.close()
+	cleanupErr := m.bridge.closeError()
 	if m.createdDir {
-		os.Remove(m.MountPoint)
+		cleanupErr = errors.Join(cleanupErr, os.Remove(m.MountPoint))
 	}
 
 	m.mu.Lock()
 	m.stopped = true
-	err := m.err
+	err := errors.Join(m.err, cleanupErr)
 	m.mu.Unlock()
 
 	close(m.done)

--- a/fusefs/node_fuse.go
+++ b/fusefs/node_fuse.go
@@ -97,13 +97,12 @@ var (
 )
 
 // writeFileHandle is one open handle on a file being written. The data goes
-// into the staging file shared by every handle on that path, and reaches the
-// backend once, when the last of them closes.
+// into the write handle shared by every FUSE open on that path. Flush makes
+// the current data durable; Release performs the same work if Flush was
+// skipped.
 type writeFileHandle struct {
-	b         *bridge
-	wh        *writeHandle
-	path      string
-	committed bool
+	b  *bridge
+	wh *writeHandle
 }
 
 // Create makes a new file. The file exists in the mount immediately — the
@@ -123,11 +122,11 @@ func (n *node) Create(ctx context.Context, name string, flags uint32, mode uint3
 	fillAttr(&out.Attr, item, childPath)
 	stable := fs.StableAttr{Ino: inodeOf(childPath), Mode: typeBits(item)}
 	inode := n.NewInode(ctx, &node{b: n.b, path: childPath}, stable)
-	return inode, &writeFileHandle{b: n.b, wh: wh, path: childPath}, 0, 0
+	return inode, &writeFileHandle{b: n.b, wh: wh}, 0, 0
 }
 
 func (f *writeFileHandle) Write(ctx context.Context, data []byte, off int64) (uint32, syscall.Errno) {
-	written, err := f.wh.writeAt(data, off)
+	written, err := f.wh.writeAt(ctx, f.b, data, off)
 	if err != nil {
 		return uint32(written), errnoOf(err)
 	}
@@ -145,46 +144,11 @@ func (f *writeFileHandle) Fsync(ctx context.Context, flags uint32) syscall.Errno
 // program that wrote the file, so the commit happens here when this is the
 // last handle. Release does it again only if Flush never ran.
 func (f *writeFileHandle) Flush(ctx context.Context) syscall.Errno {
-	if !f.wh.needsCommit() || f.committed || !f.b.isLastWriter(f.wh) {
-		return 0
-	}
-	if errno := f.commit(ctx); errno != 0 {
-		return errno
-	}
-	return 0
+	return errnoOf(f.b.flushWriter(ctx, f.wh))
 }
 
 func (f *writeFileHandle) Release(ctx context.Context) syscall.Errno {
-	last := f.b.releaseWriter(f.wh)
-	if last {
-		if f.wh.needsCommit() && !f.committed {
-			f.commit(ctx)
-		}
-		f.wh.close()
-		if !f.wh.needsCommit() {
-			// A direct write never went through commit(), which is
-			// where the parent listing is normally dropped.
-			f.b.invalidate(f.b.parentOf(f.path))
-		}
-	}
-	return 0
-}
-
-func (f *writeFileHandle) commit(ctx context.Context) syscall.Errno {
-	r, err := f.wh.staged.Reader()
-	if err != nil {
-		return errnoOf(err)
-	}
-	if err := f.b.commit(ctx, f.path, r); err != nil {
-		return errnoOf(err)
-	}
-	f.committed = true
-	// The kernel may still be holding attributes from before the write, and
-	// AttrTimeout is measured in seconds. Dropping the entry the file was
-	// listed under is the cheap half of the answer; the Getattr override
-	// above is the other half, for as long as the handle is open.
-	f.b.invalidate(f.b.parentOf(f.path))
-	return 0
+	return errnoOf(f.b.finishWriter(ctx, f.wh))
 }
 
 // writeRefusal reports why a write cannot happen, or 0 when it can. The mount
@@ -349,8 +313,7 @@ func (f *fileHandle) Read(ctx context.Context, dest []byte, off int64) (fuse.Rea
 }
 
 func (f *fileHandle) Release(ctx context.Context) syscall.Errno {
-	f.h.release()
-	return 0
+	return errnoOf(f.h.release())
 }
 
 func typeBits(item vfs.VFSItem) uint32 {
@@ -499,9 +462,9 @@ func (n *node) openForWrite(ctx context.Context, flags uint32) (fs.FileHandle, u
 		return nil, 0, errnoOf(err)
 	}
 	if flags&uint32(syscall.O_TRUNC) != 0 {
-		if err := wh.truncate(0); err != nil {
+		if err := wh.truncate(ctx, n.b, 0); err != nil {
 			if n.b.releaseWriter(wh) {
-				wh.close()
+				err = errors.Join(err, wh.close())
 			}
 			return nil, 0, errnoOf(err)
 		}
@@ -517,13 +480,13 @@ func (n *node) openForWrite(ctx context.Context, flags uint32) (fs.FileHandle, u
 				// commit a file with a hole where the old
 				// contents should have been.
 				if n.b.releaseWriter(wh) {
-					wh.close()
+					err = errors.Join(err, wh.close())
 				}
 				return nil, 0, errnoOf(err)
 			}
 		}
 	}
-	return &writeFileHandle{b: n.b, wh: wh, path: n.path}, 0, 0
+	return &writeFileHandle{b: n.b, wh: wh}, 0, 0
 }
 
 // Setattr answers chmod and touch. Size is not handled here yet: truncating
@@ -575,9 +538,9 @@ func (n *node) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn,
 // file closed — `truncate -s 0 x`, or a shell redirect onto an existing
 // file — the whole round trip happens here, because there is no close coming
 // that would otherwise do it.
-func (n *node) truncate(ctx context.Context, size int64) syscall.Errno {
+func (n *node) truncate(ctx context.Context, size int64) (errno syscall.Errno) {
 	if wh := n.b.writerFor(n.path); wh != nil {
-		if err := wh.truncate(size); err != nil {
+		if err := wh.truncate(ctx, n.b, size); err != nil {
 			return errnoOf(err)
 		}
 		return 0
@@ -589,14 +552,16 @@ func (n *node) truncate(ctx context.Context, size int64) syscall.Errno {
 	}
 	defer func() {
 		if n.b.releaseWriter(wh) {
-			wh.close()
+			if err := wh.close(); errno == 0 {
+				errno = errnoOf(err)
+			}
 		}
 	}()
 
 	// A backend written at an offset resizes its own file; there is nothing
 	// to fetch and nothing to send back.
 	if !wh.needsCommit() {
-		if err := wh.truncate(size); err != nil {
+		if err := wh.truncate(ctx, n.b, size); err != nil {
 			return errnoOf(err)
 		}
 		n.b.invalidate(n.b.parentOf(n.path))
@@ -613,7 +578,7 @@ func (n *node) truncate(ctx context.Context, size int64) syscall.Errno {
 			}
 		}
 	}
-	if err := wh.staged.Truncate(size); err != nil {
+	if err := wh.truncate(ctx, n.b, size); err != nil {
 		return errnoOf(err)
 	}
 	r, err := wh.staged.Reader()

--- a/fusefs/registry.go
+++ b/fusefs/registry.go
@@ -108,18 +108,14 @@ func Register(rec Record) (Record, error) {
 	}
 	tmpName := tmp.Name()
 	if _, err := tmp.Write(append(blob, '\n')); err != nil {
-		tmp.Close()
-		os.Remove(tmpName)
-		return rec, err
+		return rec, errors.Join(err, tmp.Close(), os.Remove(tmpName))
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpName)
-		return rec, err
+		return rec, errors.Join(err, os.Remove(tmpName))
 	}
 	// Rename so a reader never sees a half-written record.
 	if err := os.Rename(tmpName, final); err != nil {
-		os.Remove(tmpName)
-		return rec, err
+		return rec, errors.Join(err, os.Remove(tmpName))
 	}
 	return rec, nil
 }
@@ -165,11 +161,11 @@ func Mounts() ([]Record, error) {
 		}
 		var rec Record
 		if err := json.Unmarshal(blob, &rec); err != nil {
-			os.Remove(path) // corrupt: no reader can do anything with it
+			_ = os.Remove(path) // Corrupt registry cleanup is best effort; the entry is already filtered.
 			continue
 		}
 		if !processAlive(rec.PID) {
-			os.Remove(path)
+			_ = os.Remove(path) // Stale registry cleanup is best effort; the entry is already filtered.
 			continue
 		}
 		out = append(out, rec)

--- a/fusefs/writers_test.go
+++ b/fusefs/writers_test.go
@@ -1,8 +1,15 @@
 package fusefs
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
 	"sync"
 	"testing"
+
+	"github.com/unxed/f4/vfs"
 )
 
 func newWriterTestBridge() *bridge {
@@ -93,5 +100,261 @@ func TestWriterTableUnderConcurrentOpens(t *testing.T) {
 	}
 	if b.openWriters() != 0 {
 		t.Fatal("the table did not empty")
+	}
+}
+
+type lifecycleVFS struct {
+	*fakeVFS
+	mu        sync.Mutex
+	data      []byte
+	handles   []*lifecycleWriter
+	closeErrs []error
+}
+
+func newLifecycleVFS(closeErrs ...error) *lifecycleVFS {
+	return &lifecycleVFS{fakeVFS: newFakeVFS(true), closeErrs: closeErrs}
+}
+
+func (v *lifecycleVFS) GetCapabilities() vfs.VFSCapabilities {
+	return vfs.VFSCapabilities{HasRandomAccess: true, HasWrite: true}
+}
+
+func (v *lifecycleVFS) OpenWriteAt(ctx context.Context, path string) (vfs.WriterAtCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	w := &lifecycleWriter{owner: v}
+	if len(v.closeErrs) > len(v.handles) {
+		w.closeErr = v.closeErrs[len(v.handles)]
+	}
+	v.handles = append(v.handles, w)
+	return w, nil
+}
+
+type lifecycleWriter struct {
+	owner    *lifecycleVFS
+	closed   bool
+	closes   int
+	closeErr error
+}
+
+func (w *lifecycleWriter) WriteAt(p []byte, off int64) (int, error) {
+	w.owner.mu.Lock()
+	defer w.owner.mu.Unlock()
+	if w.closed {
+		return 0, os.ErrClosed
+	}
+	end := int(off) + len(p)
+	if end > len(w.owner.data) {
+		w.owner.data = append(w.owner.data, make([]byte, end-len(w.owner.data))...)
+	}
+	return copy(w.owner.data[int(off):], p), nil
+}
+
+func (w *lifecycleWriter) Truncate(size int64) error {
+	w.owner.mu.Lock()
+	defer w.owner.mu.Unlock()
+	if w.closed {
+		return os.ErrClosed
+	}
+	if size < int64(len(w.owner.data)) {
+		w.owner.data = w.owner.data[:size]
+	} else {
+		w.owner.data = append(w.owner.data, make([]byte, int(size)-len(w.owner.data))...)
+	}
+	return nil
+}
+
+func (w *lifecycleWriter) Close() error {
+	w.owner.mu.Lock()
+	defer w.owner.mu.Unlock()
+	w.closes++
+	w.closed = true
+	return w.closeErr
+}
+
+type stagedLifecycleVFS struct {
+	*fakeVFS
+	mu      sync.Mutex
+	commits []string
+}
+
+func newStagedLifecycleVFS() *stagedLifecycleVFS {
+	return &stagedLifecycleVFS{fakeVFS: newFakeVFS(true)}
+}
+
+func (v *stagedLifecycleVFS) GetCapabilities() vfs.VFSCapabilities {
+	return vfs.VFSCapabilities{HasRandomAccess: true, HasWrite: true}
+}
+
+func (v *stagedLifecycleVFS) Create(ctx context.Context, path string) (io.WriteCloser, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return &stagedLifecycleWriter{owner: v}, nil
+}
+
+type stagedLifecycleWriter struct {
+	bytes.Buffer
+	owner *stagedLifecycleVFS
+}
+
+func (w *stagedLifecycleWriter) Close() error {
+	w.owner.mu.Lock()
+	defer w.owner.mu.Unlock()
+	w.owner.commits = append(w.owner.commits, w.String())
+	return nil
+}
+
+func TestWriteHandleMultipleFlushAndWriteAfterFlush(t *testing.T) {
+	ctx := context.Background()
+	v := newLifecycleVFS()
+	b := newBridge(v, "/root", Options{})
+	t.Cleanup(b.close)
+
+	wh, _, err := b.acquireWriteHandle(ctx, "/root/out.txt")
+	if err != nil {
+		t.Fatalf("acquire writer: %v", err)
+	}
+	if _, err := wh.writeAt(ctx, b, []byte("a"), 0); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("first Flush: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	}
+	if len(v.handles) != 1 {
+		t.Fatalf("two Flush calls used %d handles, want one", len(v.handles))
+	}
+	if v.handles[0].closes != 1 {
+		t.Fatalf("two Flush calls closed the handle %d times, want once", v.handles[0].closes)
+	}
+
+	if _, err := wh.writeAt(ctx, b, []byte("b"), 1); err != nil {
+		t.Fatalf("write after Flush: %v", err)
+	}
+	if len(v.handles) != 2 {
+		t.Fatalf("write after Flush opened %d handles, want 2", len(v.handles))
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("Flush after another write: %v", err)
+	}
+	if err := b.finishWriter(ctx, wh); err != nil {
+		t.Fatalf("Release after Flush: %v", err)
+	}
+	if got := string(v.data); got != "ab" {
+		t.Fatalf("backend data = %q, want %q", got, "ab")
+	}
+	if v.handles[1].closes != 1 {
+		t.Fatalf("reopened handle closed %d times, want once", v.handles[1].closes)
+	}
+}
+
+func TestWriteHandleFlushErrorReturnedOnce(t *testing.T) {
+	ctx := context.Background()
+	v := newLifecycleVFS(os.ErrPermission)
+	b := newBridge(v, "/root", Options{})
+	t.Cleanup(b.close)
+
+	wh, _, err := b.acquireWriteHandle(ctx, "/root/out.txt")
+	if err != nil {
+		t.Fatalf("acquire writer: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); !errors.Is(err, os.ErrPermission) {
+		t.Fatalf("first Flush = %v, want os.ErrPermission", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("second Flush = %v, want success", err)
+	}
+	if err := b.finishWriter(ctx, wh); err != nil {
+		t.Fatalf("Release after failed Flush = %v", err)
+	}
+	if v.handles[0].closes != 1 {
+		t.Fatalf("failed close was retried %d times, want once", v.handles[0].closes)
+	}
+}
+
+func TestWriteHandleReleaseWithoutFlushClosesWriter(t *testing.T) {
+	ctx := context.Background()
+	v := newLifecycleVFS()
+	b := newBridge(v, "/root", Options{})
+	t.Cleanup(b.close)
+
+	wh, _, err := b.acquireWriteHandle(ctx, "/root/out.txt")
+	if err != nil {
+		t.Fatalf("acquire writer: %v", err)
+	}
+	if _, err := wh.writeAt(ctx, b, []byte("saved"), 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := b.finishWriter(ctx, wh); err != nil {
+		t.Fatalf("Release without Flush: %v", err)
+	}
+	if len(v.handles) != 1 {
+		t.Fatalf("Release used %d handles, want one", len(v.handles))
+	}
+	if v.handles[0].closes != 1 {
+		t.Fatalf("Release closed the handle %d times, want once", v.handles[0].closes)
+	}
+}
+
+func TestStagedWriteAfterFlushIsCommittedAgain(t *testing.T) {
+	ctx := context.Background()
+	v := newStagedLifecycleVFS()
+	b := newBridge(v, "/root", Options{})
+	t.Cleanup(b.close)
+
+	wh, _, err := b.acquireWriteHandle(ctx, "/root/out.txt")
+	if err != nil {
+		t.Fatalf("acquire writer: %v", err)
+	}
+	if _, err := wh.writeAt(ctx, b, []byte("a"), 0); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("first Flush: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("second Flush: %v", err)
+	}
+	if _, err := wh.writeAt(ctx, b, []byte("b"), 1); err != nil {
+		t.Fatalf("write after Flush: %v", err)
+	}
+	if err := b.flushWriter(ctx, wh); err != nil {
+		t.Fatalf("Flush after another write: %v", err)
+	}
+	if err := b.finishWriter(ctx, wh); err != nil {
+		t.Fatalf("Release after Flush: %v", err)
+	}
+	if len(v.commits) != 2 || v.commits[0] != "a" || v.commits[1] != "ab" {
+		t.Fatalf("commits = %q, want [a ab]", v.commits)
+	}
+}
+
+func TestStagedReleaseWithoutFlushCommitsAndCloses(t *testing.T) {
+	ctx := context.Background()
+	v := newStagedLifecycleVFS()
+	b := newBridge(v, "/root", Options{})
+	t.Cleanup(b.close)
+
+	wh, _, err := b.acquireWriteHandle(ctx, "/root/out.txt")
+	if err != nil {
+		t.Fatalf("acquire writer: %v", err)
+	}
+	if _, err := wh.writeAt(ctx, b, []byte("saved"), 0); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := b.finishWriter(ctx, wh); err != nil {
+		t.Fatalf("Release without Flush: %v", err)
+	}
+	if len(v.commits) != 1 || v.commits[0] != "saved" {
+		t.Fatalf("commits = %q, want [saved]", v.commits)
+	}
+	if _, err := wh.staged.Size(); !errors.Is(err, os.ErrClosed) {
+		t.Fatalf("staging file after Release = %v, want os.ErrClosed", err)
 	}
 }

--- a/fusefs/writers_test.go
+++ b/fusefs/writers_test.go
@@ -354,7 +354,7 @@ func TestStagedReleaseWithoutFlushCommitsAndCloses(t *testing.T) {
 	if len(v.commits) != 1 || v.commits[0] != "saved" {
 		t.Fatalf("commits = %q, want [saved]", v.commits)
 	}
-	if _, err := wh.staged.Size(); !errors.Is(err, os.ErrClosed) {
-		t.Fatalf("staging file after Release = %v, want os.ErrClosed", err)
+	if _, err := wh.staged.Size(); err == nil {
+		t.Fatal("staging file remained usable after Release")
 	}
 }


### PR DESCRIPTION
49 находок errcheck в `fusefs`, одна из них важная.

**Ошибка записи не доходила до того, кто писал файл.** Последний прямой писатель закрывался в `Release`, а FUSE ошибку из `Release` никому не отдаёт. Из `Flush` — отдаёт, она возвращается из `close(2)`. Перенесли туда.

Перенос не однострочный, потому что жизненный цикл разный. `Release` вызывается один раз, когда закрыт последний дескриптор. `Flush` — на каждое `close(2)`, то есть дескриптор, продублированный через `dup` или унаследованный через `fork`, даст несколько вызовов. И `Flush` может прийти, когда файл ещё открыт и в него сейчас снова напишут.

Теперь дескриптор помнит, закрыт ли он и зафиксированы ли данные: второй `Flush` не закрывает второй раз, запись после `Flush` заново открывает писателя, а `Release` по-прежнему всё дописывает, если процесс убили без `Flush`. На все четыре случая тесты.

**Попутно:** `MountVFS` мог закрыть VFS дважды на одном пути отказа. И ошибки завершения больше не заставляют `Unmount` сообщать, что уже отсоединённое не удалось отсоединить.

**Урезано при ревью:** обрыв установки при неудачном удалении временного файла. Файл уже открыт и работает независимо от того, есть у него имя.
