### PR TITLE
fix: align nightly build timestamps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -935,7 +935,10 @@ jobs:
     - name: Set Release Metadata
       run: |
         echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-        echo "BUILD_TIME=$(date +'%Y-%m-%d %H:%M:%S')" >> "$GITHUB_ENV"
+        # Go embeds the commit timestamp as vcs.time in every nightly binary.
+        # Publish that same timestamp so the updater and F1's Help Index use
+        # one source instead of comparing the workflow clock with commit time.
+        echo "BUILD_TIME=$(date -u -d "@$(git show -s --format='%ct' HEAD)" +'%Y-%m-%d %H:%M:%S')" >> "$GITHUB_ENV"
 
     - name: Download all artifacts
       uses: actions/download-artifact@v8

--- a/cmd/f4/title.go
+++ b/cmd/f4/title.go
@@ -8,6 +8,7 @@ import (
 	"runtime/debug"
 	"strings"
 	"sync"
+	"time"
 	"unicode"
 
 	"github.com/unxed/vtui"
@@ -81,10 +82,7 @@ func getGitFallback() (rev string, dirty string, timeStr string) {
 	}
 	timeOut, err := exec.Command("git", "log", "-1", "--format=%cI").Output()
 	if err == nil {
-		tStr := strings.TrimSpace(string(timeOut))
-		if len(tStr) >= 16 {
-			timeStr = strings.Replace(tStr[:16], "T", " ", 1)
-		}
+		timeStr = strings.TrimSpace(string(timeOut))
 	}
 	return rev, dirty, timeStr
 }
@@ -104,9 +102,6 @@ func getVCSInfo() (rev string, dirty string, timeStr string) {
 				}
 			case "vcs.time":
 				timeStr = s.Value
-				if len(timeStr) >= 16 {
-					timeStr = strings.Replace(timeStr[:16], "T", " ", 1)
-				}
 			}
 		}
 	}
@@ -146,7 +141,7 @@ func getLongVersionInfo() string {
 	if buildVersion != "" {
 		_, _, timeStr := getVCSInfo()
 		if timeStr != "" {
-			return buildVersion + " [" + timeStr + "]"
+			return buildVersion + " [" + formatBuildTimeForDisplay(timeStr) + "]"
 		}
 		return buildVersion
 	}
@@ -172,9 +167,31 @@ func getLongVersionInfo() string {
 		sb.WriteString(baseVer)
 	}
 	if timeStr != "" {
-		sb.WriteString(" [" + timeStr + "]")
+		sb.WriteString(" [" + formatBuildTimeForDisplay(timeStr) + "]")
 	}
 	return sb.String()
+}
+
+// formatBuildTimeForDisplay converts the UTC timestamp embedded by Go in
+// release binaries to the user's local time. Nightly release metadata uses
+// the same commit timestamp, so the updater and F1's Help Index show one
+// value instead of one UTC value and one local value.
+func formatBuildTimeForDisplay(value string) string {
+	for _, layout := range []string{time.RFC3339, "2006-01-02 15:04:05", "2006-01-02 15:04"} {
+		var (
+			parsed time.Time
+			err    error
+		)
+		if layout == time.RFC3339 {
+			parsed, err = time.Parse(layout, value)
+		} else {
+			parsed, err = time.ParseInLocation(layout, value, time.UTC)
+		}
+		if err == nil {
+			return parsed.Local().Format("2006-01-02 15:04")
+		}
+	}
+	return value
 }
 
 func UpdateWindowTitle(scr *vtui.ScreenBuf) {

--- a/cmd/f4/title_test.go
+++ b/cmd/f4/title_test.go
@@ -99,6 +99,17 @@ func TestBuildVersionOverridesVCSMetadata(t *testing.T) {
 	}
 }
 
+func TestFormatBuildTimeForDisplayUsesOneClockForVCSAndNightlyMetadata(t *testing.T) {
+	fromVCS := formatBuildTimeForDisplay("2026-08-23T06:49:17Z")
+	fromReleaseBody := formatBuildTimeForDisplay("2026-08-23 06:49:17")
+	if fromVCS != fromReleaseBody {
+		t.Fatalf("VCS time %q and release-body time %q diverged", fromVCS, fromReleaseBody)
+	}
+	if got := formatBuildTimeForDisplay("not a timestamp"); got != "not a timestamp" {
+		t.Fatalf("invalid timestamp = %q, want unchanged input", got)
+	}
+}
+
 func TestCurrentWindowTitleMatchesRenderedTitle(t *testing.T) {
 	origTemplate := AppConfig.ConsoleTitleTemplate
 	defer func() { AppConfig.ConsoleTitleTemplate = origTemplate }()

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -201,14 +201,7 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		// post-update version line agree. See #343.
 		if commit, builtOn := commitInfoFromReleaseBody(release.Body); commit != "" {
 			if builtOn != "" {
-				// The nightly workflow records BUILD_TIME with `date` on
-				// a UTC GitHub runner and without a zone suffix, so it is
-				// UTC. Treat it as such and show the user's local time so
-				// the prompt agrees with the asset-timestamp path above
-				// and never regresses to UTC. See f4 issue #343.
-				if t, err := time.ParseInLocation("2006-01-02 15:04:05", builtOn, time.UTC); err == nil {
-					builtOn = t.Local().Format("2006-01-02 15:04")
-				}
+				builtOn = formatBuildTimeForDisplay(builtOn)
 				displayVersion = "Nightly (" + commit + " [" + builtOn + "])"
 			} else {
 				displayVersion = "Nightly (" + commit + ")"


### PR DESCRIPTION
Fixes #780.

The nightly updater and F1 Help Index were displaying different timestamps: the release body used the workflow clock while the binary used Go's embedded VCS commit time, and F1 left that timestamp in UTC. This change:

- preserves the original VCS timestamp offset until display formatting;
- converts F1's VCS timestamp and the updater's release-body timestamp through one shared local-time formatter;
- makes the nightly release body publish the commit timestamp used by Go's `vcs.time`.

Validation on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland):
- focused timestamp regression test passed;
- full `go test ./cmd/f4` passed;
- `go vet ./...` passed;
- a clean ARM64 build was run on the device and its `--version` output matched the expected local commit timestamp.
