### PR TITLE
Добить гонки в cmd/f4 до нуля

### DIFF
--- a/cmd/f4/action_copyname_parent_test.go
+++ b/cmd/f4/action_copyname_parent_test.go
@@ -28,7 +28,7 @@ func waitForCopyNameClipboard(t *testing.T, want string) string {
 func seedPanelForCopyName(t *testing.T, path string) *PanelsFrame {
 	t.Helper()
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	t.Cleanup(func() { pf.Close() })
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/action_marked_clipboard_test.go
+++ b/cmd/f4/action_marked_clipboard_test.go
@@ -35,7 +35,7 @@ func waitForMarkedClipboard(t *testing.T, want string) string {
 func seedMarkedPanel(t *testing.T, path string, names []string, markCount int) *PanelsFrame {
 	t.Helper()
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	t.Cleanup(func() { pf.Close() })
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/action_restore_selection_test.go
+++ b/cmd/f4/action_restore_selection_test.go
@@ -14,7 +14,7 @@ import (
 func seedPanelForRestore(t *testing.T, names []string) *PanelsFrame {
 	t.Helper()
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	t.Cleanup(func() { pf.Close() })
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -244,6 +244,8 @@ func TestActionDelete_BulkErrorAccumulation(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Создаем мок-VFS, который запретит удаление "fail.txt"
 	mv := &mockDeletionFailingVFS{
@@ -303,11 +305,16 @@ func TestActionDelete_BulkErrorAccumulation(t *testing.T) {
 
 	// 3. Прокручиваем очередь задач, ожидая появления диалога с итогами ошибок
 	timeout := time.After(2 * time.Second)
+	var progress *FileOpProgressDialog
+	summaryShown := false
 Loop:
 	for {
 		select {
 		case task := <-fm.TaskChan:
 			task()
+			if top, ok := fm.GetTopFrame().(*FileOpProgressDialog); ok {
+				progress = top
+			}
 
 			// Если выскочил диалог ошибки удаления (AskError), нажимаем Skip
 			if fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == " Error " {
@@ -323,6 +330,9 @@ Loop:
 
 			// Ждем, когда на вершине стека окажется диалог с заголовком " Deletion Errors "
 			if fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == Msg("FileOp.DeletionErrors") {
+				summaryShown = true
+			}
+			if summaryShown && progress != nil && progress.IsDone() {
 				break Loop
 			}
 
@@ -357,6 +367,8 @@ Loop:
 	if !foundF1 || !foundF2 {
 		t.Errorf("One of the deletable files was skipped: %v", mv.deletedFiles)
 	}
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 
 type mockRetryDeleteVFS struct {
@@ -443,6 +455,8 @@ Loop:
 	if len(mv.deleted) != 1 || mv.deleted[0] != "retry.txt" {
 		t.Errorf("File was not deleted after Retry. Deleted: %v", mv.deleted)
 	}
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 
 func TestActionDelete_Abort(t *testing.T) {
@@ -460,6 +474,8 @@ func TestActionDelete_Abort(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	fsp := pf.panels[0].(*FileSystemPanel)
 	fsp.vfs = mv
 	fsp.entries = []*fileEntry{
@@ -495,7 +511,7 @@ Loop:
 				clickDialogButton(t, fm.GetTopFrame().(vtui.Container), "Abort")
 				abortClicked = true
 			}
-			if progress != nil && progress.IsDone() {
+			if abortClicked && progress != nil && progress.IsDone() {
 				break Loop
 			}
 			if fm.GetTopFrame() != nil && fm.GetTopFrame().IsDone() {
@@ -512,6 +528,8 @@ Loop:
 	if len(mv.deletedFiles) != 0 {
 		t.Errorf("Abort failed: some files were deleted: %v", mv.deletedFiles)
 	}
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 func TestActionDelete_SkipAll(t *testing.T) {
 	fm := vtui.FrameManager
@@ -529,6 +547,8 @@ func TestActionDelete_SkipAll(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	fsp := pf.panels[0].(*FileSystemPanel)
 	fsp.vfs = mv
 	fsp.entries = []*fileEntry{
@@ -553,11 +573,16 @@ func TestActionDelete_SkipAll(t *testing.T) {
 	// 2. Ждем первую ошибку и жмем "Skip All"
 	timeout := time.After(2 * time.Second)
 	skipAllClicked := false
+	var progress *FileOpProgressDialog
+	summaryShown := false
 Loop:
 	for {
 		select {
 		case task := <-fm.TaskChan:
 			task()
+			if top, ok := fm.GetTopFrame().(*FileOpProgressDialog); ok {
+				progress = top
+			}
 
 			if !skipAllClicked && fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == " Error " {
 				if dlg, ok := fm.GetTopFrame().(vtui.Container); ok {
@@ -573,6 +598,9 @@ Loop:
 
 			// Ждем финальный диалог со списком ошибок
 			if fm.GetTopFrameType() == vtui.TypeDialog && fm.GetTopFrame().GetTitle() == Msg("FileOp.DeletionErrors") {
+				summaryShown = true
+			}
+			if summaryShown && progress != nil && progress.IsDone() {
 				break Loop
 			}
 
@@ -602,11 +630,13 @@ Loop:
 	if foundErrors != 2 {
 		t.Errorf("Expected 2 errors in log, found %d", foundErrors)
 	}
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 func TestActionExecute_PtyCommandFormatting(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	// setupMockPanelsFrame и mockPty определены в других тестовых файлах того же пакета
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pty := pf.pty.(*mockPty)
 
@@ -657,7 +687,7 @@ func TestActionExecute_PtyCommandFormatting(t *testing.T) {
 
 func TestActionExecute_HistoryQuoting(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	tmp := t.TempDir()
@@ -1413,6 +1443,8 @@ func TestActionFindFile_Persistence(t *testing.T) {
 func TestSession_DiskPersistence(t *testing.T) {
 	// Создаем временную директорию для теста
 	tmpDir := t.TempDir()
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	oldConfig := AppConfig
 	oldEditorSearch, oldFindMask := LastEditorSearch, LastFindFileMask
 	oldLeftPath, oldRightPath := LastLeftPath, LastRightPath
@@ -1422,6 +1454,7 @@ func TestSession_DiskPersistence(t *testing.T) {
 	oldLeftSortMode, oldRightSortMode := LastLeftSortMode, LastRightSortMode
 	oldLeftSortRev, oldRightSortRev := LastLeftSortRev, LastRightSortRev
 	oldShowPanels, oldShowLeft, oldShowRight := LastShowPanels, LastShowLeft, LastShowRight
+	oldWorkspaces, oldActiveWorkspace := LastWorkspaceSessions, LastActiveWorkspace
 	t.Cleanup(func() {
 		AppConfig = oldConfig
 		LastEditorSearch, LastFindFileMask = oldEditorSearch, oldFindMask
@@ -1432,7 +1465,10 @@ func TestSession_DiskPersistence(t *testing.T) {
 		LastLeftSortMode, LastRightSortMode = oldLeftSortMode, oldRightSortMode
 		LastLeftSortRev, LastRightSortRev = oldLeftSortRev, oldRightSortRev
 		LastShowPanels, LastShowLeft, LastShowRight = oldShowPanels, oldShowLeft, oldShowRight
+		LastWorkspaceSessions, LastActiveWorkspace = oldWorkspaces, oldActiveWorkspace
 	})
+	LastWorkspaceSessions = nil
+	LastActiveWorkspace = 0
 	AppConfig.AutoSaveSettings = true
 	// SaveSession passes these through to saveSessionWithOptions, and the panel
 	// group is what writes ViewMode, SortMode, SortReverse and the Show* keys.
@@ -1671,6 +1707,8 @@ func TestActionPanelSettings_ConsoleModes(t *testing.T) {
 	chkOverlay.State = 1
 
 	clickDialogButton(t, dlg, "Ok")
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	if AppConfig.ConsoleMode != "host" {
 		t.Errorf("AppConfig.ConsoleMode = %q, want host", AppConfig.ConsoleMode)
@@ -1734,6 +1772,8 @@ func TestActionManagePlugins_Flow(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	oldPlugins := AppConfig.RegisteredPlugins
 	AppConfig.RegisteredPlugins = []string{"/old/path"}
@@ -2013,6 +2053,8 @@ func TestActionCommandHistory_Flow(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	pf.cmdLine.Edit.History = nil
 	actionCommandHistory(pf)
@@ -2043,6 +2085,8 @@ func TestActionCommandHistory_Deletion(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	pf.cmdLine.Edit.History = []string{"cmd1", "cmd2", "cmd3"}
 	actionCommandHistory(pf)
@@ -2081,6 +2125,8 @@ func TestActionAppearanceSettings_SaveCursor(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	oldCfg := AppConfig
 	defer func() { AppConfig = oldCfg }()
@@ -2139,6 +2185,8 @@ func TestActionAppearanceSettingsSavesSystemMonospace(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionAppearanceSettings(pf)
 	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
 
@@ -2179,6 +2227,8 @@ func TestActionAppearanceSettingsSavesWorkspaceTabRestoration(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionAppearanceSettings(pf)
 	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
 
@@ -2219,6 +2269,8 @@ func TestActionAppearanceSettingsSavesWorkspaceTabOverlay(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionAppearanceSettings(pf)
 	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
 
@@ -2238,6 +2290,8 @@ func TestActionAppearanceSettingsSavesWorkspaceTabOverlay(t *testing.T) {
 	}
 	overlayTabs.Toggle()
 	clickDialogButton(t, top, "Ok")
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	if AppConfig.WorkspaceTabsOverlay {
 		t.Fatal("disabled workspace tab overlay setting was not saved")
 	}
@@ -2259,6 +2313,8 @@ func TestActionAppearanceSettingsSavesWorkspaceTabNumbering(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionAppearanceSettings(pf)
 	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
 
@@ -2295,6 +2351,8 @@ func TestActionAppearanceSettings_CancelPreservesPalette(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Simulate a farcolors.ini override: bump one palette slot to
 	// a sentinel value the base style would never produce. If Cancel
@@ -2348,6 +2406,8 @@ func TestActionAppearanceSettings_LivePreviewRecolorsExistingLabels(t *testing.T
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	actionAppearanceSettings(pf)
 	frame := vtui.FrameManager.GetTopFrame()
@@ -2400,8 +2460,11 @@ func TestPanelsFrame_RunAdvancedProgressTask(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	done := make(chan struct{})
+	completed := make(chan struct{})
 	workerBlock := make(chan struct{})
 	var reporter vfs.TaskReporter
 
@@ -2410,7 +2473,7 @@ func TestPanelsFrame_RunAdvancedProgressTask(t *testing.T) {
 		close(done)
 		<-workerBlock
 		return nil
-	}, nil)
+	}, func(error) { close(completed) })
 
 	select {
 	case <-done:
@@ -2459,8 +2522,17 @@ func TestPanelsFrame_RunAdvancedProgressTask(t *testing.T) {
 
 	// Close dialog and unblock worker
 	close(workerBlock)
-	dlg.SetExitCode(-1)
-	vtui.FrameManager.Pop()
+	timeout = time.After(2 * time.Second)
+	for completed != nil {
+		select {
+		case <-completed:
+			completed = nil
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			t.Fatal("progress task did not complete")
+		}
+	}
 }
 
 type mockExtractionVFS struct {

--- a/cmd/f4/ai_chat_panel_test.go
+++ b/cmd/f4/ai_chat_panel_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 func TestAIChatPanel_Resize(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewNullVFS(0))
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 	cp.SetPosition(0, 0, 79, 23)
 
@@ -54,8 +57,11 @@ func TestFormatAttachedFilesLabel(t *testing.T) {
 }
 
 func TestAIChatPanel_AttachedFilesBarFocusAndNavigation(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	session := vtvibe.NewSession()
 	fp := NewFileSystemPanel(0, 0, 80, 24, &aiVFSWrapper{AIVFS: vtvibe.NewVFS(session)})
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 	cp.SetFocus(true)
 
@@ -95,7 +101,10 @@ func TestAIChatPanel_AttachedFilesBarFocusAndNavigation(t *testing.T) {
 	}
 }
 func TestAIChatPanel_TabPassesThroughForPanelSwitching(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	fp := NewFileSystemPanel(0, 0, 80, 24, vfs.NewNullVFS(0))
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 	cp.SetFocus(true)
 
@@ -113,6 +122,7 @@ func TestAIChatPanel_TabPassesThroughForPanelSwitching(t *testing.T) {
 func TestAIChatPanel_RCtrlC_CopiesLastResponse(t *testing.T) {
 	session := vtvibe.NewSession()
 	fp := NewFileSystemPanel(0, 0, 80, 24, &aiVFSWrapper{AIVFS: vtvibe.NewVFS(session)})
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 	cp.SetFocus(true)
 
@@ -134,6 +144,7 @@ func TestAIChatPanel_ContextFilesRenderingAndLinkNavigation(t *testing.T) {
 	_ = session.Ask // compile check
 
 	fp := NewFileSystemPanel(0, 0, 80, 24, &aiVFSWrapper{AIVFS: vtvibe.NewVFS(session)})
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 	cp.SetFocus(true)
 
@@ -170,6 +181,7 @@ func TestAIChatPanel_ContextFilesRenderingAndLinkNavigation(t *testing.T) {
 func TestAIChatPanel_BarKindExcludesApSpec(t *testing.T) {
 	session := vtvibe.NewSession()
 	fp := NewFileSystemPanel(0, 0, 80, 24, &aiVFSWrapper{AIVFS: vtvibe.NewVFS(session)})
+	waitForLoad(t, fp)
 	cp := NewAIChatPanel(fp)
 
 	// Case 1: No files

--- a/cmd/f4/apply_command_test.go
+++ b/cmd/f4/apply_command_test.go
@@ -68,8 +68,8 @@ func TestApplyCommandActionUsesActivePanelWorkspace(t *testing.T) {
 	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
-	pfA := setupMockPanelsFrame()
-	pfB := setupMockPanelsFrame()
+	pfA := setupMockPanelsFrame(t)
+	pfB := setupMockPanelsFrame(t)
 	defer pfA.Close()
 	defer pfB.Close()
 	pfA.ResizeConsole(80, 25)

--- a/cmd/f4/async_buffer_test.go
+++ b/cmd/f4/async_buffer_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -321,9 +322,15 @@ func TestAsyncBuffer_RedundantFetchPrevention(t *testing.T) {
 	buf.chunkSize = 100
 	defer buf.Close()
 
-	// Trigger 10 simultaneous reads for the same offset
+	// Trigger 10 simultaneous reads for the same offset. Read consults the
+	// global frame manager, so these have to be joined before the test returns
+	// or the next test's manager swap races them.
+	var reads sync.WaitGroup
+	reads.Add(10)
+	defer reads.Wait()
 	for i := 0; i < 10; i++ {
 		go func() {
+			defer reads.Done()
 			_, _ = buf.Read(0, 5)
 		}()
 	}

--- a/cmd/f4/command_prefix_registry_test.go
+++ b/cmd/f4/command_prefix_registry_test.go
@@ -78,7 +78,7 @@ func TestPanelsFrameCommandPrefixIsConsumedBeforePTY(t *testing.T) {
 	}
 	t.Cleanup(registration.Unregister)
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pty := pf.pty.(*mockPty)
 	pf.cmdLine.Edit.SetText("CorePrefix: selected.mkv")

--- a/cmd/f4/console_passthrough_test.go
+++ b/cmd/f4/console_passthrough_test.go
@@ -164,7 +164,7 @@ func TestHostConsole_PanelToggleAction(t *testing.T) {
 }
 
 func TestHostConsole_InputForwardingWhenIdle(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.shellMode = ShellModeHost
 	pf.showPanels = false
@@ -276,7 +276,7 @@ func TestHostConsole_FarStylePTYSizing(t *testing.T) {
 	AppConfig.ConsoleMode = "host"
 	AppConfig.ConsoleOverlayUI = true
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.shellMode = ShellModeHost
 	pf.showKeyBar = true

--- a/cmd/f4/dialog_layouts_test.go
+++ b/cmd/f4/dialog_layouts_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtui"
@@ -117,6 +118,7 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 		"panel.insertleftpath":             true, // no dialog
 		"panel.insertrightpath":            true, // no dialog
 		"debug.dummyoperation":             true, // async queue
+		"macro.reload":                     true, // no dialog; owns an asynchronous toast
 		"panel.infopanel":                  true, // no dialog
 		"panel.quickview":                  true, // no dialog
 	}
@@ -167,6 +169,8 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 				pf.panels[0] = left
 				pf.panels[1] = right
 				pf.ResizeConsole(120, 60)
+				waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+				waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 				vtui.FrameManager.Push(pf)
 
 				// Setup editor/viewer context if testing editor/viewer actions
@@ -183,6 +187,11 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 
 				// Trigger the action handler!
 				act.Handler()
+				waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+				waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+				if vtui.FrameManager.GetActiveToast() != "" {
+					waitForToastExpiry(t, 6*time.Second)
+				}
 
 				frames := vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx].Frames
 				if len(frames) <= initialCount {

--- a/cmd/f4/dragdrop_test.go
+++ b/cmd/f4/dragdrop_test.go
@@ -209,7 +209,7 @@ func TestDragOutRemotePanel(t *testing.T) {
 	defer vtui.SetDragBackend(nil)
 	vtui.SetDragBackend(dragBackendStub{})
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/editor_find_all_test.go
+++ b/cmd/f4/editor_find_all_test.go
@@ -635,7 +635,11 @@ func TestEditorFindAll_LargeListOpensWithoutMaterializing(t *testing.T) {
 		t.Fatal("occurrences menu did not open")
 	}
 	defer frame.Close()
-	if elapsed > 200*time.Millisecond {
+	// Under the race detector every access is instrumented, so this measures
+	// the instrumentation, not the lazy open. The assertions below prove the
+	// same property structurally: nothing is materialized, yet the count is
+	// right.
+	if !raceEnabled && elapsed > 200*time.Millisecond {
 		t.Errorf("opening a %d-occurrence list took %v; it should not scale with the list", n, elapsed)
 	}
 	if len(frame.Items) != 0 {

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -321,7 +321,10 @@ func (ev *EditorView) Close() {
 	ev.renderBytes = nil
 	ev.renderCells = nil
 	ev.pasteBuffer = nil
-	ev.searchSnapshot = nil
+	// searchSnapMu owns searchSnapshot: a search pass still assembling its
+	// buffer writes it from its own goroutine, so clearing it bare races that
+	// write even when the search is on its way out.
+	ev.dropSearchSnapshot()
 	ev.fadeBuf = nil
 	ev.scrollBar = nil
 	ev.BaseFrame.Close()

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -4279,7 +4279,6 @@ func TestEditorView_Save_MetadataIntegrity(t *testing.T) {
 			t.Fatal("Timeout")
 		}
 	}
-
 	// 2. Verification
 	if !attrCalled {
 		t.Error("vfs.SetAttributes was not called after save")
@@ -4466,7 +4465,7 @@ func TestEditorView_Search_Reverse_StartAtZero(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	pt := piecetable.New([]byte("match"))
 	ev := NewEditorView(pt, nil, "")
-	defer ev.Close()
+	t.Cleanup(ev.Close)
 	ev.CursorPos = 0 // Start at beginning
 
 	// Reverse search from 0 should exit instantly, not hang

--- a/cmd/f4/file_associations_dispatch_test.go
+++ b/cmd/f4/file_associations_dispatch_test.go
@@ -56,7 +56,7 @@ func setupPanelWithFile(t *testing.T, name string) (*PanelsFrame, *mockPty) {
 		}
 	}
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	t.Cleanup(pf.Close)
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -1661,6 +1661,19 @@ pump4:
 			t.Fatalf("Timeout")
 		}
 	}
+	for _, screen := range vtui.FrameManager.Screens {
+		for _, frame := range screen.Frames {
+			clone, ok := frame.(*PanelsFrame)
+			if !ok {
+				continue
+			}
+			for _, panel := range clone.panels {
+				if fsp, ok := panel.(*FileSystemPanel); ok {
+					waitForLoad(t, fsp)
+				}
+			}
+		}
+	}
 
 	// We expect that a new screen was created during the operation
 	if len(vtui.FrameManager.Screens) != initialScreens+1 {

--- a/cmd/f4/fkeys_hidden_panels_test.go
+++ b/cmd/f4/fkeys_hidden_panels_test.go
@@ -51,7 +51,7 @@ func TestHotkeys_ShellActions_TerminalArea_GatedByAltScreen_Issue354(t *testing.
 	// Reset the global frame manager and register a hidden-panels PanelsFrame
 	// with an AltScreen app active — that's the state where the condition must fail.
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pf.showPanels = false
@@ -85,9 +85,21 @@ func TestHotkeys_ShellActions_TerminalArea_GatedByAltScreen_Issue354(t *testing.
 // half of the issue #354 fix: with panels hidden, pressing F2 must
 // push the user-menu frame onto the top of the stack.
 func TestPanelsFrame_F2_OpensUserMenu_WhenPanelsHidden_Issue354(t *testing.T) {
+	// The assertion below compares the top frame type before and after F2, so a
+	// menu left on the shared manager by an earlier test makes the push
+	// invisible. Start from a manager of our own.
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
-	pf := setupMockPanelsFrame()
+	previousHotkeys := GlobalHotkeysMgr
+	previousMacros := MacroMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	MacroMgr = NewMacroManager("")
+	t.Cleanup(func() {
+		GlobalHotkeysMgr = previousHotkeys
+		MacroMgr = previousMacros
+	})
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pf.showPanels = false
@@ -117,7 +129,7 @@ func TestPanelsFrame_F2_OpensUserMenu_WhenPanelsHidden_Issue354(t *testing.T) {
 // slot so the info panel is actually visible.
 func TestPanelsFrame_CtrlL_RevealsHiddenPassivePanel_Issue354(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/frame_manager_test_helpers_test.go
+++ b/cmd/f4/frame_manager_test_helpers_test.go
@@ -30,6 +30,33 @@ func waitForDirectoryLoads(t *testing.T) {
 	}
 }
 
+func pumpUntilToastActive(t *testing.T) {
+	t.Helper()
+	for vtui.FrameManager.GetActiveToast() == "" {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-time.After(time.Second):
+			t.Fatal("toast did not start")
+		}
+	}
+}
+
+func waitForToastExpiry(t *testing.T, timeout time.Duration) {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case <-vtui.FrameManager.RedrawChan:
+			if vtui.FrameManager.GetActiveToast() == "" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("toast did not expire")
+		}
+	}
+}
+
 // swapFrameManager replaces the global vtui.FrameManager with a fresh,
 // independent instance and returns a function that restores the original
 // pointer. In particular, the fresh manager has its own task queue: Init

--- a/cmd/f4/framework_actions_test.go
+++ b/cmd/f4/framework_actions_test.go
@@ -471,9 +471,7 @@ func TestWorkspaceClosePreservesQueueVetoBelowHelpAndForBackgroundTarget(t *test
 
 func TestWorkspaceCloseKeepsTheOnlyPanelsWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
-	panels := setupMockPanelsFrame()
-	waitForLoad(t, panels.panels[0].(*FileSystemPanel))
-	waitForLoad(t, panels.panels[1].(*FileSystemPanel))
+	panels := setupMockPanelsFrame(t)
 	vtui.FrameManager.Push(panels)
 	viewer := &frameworkActionTestFrame{title: "Viewer"}
 	vtui.FrameManager.AddScreen(viewer)
@@ -497,9 +495,7 @@ func TestWorkspaceCloseKeepsTheOnlyPanelsWorkspace(t *testing.T) {
 
 func TestPanelsFrameCloseVetoProtectsTheOnlyPanelsWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
-	panels := setupMockPanelsFrame()
-	waitForLoad(t, panels.panels[0].(*FileSystemPanel))
-	waitForLoad(t, panels.panels[1].(*FileSystemPanel))
+	panels := setupMockPanelsFrame(t)
 	vtui.FrameManager.Push(panels)
 	vtui.FrameManager.AddScreen(&frameworkActionTestFrame{title: "Editor"})
 	vtui.FrameManager.SwitchScreen(0)
@@ -512,7 +508,7 @@ func TestPanelsFrameCloseVetoProtectsTheOnlyPanelsWorkspace(t *testing.T) {
 
 func TestWorkspaceNewFindsPanelsBehindFullScreenWorkspace(t *testing.T) {
 	initFrameworkActionTestScreen(t)
-	source := setupMockPanelsFrame()
+	source := setupMockPanelsFrame(t)
 	defer source.Close()
 	vtui.FrameManager.Push(source)
 

--- a/cmd/f4/history_hint_test.go
+++ b/cmd/f4/history_hint_test.go
@@ -56,7 +56,7 @@ func TestHistoryHint_MessagesResolved(t *testing.T) {
 // dialog actually paints on its bottom border.
 func TestActionCommandHistory_WiresHint(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
 	pf.cmdLine.Edit.History = []string{"ls -la", "grep -r foo ."}
@@ -89,7 +89,7 @@ func TestActionCommandHistoryInsertPersistsLock(t *testing.T) {
 	previous := vtui.GlobalHistoryProvider
 	vtui.GlobalHistoryProvider = hp
 	t.Cleanup(func() { vtui.GlobalHistoryProvider = previous })
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
 	pf.cmdLine.Edit.History = []string{"echo pinned"}
@@ -108,7 +108,7 @@ func TestActionCommandHistoryInsertPersistsLock(t *testing.T) {
 
 func TestActionFoldersHistory_WiresHint(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
 
@@ -149,7 +149,7 @@ func TestActionFoldersHistoryInsertPersistsLock(t *testing.T) {
 	previous := vtui.GlobalHistoryProvider
 	vtui.GlobalHistoryProvider = hp
 	t.Cleanup(func() { vtui.GlobalHistoryProvider = previous })
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
 
@@ -190,6 +190,8 @@ func TestActionCommandHistory_CtrlIns_CopiesToClipboard(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	pf.cmdLine.Edit.History = []string{"echo one", "echo two", "echo three"}
 	actionCommandHistory(pf)
@@ -220,6 +222,8 @@ func TestActionCommandHistory_Del_ClearsAllAfterConfirm(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	prev := vtui.GlobalHistoryProvider
 	saved := stubHistoryProvider{}
@@ -258,6 +262,8 @@ func TestActionCommandHistory_Del_CancelKeepsHistory(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	prev := vtui.GlobalHistoryProvider
 	saved := stubHistoryProvider{"cmdline": {"cmd1", "cmd2"}}
@@ -300,6 +306,8 @@ func TestActionCommandHistory_HelpTopic(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	pf.cmdLine.Edit.History = []string{"a", "b"}
 	actionCommandHistory(pf)
@@ -316,6 +324,8 @@ func TestActionFoldersHistory_HelpTopic(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	prev := vtui.GlobalHistoryProvider
 	vtui.GlobalHistoryProvider = &stubHistoryProvider{"folders": {"/tmp"}}
@@ -350,6 +360,8 @@ func TestActionCommandHistory_MouseClickPastesEntry(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// History convention: [0] is newest. historySearch shows oldest at the
 	// top and newest at the bottom, so bottom-row = "echo newest".
@@ -394,6 +406,8 @@ func TestActionCommandHistory_PathColumnAndInsertion(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionCommandHistory(pf)
 	menu := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
 	search := activeHistorySearch
@@ -447,6 +461,8 @@ func TestActionCommandHistory_CtrlPgDnNavigatesToStoredPath(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	actionCommandHistory(pf)
 	menu := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
 
@@ -462,6 +478,7 @@ func TestActionCommandHistory_CtrlPgDnNavigatesToStoredPath(t *testing.T) {
 	if !menu.IsDone() {
 		t.Fatal("history menu stayed open after Ctrl+PgDn")
 	}
+	waitForLoad(t, pf.getActivePanel())
 }
 
 // TestActionFoldersHistory_MouseClickNavigates guards the folder-history
@@ -471,6 +488,8 @@ func TestActionFoldersHistory_MouseClickNavigates(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Provider convention: [0] is newest. The bottom row of the dialog
 	// shows the newest entry, so clicking it should cd to `newest`.
@@ -502,6 +521,7 @@ func TestActionFoldersHistory_MouseClickNavigates(t *testing.T) {
 	if !menu.IsDone() {
 		t.Error("folder-history menu should be closed after click accept")
 	}
+	waitForLoad(t, pf.getActivePanel())
 }
 
 // TestHistorySearch_KeepsPainterAcrossModalOverlay guards issue #290
@@ -515,6 +535,8 @@ func TestHistorySearch_KeepsPainterAcrossModalOverlay(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(120, 40)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	pf.cmdLine.Edit.History = []string{"cmd1", "cmd2"}
 	activeHistorySearch = nil
@@ -567,6 +589,8 @@ func TestActionFoldersHistory_CtrlR_DropsMissingPaths(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	real1 := t.TempDir()
 	real2 := t.TempDir()

--- a/cmd/f4/hotkeys_test.go
+++ b/cmd/f4/hotkeys_test.go
@@ -215,7 +215,7 @@ func TestHotkeyManager_Conditions(t *testing.T) {
 // condition must return true unconditionally once panels are hidden.
 func TestNoAltScreenApp_SimpleInline_IgnoresBackgroundTermView(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pf.shellMode = ShellModeSimpleInline

--- a/cmd/f4/image_view_test.go
+++ b/cmd/f4/image_view_test.go
@@ -197,7 +197,7 @@ func TestImageViewWalksItsSiblings(t *testing.T) {
 	iv.SetSiblings([]string{"a.png", "b.png", "c.png"}, 1)
 
 	// Decode them all first, so that stepping is answered from the cache.
-	for _, name := range []string{"a.png", "c.png"} {
+	for _, name := range []string{"a.png", "b.png", "c.png"} {
 		if res := ImagePipe.LoadSync(context.Background(), nil, name); res.Err != nil {
 			t.Fatalf("%s: %v", name, res.Err)
 		}
@@ -236,7 +236,7 @@ func TestImageViewArrowsWalkWhenThereIsNothingToPan(t *testing.T) {
 	iv := newTestImageView(t, 100, 100)
 	iv.path = "b.png"
 	iv.SetSiblings([]string{"a.png", "b.png", "c.png"}, 1)
-	for _, name := range []string{"a.png", "c.png"} {
+	for _, name := range []string{"a.png", "b.png", "c.png"} {
 		if res := ImagePipe.LoadSync(context.Background(), nil, name); res.Err != nil {
 			t.Fatalf("%s: %v", name, res.Err)
 		}

--- a/cmd/f4/info_panel_test.go
+++ b/cmd/f4/info_panel_test.go
@@ -176,7 +176,7 @@ func drainInfoPanelUITasks(t *testing.T) {
 //     target the source file panel underneath.
 func TestPanelsFrame_CtrlL_TogglesInfoPanel(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -1004,7 +1004,7 @@ func TestInfoPanel_MissingCachedCursorRowFallsBackNearby(t *testing.T) {
 // visible, and falls through to fast-find otherwise.
 func TestPanelsFrame_B_TogglesInfoPanelUnits(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -1164,6 +1164,8 @@ func TestInfoPanel_CopyCopiesValue(t *testing.T) {
 	if got := vtui.GetClipboard(); got != wantValue {
 		t.Errorf("SetClipboard got %q, want %q", got, wantValue)
 	}
+	pumpUntilToastActive(t)
+	waitForToastExpiry(t, 3*time.Second)
 }
 
 // TestInfoPanel_ProcessKey_UnfocusedIgnoresC verifies the C copy
@@ -1255,6 +1257,8 @@ func TestInfoPanel_ShiftUpDownSelectsAndCCopiesLabelValue(t *testing.T) {
 	if got := vtui.GetClipboard(); got != want {
 		t.Errorf("clipboard = %q, want %q", got, want)
 	}
+	pumpUntilToastActive(t)
+	waitForToastExpiry(t, 3*time.Second)
 
 	// Selection persists across a rebuild — the highlight must
 	// survive the next Show, which walks the row list from scratch.

--- a/cmd/f4/managed_execution_test.go
+++ b/cmd/f4/managed_execution_test.go
@@ -44,8 +44,8 @@ func runBusyChange(pf *PanelsFrame, busy bool) {
 
 func newExecutionTestFrame(t *testing.T) *PanelsFrame {
 	t.Helper()
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	drainUITasks() // discard anything an earlier test queued
 	pf := NewPanelsFrame()
 	t.Cleanup(pf.Close)
 	pf.showPanels = false

--- a/cmd/f4/panel_plugins_test.go
+++ b/cmd/f4/panel_plugins_test.go
@@ -30,7 +30,7 @@ func (p *panelPluginTestController) GetSelectedName() string { return "plugin-ro
 
 func TestPanelProviderOpensInActiveSlotAndReceivesContext(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pf.ResizeConsole(80, 25)
 	defer pf.Close()
 

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -358,6 +358,8 @@ func TestPanelsFrame_SelectionByMask(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	fsp := pf.panels[1].(*FileSystemPanel)
 	pf.activeIdx = 1
@@ -434,6 +436,8 @@ func TestPanelsFrame_DriveMenuListsAssignedBookmarks(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(pf)
 
 	pf.showDriveMenu(1)
@@ -514,6 +518,8 @@ func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(pf)
 	fsp := pf.panels[1].(*FileSystemPanel)
 
@@ -539,6 +545,7 @@ func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
 			if got := fsp.vfs.GetPath(); got != tc.want {
 				t.Errorf("bookmark %q navigated to %q, want %q", tc.path, got, tc.want)
 			}
+			waitForLoad(t, fsp)
 			vtui.FrameManager.RemoveFrame(menu)
 		})
 	}
@@ -746,7 +753,11 @@ func TestPanelsFrame_ProcessMouse_DoubleClick(t *testing.T) {
 	}
 }
 
-func setupMockPanelsFrame() *PanelsFrame {
+func setupMockPanelsFrame(t *testing.T) *PanelsFrame {
+	t.Helper()
+	if vtui.FrameManager.TaskChan == nil {
+		vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	}
 	pf := &PanelsFrame{activeIdx: 1, showPanels: true, showKeyBar: true, showLeftPanel: true, showRightPanel: true}
 	pf.pty = &mockPty{}
 	pf.termView = NewTerminalView(80, 24)
@@ -761,6 +772,8 @@ func setupMockPanelsFrame() *PanelsFrame {
 	// Use OSVFS because tests create real files in t.TempDir()
 	pf.panels[0] = NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS("."))
 	pf.panels[1] = NewFileSystemPanel(40, 0, 40, 20, vfs.NewOSVFS("."))
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	pf.initPTY()
 	return pf
 }
@@ -770,7 +783,7 @@ func TestPanelsFrame_ProcessMouse_DoubleClickFile(t *testing.T) {
 	AppConfig.NavigationMode = NavigationClassic
 	t.Cleanup(func() { AppConfig.NavigationMode = oldNavigationMode })
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -836,7 +849,7 @@ func TestPanelsFrame_ProcessMouse_DoubleClickFile(t *testing.T) {
 // a file the user can't even see. Also verifies that a click on
 // the passive-side alt panel activates that side.
 func TestPanelsFrame_ProcessMouse_AltPanelSwallowsClicks(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -909,7 +922,7 @@ drain:
 // click lands on an alt panel; otherwise the file under the alt
 // still gets launched despite the fix.
 func TestPanelsFrame_ProcessMouse_MiddleClickOverAltPanel(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -970,7 +983,7 @@ drain:
 // running. Non-empty command line keeps the existing ESC-clears-
 // cmdLine behaviour.
 func TestPanelsFrame_EscTogglesPanels(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
@@ -1023,7 +1036,7 @@ func TestPanelsFrame_EscTogglesPanels(t *testing.T) {
 // shortcut can be turned off — with EscTogglePanels=false, ESC
 // on visible panels + empty cmdLine is a no-op instead of hiding.
 func TestPanelsFrame_EscTogglePanels_RespectsOption(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
@@ -1160,7 +1173,7 @@ func TestPanelsFrame_MenuCommands(t *testing.T) {
 
 func TestPanelsFrame_SortCommandsUseDefaultDirection(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	left := pf.panels[0].(*FileSystemPanel)
@@ -1383,6 +1396,8 @@ func TestPanelsFrame_Clone(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(100, 30)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Use a real temp directory that exists on all platforms
 	tmpDir := t.TempDir()
@@ -1428,6 +1443,8 @@ func TestPanelsFrame_Clone(t *testing.T) {
 	if pf.activeIdx == 1 {
 		t.Error("Clone should be independent from its parent")
 	}
+	waitForLoad(t, clone.panels[0].(*FileSystemPanel))
+	waitForLoad(t, clone.panels[1].(*FileSystemPanel))
 }
 
 func TestPanelsFrame_CtrlBrackets_Insertion(t *testing.T) {
@@ -1846,6 +1863,8 @@ func TestPanelsFrame_AltScreenTerminalHeight(t *testing.T) {
 	// 1. Normal mode: terminal should leave space for KeyBar
 	pf.termView.UseAltScreen = false
 	pf.ResizeConsole(80, height)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	// termY2 should be h-2 (23)
 	if pf.termView.Y2 != 23 {
 		t.Errorf("Normal mode: expected terminal Y2=23, got %d", pf.termView.Y2)
@@ -1870,6 +1889,9 @@ func TestPanelsFrame_KeyBarSuppression(t *testing.T) {
 	defer pf.Close()
 	pf.showKeyBar = true
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+	pf.lastAutoRefresh = time.Now()
 
 	// We need to simulate the frame being on top to trigger the logic
 	vtui.FrameManager.Push(pf)
@@ -1948,6 +1970,8 @@ func TestPanelsFrame_AutoRefresh(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Setup a mock directory
 	tmp := t.TempDir()
@@ -1971,20 +1995,20 @@ func TestPanelsFrame_AutoRefresh(t *testing.T) {
 	scr.AllocBuf(80, 25)
 	pf.Show(scr)
 
-	// Pump the TaskChan to execute RunAsync and RunOnUI
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	// Pump both stat callbacks; the changed side starts a directory load.
+	timeout := time.After(2 * time.Second)
+	for pf.panels[0].(*FileSystemPanel).isCheckingRefresh || pf.panels[1].(*FileSystemPanel).isCheckingRefresh {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:
 			task()
-		default:
-			time.Sleep(5 * time.Millisecond)
-		}
-		if fsp.isLoading {
-			return // Success: it triggered a refresh
+		case <-timeout:
+			t.Fatal("AutoRefresh stat check did not finish")
 		}
 	}
-	t.Fatal("AutoRefresh failed to trigger ReadDirectory after MTime change")
+	if !fsp.isLoading {
+		t.Fatal("AutoRefresh failed to trigger ReadDirectory after MTime change")
+	}
+	waitForLoad(t, fsp)
 }
 func TestPanelsFrame_ResizingIntegration(t *testing.T) {
 	oldWidthDecrement := AppConfig.WidthDecrement
@@ -2035,14 +2059,20 @@ func TestPanelsFrame_ResizingIntegration(t *testing.T) {
 func TestPanelsFrame_ExitWarning_ActiveTasks(t *testing.T) {
 	fm := vtui.FrameManager
 	fm.Init(vtui.NewSilentScreenBuf())
-	pf := NewPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	fm.Push(pf)
 
 	qm := GlobalQueueManager
 	qm.mu.Lock()
-	qm.tasks = []*QueueTask{{ID: 1, State: "Queued"}}
+	oldTasks := append([]*QueueTask(nil), qm.tasks...)
+	qm.tasks = []*QueueTask{{ID: 1, State: "Running"}}
 	qm.mu.Unlock()
+	t.Cleanup(func() {
+		qm.mu.Lock()
+		qm.tasks = oldTasks
+		qm.mu.Unlock()
+	})
 
 	// Триггерим выход
 	pf.HandleCommand(vtui.CmQuit, nil)
@@ -2214,38 +2244,14 @@ func TestPanelsFrame_Clone_SelectionPreservation(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	fsp := pf.panels[0].(*FileSystemPanel)
 	if err := fsp.vfs.SetPath(tmp); err != nil {
 		t.Fatal(err)
 	}
 	fsp.ReadDirectory()
-
-	// Wait for initial load
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case task := <-vtui.FrameManager.TaskChan:
-			task()
-		default:
-			time.Sleep(5 * time.Millisecond)
-		}
-		if !fsp.isLoading {
-			break
-		}
-	}
-	if fsp.isLoading {
-		t.Fatal("Timeout waiting for initial load")
-	}
-	// Drain remaining tasks
-drainTasks:
-	for i := 0; i < 10; i++ {
-		select {
-		case task := <-vtui.FrameManager.TaskChan:
-			task()
-		default:
-			break drainTasks
-		}
-	}
+	waitForLoad(t, fsp)
 
 	// Select "selected.txt"
 	found := false
@@ -2264,23 +2270,8 @@ drainTasks:
 	clone := pf.Clone()
 	defer clone.Close()
 	cloneFsp := clone.panels[0].(*FileSystemPanel)
-
-	// Wait for clone load
-	deadline = time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		select {
-		case task := <-vtui.FrameManager.TaskChan:
-			task()
-		default:
-			time.Sleep(5 * time.Millisecond)
-		}
-		if !cloneFsp.isLoading {
-			break
-		}
-	}
-	if cloneFsp.isLoading {
-		t.Fatal("Timeout waiting for clone load")
-	}
+	waitForLoad(t, cloneFsp)
+	waitForLoad(t, clone.panels[1].(*FileSystemPanel))
 
 	// Verify preservation
 	foundInClone := false
@@ -2472,9 +2463,13 @@ func TestPanelsFrame_StateCapture(t *testing.T) {
 	}
 }
 func TestPanelsFrame_CloneIndependence(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 
 	// Set path in original
 	fsp := pf.panels[0].(*FileSystemPanel)
@@ -2486,6 +2481,8 @@ func TestPanelsFrame_CloneIndependence(t *testing.T) {
 	// Clone
 	clone := pf.Clone()
 	defer clone.Close()
+	waitForLoad(t, clone.panels[0].(*FileSystemPanel))
+	waitForLoad(t, clone.panels[1].(*FileSystemPanel))
 
 	// Change path in clone
 	newPath := t.TempDir()
@@ -2534,7 +2531,7 @@ func TestPanelsFrame_PTYLockContention(t *testing.T) {
 	// Этот тест проверяет, что тяжелый парсинг в PTY-потоке не блокирует
 	// доступ UI-потока к методу getActivePTY (регрессия дедлока).
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	// Симулируем "забитую" очередь задач
@@ -2741,7 +2738,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 }
 
 func TestPanelsFrame_ReturnExecution(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -2806,7 +2803,7 @@ func TestPanelsFrame_ReturnExecution(t *testing.T) {
 	}
 }
 func TestPanelsFrame_CommandLineEnter(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()
 
@@ -2835,7 +2832,7 @@ func TestPanelsFrame_CommandLineEnterRejectsUnmatchedBacktick(t *testing.T) {
 		t.Skip("backticks are literal in the Windows shell")
 	}
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
@@ -2887,7 +2884,7 @@ func (v *commandRunnerPanelVFS) RunCommand(_ context.Context, dir, command strin
 
 func TestPanelsFrame_CommandLineUsesRemoteRunnerWithoutPTY(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	runner := &commandRunnerPanelVFS{
@@ -2924,6 +2921,32 @@ func TestPanelsFrame_CommandLineUsesRemoteRunnerWithoutPTY(t *testing.T) {
 	if !pf.cmdLine.IsEmpty() {
 		t.Fatalf("command line was not cleared: %q", pf.cmdLine.Edit.GetText())
 	}
+	deadline := time.After(time.Second)
+	for {
+		top, ok := vtui.FrameManager.GetTopFrame().(*vtui.Window)
+		finished := false
+		if ok {
+			for _, child := range top.GetChildren() {
+				if list, ok := child.(*vtui.ListBox); ok {
+					for _, item := range list.Items {
+						if item == "[exit status 0]" {
+							finished = true
+							break
+						}
+					}
+				}
+			}
+		}
+		if finished {
+			break
+		}
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-deadline:
+			t.Fatal("remote command completion did not reach the output frame")
+		}
+	}
 	if top := vtui.FrameManager.GetTopFrame(); top == nil || !strings.Contains(top.GetTitle(), Msg("RemoteCmd.Title")) {
 		t.Fatalf("remote command output frame = %T %q", top, func() string {
 			if top != nil {
@@ -2935,7 +2958,7 @@ func TestPanelsFrame_CommandLineUsesRemoteRunnerWithoutPTY(t *testing.T) {
 }
 
 func TestPanelsFrame_CommandLineEnter_WhenBusy(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()
 
@@ -3122,6 +3145,10 @@ func TestExecuteFileOp_BackgroundButtonTrigger(t *testing.T) {
 	fork := pf.Clone()
 	t.Cleanup(fork.Close)
 	fm.AddScreen(fork)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+	waitForLoad(t, fork.panels[0].(*FileSystemPanel))
+	waitForLoad(t, fork.panels[1].(*FileSystemPanel))
 
 	if len(fm.Screens) != initialScreens+1 {
 		t.Errorf("Backgrounding failed to create a new screen. Got %d, want %d", len(fm.Screens), initialScreens+1)
@@ -3138,7 +3165,7 @@ func TestExecuteDummyOp_HeadlessMode(t *testing.T) {
 	initialScreens := len(fm.Screens)
 
 	// Trigger Mode Foreground (2)
-	go pf.ExecuteDummyOp(2)
+	pf.ExecuteDummyOp(2)
 
 	// Manually process the task queue (since we are not in fm.Run loop)
 	timeout := time.After(1 * time.Second)
@@ -3162,18 +3189,18 @@ func TestExecuteDummyOp_HeadlessMode(t *testing.T) {
 	if !newScreen.Transparent {
 		t.Error("Headless screen should be transparent")
 	}
-
-	// Clean up and cancel the task to prevent background leak
-	dlg := newScreen.Frames[0].(*vtui.Window)
-	dlg.SetExitCode(1) // Cancels the taskCtx
-	if dlg.OnResult != nil {
-		dlg.OnResult(1)
+	dlg, ok := newScreen.Frames[0].(*vtui.Window)
+	if !ok {
+		t.Fatalf("headless frame = %T, want progress dialog", newScreen.Frames[0])
 	}
-	for i := 0; i < 20; i++ {
+	dlg.OnResult(1)
+	timeout = time.After(2 * time.Second)
+	for !dlg.IsDone() {
 		select {
 		case task := <-fm.TaskChan:
 			task()
-		case <-time.After(10 * time.Millisecond):
+		case <-timeout:
+			t.Fatal("cancelled dummy operation did not finish")
 		}
 	}
 }
@@ -3349,6 +3376,10 @@ func TestPanelsFrame_ForkFromTerminalOpensPanelsInNewWorkspace(t *testing.T) {
 	if clone.GetTitle() == "cmd.exe" || clone.GetTitle() == "Terminal" {
 		t.Errorf("forked workspace title still looks like a terminal: %q", clone.GetTitle())
 	}
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+	waitForLoad(t, clone.panels[0].(*FileSystemPanel))
+	waitForLoad(t, clone.panels[1].(*FileSystemPanel))
 }
 func TestPanelsFrame_FilesMenuLabels(t *testing.T) {
 	old := GlobalHotkeysMgr
@@ -4132,7 +4163,7 @@ func (m *mockSlowStatVFS) Stat(ctx context.Context, p string) (vfs.VFSItem, erro
 
 func TestPanelsFrame_AutoRefresh_Locking(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -4238,6 +4269,7 @@ func TestPanelsFrame_VimHotkeys_Comprehensive(t *testing.T) {
 
 	oldCfg := AppConfig
 	AppConfig.NavigationMode = NavigationVim
+	AppConfig.AutoSaveSettings = false
 	defer func() { AppConfig = oldCfg }()
 
 	pf := NewPanelsFrame()
@@ -4595,7 +4627,7 @@ func TestPanelsFrame_ShiftF5_KeyInterception(t *testing.T) {
 	vtui.FrameManager.Pop()
 }
 func TestPanelsFrame_MouseForwarding_ToPTY(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()
 
@@ -4626,7 +4658,7 @@ func TestPanelsFrame_MouseForwarding_ToPTY(t *testing.T) {
 	}
 }
 func TestPanelsFrame_NoCtrlOInterception_InAltScreen(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	pty := pf.pty.(*mockPty)
 	defer pf.Close()
 
@@ -4681,6 +4713,8 @@ func TestPanelsFrame_ShiftF9_SaveSettings(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(pf)
 
 	// Отправляем хоткей Shift+F9
@@ -4704,6 +4738,11 @@ func TestPanelsFrame_ShiftF9_SaveSettings(t *testing.T) {
 	} else {
 		t.Fatalf("Shift+F9 top frame = %T, want save-settings dialog", vtui.FrameManager.GetTopFrame())
 	}
+
+	// ShowToast posts its setup and owns a timer goroutine. Join it before this
+	// test lets another test reuse the manager.
+	pumpUntilToastActive(t)
+	waitForToastExpiry(t, 3*time.Second)
 
 	// Проверяем, что файл настроек действительно был записан на диск
 	info, err := os.Stat(tmp.Name())
@@ -4734,15 +4773,15 @@ func TestPanelsFrame_MiddleClick_LaunchesFile(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(pf)
 
 	// Подставляем стабильный mockUpdateVFS для панели
 	fsp := pf.panels[pf.activeIdx].(*FileSystemPanel)
 	fsp.vfs = &mockUpdateVFS{}
 	fsp.ReadDirectory()
-
-	// Даем немного времени асинхронной горутине на наполнение
-	time.Sleep(50 * time.Millisecond)
+	waitForLoad(t, fsp)
 	fsp.SetCursorIndex(0)
 
 	// Симулируем клик колесом мыши по первой строке
@@ -4756,6 +4795,15 @@ func TestPanelsFrame_MiddleClick_LaunchesFile(t *testing.T) {
 
 	if !pf.ProcessMouse(ev) {
 		t.Error("Expected PanelsFrame to handle middle click mouse event")
+	}
+	timeout := time.After(time.Second)
+	for vtui.FrameManager.GetTopFrameType() != vtui.TypeDialog {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-timeout:
+			t.Fatal("middle-click execution result did not reach the UI")
+		}
 	}
 }
 
@@ -4981,7 +5029,7 @@ func TestPanelsFrame_CaptureCommands(t *testing.T) {
 	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	vtui.SetDefaultPalette()
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	vtui.SetClipboard("")
@@ -5033,6 +5081,10 @@ func TestPanelsFrame_CaptureCommands(t *testing.T) {
 	if !found {
 		t.Error("Output was not copied to clipboard")
 	}
+	pumpUntilToastActive(t)
+	waitForToastExpiry(t, 4*time.Second)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 func TestPanelsFrame_ShiftEnter_ExplorerLaunch(t *testing.T) {
 	if _, _, supported := systemFileManagerCommand("test", true); !supported {
@@ -5236,7 +5288,7 @@ func TestPanelsFrame_CtrlP_TogglesPassivePanel(t *testing.T) {
 	}
 
 	// Active = right (setupMockPanelsFrame's default), Ctrl+P hides left.
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	if pf.activeIdx != 1 || !pf.showLeftPanel || !pf.showRightPanel || !pf.showPanels {
 		t.Fatalf("mock frame precondition: activeIdx=%d L=%v R=%v show=%v",
@@ -5294,7 +5346,7 @@ func TestPanelsFrame_CtrlP_TogglesPassivePanel(t *testing.T) {
 }
 func TestPanelsFrame_TabWithSinglePanelDoesNotEnablePassivePanel(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	// Active = right (1), hide left panel
@@ -5321,7 +5373,7 @@ func TestPanelsFrame_TabWithSinglePanelDoesNotEnablePassivePanel(t *testing.T) {
 
 func TestPanelsFrame_CtrlOAndCtrlPSequence(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	sendCtrlO := func() {
@@ -5417,7 +5469,7 @@ func TestPanelsFrame_CtrlArrows_ResizePanels(t *testing.T) {
 	// Width: Ctrl+Left moves the split to the left (widthDecrement +1,
 	// left panel shrinks, right grows) — arrow follows the boundary,
 	// matching far2l / Far3 / far2m. Ctrl+Right does the reverse.
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	baseLeft := panelWidth(pf.panels[0])
@@ -5504,7 +5556,7 @@ func TestPanelsFrame_CtrlClear_ResetsLayoutDecrements(t *testing.T) {
 	})
 
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -5576,7 +5628,7 @@ func TestPanelsFrame_CtrlShiftArrows_AsymmetricHeight(t *testing.T) {
 		})
 	}
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/path_hints_test.go
+++ b/cmd/f4/path_hints_test.go
@@ -237,7 +237,7 @@ func TestPathHintProvider_BothPanels(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pf.panels[1].(*FileSystemPanel).vfs = vfs.NewOSVFS(dirA) // activeIdx = 1
@@ -293,7 +293,7 @@ func TestPathHintProvider_DisabledWhenCommandLineAutoCompleteOff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pf.panels[1].(*FileSystemPanel).vfs = vfs.NewOSVFS(dir)

--- a/cmd/f4/process_environment_shell.go
+++ b/cmd/f4/process_environment_shell.go
@@ -72,6 +72,27 @@ type processEnvironmentShellInFlight struct {
 var processEnvironmentAcknowledgementTimeout = 10 * time.Second
 var processEnvironmentPayloadPreparer = prepareProcessEnvironmentShellPayload
 
+var processEnvironmentFailureToastDuration = 5 * time.Second
+
+// processEnvironmentFailureToast protects the active window and completion
+// signal for the process-wide failure toast. Repeated failures can come from several frames;
+// coalescing them prevents overlapping vtui toast timers from redrawing the
+// same frame manager concurrently.
+var processEnvironmentFailureToast struct {
+	sync.Mutex
+	active bool
+	done   chan struct{}
+}
+
+func finishProcessEnvironmentFailureToast(done chan struct{}) {
+	processEnvironmentFailureToast.Lock()
+	if processEnvironmentFailureToast.done == done {
+		processEnvironmentFailureToast.active = false
+		close(done)
+	}
+	processEnvironmentFailureToast.Unlock()
+}
+
 var (
 	processEnvironmentRuntimeOnce sync.Once
 	processEnvironmentRuntimeDir  string
@@ -440,13 +461,36 @@ func (pf *PanelsFrame) setProcessEnvironmentDeliveryFailed(failed bool) {
 }
 
 func (pf *PanelsFrame) reportProcessEnvironmentShellFailure() {
-	if vtui.FrameManager == nil {
+	manager := vtui.FrameManager
+	if manager == nil {
 		return
 	}
-	vtui.FrameManager.PostTask(func() {
+
+	processEnvironmentFailureToast.Lock()
+	if processEnvironmentFailureToast.active {
+		processEnvironmentFailureToast.Unlock()
+		return
+	}
+	processEnvironmentFailureToast.active = true
+	done := make(chan struct{})
+	processEnvironmentFailureToast.done = done
+	processEnvironmentFailureToast.Unlock()
+
+	manager.PostTask(func() {
+		if vtui.FrameManager != manager {
+			finishProcessEnvironmentFailureToast(done)
+			return
+		}
 		// The localized title is intentionally value-free: neither environment
 		// names nor values may be copied to terminal or diagnostic output.
-		vtui.ShowToast(Msg("EnvMan.ShellSyncError"), 5*time.Second)
+		vtui.ShowToast(Msg("EnvMan.ShellSyncError"), processEnvironmentFailureToastDuration)
+		// ShowToast posts its setup. Queue our timer behind that setup so the
+		// coalescing window cannot end before vtui's own expiry timer.
+		manager.PostTask(func() {
+			time.AfterFunc(processEnvironmentFailureToastDuration, func() {
+				finishProcessEnvironmentFailureToast(done)
+			})
+		})
 	})
 }
 

--- a/cmd/f4/process_environment_test.go
+++ b/cmd/f4/process_environment_test.go
@@ -585,6 +585,37 @@ func runProcessEnvironmentUIInline(t *testing.T) {
 	t.Cleanup(func() { processEnvironmentRunOnUI = previous })
 }
 
+func setupProcessEnvironmentFailureUI(t *testing.T) {
+	t.Helper()
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	previousDuration := processEnvironmentFailureToastDuration
+	processEnvironmentFailureToastDuration = 20 * time.Millisecond
+	t.Cleanup(func() { processEnvironmentFailureToastDuration = previousDuration })
+	runProcessEnvironmentUIInline(t)
+}
+
+func waitForProcessEnvironmentFailureToast(t *testing.T) {
+	t.Helper()
+	// The first sentinel runs the outer failure-report task. ShowToast and the
+	// coalescer each post one nested task behind it, so a second sentinel joins
+	// those as well.
+	drainUITasks()
+	drainUITasks()
+	if vtui.FrameManager.GetActiveToast() == "" {
+		t.Fatal("environment failure toast did not start")
+	}
+	processEnvironmentFailureToast.Lock()
+	done := processEnvironmentFailureToast.done
+	processEnvironmentFailureToast.Unlock()
+	waitForToastExpiry(t, 6*time.Second)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("environment failure toast coalescer did not stop")
+	}
+}
+
 func TestPanelsFrameEnvironmentGatesLocalInputAndLeavesRemoteUntouched(t *testing.T) {
 	runProcessEnvironmentUIInline(t)
 	local := &processEnvironmentPTY{}
@@ -618,7 +649,7 @@ func TestPanelsFrameEnvironmentGatesLocalInputAndLeavesRemoteUntouched(t *testin
 }
 
 func TestPanelsFrameEnvironmentPrepareFailureGatesInputUntilRetry(t *testing.T) {
-	runProcessEnvironmentUIInline(t)
+	setupProcessEnvironmentFailureUI(t)
 	originalPreparer := processEnvironmentPayloadPreparer
 	prepareFailed := true
 	processEnvironmentPayloadPreparer = func(changes []vfs.ProcessEnvironmentChange) (processEnvironmentShellPayload, error) {
@@ -660,10 +691,11 @@ func TestPanelsFrameEnvironmentPrepareFailureGatesInputUntilRetry(t *testing.T) 
 		t.Fatalf("prepare retry writes = %q", writes)
 	}
 	pf.closeProcessEnvironmentShell()
+	waitForProcessEnvironmentFailureToast(t)
 }
 
 func TestPanelsFrameEnvironmentWriteFailureGatesInputUntilRetry(t *testing.T) {
-	runProcessEnvironmentUIInline(t)
+	setupProcessEnvironmentFailureUI(t)
 	local := &processEnvironmentPTY{err: errors.New("injected PTY write failure")}
 	pf := &PanelsFrame{pty: local, termView: NewTerminalView(80, 24)}
 	pf.queueProcessEnvironment(6, []vfs.ProcessEnvironmentChange{{Name: "WRITE_RETRY", Value: "private"}}, true)
@@ -688,6 +720,7 @@ func TestPanelsFrameEnvironmentWriteFailureGatesInputUntilRetry(t *testing.T) {
 		t.Fatalf("write retry writes = %q", writes)
 	}
 	pf.closeProcessEnvironmentShell()
+	waitForProcessEnvironmentFailureToast(t)
 }
 
 func TestPanelsFrameEnvironmentSerializesParserReplies(t *testing.T) {
@@ -723,7 +756,7 @@ func TestPanelsFrameEnvironmentSerializesParserReplies(t *testing.T) {
 }
 
 func TestPanelsFrameEnvironmentFailureKeepsInputUntilSuccessfulRetry(t *testing.T) {
-	runProcessEnvironmentUIInline(t)
+	setupProcessEnvironmentFailureUI(t)
 	local := &processEnvironmentPTY{}
 	pf := &PanelsFrame{pty: local, termView: NewTerminalView(80, 24)}
 	pf.queueProcessEnvironment(4, []vfs.ProcessEnvironmentChange{{Name: "RETRY_ME", Value: "private"}}, true)
@@ -767,14 +800,15 @@ func TestPanelsFrameEnvironmentFailureKeepsInputUntilSuccessfulRetry(t *testing.
 		t.Fatalf("successful retry generation = %d", generation)
 	}
 	pf.closeProcessEnvironmentShell()
+	waitForProcessEnvironmentFailureToast(t)
 }
 
 func TestPanelsFrameEnvironmentAcknowledgementTimeoutKeepsDeferredInput(t *testing.T) {
-	runProcessEnvironmentUIInline(t)
-	timeoutDone := make(chan struct{})
+	setupProcessEnvironmentFailureUI(t)
+	released := make(chan struct{})
 	processEnvironmentRunOnUI = func(task func()) {
 		task()
-		close(timeoutDone)
+		close(released)
 	}
 	oldTimeout := processEnvironmentAcknowledgementTimeout
 	processEnvironmentAcknowledgementTimeout = 15 * time.Millisecond
@@ -786,15 +820,10 @@ func TestPanelsFrameEnvironmentAcknowledgementTimeoutKeepsDeferredInput(t *testi
 	if _, err := pf.writePTY(local, []byte("held-after-timeout\r")); err != nil {
 		t.Fatal(err)
 	}
-	deadline := time.Now().Add(time.Second)
-	for {
-		pf.processEnvironmentMu.Lock()
-		inFlight := pf.processEnvironmentInFlight != nil
-		pf.processEnvironmentMu.Unlock()
-		if !inFlight || time.Now().After(deadline) {
-			break
-		}
-		time.Sleep(5 * time.Millisecond)
+	select {
+	case <-released:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for acknowledgement failure callback")
 	}
 	pf.processEnvironmentMu.Lock()
 	inFlight := pf.processEnvironmentInFlight
@@ -808,12 +837,8 @@ func TestPanelsFrameEnvironmentAcknowledgementTimeoutKeepsDeferredInput(t *testi
 	if writes := local.snapshotWrites(); len(writes) != 1 {
 		t.Fatalf("timeout released held input: %q", writes)
 	}
-	select {
-	case <-timeoutDone:
-	case <-time.After(time.Second):
-		t.Fatal("timeout callback did not finish")
-	}
 	pf.closeProcessEnvironmentShell()
+	waitForProcessEnvironmentFailureToast(t)
 }
 
 func TestPanelsFrameExplicitBusyNeverExpiresFromBackendIdle(t *testing.T) {

--- a/cmd/f4/quick_view_panel_test.go
+++ b/cmd/f4/quick_view_panel_test.go
@@ -18,7 +18,7 @@ import (
 // and Ctrl+Q on the focused alt closes IT (not spawns a second one).
 func TestPanelsFrame_CtrlQ_TogglesQuickView(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -64,7 +64,7 @@ func TestPanelsFrame_CtrlQ_TogglesQuickView(t *testing.T) {
 // info on one side, quick view on the other — without collisions.
 func TestPanelsFrame_CtrlLQ_CoexistOnDifferentSides(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -239,7 +239,7 @@ func TestPanelsFrame_QuickViewWheel_ActivePanelScrolls(t *testing.T) {
 	vtui.FrameManager.Init(scr)
 	vtui.SetDefaultPalette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -265,6 +265,7 @@ func TestPanelsFrame_QuickViewWheel_ActivePanelScrolls(t *testing.T) {
 		VirtualKeyCode: vtinput.VK_Q, ControlKeyState: vtinput.LeftCtrlPressed,
 	})
 	q := pf.altPanels[0].(*QuickViewPanel)
+	pf.lastAutoRefresh = time.Now()
 	pf.Show(scr)
 
 	// Tab — active moves to left (alt slot). From now on wheel should
@@ -566,7 +567,7 @@ func TestQuickView_DirScan_CancelsOnSelectionChange(t *testing.T) {
 // this PR the B toggle only fired for `info` alts.
 func TestPanelsFrame_BToggle_WithQuickView(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/quick_view_provider_test.go
+++ b/cmd/f4/quick_view_provider_test.go
@@ -329,6 +329,7 @@ func TestQuickViewImagePreviewPrecedesRegisteredProviders(t *testing.T) {
 	qoi := []byte{'q', 'o', 'i', 'f', 0, 0, 0, 1, 0, 0, 0, 1, 4, 0, 0xff, 0xff, 0, 0, 0xff}
 	quickView, _, screen := newQuickViewProviderFixture(t, map[string][]byte{"image.qoi": qoi})
 	quickView.Show(screen)
+	waitForQuickView(t, func() bool { return quickView.imageSurf != nil })
 	if !quickView.cacheImage || calls.Load() != 0 {
 		t.Fatalf("image precedence: cacheImage=%t provider calls=%d", quickView.cacheImage, calls.Load())
 	}

--- a/cmd/f4/race_disabled_test.go
+++ b/cmd/f4/race_disabled_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package main
+
+// raceEnabled reports whether the binary was built with the race detector.
+// See race_enabled_test.go.
+const raceEnabled = false

--- a/cmd/f4/race_enabled_test.go
+++ b/cmd/f4/race_enabled_test.go
@@ -1,0 +1,8 @@
+//go:build race
+
+package main
+
+// raceEnabled reports whether the binary was built with the race detector.
+// The detector instruments every memory access, so wall-clock assertions
+// measure the instrumentation rather than the code under test.
+const raceEnabled = true

--- a/cmd/f4/shell_integration_test.go
+++ b/cmd/f4/shell_integration_test.go
@@ -57,7 +57,7 @@ func TestPanelsFrame_CtrlEnter_Escaping(t *testing.T) {
 
 func TestPanelsFrame_CtrlEnterOnDirectoryInsertsWithoutEntering(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 
 	tmp := t.TempDir()
@@ -134,7 +134,7 @@ func TestPanelsFrame_CD_QuotedParsing(t *testing.T) {
 }
 
 func TestPanelsFrame_PTY_SyncEscaping(t *testing.T) {
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pty := pf.pty.(*mockPty)

--- a/cmd/f4/simple_exec_test.go
+++ b/cmd/f4/simple_exec_test.go
@@ -18,7 +18,7 @@ func TestSimpleInline_CommandExecution(t *testing.T) {
 	vtui.FrameManager.Init(scr)
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.shellMode = ShellModeSimpleInline
 	pf.ResizeConsole(80, 25)
@@ -182,6 +182,8 @@ func TestSimpleCaptured_ToggleShowsToast(t *testing.T) {
 	defer pf.Close()
 	pf.shellMode = ShellModeSimpleCaptured
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	vtui.FrameManager.Push(pf)
 
 	RunAction("Panel.Toggle")
@@ -206,6 +208,9 @@ Loop:
 			t.Fatalf("Timeout waiting for toast %q, last seen %q", want, toast)
 		}
 	}
+	waitForToastExpiry(t, 4*time.Second)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 }
 
 // TestSimpleInline_FarStyleKeepsConsoleAndTypes covers the Ctrl+O screen users

--- a/cmd/f4/terminal_selection_test.go
+++ b/cmd/f4/terminal_selection_test.go
@@ -193,6 +193,8 @@ func panelsFrameWithMouseSelect(t *testing.T) (*PanelsFrame, *fakePTY) {
 	SetDefaultF4Palette()
 	pf := NewPanelsFrame()
 	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
 	pf.showPanels = false
 	pf.termView.SetPosition(0, 0, 79, 22)
 	pf.termView.clipboardWriter = func(string) {}

--- a/cmd/f4/terminal_view_test.go
+++ b/cmd/f4/terminal_view_test.go
@@ -272,6 +272,7 @@ Loop:
 	if !foundToast {
 		t.Error("Notification APC did not result in a Toast")
 	}
+	waitForToastExpiry(t, 4*time.Second)
 }
 
 func TestTerminalView_ProcessFar2lInteract_FKeys(t *testing.T) {

--- a/cmd/f4/user_menu_ui_test.go
+++ b/cmd/f4/user_menu_ui_test.go
@@ -205,7 +205,7 @@ func TestUserMenu_ExecuteCommands(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pty := pf.pty.(*mockPty)
@@ -251,7 +251,7 @@ func TestUserMenu_ExecuteMultipleCommands(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 	pty := pf.pty.(*mockPty)
@@ -320,7 +320,7 @@ func TestUserMenu_InteractiveEdit(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -374,7 +374,7 @@ func TestUserMenu_EditItemMultilineCommand(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 
@@ -439,7 +439,7 @@ func TestUserMenu_EditItemStripsBlankLines(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
 
-	pf := setupMockPanelsFrame()
+	pf := setupMockPanelsFrame(t)
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
 

--- a/cmd/f4/workspace_routing_test.go
+++ b/cmd/f4/workspace_routing_test.go
@@ -21,6 +21,14 @@ func screenIndexOfFrame(f vtui.Frame) int {
 	return -1
 }
 
+func waitForWorkspacePanels(t *testing.T, frames ...*PanelsFrame) {
+	t.Helper()
+	for _, frame := range frames {
+		waitForLoad(t, frame.panels[0].(*FileSystemPanel))
+		waitForLoad(t, frame.panels[1].(*FileSystemPanel))
+	}
+}
+
 // Issue #424: with two workspaces open, actions and hotkey conditions must
 // read the workspace the user is looking at, not the oldest one.
 func TestFindPanelsFrameAnyScreen_PrefersActiveWorkspace(t *testing.T) {
@@ -34,6 +42,7 @@ func TestFindPanelsFrameAnyScreen_PrefersActiveWorkspace(t *testing.T) {
 	second := NewPanelsFrame()
 	defer second.Close()
 	vtui.FrameManager.AddScreen(second)
+	waitForWorkspacePanels(t, first, second)
 
 	if got := findPanelsFrameAnyScreen(); got != second {
 		t.Fatalf("after Ctrl+N the new workspace is active, got %v", got == first)
@@ -63,6 +72,7 @@ func TestConditionsFollowActiveWorkspace(t *testing.T) {
 	second := NewPanelsFrame()
 	defer second.Close()
 	vtui.FrameManager.AddScreen(second)
+	waitForWorkspacePanels(t, first, second)
 
 	second.cmdLine.Edit.SetText("ls -la")
 
@@ -99,6 +109,7 @@ func TestFindPanelsFrameAnyScreen_FallsBackToMostRecent(t *testing.T) {
 	second := NewPanelsFrame()
 	defer second.Close()
 	vtui.FrameManager.AddScreen(second)
+	waitForWorkspacePanels(t, first, second)
 
 	firstIdx := screenIndexOfFrame(first)
 	if firstIdx < 0 {
@@ -127,6 +138,7 @@ func TestFindPanelsFrameAnyScreen_SkipsClosedFrame(t *testing.T) {
 	second := NewPanelsFrame()
 	defer second.Close()
 	vtui.FrameManager.AddScreen(second)
+	waitForWorkspacePanels(t, first, second)
 
 	second.closed = true
 

--- a/vfs/trash_darwin.go
+++ b/vfs/trash_darwin.go
@@ -127,8 +127,12 @@ func darwinCString(pointer uintptr) string {
 	if pointer == 0 {
 		return ""
 	}
+	// The address comes from the Objective-C FFI boundary, whose API returns
+	// pointers as uintptr values. Recover the pointer through its storage so
+	// vet does not mistake this valid foreign pointer for Go pointer arithmetic.
+	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&pointer))
 	const maxErrorDescription = 1 << 20
-	bytes := unsafe.Slice((*byte)(unsafe.Pointer(pointer)), maxErrorDescription)
+	bytes := unsafe.Slice((*byte)(ptr), maxErrorDescription)
 	for i, b := range bytes {
 		if b == 0 {
 			return string(bytes[:i])


### PR DESCRIPTION
Детектор гонок на main красный. После правок, которые уже влиты, осталось три места, плюс один тест ронял сборку сам по себе.

**Что чинится в боевом коде**

- `EditorView.Close` чистил `searchSnapshot` без замка, хотя замок у этого поля есть и `dropSearchSnapshot` для этого уже написан. Фоновый поиск в это время мог ещё собирать буфер.
- При сбое синхронизации окружения всплывало по тосту на каждое окно, и их таймеры одновременно перерисовывали один и тот же экран. Теперь один тост на окно времени.
- `vfs/trash_darwin.go`: адрес приходит из Objective-C как `uintptr`, и `go vet` на маке считал прямое преобразование подозрительным. Указатель восстанавливается через своё хранилище, предупреждение уходит.

**Тесты**

34 файла: воркеры дожидаются перед подменою менеджера экрана, тосты гасятся, а не утекают в следующий тест.

Отдельно — `editor_find_all_test.go` проверял, что открытие списка из 500000 совпадений укладывается в 200 мс. Под детектором гонок инструментируется каждое обращение к памяти, поэтому проверка замеряла инструментацию, а не код, и роняла сборку случайным образом. То же свойство тест проверяет двумя строчками ниже структурно: ни один элемент не материализован, а счётчик верный. Замер отключён под детектором.

**Проверено**

`go test -race -shuffle=on ./cmd/f4/` — 20 чистых прогонов подряд. Полный набор тестов, `go vet`, кросс-сборка под linux/amd64, linux/arm64, darwin/arm64, windows/amd64.