### PR TITLE
test: join the panel workers before the next test moves the ground

### DIFF
--- a/cmd/f4/command_palette_direct_panels_test.go
+++ b/cmd/f4/command_palette_direct_panels_test.go
@@ -179,15 +179,19 @@ func TestCommandPaletteSearchFirstFocusToggleIsStateSpecific(t *testing.T) {
 }
 
 func TestCommandPaletteAISendDraftOnlyForCurrentNonEmptyInput(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	left := NewFileSystemPanel(0, 0, 40, 20, vfs.NewNullVFS(0))
 	right := NewFileSystemPanel(40, 0, 80, 20, vfs.NewNullVFS(0))
+	waitForLoad(t, left)
+	waitForLoad(t, right)
 	pf := newDirectPalettePanelsFrame(left, right)
 	chat := NewAIChatPanel(left)
 	chat.SetFocus(true)
 	chat.focusedLinkIdx = -1
 	chat.input.SetText("review this patch")
 	pf.altPanels[0] = chat
-	setDirectPaletteTopFrame(t, pf)
+	vtui.FrameManager.Push(pf)
 
 	entry, found := commandPaletteTestEntryByID(commandPalettePanelsContextEntries(pf), "AI.SendDraft")
 	if !found || entry.Description != Msg("CommandPalette.AI.SendDraft.Desc") {

--- a/cmd/f4/dialog_layouts_test.go
+++ b/cmd/f4/dialog_layouts_test.go
@@ -160,8 +160,12 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 				localVFS := vfs.NewOSVFS(tmpDir)
 				_ = localVFS.SetPath(tmpDir)
 				pf := NewPanelsFrame()
-				pf.panels[0] = NewFileSystemPanel(0, 0, 40, 20, localVFS)
-				pf.panels[1] = NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+				left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
+				right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+				waitForLoad(t, left)
+				waitForLoad(t, right)
+				pf.panels[0] = left
+				pf.panels[1] = right
 				pf.ResizeConsole(120, 60)
 				vtui.FrameManager.Push(pf)
 

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -4644,6 +4644,7 @@ func TestFileSystemPanel_PendingSelectionPriority(t *testing.T) {
 	// имеет приоритет над текущим положением курсора при прилете чанков данных.
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	fp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewNullVFS(0))
+	waitForLoad(t, fp)
 
 	// Устанавливаем цель (новое имя файла после ренейма)
 	fp.pendingSelection = "new_name.txt"

--- a/cmd/f4/framework_actions_test.go
+++ b/cmd/f4/framework_actions_test.go
@@ -472,6 +472,8 @@ func TestWorkspaceClosePreservesQueueVetoBelowHelpAndForBackgroundTarget(t *test
 func TestWorkspaceCloseKeepsTheOnlyPanelsWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
 	panels := setupMockPanelsFrame()
+	waitForLoad(t, panels.panels[0].(*FileSystemPanel))
+	waitForLoad(t, panels.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(panels)
 	viewer := &frameworkActionTestFrame{title: "Viewer"}
 	vtui.FrameManager.AddScreen(viewer)
@@ -496,6 +498,8 @@ func TestWorkspaceCloseKeepsTheOnlyPanelsWorkspace(t *testing.T) {
 func TestPanelsFrameCloseVetoProtectsTheOnlyPanelsWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
 	panels := setupMockPanelsFrame()
+	waitForLoad(t, panels.panels[0].(*FileSystemPanel))
+	waitForLoad(t, panels.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(panels)
 	vtui.FrameManager.AddScreen(&frameworkActionTestFrame{title: "Editor"})
 	vtui.FrameManager.SwitchScreen(0)


### PR DESCRIPTION
Шесть сообщений детектора гонок вокруг `file_panel.go`, все шесть — ошибки тестов.

Горутина чтения каталога читает глобальное состояние: `AppConfig.ShowHiddenFiles`, `vtui.FrameManager` и очередь задач этого менеджера. Тесты запускали чтение и возвращались, а следом очистка восстанавливала `AppConfig` или следующий тест ставил свой менеджер — под работающей горутиной.

Детектор показывает пакет, где произошло **чтение**, а виноват тот, кто **пишет**, и это другой тест, часто в другом файле. Поэтому все шесть указывали на `file_panel.go`, а чинить пришлось в четырёх посторонних тестах.
