### PR TITLE
test: give the shuffled tests a frame manager that can answer

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -481,13 +481,21 @@ func TestActionDelete_Abort(t *testing.T) {
 
 	// Ждем ошибку и жмем Abort
 	timeout := time.After(2 * time.Second)
+	abortClicked := false
+	var progress *FileOpProgressDialog
 Loop:
 	for {
 		select {
 		case task := <-fm.TaskChan:
 			task()
-			if fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == " Error " {
+			if top, ok := fm.GetTopFrame().(*FileOpProgressDialog); ok {
+				progress = top
+			}
+			if !abortClicked && fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == " Error " {
 				clickDialogButton(t, fm.GetTopFrame().(vtui.Container), "Abort")
+				abortClicked = true
+			}
+			if progress != nil && progress.IsDone() {
 				break Loop
 			}
 			if fm.GetTopFrame() != nil && fm.GetTopFrame().IsDone() {

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -4473,11 +4473,17 @@ func TestEditorView_Search_Reverse_StartAtZero(t *testing.T) {
 	ev.Search("match", false, true, false, false, false)
 
 	timeout := time.After(2 * time.Second)
-	select {
-	case task := <-vtui.FrameManager.TaskChan:
-		task()
-	case <-timeout:
-		t.Fatal("Reverse search at offset 0 hung")
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+			if result := vtui.FrameManager.GetTopFrame(); result != nil && result.GetTitle() == Msg("Search.Title") {
+				vtui.FrameManager.RemoveFrame(result)
+				return
+			}
+		case <-timeout:
+			t.Fatal("Reverse search at offset 0 hung")
+		}
 	}
 }
 

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -2894,6 +2894,7 @@ func TestFileSystemPanel_DirectoryCache(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 20, v)
+	waitForLoad(t, fp)
 	t.Cleanup(func() {
 		if fp.cancelLoad != nil {
 			fp.cancelLoad()
@@ -3099,6 +3100,7 @@ func TestFileSystemPanel_TitleDoesNotContainSortIndicator(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 24, v)
+	waitForLoad(t, fp)
 	fp.currentTitle = "C:\\work"
 
 	scr := vtui.NewSilentScreenBuf()
@@ -3131,6 +3133,7 @@ func TestFileSystemPanel_CurrentTitleKeepsTheSameColorWhenFocused(t *testing.T) 
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 24, v)
+	waitForLoad(t, fp)
 	fp.currentTitle = "C:\\work"
 
 	scr := vtui.NewSilentScreenBuf()
@@ -3171,6 +3174,7 @@ func TestFileSystemPanel_FastFind_Visibility(t *testing.T) {
 	// Создаем много файлов, чтобы список мог скроллиться
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 40, 10, v)
+	waitForLoad(t, fp)
 	fp.viewMode = ViewModeDetailed
 
 	for i := 0; i < 20; i++ {
@@ -3201,6 +3205,7 @@ func TestFileSystemPanel_Sorting(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	v := vfs.NewOSVFS(t.TempDir())
 	fp := NewFileSystemPanel(0, 0, 80, 24, v)
+	waitForLoad(t, fp)
 
 	t1 := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
 	t2 := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -3388,6 +3393,7 @@ func TestFileSystemPanel_HeaderClickSortsAndToggles(t *testing.T) {
 	if _, ok := fp.headerSortModeAt(separatorX, fp.table.Y1); ok {
 		t.Fatal("column separator was treated as a sortable header")
 	}
+	waitForLoad(t, fp)
 }
 
 func TestFileSystemPanel_HeaderSortMappingAllViewModes(t *testing.T) {
@@ -3577,6 +3583,7 @@ func TestFileSystemPanel_CacheLoadPreservesSelection(t *testing.T) {
 	if !found {
 		t.Error("keep.txt not found in panel after cache reload")
 	}
+	waitForLoad(t, fp)
 }
 
 func TestFileSystemPanel_SyncPanelLoad(t *testing.T) {

--- a/cmd/f4/terminal_selection_test.go
+++ b/cmd/f4/terminal_selection_test.go
@@ -195,6 +195,7 @@ func panelsFrameWithMouseSelect(t *testing.T) (*PanelsFrame, *fakePTY) {
 	pf.ResizeConsole(80, 25)
 	pf.showPanels = false
 	pf.termView.SetPosition(0, 0, 79, 22)
+	pf.termView.clipboardWriter = func(string) {}
 	// zoin-bot: these tests exercise the terminal/PTy mouse path. A visible
 	// f4 command line has its own paste path and is covered separately below.
 	pf.cmdLine.SetVisible(false)

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -60,6 +60,7 @@ func preserveActionRegistry(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	vfs.InitSudoClient("/usr/bin/f4", "")
 
 	// Unit tests must never hand control to the user's desktop. Individual

--- a/plugins/android/adb_transport_test.go
+++ b/plugins/android/adb_transport_test.go
@@ -621,22 +621,19 @@ func TestFailedConnectStartsInstalledADBAndRetries(t *testing.T) {
 }
 
 func TestCancelledHostRequestUnblocksRead(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	server, dialer := testServer(t, func(conn net.Conn) {
 		expectTestRequest(t, conn, "host:devices-l")
+		cancel()
 		_, _ = io.Copy(io.Discard, conn)
 	})
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
-	defer cancel()
-	started := time.Now()
 	_, err := server.Devices(ctx)
 	if err == nil {
 		t.Fatal("Devices unexpectedly succeeded")
 	}
-	if !errors.Is(err, context.DeadlineExceeded) {
-		t.Fatalf("Devices error = %v, want context deadline", err)
-	}
-	if time.Since(started) > time.Second {
-		t.Fatalf("cancellation took %v", time.Since(started))
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Devices error = %v, want context canceled", err)
 	}
 	dialer.assertDone()
 }


### PR DESCRIPTION
Чинит красный main: два падения на Windows и macOS, на тестах, которые локально проходят.

**Панельные тесты** (`TestFileSystemPanel_MultiSelect`, `TestFileSystemPanel_FocusLoss_FastFind`) отваливались по таймауту в две секунды, ожидая загрузки каталога. Очевидное объяснение — бегунки медленнее бюджета, очевидная починка — поднять число. Оба неверны.

Пока ни один тест не инициализировал `vtui.FrameManager`, его канал задач никем не читается. Горутина загрузки отрабатывала, отправляла завершение, и колбэк, снимающий признак «идёт загрузка», выбрасывался. Ожидание не могло закончиться никогда. В исходном порядке первым всегда случайно оказывался тест, который менеджер поднимал; шаффл это совпадение убрал.

`TestMain` теперь его инициализирует. Ни один таймаут не тронут.

Прогон под шаффлом попутно выявил несколько тестов, возвращавшихся с незавершённой асинхронной работой — каждый теперь дожидается своей.

**Android-тест** `TestCancelledHostRequestUnblocksRead` отменял запрос через 30 мс независимо от того, прочитал ли его собеседник. Если не успевал — тест возвращался, а запоздавший обработчик звал `t.Errorf`, что после завершения теста роняет процесс с паникой. Теперь отмена после доставки запроса, проверяется по-прежнему то же самое.
