### PR TITLE
Preserve Right Ctrl in hotkey assignment

### DIFF
--- a/ISSUE_492_SOLUTION_REVIEW.md
+++ b/ISSUE_492_SOLUTION_REVIEW.md
@@ -1,0 +1,49 @@
+# Issue #492 solution review
+
+## Report and current behavior
+
+Issue #492 was previously fixed for runtime dispatch, but a follow-up report
+says that Right Ctrl+A still cannot be reassigned to file properties and that
+the default AI shortcut remains unusable. The current code has two deliberate
+key-string layers:
+
+- `EventToFarString` normalizes Left Ctrl and Right Ctrl to the same `Ctrl...`
+  spelling for macros and historical compatibility.
+- `EventToHotkeyString` preserves a distinct `RCtrl...` spelling for the
+  configurable action dispatcher.
+
+The hotkey assignment dialog still uses the first function, so a captured
+Right Ctrl+A is stored as `CtrlA`. That does not override the default
+`RCtrlA=AI.TogglePanel` binding. This is the direct cause of the follow-up
+report.
+
+## Three-pass review
+
+### Pass 1: change the global key normalizer
+
+Make `EventToFarString` preserve Right Ctrl everywhere. Reject: macro storage,
+bookmark shortcuts, and existing compatibility behavior intentionally treat
+both Ctrl keys as the same key. A global change would alter unrelated input
+surfaces and existing user configurations.
+
+### Pass 2: add a second ad-hoc Right Ctrl conversion in the dialog
+
+Teach `HotkeyAssignFrame.ProcessKey` to inspect modifier flags and prepend
+`RCtrl` itself. Reject: this duplicates the canonical configurable-hotkey
+conversion already used by `MacroManager.Filter` and `LookupHotkey`, making
+future modifier fixes diverge between runtime and assignment.
+
+### Pass 3: use the configurable-hotkey representation at capture time
+
+Replace the assignment dialog's `EventToFarString(e)` call with
+`EventToHotkeyString(e)`. This stores `RCtrlA` as `RCtrlA`, leaves ordinary
+Left Ctrl capture as `CtrlA`, and makes the dialog use the same spelling the
+runtime dispatcher resolves. Select this pass.
+
+## Safety checks
+
+Add a regression test that feeds Right Ctrl+A through the real
+`HotkeyAssignFrame.ProcessKey` and verifies the draft binds `RCtrlA`, while a
+Left Ctrl+A test still binds `CtrlA`. Native Win32 validation will confirm that
+the assignment dialog can capture Right Ctrl+A and that the saved binding
+overrides the AI default without changing ordinary Ctrl behavior.

--- a/cmd/f4/hotkeys_ui.go
+++ b/cmd/f4/hotkeys_ui.go
@@ -447,7 +447,7 @@ func (f *HotkeyAssignFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		return false
 	}
 
-	keyStr := EventToFarString(e)
+	keyStr := EventToHotkeyString(e)
 
 	if f.hm != nil {
 		f.hm.Bind(f.area, keyStr, f.actionName)

--- a/cmd/f4/hotkeys_ui_test.go
+++ b/cmd/f4/hotkeys_ui_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
 
@@ -44,6 +45,41 @@ func TestHotkeyRow(t *testing.T) {
 	}
 	if row.GetCellText(4) != "Description" {
 		t.Errorf("Expected Description")
+	}
+}
+
+func TestHotkeyAssignFramePreservesRightCtrl(t *testing.T) {
+	previous := GlobalHotkeysMgr
+	t.Cleanup(func() { GlobalHotkeysMgr = previous })
+
+	hm := NewHotkeyManager("")
+	f := NewHotkeyAssignFrame(hm, "File.Attributes", "Shell", nil)
+	ctrlABefore, ctrlAExists := hm.Bindings["Shell"]["CtrlA"]
+
+	rightCtrlA := &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_A,
+		ControlKeyState: vtinput.RightCtrlPressed,
+	}
+	if !f.ProcessKey(rightCtrlA) {
+		t.Fatal("Right Ctrl+A was not consumed by the assignment dialog")
+	}
+	if got := hm.Bindings["Shell"]["RCtrlA"]; got != "File.Attributes" {
+		t.Fatalf("captured Right Ctrl+A = %q, want File.Attributes under RCtrlA", got)
+	}
+	if got, exists := hm.Bindings["Shell"]["CtrlA"]; exists != ctrlAExists || (exists && got != ctrlABefore) {
+		t.Fatalf("Right Ctrl+A changed the normalized CtrlA binding from %q to %q", ctrlABefore, got)
+	}
+
+	left := NewHotkeyAssignFrame(hm, "File.Attributes", "Shell", nil)
+	leftCtrlA := *rightCtrlA
+	leftCtrlA.ControlKeyState = vtinput.LeftCtrlPressed
+	if !left.ProcessKey(&leftCtrlA) {
+		t.Fatal("Left Ctrl+A was not consumed by the assignment dialog")
+	}
+	if got := hm.Bindings["Shell"]["CtrlA"]; got != "File.Attributes" {
+		t.Fatalf("captured Left Ctrl+A = %q, want File.Attributes under CtrlA", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- preserve the physical Right Ctrl modifier when a user assigns a configurable hotkey;
- keep the existing normalized Ctrl representation for Left Ctrl, macros, and bookmarks;
- add a regression test covering both Right Ctrl+A and Left Ctrl+A assignment paths.

## Validation

- go test ./... -count=1
- go vet -unsafeptr=false ./...
- native Win32 validation on Windows 10 x64: launched the fixed build, opened Hotkey Configurator, entered the area-selection and Assign Hotkey dialogs, and verified the assignment flow. The desktop key injector presents Right Ctrl as normalized Ctrl, so the exact RCtrl representation is covered by the vtinput regression test.

The branch is based on the fetched upstream/main commit aabfa03ac78ab32b36af472d6fc6670fea72dad6 because the fork's origin/main is stale.

— zoin-bot