### PR TITLE
fix: keep Classic selection on the blue panel background

### DIFF
--- a/cmd/f4/style_test.go
+++ b/cmd/f4/style_test.go
@@ -123,6 +123,9 @@ func TestApplyColorStyleModernAndClassic(t *testing.T) {
 	if got := vtui.GetRGBBack(vtui.Palette[ColPanelText]); got != 0x0000A0 {
 		t.Fatalf("classic panel background: got %06X", got)
 	}
+	if got := vtui.GetRGBBack(vtui.Palette[ColPanelSelectedText]); got != 0x0000A0 {
+		t.Fatalf("classic selected panel background: got %06X, want 0000A0", got)
+	}
 	if got := vtui.GetRGBBack(vtui.Palette[vtui.ColKeyBarNum]); got != 0x000000 {
 		t.Fatalf("classic key bar gap background: got %06X", got)
 	}

--- a/cmd/f4/styles/classic.ini
+++ b/cmd/f4/styles/classic.ini
@@ -5,10 +5,9 @@ Name = Classic
 # The classic style intentionally uses f4's original built-in palette.
 Panel.Cursor.Inactive = foreground:#D3D7CF | background:#555753
 Panel.Cursor.Inactive.Selected = foreground:#FFFF00 | background:#555753
-# Explicit override: without it, selected (non-cursor) files use the
-# f4-default yellow-on-blue, which is too close to the base panel
-# background to read as "selected" at a glance (issue #524).
-Panel.Text.Selected = foreground:#FFFF00 | background:#26268C
+# Keep Classic selection on the same blue background as far2l/Norton
+# Commander; the yellow foreground is the selection indicator.
+Panel.Text.Selected = foreground:#FFFF00 | background:#0000A0
 CommandLine.Prompt.Inactive = foreground:#555753 | background:#000000
 KeyBar.Numbers = foreground:#D3D7CF | background:#000000
 KeyBar.Labels = foreground:#000000 | background:#06989A


### PR DESCRIPTION
## Summary
- keep selected non-cursor files in the Classic style on the same blue background as the panel
- retain the yellow foreground as the selection indicator
- add a regression assertion for the Classic selected-file background

This addresses issue #786 and keeps the change scoped to the Classic style; other themes retain their contrast-oriented selection backgrounds.

Tested on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland): `go test ./cmd/f4` and a live attached TTY run with multiple selected rows.