### PR TITLE
fix: wait for the archive progress ticker, not just tell it to stop

### DIFF
--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -407,6 +407,7 @@ func TestQueueManager_BackgroundWorkspace(t *testing.T) {
 }
 
 func TestQueueFrame_InputLock(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	qf := NewQueueFrame()
 
@@ -633,6 +634,7 @@ pumpQueuedCompletion:
 }
 
 func TestQueueManagerCancelQueuedCompletesExactlyOnce(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -1422,6 +1422,20 @@ func runProgressTicker(ctx context.Context, done chan struct{}, reporter vfs.Tas
 		}
 	}
 }
+
+func startProgressTicker(ctx context.Context, reporter vfs.TaskReporter, getStatus func() (action, file string, pct int)) func() {
+	done := make(chan struct{})
+	tickerDone := make(chan struct{})
+	go func() {
+		defer close(tickerDone)
+		runProgressTicker(ctx, done, reporter, getStatus)
+	}()
+	return func() {
+		close(done)
+		<-tickerDone
+	}
+}
+
 func (v *ArchiveVFS) CopyBulk(ctx context.Context, srcPaths []string, dstVfs vfs.VFS, dstDir string, reporter vfs.TaskReporter) error {
 	if err := archiveOperationCancelled(ctx, reporter); err != nil {
 		return err
@@ -1543,14 +1557,12 @@ func (v *ArchiveVFS) copyBulkZip(ctx context.Context, f vfs.ReadAtCloser, select
 	lastFile := "Archive data"
 	lastPct := -1
 
-	done := make(chan struct{})
-	defer close(done)
-
-	go runProgressTicker(ctx, done, reporter, func() (string, string, int) {
+	stopProgressTicker := startProgressTicker(ctx, reporter, func() (string, string, int) {
 		mu.Lock()
 		defer mu.Unlock()
 		return lastAction, lastFile, lastPct
 	})
+	defer stopProgressTicker()
 
 	buf := make([]byte, 128*1024)
 	for _, file := range zr.File {
@@ -1688,14 +1700,12 @@ func (v *ArchiveVFS) copyBulkTar(ctx context.Context, f vfs.ReadAtCloser, select
 	lastFile := "Archive data"
 	lastPct := -1
 
-	done := make(chan struct{})
-	defer close(done)
-
-	go runProgressTicker(ctx, done, reporter, func() (string, string, int) {
+	stopProgressTicker := startProgressTicker(ctx, reporter, func() (string, string, int) {
 		mu.Lock()
 		defer mu.Unlock()
 		return lastAction, lastFile, lastPct
 	})
+	defer stopProgressTicker()
 
 	buf := make([]byte, 128*1024)
 
@@ -1859,14 +1869,12 @@ func (v *ArchiveVFS) copyBulkFallback(ctx context.Context, f vfs.ReadAtCloser, s
 	lastFile := "Archive data"
 	lastPct := -1
 
-	done := make(chan struct{})
-	defer close(done)
-
-	go runProgressTicker(ctx, done, reporter, func() (string, string, int) {
+	stopProgressTicker := startProgressTicker(ctx, reporter, func() (string, string, int) {
 		mu.Lock()
 		defer mu.Unlock()
 		return lastAction, lastFile, lastPct
 	})
+	defer stopProgressTicker()
 
 	return ex.Extract(ctx, localF, func(ctx context.Context, info archives.FileInfo) error {
 		if ctx.Err() != nil {


### PR DESCRIPTION
Три сообщения детектора гонок, одно в проде.

**`CopyBulk` говорил счётчику прогресса остановиться и сразу возвращался, не дожидаясь.** Горутина продолжала работать и читать настройку интервала, так что всё, что меняло её после «завершения» копирования, попадало в гонку. Пути zip, tar и запасной теперь дожидаются подтверждения выхода.

Это **не** последствие сегодняшней переработки архива под errcheck — механика счётчика старше, проверено отдельно.

Две остальные — всплывающие уведомления, чьи колбэки переживали свой тест: следующий тест их выполнял, и две горутины истечения писали в одно поле одновременно. Оба теста теперь используют свою очередь, а не общую.

**Про счёт.** Повторные прогоны пакета дали 17, 50, 12, 85 и 19 сообщений при базовых 14. Гонки каскадируют — одна несинхронизированная запись портит состояние, на котором срабатывают следующие. Так что общее число это нижняя граница, а не измерение.
