### PR TITLE
fix: give QueueTask.State one owner

### DIFF
--- a/cmd/f4/delete_trash_test.go
+++ b/cmd/f4/delete_trash_test.go
@@ -74,6 +74,9 @@ func TestQueuedTrashUsesActionBoundaryPathSnapshot(t *testing.T) {
 	if err := task.Run(context.Background(), &DummyReporter{}, nil); err != nil {
 		t.Fatal(err)
 	}
+	task.mu.Lock()
+	task.State = "Done"
+	task.mu.Unlock()
 	want := probe.Join(basePath, "item.txt")
 	if len(probe.trashed) != 1 || probe.trashed[0] != want {
 		t.Fatalf("trashed paths = %v, want %q", probe.trashed, want)
@@ -93,6 +96,9 @@ func TestDeleteDoesNotRetryPartialRemoteMutation(t *testing.T) {
 	task := queue.tasks[0]
 	queue.mu.Unlock()
 	err := task.Run(context.Background(), &DummyReporter{}, nil)
+	task.mu.Lock()
+	task.State = "Done"
+	task.mu.Unlock()
 	if !errors.Is(err, vfs.ErrOperationPartial) {
 		t.Fatalf("Run error = %v, want partial operation", err)
 	}

--- a/cmd/f4/editor_find_all_test.go
+++ b/cmd/f4/editor_find_all_test.go
@@ -434,7 +434,7 @@ func TestEditorFindAll_NotFound(t *testing.T) {
 		if _, ok := f.(*findAllFrame); ok {
 			t.Fatal("no occurrences menu expected for a miss")
 		}
-		return f != nil && f.GetType() == vtui.TypeDialog
+		return f != nil && f.GetTitle() == Msg("Search.Title")
 	})
 	if ev.selActive {
 		t.Error("a miss must not create a selection")

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -252,7 +252,7 @@ func TestEditor_StatefulHighlighting_BackgroundCatchUpAfterEdit(t *testing.T) {
 	ev.Show(scr)
 
 	timeout := time.After(2 * time.Second)
-	for len(ev.lineStates) < 1400 {
+	for len(ev.lineStates) < 1400 || ev.highlighting {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
 			task()

--- a/cmd/f4/process_environment_test.go
+++ b/cmd/f4/process_environment_test.go
@@ -771,6 +771,11 @@ func TestPanelsFrameEnvironmentFailureKeepsInputUntilSuccessfulRetry(t *testing.
 
 func TestPanelsFrameEnvironmentAcknowledgementTimeoutKeepsDeferredInput(t *testing.T) {
 	runProcessEnvironmentUIInline(t)
+	timeoutDone := make(chan struct{})
+	processEnvironmentRunOnUI = func(task func()) {
+		task()
+		close(timeoutDone)
+	}
 	oldTimeout := processEnvironmentAcknowledgementTimeout
 	processEnvironmentAcknowledgementTimeout = 15 * time.Millisecond
 	defer func() { processEnvironmentAcknowledgementTimeout = oldTimeout }()
@@ -802,6 +807,11 @@ func TestPanelsFrameEnvironmentAcknowledgementTimeoutKeepsDeferredInput(t *testi
 	}
 	if writes := local.snapshotWrites(); len(writes) != 1 {
 		t.Fatalf("timeout released held input: %q", writes)
+	}
+	select {
+	case <-timeoutDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout callback did not finish")
 	}
 	pf.closeProcessEnvironmentShell()
 }

--- a/cmd/f4/queue_manager.go
+++ b/cmd/f4/queue_manager.go
@@ -188,6 +188,8 @@ func (r *DummyReporter) UpdateTransfer(action, filename string, currentPct int, 
 func (r *DummyReporter) IsCancelled() bool { return false }
 
 type QueueTask struct {
+	// mu owns State, Progress, TotalText, Speed, CurrentFile, ErrorMsg,
+	// and queuedFinalizing.
 	mu          sync.Mutex
 	ID          int
 	Type        string
@@ -286,6 +288,7 @@ func queueTaskCancellable(state string) bool {
 }
 
 type OpQueueManager struct {
+	// When both manager and task state are needed, lock mu before QueueTask.mu.
 	mu             sync.Mutex
 	tasks          []*QueueTask
 	nextID         int
@@ -296,6 +299,7 @@ type OpQueueManager struct {
 }
 
 var GlobalQueueManager *OpQueueManager
+var queueShowToast = vtui.ShowToast
 
 func init() {
 	GlobalQueueManager = &OpQueueManager{
@@ -358,7 +362,9 @@ func (qm *OpQueueManager) Enqueue(task *QueueTask) {
 	qm.mu.Lock()
 	qm.nextID++
 	task.ID = qm.nextID
+	task.mu.Lock()
 	task.State = "Queued"
+	task.mu.Unlock()
 	task.ctx, task.cancel = context.WithCancel(context.Background())
 	qm.tasks = append(qm.tasks, task)
 	qm.mu.Unlock()
@@ -372,18 +378,19 @@ func (qm *OpQueueManager) Enqueue(task *QueueTask) {
 	go func(id int) {
 		time.Sleep(500 * time.Millisecond)
 		qm.mu.Lock()
-		defer qm.mu.Unlock()
+		active := false
 		for _, t := range qm.tasks {
 			if t.ID != id {
 				continue
 			}
 			t.mu.Lock()
-			active := queueTaskActive(t.State)
+			active = queueTaskActive(t.State)
 			t.mu.Unlock()
-			if active {
-				vtui.ShowToast("Background operation started. Press Ctrl+Tab for Queue.", 4*time.Second)
-			}
 			break
+		}
+		qm.mu.Unlock()
+		if active {
+			queueShowToast("Background operation started. Press Ctrl+Tab for Queue.", 4*time.Second)
 		}
 	}(task.ID)
 }
@@ -646,6 +653,7 @@ func (qm *OpQueueManager) executeTask(t *QueueTask) {
 		t.ErrorMsg = nil
 	}
 	finalState := t.State
+	finalError := t.ErrorMsg
 	t.mu.Unlock()
 
 	qm.mu.Lock()
@@ -655,7 +663,7 @@ func (qm *OpQueueManager) executeTask(t *QueueTask) {
 	qm.mu.Unlock()
 	qm.signalWorker()
 
-	vtui.DebugLog("QUEUE_DEBUG: Task %d finalized with state %s (Error: %v). Posting OnComplete.", t.ID, finalState, t.ErrorMsg)
+	vtui.DebugLog("QUEUE_DEBUG: Task %d finalized with state %s (Error: %v). Posting OnComplete.", t.ID, finalState, finalError)
 
 	qm.postTaskCompletion(t)
 }
@@ -852,7 +860,7 @@ func (qf *QueueFrame) vetoCloseWhileActive() bool {
 	if !queueHasActiveTasks() {
 		return false
 	}
-	vtui.ShowToast("Cannot close queue while operations are active. Use Ctrl+Tab to switch.", 3*time.Second)
+	queueShowToast("Cannot close queue while operations are active. Use Ctrl+Tab to switch.", 3*time.Second)
 	return true
 }
 

--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -26,6 +26,7 @@ func TestQueueManager_Lifecycle(t *testing.T) {
 	qm.mu.Unlock()
 
 	executed := false
+	completed := make(chan struct{})
 	task := &QueueTask{
 		Type:    "Test",
 		Desc:    "Dummy",
@@ -34,6 +35,7 @@ func TestQueueManager_Lifecycle(t *testing.T) {
 			executed = true
 			return nil
 		},
+		OnComplete: func() { close(completed) },
 	}
 
 	qm.Enqueue(task)
@@ -41,13 +43,9 @@ func TestQueueManager_Lifecycle(t *testing.T) {
 	// Wait for worker to execute
 	timeout := time.After(1 * time.Second)
 	for {
-		qm.mu.Lock()
-		if len(qm.tasks) == 0 {
-			qm.mu.Unlock()
-			continue
-		}
-		state := qm.tasks[0].State
-		qm.mu.Unlock()
+		task.mu.Lock()
+		state := task.State
+		task.mu.Unlock()
 		if state == "Done" {
 			break
 		}
@@ -60,6 +58,7 @@ func TestQueueManager_Lifecycle(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+	waitForQueueCompletion(t, completed)
 
 	if !executed {
 		t.Error("Task was not executed")
@@ -88,12 +87,14 @@ func TestQueueManager_ConcurrencyLimit(t *testing.T) {
 	}
 
 	task2Started := false
+	task2Completed := make(chan struct{})
 	task2 := &QueueTask{
 		ResKeys: []string{"shared_res"},
 		Run: func(ctx context.Context, r TaskReporter, a vtui.Frame) error {
 			task2Started = true
 			return nil
 		},
+		OnComplete: func() { close(task2Completed) },
 	}
 
 	qm.Enqueue(task1)
@@ -103,9 +104,9 @@ func TestQueueManager_ConcurrencyLimit(t *testing.T) {
 
 	time.Sleep(300 * time.Millisecond)
 
-	qm.mu.Lock()
+	task2.mu.Lock()
 	state2 := task2.State
-	qm.mu.Unlock()
+	task2.mu.Unlock()
 
 	if state2 != "Queued" {
 		t.Errorf("Task 2 should be Queued because resource is locked, but is %s", state2)
@@ -118,9 +119,9 @@ func TestQueueManager_ConcurrencyLimit(t *testing.T) {
 
 	timeout := time.After(1 * time.Second)
 	for {
-		qm.mu.Lock()
+		task2.mu.Lock()
 		s2 := task2.State
-		qm.mu.Unlock()
+		task2.mu.Unlock()
 		if s2 == "Done" {
 			break
 		}
@@ -133,6 +134,7 @@ func TestQueueManager_ConcurrencyLimit(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+	waitForQueueCompletion(t, task2Completed)
 
 	if !task2Started {
 		t.Error("Task 2 never started")
@@ -156,13 +158,15 @@ func TestQueueManager_ConflictDetection(t *testing.T) {
 	qm.mu.Unlock()
 
 	// 1. Ставим задачу в очередь с текущим состоянием файла
+	completed := make(chan struct{})
 	task := &QueueTask{
 		Type:    "Copy",
 		ResKeys: []string{getResourceKey(v)},
 		Preconditions: []OpPrecondition{
 			{Vfs: v, Path: path, MTime: st.MTime, Size: st.Size, IsDir: false},
 		},
-		Run: func(ctx context.Context, r TaskReporter, a vtui.Frame) error { return nil },
+		Run:        func(ctx context.Context, r TaskReporter, a vtui.Frame) error { return nil },
+		OnComplete: func() { close(completed) },
 	}
 
 	// Блокируем очередь, чтобы задача не запустилась мгновенно
@@ -190,9 +194,9 @@ func TestQueueManager_ConflictDetection(t *testing.T) {
 	// Ждем обработки
 	timeout := time.After(2 * time.Second)
 	for {
-		qm.mu.Lock()
+		task.mu.Lock()
 		state := task.State
-		qm.mu.Unlock()
+		task.mu.Unlock()
 		if state == "Error" || state == "Done" {
 			break
 		}
@@ -205,6 +209,7 @@ func TestQueueManager_ConflictDetection(t *testing.T) {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+	waitForQueueCompletion(t, completed)
 
 	task.mu.Lock()
 	state, taskErr := task.State, task.ErrorMsg
@@ -222,6 +227,7 @@ func TestQueueManager_ResourceIndependence(t *testing.T) {
 	qm.mu.Unlock()
 
 	start := make(chan bool, 2)
+	completed := make(chan bool, 2)
 
 	task1 := &QueueTask{
 		ResKeys: []string{"disk_A"},
@@ -230,6 +236,7 @@ func TestQueueManager_ResourceIndependence(t *testing.T) {
 			time.Sleep(200 * time.Millisecond)
 			return nil
 		},
+		OnComplete: func() { completed <- true },
 	}
 	task2 := &QueueTask{
 		ResKeys: []string{"disk_B"}, // Другой ресурс!
@@ -237,6 +244,7 @@ func TestQueueManager_ResourceIndependence(t *testing.T) {
 			start <- true
 			return nil
 		},
+		OnComplete: func() { completed <- true },
 	}
 
 	qm.Enqueue(task1)
@@ -255,6 +263,34 @@ Loop:
 		case <-timeout:
 			t.Fatalf("Only %d tasks started, expected 2 (independence check)", count)
 			break Loop
+		}
+	}
+	completionTimeout := time.NewTimer(time.Second)
+	defer completionTimeout.Stop()
+	for count = 0; count < 2; {
+		select {
+		case <-completed:
+			count++
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-completionTimeout.C:
+			t.Fatalf("Only %d tasks completed, expected 2", count)
+		}
+	}
+}
+
+func waitForQueueCompletion(t *testing.T, completed <-chan struct{}) {
+	t.Helper()
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-completed:
+			return
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timer.C:
+			t.Fatal("queue completion callback did not run")
 		}
 	}
 }
@@ -411,9 +447,10 @@ func TestQueueFrame_InputLock(t *testing.T) {
 	qf := NewQueueFrame()
 
 	qm := GlobalQueueManager
+	task := &QueueTask{ID: 1, State: "Running"}
 	qm.mu.Lock()
 	// Имитируем активную задачу
-	qm.tasks = []*QueueTask{{ID: 1, State: "Running"}}
+	qm.tasks = []*QueueTask{task}
 	qm.mu.Unlock()
 
 	// Попытка нажать Esc
@@ -441,9 +478,9 @@ func TestQueueFrame_InputLock(t *testing.T) {
 	}
 
 	// Завершаем задачи
-	qm.mu.Lock()
-	qm.tasks[0].State = "Done"
-	qm.mu.Unlock()
+	task.mu.Lock()
+	task.State = "Done"
+	task.mu.Unlock()
 
 	// Теперь Esc не должен поглощаться самим фреймом (вернет false или обработает BaseWindow)
 	if qf.ProcessKey(ev) {

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/unxed/vtui"
 	"os"
 	"testing"
+	"time"
 )
 
 // pressKey dispatches a key through the production input path: the
@@ -78,6 +79,7 @@ func TestMain(m *testing.M) {
 	// for its own scope.
 	vtui.SkipOSClipboard(true)
 	vtui.DisableTerminalClipboard()
+	queueShowToast = func(string, time.Duration) {}
 
 	tmpDir, err := os.MkdirTemp("", "f4-test-config-*")
 	if err == nil {


### PR DESCRIPTION
Четыре сообщения детектора гонок. Одно привело к настоящему багу в проде.

Отчёт был про то, что `executeTask` пишет `task.State` под замком задачи, а тест читает под замком менеджера. Починить тест — простой ответ, но он верен только если прод сам с собой согласен.

Вычитал все обращения к полю: двадцать с лишним в `queue_manager.go` плюс несколько в `command_palette_frames.go` и `apply_command.go`. **Владеет полем `task.mu`**, а обходы списка берут сначала `qm.mu`, то есть порядок `qm.mu → task.mu`. Все места так и делают, **кроме `Enqueue`** — он писал состояние, держа только `qm.mu`.

Гонка достижимая: `Enqueue` вызывается тем, кто ставит операцию в очередь, ровно тогда, когда исполнитель и отрисовка строки читают то же поле.

Теперь `Enqueue` берёт нужный замок, а владение и порядок записаны рядом с полем — иначе следующему пришлось бы выводить это заново из двадцати мест.

**Попутно:** отложенное уведомление отправлялось, держа `qm.mu` — та же форма, что чуть не дала взаимоблокировку в диалоге прогресса. И финальный `ErrorMsg` снимается под замком, а не после.

Остальные три — обычные утечки тестов: рабочая горутина поиска, обходчик подсветки и колбэк таймаута переживали свои тесты.
