### PR TITLE
Fix Command Palette menu action

### DIFF
--- a/ISSUE_793_SOLUTION_REVIEW.md
+++ b/ISSUE_793_SOLUTION_REVIEW.md
@@ -1,0 +1,57 @@
+# Issue #793 solution review
+
+## Reproduction
+
+On Windows 10 x64, using the native Win32 GUI build from `upstream/main` at
+`06281917f6b6bdaad9864802aae507b52d6c0639`:
+
+1. Open the main menu with F9.
+2. Open `Commands`.
+3. Select the final `Command palette` item and press Enter.
+
+The submenu closes, but the command palette is not shown. Ctrl+Shift+P opens
+the same palette successfully, so the action registration and dialog itself
+work.
+
+## Three-pass review
+
+### Pass 1: change the action/menu callback
+
+Change `BuildMenuBarItems` so the command-palette item closes the menu or calls
+a special menu-only handler. This would duplicate menu lifecycle knowledge in
+f4 and make the generic action path behave differently from the hotkey path.
+Reject: the existing action registry already provides one shared execution
+path, and the bug is in the precondition order inside `ShowCommandPalette`.
+
+### Pass 2: keep the deferred retry, but make it reachable
+
+`ShowCommandPalette` already defers itself while `GetActiveMenuBar().Active` is
+true because vtui invokes `OnClick` before the submenu is closed. However, the
+unknown-modal guard currently runs first. A `VMenu` is modal, so it consumes the
+request before the active-menu branch can post the retry. Move the active-menu
+check before the modal whitelist. After the current input dispatch removes the
+submenu, the posted retry sees the underlying workspace frame and opens the
+palette normally.
+
+This preserves the modal whitelist for real modal dialogs and keeps the hotkey
+path unchanged.
+
+### Pass 3: consider a vtui lifecycle change
+
+Change vtui so a menu item's callback runs after the menu is removed, or add a
+new explicit close-and-run API. That would affect every menu action and risks
+changing callback ordering for existing commands, including actions that rely
+on the current owner/menu state.
+
+Reject for this ticket: no vtui change is needed once f4 reaches its existing
+deferred path. The f4-only change is smaller, testable, and avoids a dependency
+update.
+
+## Selected solution and safety checks
+
+Select Pass 2. The regression test will invoke `RunAction` with an active
+submenu, close the submenu as the input dispatcher does, drain the posted UI
+task, and verify that a `commandPaletteDialog` is pushed. Existing direct
+palette tests continue to cover the hotkey path. The native validation will
+repeat both paths and confirm that the menu path displays the palette without
+breaking ordinary menu closing.

--- a/cmd/f4/command_palette.go
+++ b/cmd/f4/command_palette.go
@@ -60,11 +60,6 @@ func ShowCommandPalette() bool {
 	if _, alreadyOpen := vtui.FrameManager.GetTopFrame().(*commandPaletteDialog); alreadyOpen {
 		return true
 	}
-	if top := vtui.FrameManager.GetTopFrame(); top != nil && top.IsModal() && !commandPaletteModalFrameSupported(top) {
-		// Unknown modal owners keep their complete input contract. Consume the
-		// palette chord without stacking an unrelated dialog above them.
-		return true
-	}
 	if menu := vtui.FrameManager.GetActiveMenuBar(); menu != nil && menu.Active {
 		// vtui's VMenu fires a clicked item's OnClick synchronously, before the
 		// menu bar closes itself (VMenu.FireAction runs ahead of SetExitCode),
@@ -72,6 +67,11 @@ func ShowCommandPalette() bool {
 		// Defer and retry once the current input dispatch (and the menu close
 		// it triggers) has completed, instead of silently swallowing the click.
 		vtui.FrameManager.PostTask(func() { ShowCommandPalette() })
+		return true
+	}
+	if top := vtui.FrameManager.GetTopFrame(); top != nil && top.IsModal() && !commandPaletteModalFrameSupported(top) {
+		// Unknown modal owners keep their complete input contract. Consume the
+		// palette chord without stacking an unrelated dialog above them.
 		return true
 	}
 	area := (&MacroManager{}).GetCurrentArea()

--- a/cmd/f4/command_palette_menu_test.go
+++ b/cmd/f4/command_palette_menu_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/unxed/vtui"
+)
+
+func TestCommandPaletteActionFromActiveMenuWaitsForMenuClose(t *testing.T) {
+	initFrameworkActionTestScreen(t)
+
+	menu := vtui.NewMenuBar([]string{"&Commands"})
+	host := &frameworkActionTestFrame{title: "Panels", menu: menu}
+	vtui.FrameManager.Push(host)
+	menu.Items[0].SubItems = []vtui.MenuItem{{
+		Text:    "&Command palette",
+		OnClick: func() { RunAction(commandPaletteActionName) },
+	}}
+	menu.Active = true
+	menu.ActivateSubMenu(0)
+
+	if vtui.FrameManager.GetTopFrame().GetType() != vtui.TypeMenu {
+		t.Fatalf("top frame before click = %T, want VMenu", vtui.FrameManager.GetTopFrame())
+	}
+	if !RunAction(commandPaletteActionName) {
+		t.Fatal("command palette action was not handled from the active menu")
+	}
+
+	// This is the ordering used by FrameManager after VMenu.OnClick returns:
+	// the menu is marked done and the menu bar is inactive before the posted
+	// task is allowed to open the replacement dialog.
+	menu.Active = false
+	vtui.FrameManager.GetTopFrame().Close()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		vtui.FrameManager.Step(0)
+		if _, ok := vtui.FrameManager.GetTopFrame().(*commandPaletteDialog); ok {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("top frame after deferred menu action = %T, want commandPaletteDialog", vtui.FrameManager.GetTopFrame())
+}


### PR DESCRIPTION
## Summary
- allow the Command Palette action to defer while an active menu is closing
- keep the unknown-modal guard for real modal frames
- add a regression test and document the three-pass solution review

## Validation
- go test ./... -count=1
- go vet -unsafeptr=false ./...
- native Windows 10 x64 Win32 GUI build: F9 -> Commands -> Command palette -> Enter opens the palette
- native Ctrl+Shift+P still opens the palette

The branch is based on fetched upstream/main commit 06281917f6b6bdaad9864802aae507b52d6c0639 because the fork origin/main is stale.

— zoin-bot