### PR TITLE
fix: clear remaining CI failures

### DIFF
--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -2521,6 +2521,10 @@ func TestFileSystemPanel_NavigateDown_CursorReset(t *testing.T) {
 	if fp.GetCursorIndex() != 0 {
 		t.Errorf("Cursor did not reset to '..'. Index is %d", fp.GetCursorIndex())
 	}
+	// Pressing Enter above starts an asynchronous load of subdir. Wait for it
+	// before t.TempDir is removed, otherwise the worker can enqueue an error
+	// dialog for the next test after this test has already returned.
+	waitForDirectoryLoads(t)
 }
 func TestFileSystemPanel_FastFind(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())

--- a/cmd/f4/image_x11_overlay.go
+++ b/cmd/f4/image_x11_overlay.go
@@ -137,21 +137,6 @@ func (x *x11ImageOverlay) hide() {
 	x.key = ""
 }
 
-// suspend takes the picture off the screen but leaves the overlay wanting to
-// be there, so the event loop can put it back when the focus returns.
-//
-// The remembered frame goes with it. An unmapped window keeps its pixels only
-// if the server has backing store, and modern Xorg does not: the window comes
-// back blank, and a cache that still believed the right thing was on it would
-// never repaint. That is what turned an alt-tab into an empty viewer.
-func (x *x11ImageOverlay) suspend() {
-	if x == nil {
-		return
-	}
-	x.ov.Suspend()
-	x.key = ""
-}
-
 // overlayCellRect converts a rectangle of character cells into a rectangle of
 // screen pixels. The size of a cell is not asked for: it is the size of the
 // terminal window divided by the number of cells in it, which is exact when

--- a/internal/ttyx/overlay.go
+++ b/internal/ttyx/overlay.go
@@ -193,10 +193,9 @@ func (o *Overlay) Place(r Rect) error {
 }
 
 // Suspend takes the overlay off the screen without forgetting that the caller
-// wants it there, so that resume can put it back. The event loop calls it when
-// the terminal loses the focus, because an override-redirect window is above
-// everything and nothing else in X will move it out of the way; a caller that
-// notices the same thing first can call it too.
+// wants it there. The event loop calls it when the terminal loses the focus,
+// because an override-redirect window is above everything and nothing else in
+// X will move it out of the way.
 func (o *Overlay) Suspend() {
 	o.s.mu.Lock()
 	defer o.s.mu.Unlock()
@@ -205,19 +204,6 @@ func (o *Overlay) Suspend() {
 	}
 	xproto.UnmapWindow(o.s.conn, o.win)
 	o.mapped = false
-}
-
-// resume puts it back when the focus comes back.
-func (o *Overlay) resume() {
-	o.s.mu.Lock()
-	defer o.s.mu.Unlock()
-	if o.s.conn == nil || o.mapped || !o.wanted || o.rect.W <= 0 || o.rect.H <= 0 {
-		return
-	}
-	xproto.ConfigureWindow(o.s.conn, o.win, xproto.ConfigWindowStackMode,
-		[]uint32{xproto.StackModeAbove})
-	xproto.MapWindow(o.s.conn, o.win)
-	o.mapped = true
 }
 
 // followedParent records that the terminal window moved and took the overlay

--- a/internal/ttyx/watch.go
+++ b/internal/ttyx/watch.go
@@ -211,9 +211,3 @@ func (s *Session) unregisterOverlay(o *Overlay) {
 	s.overlays = kept
 	s.mu.Unlock()
 }
-
-func (s *Session) overlaySnapshot() []*Overlay {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return append([]*Overlay(nil), s.overlays...)
-}


### PR DESCRIPTION
Fixes #776.

Changes:
- wait for the asynchronous directory loader in `TestFileSystemPanel_NavigateDown_CursorReset` before its temporary directory is removed, preventing a stale error dialog from leaking into the next test;
- remove three unused overlay helpers that fail the strict whole-tree lint (`x11ImageOverlay.suspend`, `ttyx.Overlay.resume`, and `ttyx.Session.overlaySnapshot`).

Validation on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland):
- `go vet ./...`
- focused CI regression tests pass;
- the exact shuffle seed from the reported failure passes all packages except `internal/ttyx`, whose X11 tests cannot run in this Wayland session and fail with environment-specific `BadMatch`/geometry errors;
- cross-builds pass for Darwin amd64 and Windows amd64.
