### PR TITLE
Fix hotkey dialog selection after search

### DIFF
--- a/ISSUE_493_SOLUTION_REVIEW.md
+++ b/ISSUE_493_SOLUTION_REVIEW.md
@@ -1,0 +1,30 @@
+# Issue #493 solution review
+
+## Pass 1 — direct index replacement
+
+Replace every `table.SelectPos` use with an offset into `hkRows` and adjust
+the list whenever filtering changes. Rejected: the table can also reorder rows
+for sortable columns, so maintaining a second mapping would duplicate vtui's
+selection model and could drift again.
+
+## Pass 2 — rebuild `hkRows` in display order
+
+Keep the existing button callbacks and reorder the application slice whenever
+the table changes. Rejected: `vtui.Table` intentionally keeps `Rows` stable
+and stores display ordering/filtering separately; copying that state into f4
+would couple the dialog to internal widget behavior.
+
+## Pass 3 — resolve the selected row through `Table.RowAt`
+
+Use `table.RowAt(table.SelectPos)` for both Assign and Unbind, then index the
+stable `hkRows` slice with the returned source row. This is the common fix for
+sorting and QuickSearch because the same mapping covers keyboard navigation,
+mouse selection, and Enter activation.
+
+## Safety checks
+
+- out-of-range and nil table selections are ignored;
+- both Assign and Unbind use the same mapping;
+- a regression test covers a sorted display and a filtered display;
+- native Win32 validation will reproduce search, cursor movement, and Enter
+  activation in the hotkey configurator.

--- a/cmd/f4/hotkeys_ui.go
+++ b/cmd/f4/hotkeys_ui.go
@@ -122,6 +122,17 @@ func hotkeyTableColumns(rows []hotkeyRow, dialogWidth int) []vtui.TableColumn {
 	return columns
 }
 
+func selectedHotkeyRow(table *vtui.Table, rows []hotkeyRow) (hotkeyRow, bool) {
+	if table == nil {
+		return hotkeyRow{}, false
+	}
+	idx := table.RowAt(table.SelectPos)
+	if idx < 0 || idx >= len(rows) {
+		return hotkeyRow{}, false
+	}
+	return rows[idx], true
+}
+
 func actionHotkeyConfig(pf *PanelsFrame) {
 	w, h := 120, 48
 	if vtui.FrameManager != nil {
@@ -257,17 +268,13 @@ func actionHotkeyConfig(pf *PanelsFrame) {
 	}
 
 	btnAssign.OnClick = func() {
-		idx := table.SelectPos
-		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
-			row := hkRows[idx]
+		if row, ok := selectedHotkeyRow(table, hkRows); ok && row.Editable {
 			showAreaSelectDialog(draft, row.Action, row.Area, row.Condition, refresh)
 		}
 	}
 
 	btnUnbind.OnClick = func() {
-		idx := table.SelectPos
-		if idx >= 0 && idx < len(hkRows) && hkRows[idx].Editable {
-			row := hkRows[idx]
+		if row, ok := selectedHotkeyRow(table, hkRows); ok && row.Editable {
 			if row.RawKey != "" && row.Area != "" {
 				question := fmt.Sprintf("%s %s?", plainLabel(Msg("Hotkeys.BtnUnbind")), row.Key)
 				vtui.ShowMessageOn(dlg, Msg("Hotkeys.Title"), question, []string{Msg("vtui.Ok"), Msg("vtui.Cancel")}).OnResult = func(choice int) {

--- a/cmd/f4/hotkeys_ui_test.go
+++ b/cmd/f4/hotkeys_ui_test.go
@@ -72,6 +72,31 @@ func TestHotkeyTableColumnsFitContentWhenSpaceAllows(t *testing.T) {
 	}
 }
 
+func TestSelectedHotkeyRowUsesDisplayedTablePosition(t *testing.T) {
+	rows := []hotkeyRow{
+		{Label: "Zulu action"},
+		{Label: "Alpha action"},
+		{Label: "Middle action"},
+	}
+	table := vtui.NewTable(0, 0, 80, 10, []vtui.TableColumn{{Title: "Command", Width: 40}})
+	table.Sortable = true
+	table.SetRows([]vtui.TableRow{rows[0], rows[1], rows[2]})
+	table.SetSort(0, true)
+
+	row, ok := selectedHotkeyRow(table, rows)
+	if !ok || row.Label != "Alpha action" {
+		t.Fatalf("sorted display row selected %q, want Alpha action", row.Label)
+	}
+
+	table.QuickSearch = true
+	table.SetSearchText("middle")
+	table.SelectPos = 0
+	row, ok = selectedHotkeyRow(table, rows)
+	if !ok || row.Label != "Middle action" {
+		t.Fatalf("filtered display row selected %q, want Middle action", row.Label)
+	}
+}
+
 func TestNativeHotkeyInventory(t *testing.T) {
 	selectAction, ok := GetAction("Panel.SelectNavigation")
 	if !ok {


### PR DESCRIPTION
## Summary

- resolve the selected hotkey row through vtui.Table.RowAt;
- use the same display-to-source mapping for Assign and Unbind;
- add regression coverage for sorted and QuickSearch-filtered tables.

## Validation

- go test ./... -count=1
- go vet -unsafeptr=false ./...
- native Win32 validation on Windows 10 x64: downloaded and inspected the issue reproduction video, launched the fixed build, filtered the Hotkey Configurator, moved the selection with arrows, and pressed Enter. The selected "AI View: Artifacts" row opened the matching AI.Left.ViewOut assignment dialog.

The branch is based on fetched upstream/main commit aabfa03ac78ab32b36af472d6fc6670fea72dad6 because the fork's origin/main is stale.

— zoin-bot