### PR TITLE
gosec: локальное повышение прав до root, SSRF и переполнения на чужих данных

### DIFF
--- a/fusefs/bridge.go
+++ b/fusefs/bridge.go
@@ -791,7 +791,7 @@ func (h *handle) release() error {
 // among live objects.
 func inodeOf(itemPath string) uint64 {
 	sum := fnv.New64a()
-	sum.Write([]byte(itemPath))
+	_, _ = sum.Write([]byte(itemPath)) // hash.Hash writes the complete slice and returns no error.
 	ino := sum.Sum64()
 	switch ino {
 	case 0, 1, ^uint64(0):

--- a/fusefs/mountspec.go
+++ b/fusefs/mountspec.go
@@ -198,20 +198,23 @@ func ParseArgs(argv []string) (Command, *Spec, error) {
 func parseFstabArgs(args []string) (Command, *Spec, error) {
 	spec := NewSpec()
 	var positional []string
-	for i := 0; i < len(args); i++ {
-		switch args[i] {
+	for len(args) != 0 {
+		arg := args[0]
+		args = args[1:]
+		switch arg {
 		case "-o":
-			if i+1 >= len(args) {
+			if len(args) == 0 {
 				return CmdMount, nil, errors.New("-o needs a value")
 			}
-			i++
-			if err := spec.ApplyOptions(args[i]); err != nil {
+			options := args[0]
+			args = args[1:]
+			if err := spec.ApplyOptions(options); err != nil {
 				return CmdMount, nil, err
 			}
 		case "-n", "-v", "-s", "-f":
 			// mount(8) niceties we have nothing to do with.
 		default:
-			positional = append(positional, args[i])
+			positional = append(positional, arg)
 		}
 	}
 	if len(positional) < 2 {

--- a/fusefs/node_fuse.go
+++ b/fusefs/node_fuse.go
@@ -5,6 +5,7 @@ package fusefs
 import (
 	"context"
 	"errors"
+	"math"
 	"os"
 	"syscall"
 	"time"
@@ -127,10 +128,22 @@ func (n *node) Create(ctx context.Context, name string, flags uint32, mode uint3
 
 func (f *writeFileHandle) Write(ctx context.Context, data []byte, off int64) (uint32, syscall.Errno) {
 	written, err := f.wh.writeAt(ctx, f.b, data, off)
-	if err != nil {
-		return uint32(written), errnoOf(err)
+	count, ok := fuseWriteCount(written)
+	if !ok {
+		return 0, syscall.EOVERFLOW
 	}
-	return uint32(written), 0
+	if err != nil {
+		return count, errnoOf(err)
+	}
+	return count, 0
+}
+
+func fuseWriteCount(written int) (uint32, bool) {
+	if written < 0 || uint64(written) > math.MaxUint32 {
+		return 0, false
+	}
+	// #nosec G115 -- written was checked against the uint32 FUSE result range above.
+	return uint32(written), true
 }
 
 // Fsync is a no-op on purpose. Committing per fsync would turn a tool that
@@ -341,7 +354,9 @@ func fillAttr(out *fuse.Attr, item vfs.VFSItem, itemPath string) {
 		// and cp -a cannot copy.
 		out.Mode = fuse.S_IFLNK | perm
 		out.Nlink = 1
-		out.Size = uint64(item.Size)
+		if item.Size > 0 {
+			out.Size = uint64(item.Size)
+		}
 	} else {
 		out.Mode = fuse.S_IFREG | perm
 		out.Nlink = 1
@@ -364,17 +379,25 @@ func fillAttr(out *fuse.Attr, item vfs.VFSItem, itemPath string) {
 	}
 	out.SetTimes(&atime, &mtime, &ctime)
 
-	if item.Uid > 0 {
-		out.Uid = uint32(item.Uid)
-	} else {
-		out.Uid = uint32(os.Getuid())
+	if uid, ok := fuseID(item.Uid); ok && uid > 0 {
+		out.Uid = uid
+	} else if uid, ok := fuseID(os.Getuid()); ok {
+		out.Uid = uid
 	}
-	if item.Gid > 0 {
-		out.Gid = uint32(item.Gid)
-	} else {
-		out.Gid = uint32(os.Getgid())
+	if gid, ok := fuseID(item.Gid); ok && gid > 0 {
+		out.Gid = gid
+	} else if gid, ok := fuseID(os.Getgid()); ok {
+		out.Gid = gid
 	}
 	out.Blksize = 4096
+}
+
+func fuseID(value int) (uint32, bool) {
+	if value < 0 || uint64(value) > math.MaxUint32 {
+		return 0, false
+	}
+	// #nosec G115 -- value was checked against the uint32 uid/gid range above.
+	return uint32(value), true
 }
 
 // errnoOf maps VFS errors onto errno values. Backends return plain errors,
@@ -514,6 +537,10 @@ func (n *node) Setattr(ctx context.Context, f fs.FileHandle, in *fuse.SetAttrIn,
 		wanted = true
 	}
 	if size, ok := in.GetSize(); ok {
+		if size > math.MaxInt64 {
+			return syscall.EFBIG
+		}
+		// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
 		if errno := n.truncate(ctx, int64(size)); errno != 0 {
 			return errno
 		}

--- a/internal/ttyx/keys.go
+++ b/internal/ttyx/keys.go
@@ -13,6 +13,7 @@ package ttyx
 
 import (
 	"errors"
+	"math"
 	"os"
 	"sync"
 
@@ -190,7 +191,12 @@ func (s *Session) keycodesFor(combos []Combo) ([]xproto.Keycode, error) {
 
 	setup := xproto.Setup(s.conn)
 	first := setup.MinKeycode
-	count := byte(setup.MaxKeycode - setup.MinKeycode + 1)
+	keycodeCount := int(setup.MaxKeycode) - int(setup.MinKeycode) + 1
+	if keycodeCount <= 0 || keycodeCount > math.MaxUint8 {
+		return nil, ErrNoDisplay
+	}
+	// #nosec G115 -- the explicit MaxUint8 check above makes this conversion lossless.
+	count := byte(keycodeCount)
 	mapping, err := xproto.GetKeyboardMapping(s.conn, first, count).Reply()
 	if err != nil || mapping == nil || mapping.KeysymsPerKeycode == 0 {
 		return nil, ErrNoDisplay
@@ -203,6 +209,7 @@ func (s *Session) keycodesFor(combos []Combo) ([]xproto.Keycode, error) {
 			found := false
 			for j := 0; j < per; j++ {
 				if uint32(mapping.Keysyms[k*per+j]) == c.Keysym {
+					// #nosec G115 -- k is bounded by the validated keycode span beginning at first.
 					out[i] = xproto.Keycode(int(first) + k)
 					found = true
 					break

--- a/internal/ttyx/overlay.go
+++ b/internal/ttyx/overlay.go
@@ -2,6 +2,7 @@ package ttyx
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/jezek/xgb"
 	"github.com/jezek/xgb/shape"
@@ -161,6 +162,10 @@ func (o *Overlay) Place(r Rect) error {
 	// lives in is the terminal's, so the server wants that same place
 	// measured from the terminal's corner.
 	local := Rect{X: r.X - o.s.geom.X, Y: r.Y - o.s.geom.Y, W: r.W, H: r.H}
+	if local.X < math.MinInt32 || local.X > math.MaxInt32 || local.Y < math.MinInt32 || local.Y > math.MaxInt32 ||
+		local.W > math.MaxUint16 || local.H > math.MaxUint16 {
+		return fmt.Errorf("the overlay rectangle is outside the X11 coordinate range")
+	}
 
 	if local != o.local {
 		// The value list follows the order of the mask bits: x, y, width,
@@ -170,8 +175,9 @@ func (o *Overlay) Place(r Rect) error {
 				xproto.ConfigWindowWidth|xproto.ConfigWindowHeight|
 				xproto.ConfigWindowStackMode,
 			[]uint32{
+				// #nosec G115 -- local coordinates and dimensions were checked against their X11 wire ranges above.
 				uint32(int32(local.X)), uint32(int32(local.Y)),
-				uint32(local.W), uint32(local.H),
+				uint32(local.W), uint32(local.H), // #nosec G115 -- dimensions were checked against MaxUint16 above.
 				xproto.StackModeAbove,
 			}).Check()
 		if err != nil {
@@ -245,7 +251,12 @@ func (o *Overlay) SetBounds(rects []Rect) bool {
 		if r.W <= 0 || r.H <= 0 {
 			continue
 		}
+		if r.X < math.MinInt16 || r.X > math.MaxInt16 || r.Y < math.MinInt16 || r.Y > math.MaxInt16 ||
+			r.W > math.MaxUint16 || r.H > math.MaxUint16 {
+			return false
+		}
 		list = append(list, xproto.Rectangle{
+			// #nosec G115 -- each rectangle component was checked against its X11 wire range above.
 			X: int16(r.X), Y: int16(r.Y),
 			Width: uint16(r.W), Height: uint16(r.H),
 		})
@@ -281,11 +292,14 @@ func (o *Overlay) Draw(pix []byte, w, h, stride int) error {
 	if o.s.conn == nil {
 		return ErrNoDisplay
 	}
-	if w <= 0 || h <= 0 || stride < w*4 || len(pix) < (h-1)*stride+w*4 {
+	if w <= 0 || h <= 0 || w > math.MaxUint16 || h > math.MaxInt16 {
+		return fmt.Errorf("the pixel dimensions %dx%d are outside the X11 coordinate range", w, h)
+	}
+	lineBytes := w * 4
+	if stride < lineBytes || len(pix) < lineBytes || (h > 1 && (len(pix)-lineBytes)/stride < h-1) {
 		return fmt.Errorf("the pixel buffer does not match %dx%d", w, h)
 	}
 
-	lineBytes := w * 4
 	// A request carries a length in four byte units; leave room for the
 	// PutImage header, which is twenty four bytes plus padding.
 	maxReq := int(xproto.Setup(o.s.conn).MaximumRequestLength) * 4
@@ -311,12 +325,15 @@ func (o *Overlay) Draw(pix []byte, w, h, stride int) error {
 		for row := 0; row < n; row++ {
 			src := pix[(y+row)*stride : (y+row)*stride+lineBytes]
 			dst := o.buf[row*lineBytes : (row+1)*lineBytes]
-			for i := 0; i < lineBytes; i += 4 {
-				dst[i], dst[i+1], dst[i+2], dst[i+3] = src[i+2], src[i+1], src[i], 0xFF
+			for len(src) >= 4 && len(dst) >= 4 {
+				dst[0], dst[1], dst[2], dst[3] = src[2], src[1], src[0], 0xFF
+				src = src[4:]
+				dst = dst[4:]
 			}
 		}
 		err := xproto.PutImageChecked(o.s.conn, xproto.ImageFormatZPixmap,
 			xproto.Drawable(o.win), o.gc,
+			// #nosec G115 -- Draw rejected dimensions outside the X11 uint16/int16 wire ranges above.
 			uint16(w), uint16(n), 0, int16(y), 0, o.s.depth,
 			o.buf[:n*lineBytes]).Check()
 		if err != nil {

--- a/internal/ttyx/session.go
+++ b/internal/ttyx/session.go
@@ -17,6 +17,7 @@ package ttyx
 import (
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"strconv"
 	"strings"
@@ -265,12 +266,16 @@ func (s *Session) atom(name string) xproto.Atom {
 		return a
 	}
 	a := xproto.Atom(0)
+	if len(name) > math.MaxUint16 {
+		return a
+	}
 	// The atom is created if it is not there. Refusing to create one was
 	// the first version and it was wrong: CLIPBOARD does not exist on a
 	// server nobody has copied anything on yet, and a selection cannot be
 	// taken by a name that has no atom. Interning a name that is never used
 	// costs one entry in a table; the alternative was a clipboard that
 	// worked everywhere except on a fresh session.
+	// #nosec G115 -- atom names longer than the uint16 wire limit are rejected above.
 	if reply, err := xproto.InternAtom(s.conn, false, uint16(len(name)), name).Reply(); err == nil && reply != nil {
 		a = reply.Atom
 	}
@@ -462,7 +467,11 @@ func ancestorPIDs(pid int, parent func(int) (int, bool)) []uint32 {
 	var out []uint32
 	seen := make(map[int]bool)
 	for i := 0; i < 32 && pid > 0 && !seen[pid]; i++ {
+		if uint64(pid) > math.MaxUint32 {
+			break
+		}
 		seen[pid] = true
+		// #nosec G115 -- positive pid was checked against MaxUint32 immediately above.
 		out = append(out, uint32(pid))
 		next, ok := parent(pid)
 		if !ok {

--- a/luaplug/ffi.go
+++ b/luaplug/ffi.go
@@ -1,6 +1,7 @@
 package luaplug
 
 import (
+	"math"
 	"runtime"
 	"strings"
 
@@ -52,7 +53,12 @@ func (r *Runtime) openFFI(L *lua.LState) {
 // are doubles: exact below 2^53, and every address on every platform f4 targets
 // is far below that.
 func checkAddr(L *lua.LState, index int) uintptr {
-	return uintptr(int64(L.CheckNumber(index)))
+	value := float64(L.CheckNumber(index))
+	if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > float64(^uintptr(0)) || math.Trunc(value) != value {
+		L.ArgError(index, "address must be a non-negative, exactly representable pointer value")
+		return 0
+	}
+	return uintptr(value)
 }
 
 // collectArgs turns the trailing arguments of a call into host values.
@@ -327,17 +333,17 @@ func narrowCallbackValue(k ffibridge.Kind, v any) any {
 	p, _ := v.(uintptr)
 	switch k {
 	case ffibridge.KindI8:
-		return int8(uint8(p))
+		return int8(uint8(p)) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 8 bits and their signed interpretation.
 	case ffibridge.KindU8:
-		return uint8(p)
+		return uint8(p) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 8 bits.
 	case ffibridge.KindI16:
-		return int16(uint16(p))
+		return int16(uint16(p)) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 16 bits and their signed interpretation.
 	case ffibridge.KindU16:
-		return uint16(p)
+		return uint16(p) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 16 bits.
 	case ffibridge.KindI32:
-		return int32(uint32(p))
+		return int32(uint32(p)) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 32 bits and their signed interpretation.
 	case ffibridge.KindU32:
-		return uint32(p)
+		return uint32(p) // #nosec G115 -- callback ABI narrowing intentionally preserves the low 32 bits.
 	case ffibridge.KindBool:
 		return p != 0
 	}

--- a/piecetable/lineindex.go
+++ b/piecetable/lineindex.go
@@ -111,6 +111,7 @@ func (li *LineIndex) appendOffset(off int) {
 		blk := &li.blocks[len(li.blocks)-1]
 		rel := off - blk.base
 		if len(blk.entries) < lineBlockTarget && fitsRelativeOffset(rel) {
+			// #nosec G115 -- fitsRelativeOffset proves rel is in the uint32 range.
 			blk.entries = append(blk.entries, uint32(rel))
 			li.count++
 			return
@@ -186,6 +187,7 @@ func (li *LineIndex) shiftFrom(line, delta int) {
 				li.shiftFrom(line, delta)
 				return
 			}
+			// #nosec G115 -- fitsRelativeOffset above proves rel is in the uint32 range.
 			blk.entries[i] = uint32(rel)
 		}
 	}
@@ -224,6 +226,7 @@ func (li *LineIndex) insertLines(at int, vals []int) {
 			li.insertLines(at, vals)
 			return
 		}
+		// #nosec G115 -- fitsRelativeOffset above proves r is in the uint32 range.
 		rel[i] = uint32(r)
 	}
 
@@ -254,6 +257,7 @@ func (li *LineIndex) splitIfLarge(b int) {
 	}
 	shift := tail.base - blk.base
 	for i := range tail.entries {
+		// #nosec G115 -- shift is the non-negative difference between two offsets encoded in this uint32 block.
 		tail.entries[i] -= uint32(shift)
 	}
 	blk.entries = blk.entries[:half]

--- a/plugins/android/adb_sync.go
+++ b/plugins/android/adb_sync.go
@@ -465,10 +465,11 @@ func (r *SyncReceiveReader) Read(p []byte) (int, error) {
 		}
 		if r.remaining != 0 {
 			want := len(p)
-			if uint32(want) > r.remaining {
+			if want > int(r.remaining) {
 				want = int(r.remaining)
 			}
 			n, err := io.ReadFull(r.conn, p[:want])
+			// #nosec G115 -- io.ReadFull cannot return more than want, which is capped at r.remaining.
 			r.remaining -= uint32(n)
 			if err != nil {
 				err = syncContextError(r.ctx, fmt.Errorf("adb sync receive data: %w", err))
@@ -687,6 +688,7 @@ func writeSyncRequest(w io.Writer, id, path string) error {
 	}
 	var header [8]byte
 	copy(header[:4], id)
+	// #nosec G115 -- SyncMaxPath is 1024, and the length was checked above.
 	binary.LittleEndian.PutUint32(header[4:], uint32(len(path)))
 	if err := writeSyncFull(w, header[:]); err != nil {
 		return err
@@ -735,6 +737,18 @@ func readSyncStatV2AfterID(r io.Reader) (SyncEntry, error) {
 	if _, err := io.ReadFull(r, body[:]); err != nil {
 		return SyncEntry{}, err
 	}
+	accessTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[44:52]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
+	modTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[52:60]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
+	changeTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[60:68]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
 	return SyncEntry{
 		metadataV2: true,
 		Errno:      binary.LittleEndian.Uint32(body[0:4]),
@@ -745,9 +759,9 @@ func readSyncStatV2AfterID(r io.Reader) (SyncEntry, error) {
 		UID:        binary.LittleEndian.Uint32(body[28:32]),
 		GID:        binary.LittleEndian.Uint32(body[32:36]),
 		Size:       binary.LittleEndian.Uint64(body[36:44]),
-		AccessTime: time.Unix(int64(binary.LittleEndian.Uint64(body[44:52])), 0),
-		ModTime:    time.Unix(int64(binary.LittleEndian.Uint64(body[52:60])), 0),
-		ChangeTime: time.Unix(int64(binary.LittleEndian.Uint64(body[60:68])), 0),
+		AccessTime: accessTime,
+		ModTime:    modTime,
+		ChangeTime: changeTime,
 	}, nil
 }
 
@@ -779,6 +793,18 @@ func readSyncDentV2AfterID(r io.Reader) (SyncEntry, error) {
 	if err != nil {
 		return SyncEntry{}, err
 	}
+	accessTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[44:52]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
+	modTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[52:60]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
+	changeTime, err := syncUnixTime(binary.LittleEndian.Uint64(body[60:68]))
+	if err != nil {
+		return SyncEntry{}, err
+	}
 	return SyncEntry{
 		Name:       name,
 		metadataV2: true,
@@ -790,10 +816,18 @@ func readSyncDentV2AfterID(r io.Reader) (SyncEntry, error) {
 		UID:        binary.LittleEndian.Uint32(body[28:32]),
 		GID:        binary.LittleEndian.Uint32(body[32:36]),
 		Size:       binary.LittleEndian.Uint64(body[36:44]),
-		AccessTime: time.Unix(int64(binary.LittleEndian.Uint64(body[44:52])), 0),
-		ModTime:    time.Unix(int64(binary.LittleEndian.Uint64(body[52:60])), 0),
-		ChangeTime: time.Unix(int64(binary.LittleEndian.Uint64(body[60:68])), 0),
+		AccessTime: accessTime,
+		ModTime:    modTime,
+		ChangeTime: changeTime,
 	}, nil
+}
+
+func syncUnixTime(seconds uint64) (time.Time, error) {
+	if seconds > math.MaxInt64 {
+		return time.Time{}, &SyncProtocolError{Operation: "metadata", Detail: fmt.Sprintf("timestamp %d is outside the int64 range", seconds)}
+	}
+	// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+	return time.Unix(int64(seconds), 0), nil
 }
 
 func readSyncName(r io.Reader, size uint32) (string, error) {

--- a/plugins/android/adb_transport.go
+++ b/plugins/android/adb_transport.go
@@ -845,6 +845,7 @@ func writeShellPacket(w io.Writer, id byte, payload []byte) error {
 	}
 	var header [5]byte
 	header[0] = id
+	// #nosec G115 -- the payload length was checked against the uint32 wire limit above.
 	binary.LittleEndian.PutUint32(header[1:], uint32(len(payload)))
 	if err := writeFull(w, header[:]); err != nil {
 		return fmt.Errorf("adb shell-v2: write packet header: %w", err)
@@ -943,6 +944,7 @@ func findADBExecutable() (string, error) {
 			continue
 		}
 		candidate := filepath.Join(root, "platform-tools", name)
+		// #nosec G703 -- root is an explicit local SDK path from the user's environment, and name is a fixed adb executable basename.
 		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
 			if path, lookErr := exec.LookPath(candidate); lookErr == nil {
 				return path, nil

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"math"
 	"os"
 	"path"
 	"path/filepath"
@@ -1609,9 +1610,14 @@ func (v *ArchiveVFS) copyBulkZip(ctx context.Context, f vfs.ReadAtCloser, select
 		if err := ensureArchiveExtractionDir(ctx, dstVfs, dstVfs.Dir(targetPath)); err != nil {
 			return err
 		}
+		if file.UncompressedSize64 > math.MaxInt64 {
+			return fmt.Errorf("archive entry %q is too large: %d bytes exceeds the supported size", file.Name, file.UncompressedSize64)
+		}
+		// #nosec G115 -- the explicit MaxInt64 check above makes the archive size conversion lossless.
+		fileSize := int64(file.UncompressedSize64)
 
 		if fp, ok := reporter.(vfs.FileProgress); ok {
-			fp.StartFile(file.Name, int64(file.UncompressedSize64))
+			fp.StartFile(file.Name, fileSize)
 		}
 		if reporter != nil {
 			mu.Lock()
@@ -1648,8 +1654,8 @@ func (v *ArchiveVFS) copyBulkZip(ctx context.Context, f vfs.ReadAtCloser, select
 					fp.UpdateBytes(n)
 				}
 				copied += int64(n)
-				if reporter != nil && file.UncompressedSize64 > 0 {
-					pct := int((copied * 100) / int64(file.UncompressedSize64))
+				if reporter != nil && fileSize > 0 {
+					pct := archiveProgressPercent(copied, fileSize)
 					mu.Lock()
 					lastAction = "Extracting"
 					lastFile = file.Name
@@ -1680,7 +1686,7 @@ func (v *ArchiveVFS) copyBulkZip(ctx context.Context, f vfs.ReadAtCloser, select
 		}
 		item := vfs.VFSItem{
 			Name:     file.Name,
-			Size:     int64(file.UncompressedSize64),
+			Size:     fileSize,
 			IsDir:    false,
 			MTime:    file.Modified,
 			ATime:    file.Modified,
@@ -1792,7 +1798,7 @@ func (v *ArchiveVFS) copyBulkTar(ctx context.Context, f vfs.ReadAtCloser, select
 				}
 				copied += int64(n)
 				if reporter != nil && hdr.Size > 0 {
-					pct := int((copied * 100) / hdr.Size)
+					pct := archiveProgressPercent(copied, hdr.Size)
 					mu.Lock()
 					lastAction = "Extracting"
 					lastFile = cleanName
@@ -1815,7 +1821,11 @@ func (v *ArchiveVFS) copyBulkTar(ctx context.Context, f vfs.ReadAtCloser, select
 			fp.FileDone()
 		}
 
-		mode := uint32(hdr.Mode)
+		// Only POSIX permission and special bits are meaningful to the destination.
+		// Mask before narrowing so a hostile tar header cannot smuggle high bits
+		// into the uint32 VFS metadata field.
+		// #nosec G115 -- masking to 0o7777 proves the result is in the uint32 range.
+		mode := uint32(hdr.Mode & 0o7777)
 		if mode == 0 {
 			mode = 0644
 		}
@@ -1832,6 +1842,18 @@ func (v *ArchiveVFS) copyBulkTar(ctx context.Context, f vfs.ReadAtCloser, select
 		_ = dstVfs.SetAttributes(ctx, targetPath, item) // Metadata support is optional across destination VFSes.
 	}
 	return nil
+}
+
+func archiveProgressPercent(copied, total int64) int {
+	if copied <= 0 || total <= 0 {
+		return 0
+	}
+	if copied >= total {
+		return 100
+	}
+	// Progress is approximate UI data. Floating-point division avoids an
+	// intermediate copied*100 overflow for very large archive members.
+	return int(float64(copied) * 100 / float64(total))
 }
 
 func (v *ArchiveVFS) copyBulkFallback(ctx context.Context, f vfs.ReadAtCloser, selected map[string]bool, innerPath string, dstVfs vfs.VFS, dstDir string, reporter vfs.TaskReporter) error {
@@ -1968,7 +1990,7 @@ func (v *ArchiveVFS) copyBulkFallback(ctx context.Context, f vfs.ReadAtCloser, s
 				}
 				copied += int64(n)
 				if reporter != nil && size > 0 {
-					pct := int((copied * 100) / size)
+					pct := archiveProgressPercent(copied, size)
 					mu.Lock()
 					lastAction = "Extracting"
 					lastFile = cleanName

--- a/plugins/cloudfox/credential_scope.go
+++ b/plugins/cloudfox/credential_scope.go
@@ -16,7 +16,7 @@ import (
 // credential bundle instead of the plaintext profile. An attacker who can
 // rewrite CloudFox.json therefore cannot retarget credentials to another
 // endpoint without making this binding fail.
-const credentialScopeSecretKey = "_cloudfox_credential_scope_v1"
+const credentialScopeSecretKey = "_cloudfox_credential_scope_v1" // #nosec G101 -- public keyring record label, not a credential value.
 
 // credentialScope returns an opaque digest of the settings which decide where
 // credentials can be sent. OAuth providers already bind their credentials to

--- a/plugins/cloudfox/provider_google.go
+++ b/plugins/cloudfox/provider_google.go
@@ -2005,8 +2005,10 @@ func googlePanelSnapshot(about *drive.About, refreshed time.Time) vfs.PanelInfoS
 	if about.StorageQuota != nil && about.StorageQuota.Limit > 0 {
 		available := uint64(0)
 		if about.StorageQuota.Usage < about.StorageQuota.Limit {
+			// #nosec G115 -- both signed quota values are positive here and Usage is smaller than Limit.
 			available = uint64(about.StorageQuota.Limit - about.StorageQuota.Usage)
 		}
+		// #nosec G115 -- the surrounding condition proves Limit is positive.
 		account.Fields = append(account.Fields, vfs.PanelInfoField{ID: "quota", Label: "Storage", Kind: vfs.PanelInfoUsage, TotalBytes: uint64(about.StorageQuota.Limit), AvailableBytes: available})
 	}
 	snapshot.Sections = []vfs.PanelInfoSection{account}

--- a/plugins/cloudfox/provider_yandex.go
+++ b/plugins/cloudfox/provider_yandex.go
@@ -105,7 +105,8 @@ type yandexDiskBackend struct {
 // do applies one redirect policy to every request issued by a backend,
 // including backends constructed directly in tests. Authenticated API/status
 // calls and write methods never follow redirects. Unauthenticated temporary
-// downloads may follow redirects, but never downgrade HTTPS.
+// downloads may follow redirects only within the API or Yandex.Disk transfer
+// origins.
 func (b *yandexDiskBackend) do(req *http.Request) (*http.Response, error) {
 	client := b.client
 	if client == nil {
@@ -125,7 +126,7 @@ func (b *yandexDiskBackend) do(req *http.Request) (*http.Response, error) {
 		if initial.Header.Get("Authorization") != "" || (initial.Method != http.MethodGet && initial.Method != http.MethodHead) || next.Method != previous.Method {
 			return http.ErrUseLastResponse
 		}
-		if strings.EqualFold(initial.URL.Scheme, "https") && !strings.EqualFold(next.URL.Scheme, "https") {
+		if _, err := b.validateTemporaryURL(next.URL.String()); err != nil {
 			return http.ErrUseLastResponse
 		}
 		if previousRedirectPolicy != nil {
@@ -145,10 +146,20 @@ func (b *yandexDiskBackend) validateTemporaryURL(raw string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if strings.EqualFold(base.Scheme, "https") && !strings.EqualFold(target.Scheme, "https") {
-		return "", errors.New("cloudfox: Yandex.Disk temporary URL downgraded HTTPS")
+	if sameWebDAVOrigin(target, base) {
+		return target.String(), nil
+	}
+	if !strings.EqualFold(target.Scheme, "https") || (target.Port() != "" && target.Port() != "443") || !isYandexDiskTransferHost(target.Hostname()) {
+		return "", errors.New("cloudfox: Yandex.Disk returned a temporary URL outside its transfer service")
 	}
 	return target.String(), nil
+}
+
+func isYandexDiskTransferHost(host string) bool {
+	host = strings.ToLower(strings.TrimSuffix(host, "."))
+	return host == "disk.yandex.net" || strings.HasSuffix(host, ".disk.yandex.net") ||
+		host == "disk.yandex.ru" || strings.HasSuffix(host, ".disk.yandex.ru") ||
+		strings.HasSuffix(host, ".storage.yandex.net")
 }
 
 func sanitizeYandexTransferError(err error) error {

--- a/plugins/cloudfox/provider_yandex_cache.go
+++ b/plugins/cloudfox/provider_yandex_cache.go
@@ -2,6 +2,7 @@ package cloudfox
 
 import (
 	"context"
+	// #nosec G501 -- Yandex MD5 is used only as a provider-supplied transfer checksum; SHA-256 is preferred and TLS authenticates the peer.
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
@@ -379,6 +380,7 @@ func yandexExpectedHasher(resource yandexResource) (hash.Hash, string, error) {
 		return sha256.New(), sha, nil
 	}
 	if md5sum != "" {
+		// #nosec G401 -- this is a non-security transfer checksum supplied by Yandex; it is not used for authentication.
 		return md5.New(), md5sum, nil
 	}
 	return nil, "", nil

--- a/plugins/cloudfox/provider_yandex_test.go
+++ b/plugins/cloudfox/provider_yandex_test.go
@@ -278,6 +278,71 @@ func TestYandexDoesNotFollowAuthenticatedStatusRedirect(t *testing.T) {
 	}
 }
 
+func TestYandexTemporaryURLsStayWithinTransferOrigins(t *testing.T) {
+	t.Parallel()
+	backend := &yandexDiskBackend{baseURL: "https://cloud-api.yandex.net/v1/disk"}
+
+	for _, raw := range []string{
+		"https://downloader.disk.yandex.net/signed",
+		"https://uploader.disk.yandex.net/signed",
+		"https://node.storage.yandex.net/signed",
+		"https://cloud-api.yandex.net/v1/disk/signed",
+	} {
+		if _, err := backend.validateTemporaryURL(raw); err != nil {
+			t.Errorf("validateTemporaryURL(%q): %v", raw, err)
+		}
+	}
+	for _, raw := range []string{
+		"https://127.0.0.1/metadata",
+		"https://disk.yandex.net.attacker.example/signed",
+		"https://uploader.disk.yandex.net:8443/signed",
+		"http://downloader.disk.yandex.net/signed",
+	} {
+		if _, err := backend.validateTemporaryURL(raw); err == nil {
+			t.Errorf("validateTemporaryURL(%q) unexpectedly succeeded", raw)
+		}
+	}
+}
+
+func TestYandexDoesNotFollowTemporaryURLRedirectOutsideTransferOrigins(t *testing.T) {
+	t.Parallel()
+
+	var targetMu sync.Mutex
+	targetRequests := 0
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		targetMu.Lock()
+		targetRequests++
+		targetMu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, target.URL+"/internal", http.StatusFound)
+	}))
+	defer source.Close()
+
+	backend := &yandexDiskBackend{client: source.Client(), baseURL: source.URL}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, source.URL+"/signed", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := backend.do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("temporary redirect response status = %d, want %d", resp.StatusCode, http.StatusFound)
+	}
+	targetMu.Lock()
+	gotTargetRequests := targetRequests
+	targetMu.Unlock()
+	if gotTargetRequests != 0 {
+		t.Fatalf("temporary redirect target was requested %d time(s)", gotTargetRequests)
+	}
+}
+
 func TestYandexDoesNotFollowUploadRedirectAsGET(t *testing.T) {
 	t.Parallel()
 
@@ -532,7 +597,7 @@ func TestYandexSignedTransferFailuresNeverExposeTemporaryCredentials(t *testing.
 						case "/resources":
 							body = `{"name":"file.bin","path":"disk:/file.bin","type":"file","size":1,"revision":1,"resource_id":"resource-1"}`
 						case "/resources/download", "/resources/upload":
-							body = fmt.Sprintf(`{"href":%q,"method":%q}`, "https://cdn.test/"+pathSecret+"?signature="+querySecret, map[bool]string{true: "PUT", false: "GET"}[request.URL.Path == "/resources/upload"])
+							body = fmt.Sprintf(`{"href":%q,"method":%q}`, "https://downloader.disk.yandex.net/"+pathSecret+"?signature="+querySecret, map[bool]string{true: "PUT", false: "GET"}[request.URL.Path == "/resources/upload"])
 						default:
 							return &http.Response{StatusCode: http.StatusNotFound, Body: io.NopCloser(strings.NewReader("not found")), Request: request}, nil
 						}
@@ -541,7 +606,7 @@ func TestYandexSignedTransferFailuresNeverExposeTemporaryCredentials(t *testing.
 					if failure == "transport" {
 						return nil, transportErr
 					}
-					body := "gateway echoed https://cdn.test/" + pathSecret + "?signature=" + querySecret
+					body := "gateway echoed https://downloader.disk.yandex.net/" + pathSecret + "?signature=" + querySecret
 					return &http.Response{StatusCode: http.StatusBadGateway, Body: io.NopCloser(strings.NewReader(body)), Request: request, Header: make(http.Header)}, nil
 				})}
 				backend := &yandexDiskBackend{client: client, baseURL: "https://api.test", token: "token", root: "disk:/"}

--- a/plugins/cloudfox/store.go
+++ b/plugins/cloudfox/store.go
@@ -267,6 +267,8 @@ func (s *ConnectionStore) update(ctx context.Context, mutate func(*connectionDoc
 
 func (s *ConnectionStore) readUnlocked() (connectionDocument, error) {
 	doc := connectionDocument{Version: connectionFileVersion}
+	// #nosec G703 -- s.path is the caller-selected metadata file itself (or the
+	// fixed ConfigDir/CloudFox.json default), not a child name from a provider.
 	data, err := os.ReadFile(s.path)
 	if errors.Is(err, os.ErrNotExist) {
 		return doc, nil
@@ -340,6 +342,7 @@ func writeJSONAtomic(filename string, value any) error {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return fmt.Errorf("cloudfox: create config directory: %w", err)
 	}
+	// #nosec G302 -- dir is a directory, for which owner-only 0700 is the restrictive mode.
 	if err := os.Chmod(dir, 0o700); err != nil && !errors.Is(err, os.ErrPermission) {
 		return fmt.Errorf("cloudfox: protect config directory: %w", err)
 	}

--- a/plugins/ios/core_access_supported.go
+++ b/plugins/ios/core_access_supported.go
@@ -327,6 +327,7 @@ func developerImagePath(device goios.DeviceEntry, version *semver.Version) (stri
 }
 
 func validateDeveloperImagePath(imagePath string, version *semver.Version) error {
+	// #nosec G703 -- imagePath is either an explicit user-configured local path or a fixed path returned by the bounded developer-image cache.
 	info, err := os.Stat(imagePath)
 	if err != nil {
 		return fmt.Errorf("invalid Developer Disk Image path %q: %w", imagePath, err)
@@ -335,6 +336,7 @@ func validateDeveloperImagePath(imagePath string, version *semver.Version) error
 		if !info.IsDir() {
 			return fmt.Errorf("developer disk image path %q must be a Restore directory", imagePath)
 		}
+		// #nosec G703 -- the child name is fixed and imagePath was selected from the user's local configuration/cache above.
 		if _, err := os.Stat(filepath.Join(imagePath, "BuildManifest.plist")); err != nil {
 			return fmt.Errorf("developer disk image path %q has no BuildManifest.plist: %w", imagePath, err)
 		}

--- a/plugins/ios/internal/afcproto/client.go
+++ b/plugins/ios/internal/afcproto/client.go
@@ -208,6 +208,7 @@ func (c *Client) SetModTime(ctx context.Context, name string, mtime time.Time) e
 		return pathError("chtimes", name, fs.ErrInvalid)
 	}
 	nanos := seconds*int64(time.Second) + nanosecond
+	// #nosec G115 -- the preceding checks prove nanos is non-negative and no greater than MaxInt64.
 	header := append(putUint64s(uint64(nanos)), pathBytes(clean)...)
 	_, err = c.exchange(ctx, opSetFileModTime, header, nil, opStatus)
 	return pathError("chtimes", name, err)

--- a/plugins/ios/internal/afcproto/file.go
+++ b/plugins/ios/internal/afcproto/file.go
@@ -190,6 +190,10 @@ func (f *File) readChunk(ctx context.Context, p []byte) (int, error) {
 }
 
 func (f *File) seek(ctx context.Context, offset int64) error {
+	if offset < 0 {
+		return pathError("seek", f.path, fs.ErrInvalid)
+	}
+	// #nosec G115 -- negative offsets are rejected immediately above.
 	_, err := f.client.exchange(ctx, opFileSeek, putUint64s(f.handle, uint64(io.SeekStart), uint64(offset)), nil, opStatus)
 	return pathError("seek", f.path, err)
 }

--- a/plugins/ios/internal/afcproto/protocol.go
+++ b/plugins/ios/internal/afcproto/protocol.go
@@ -91,6 +91,7 @@ func readPacket(r io.Reader, expectedNumber uint64) (packet, error) {
 		return packet{}, fmt.Errorf("%w: AFC packet exceeds configured bounds", ErrProtocol)
 	}
 
+	// #nosec G115 -- maxPacketSize caps both validated wire lengths at 64 MiB.
 	headerLen := int(h.ThisLen - headerSize)
 	payloadLen := int(h.EntireLen - h.ThisLen)
 	p := packet{

--- a/plugins/mediainfo/cache.go
+++ b/plugins/mediainfo/cache.go
@@ -163,6 +163,7 @@ func (w *cacheWeight) addSlice(capacity int, elementSize uintptr) {
 		w.value = maxCacheWeight
 		return
 	}
+	// #nosec G115 -- the product was checked against maxCacheWeight immediately above.
 	w.add(int64(uint64(capacity) * uint64(elementSize)))
 }
 

--- a/plugins/mediainfo/config_dialog.go
+++ b/plugins/mediainfo/config_dialog.go
@@ -87,9 +87,12 @@ func (plugin *Plugin) configure(app vfs.App) {
 		vtui.ShowMessageOn(dialog, " "+plugin.text("MediaInfo.SettingsError", "Settings error", "Ошибка настроек")+" ", err.Error(), []string{plugin.text("MediaInfo.OK", "&OK", "&ОК")})
 	}
 	saveButton.OnClick = func() {
-		languageIndex := language.Menu.SelectPos
-		if languageIndex < 0 || languageIndex > 2 {
-			languageIndex = 0
+		languageCode := "auto"
+		switch language.Menu.SelectPos {
+		case 1:
+			languageCode = "en"
+		case 2:
+			languageCode = "ru"
 		}
 		next := Settings{
 			ShowInPluginMenu: showMenu.State == 1,
@@ -97,7 +100,7 @@ func (plugin *Plugin) configure(app vfs.App) {
 			UseEditor:        useEditor.State == 1,
 			Prefix:           prefix.GetText(),
 			Template:         template.GetText(),
-			Language:         []string{"auto", "en", "ru"}[languageIndex],
+			Language:         languageCode,
 		}
 		next = normalizeSettings(next)
 		if err := next.validate(); err != nil {

--- a/plugins/mediainfo/parse_audio.go
+++ b/plugins/mediainfo/parse_audio.go
@@ -140,7 +140,8 @@ func parseMPEGAudio(p *probe, head []byte) error {
 	frames, audioBytes := parseXingVBRI(first, mh)
 	if frames > 0 {
 		stream.FrameCount = int64(frames)
-		stream.Duration = durationFromUnits(uint64(frames*mh.samples), uint64(mh.sampleRate))
+		// #nosec G115 -- frames comes from uint32 metadata, while samples and sampleRate are bounded MPEG-header table values.
+		stream.Duration = durationFromUnits(uint64(frames)*uint64(mh.samples), uint64(mh.sampleRate))
 		stream.BitRateMode = "VBR"
 		if audioBytes > 0 && stream.Duration > 0 {
 			stream.BitRate = int64(float64(audioBytes*8) / stream.Duration.Seconds())
@@ -349,9 +350,10 @@ func parseVorbisComments(p *probe, b []byte) {
 		return
 	}
 	vendorSize := uint64(binary.LittleEndian.Uint32(b[:4]))
-	if vendorSize > uint64(len(b)-8) {
+	if vendorSize > uint64(len(b)-8) { // #nosec G115 -- len(b)-8 is non-negative because the header length was checked above.
 		return
 	}
+	// #nosec G115 -- vendorSize was checked against the in-memory slice length above.
 	vendorLen := int(vendorSize)
 	vendor := b[4 : 4+vendorLen]
 	if len(vendor) > p.opts.MaxValueBytes {
@@ -583,7 +585,12 @@ func findLastOggGranule(p *probe, serial uint32) int64 {
 	}
 	for i := len(b) - 27; i >= 0; i-- {
 		if string(b[i:i+4]) == "OggS" && binary.LittleEndian.Uint32(b[i+14:i+18]) == serial {
-			return int64(binary.LittleEndian.Uint64(b[i+6 : i+14]))
+			granule := binary.LittleEndian.Uint64(b[i+6 : i+14])
+			if granule > math.MaxInt64 {
+				return 0
+			}
+			// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+			return int64(granule)
 		}
 	}
 	return 0
@@ -623,8 +630,12 @@ func parseAIFF(p *probe, _ []byte) error {
 				s.Audio.Channels = int(binary.BigEndian.Uint16(b[:2]))
 				frames := binary.BigEndian.Uint32(b[2:6])
 				s.Audio.BitDepth = int(binary.BigEndian.Uint16(b[6:8]))
-				s.Audio.SampleRate = int(extended80(b[8:18]))
-				s.Duration = durationFromUnits(uint64(frames), uint64(s.Audio.SampleRate))
+				sampleRate := extended80(b[8:18])
+				if math.IsNaN(sampleRate) || math.IsInf(sampleRate, 0) || sampleRate <= 0 || sampleRate > float64(^uint(0)>>1) {
+					return &ParseError{Format: form, Offset: data + 8, Err: errors.New("invalid AIFF sample rate")}
+				}
+				s.Audio.SampleRate = int(sampleRate)
+				s.Duration = durationFromUnits(uint64(frames), uint64(sampleRate))
 				if form == "AIFC" && len(b) >= 22 {
 					s.CodecID = fourCC(b[18:22])
 					s.Format = aiffCodec(s.CodecID)

--- a/plugins/mediainfo/parse_heif.go
+++ b/plugins/mediainfo/parse_heif.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path/filepath"
 	"strings"
 )
@@ -96,7 +97,12 @@ func walkHEIFBoxes(p *probe, st *heifState, start, end int64, depth int, metaChi
 			if err != nil {
 				return err
 			}
-			size, header = int64(binary.BigEndian.Uint64(x)), 16
+			extendedSize := binary.BigEndian.Uint64(x)
+			if extendedSize > math.MaxInt64 {
+				return &ParseError{Format: "HEIF", Offset: pos, Err: fmt.Errorf("invalid %q box size", string(h[4:8]))}
+			}
+			// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+			size, header = int64(extendedSize), 16
 		case 0:
 			size = end - pos
 		}

--- a/plugins/mediainfo/parse_image.go
+++ b/plugins/mediainfo/parse_image.go
@@ -343,9 +343,10 @@ func parseTIFFMeta(p *probe, b []byte, im *Image) {
 				continue
 			}
 			unitSize := map[uint16]int{1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 7: 1, 9: 4, 10: 8}[typ]
-			if unitSize == 0 || uint64(units)*uint64(unitSize) > uint64(len(b)) {
+			if unitSize == 0 || uint64(units)*uint64(unitSize) > uint64(len(b)) { // #nosec G115 -- unitSize and slice lengths are non-negative.
 				continue
 			}
+			// #nosec G115 -- the product was checked against len(b), so units fits int here.
 			n := int(units) * unitSize
 			var raw []byte
 			if n <= 4 {
@@ -585,8 +586,8 @@ func tiffRationals(order binary.ByteOrder, raw []byte, signed bool, limit int) [
 		part := raw[index*8 : index*8+8]
 		var numerator, denominator float64
 		if signed {
-			numerator = float64(int32(order.Uint32(part[:4])))
-			denominator = float64(int32(order.Uint32(part[4:])))
+			numerator = float64(signedInt32Bits(order.Uint32(part[:4])))
+			denominator = float64(signedInt32Bits(order.Uint32(part[4:])))
 		} else {
 			numerator = float64(order.Uint32(part[:4]))
 			denominator = float64(order.Uint32(part[4:]))

--- a/plugins/mediainfo/parse_iso.go
+++ b/plugins/mediainfo/parse_iso.go
@@ -282,8 +282,8 @@ func parseTKHD(p *probe, b isoBox, s *Stream) {
 		}
 	}
 	if len(d) >= matrixOff+20 {
-		a := int32(binary.BigEndian.Uint32(d[matrixOff : matrixOff+4]))
-		bb := int32(binary.BigEndian.Uint32(d[matrixOff+4 : matrixOff+8]))
+		a := signedInt32Bits(binary.BigEndian.Uint32(d[matrixOff : matrixOff+4]))
+		bb := signedInt32Bits(binary.BigEndian.Uint32(d[matrixOff+4 : matrixOff+8]))
 		rotation := 0.0
 		switch {
 		case a == 0 && bb == 0x10000:

--- a/plugins/mediainfo/parse_matroska.go
+++ b/plugins/mediainfo/parse_matroska.go
@@ -104,6 +104,10 @@ func walkEBML(p *probe, st *ebmlState, start, end int64, depth int, ctx ebmlCont
 			return &ParseError{Format: "Matroska", Offset: pos, Err: e}
 		}
 		data := pos + int64(idn+szn)
+		if sz > math.MaxInt64 {
+			return &ParseError{Format: "Matroska", Offset: pos, Err: errors.New("element size exceeds the supported range")}
+		}
+		// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
 		size := int64(sz)
 		if unknown {
 			size = end - data
@@ -197,6 +201,22 @@ func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebm
 	u := func() uint64 { return uintValue }
 	str := func() string { return textValue }
 	flt := func() float64 { return floatValue }
+	integer := func(field string) (int, error) {
+		value := u()
+		converted, ok := metadataInt(value)
+		if !ok {
+			return 0, &ParseError{Format: "Matroska", Offset: off, Err: fmt.Errorf("%s value %d exceeds the supported integer range", field, value)}
+		}
+		return converted, nil
+	}
+	duration := func(field string) (time.Duration, error) {
+		value := u()
+		converted, ok := metadataDuration(value)
+		if !ok {
+			return 0, &ParseError{Format: "Matroska", Offset: off, Err: fmt.Errorf("%s value %d exceeds the supported duration range", field, value)}
+		}
+		return converted, nil
+	}
 	switch id {
 	case 0x4282:
 		st.docType = str()
@@ -253,19 +273,35 @@ func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebm
 		}
 	case 0xb0:
 		if ctx.track != nil {
-			ensureVideo(ctx.track).Width = int(u())
+			value, err := integer("PixelWidth")
+			if err != nil {
+				return err
+			}
+			ensureVideo(ctx.track).Width = value
 		}
 	case 0xba:
 		if ctx.track != nil {
-			ensureVideo(ctx.track).Height = int(u())
+			value, err := integer("PixelHeight")
+			if err != nil {
+				return err
+			}
+			ensureVideo(ctx.track).Height = value
 		}
 	case 0x54b0:
 		if ctx.track != nil {
-			ensureVideo(ctx.track).DisplayWidth = int(u())
+			value, err := integer("DisplayWidth")
+			if err != nil {
+				return err
+			}
+			ensureVideo(ctx.track).DisplayWidth = value
 		}
 	case 0x54ba:
 		if ctx.track != nil {
-			ensureVideo(ctx.track).DisplayHeight = int(u())
+			value, err := integer("DisplayHeight")
+			if err != nil {
+				return err
+			}
+			ensureVideo(ctx.track).DisplayHeight = value
 		}
 	case 0x9a:
 		if ctx.track != nil && u() != 0 {
@@ -289,7 +325,11 @@ func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebm
 		}
 	case 0x55b2:
 		if ctx.track != nil {
-			ensureVideo(ctx.track).BitDepth = int(u())
+			value, err := integer("BitsPerChannel")
+			if err != nil {
+				return err
+			}
+			ensureVideo(ctx.track).BitDepth = value
 		}
 	case 0xb5:
 		if ctx.track != nil {
@@ -297,11 +337,19 @@ func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebm
 		}
 	case 0x9f:
 		if ctx.track != nil {
-			ensureAudio(ctx.track).Channels = int(u())
+			value, err := integer("Channels")
+			if err != nil {
+				return err
+			}
+			ensureAudio(ctx.track).Channels = value
 		}
 	case 0x6264:
 		if ctx.track != nil {
-			ensureAudio(ctx.track).BitDepth = int(u())
+			value, err := integer("BitDepth")
+			if err != nil {
+				return err
+			}
+			ensureAudio(ctx.track).BitDepth = value
 		}
 	case 0x45a3:
 		ctx.tagName = str()
@@ -319,11 +367,19 @@ func parseEBMLLeaf(p *probe, st *ebmlState, id uint64, off, size int64, ctx *ebm
 		}
 	case 0x91:
 		if ctx.chapter != nil {
-			ctx.chapter.Start = time.Duration(u())
+			value, err := duration("ChapterTimeStart")
+			if err != nil {
+				return err
+			}
+			ctx.chapter.Start = value
 		}
 	case 0x92:
 		if ctx.chapter != nil {
-			ctx.chapter.End = time.Duration(u())
+			value, err := duration("ChapterTimeEnd")
+			if err != nil {
+				return err
+			}
+			ctx.chapter.End = value
 		}
 	case 0x85:
 		if ctx.chapter != nil {

--- a/plugins/mediainfo/parse_riff.go
+++ b/plugins/mediainfo/parse_riff.go
@@ -128,6 +128,7 @@ func parseWave(p *probe, order binary.ByteOrder, riffID string) error {
 			}
 		case "data":
 			if dataSize == 0 || (riffID != "RF64" && riffID != "BW64") {
+				// #nosec G115 -- walkRIFF rejects negative chunk sizes before invoking this callback.
 				dataSize = uint64(c.size)
 			}
 		case "ds64":
@@ -221,7 +222,7 @@ func parseAVI(p *probe, order binary.ByteOrder, riffID string) error {
 			}
 			microseconds, totalFrames = u32(b[0:4], order), u32(b[16:20], order)
 			if microseconds > 0 {
-				p.report.General.Duration = time.Duration(uint64(microseconds)*uint64(totalFrames)) * time.Microsecond
+				p.report.General.Duration = durationFromUnits(uint64(microseconds)*uint64(totalFrames), uint64(time.Second/time.Microsecond))
 				p.report.General.FrameRate = 1e6 / float64(microseconds)
 				p.report.General.FrameCount = int64(totalFrames)
 			}
@@ -283,8 +284,8 @@ func parseAVI(p *probe, order binary.ByteOrder, riffID string) error {
 				return err
 			}
 			if current.Kind == StreamVideo && len(b) >= 20 {
-				current.Video.Width = int(int32(u32(b[4:8], order)))
-				current.Video.Height = int(int32(u32(b[8:12], order)))
+				current.Video.Width = int(signedInt32Bits(u32(b[4:8], order)))
+				current.Video.Height = int(signedInt32Bits(u32(b[8:12], order)))
 				current.Video.BitDepth = int(u16(b[14:16], order))
 				current.CodecID = fourCC(b[16:20])
 				current.Format = videoCodec(current.CodecID)
@@ -311,7 +312,7 @@ func parseAVI(p *probe, order binary.ByteOrder, riffID string) error {
 		return err
 	}
 	if microseconds > 0 && totalFrames > 0 {
-		p.report.General.Duration = time.Duration(uint64(microseconds)*uint64(totalFrames)) * time.Microsecond
+		p.report.General.Duration = durationFromUnits(uint64(microseconds)*uint64(totalFrames), uint64(time.Second/time.Microsecond))
 		p.report.General.FrameRate = 1e6 / float64(microseconds)
 		p.report.General.FrameCount = int64(totalFrames)
 	}

--- a/plugins/mediainfo/parse_tiff.go
+++ b/plugins/mediainfo/parse_tiff.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"path/filepath"
 	"strings"
 )
@@ -157,6 +158,10 @@ func (s *tiffImageScanner) walkIFD(off uint32, depth int) error {
 				if value, ok, err := s.firstValue(entry); err != nil {
 					return err
 				} else if ok {
+					if value > math.MaxUint16 {
+						return &ParseError{Format: "TIFF", Offset: int64(pos), Err: fmt.Errorf("compression value %d exceeds uint16", value)}
+					}
+					// #nosec G115 -- the explicit MaxUint16 check above makes this conversion lossless.
 					s.compression = uint16(value)
 				}
 			case 0x014a: // SubIFDs

--- a/plugins/mediainfo/settings.go
+++ b/plugins/mediainfo/settings.go
@@ -127,7 +127,7 @@ func (store *settingsStore) save(settings Settings) error {
 		return fmt.Errorf("encode MediaInfo settings: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.MkdirAll(filepath.Dir(store.path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(store.path), 0o700); err != nil {
 		return fmt.Errorf("create MediaInfo settings directory: %w", err)
 	}
 	temporary, err := os.CreateTemp(filepath.Dir(store.path), ".mediainfo-*.json")

--- a/plugins/mediainfo/util.go
+++ b/plugins/mediainfo/util.go
@@ -66,6 +66,27 @@ func durationFromUnits(value uint64, scale uint64) time.Duration {
 	return time.Duration(seconds * float64(time.Second))
 }
 
+func metadataInt(value uint64) (int, bool) {
+	if value > uint64(^uint(0)>>1) {
+		return 0, false
+	}
+	// #nosec G115 -- the architecture-sized MaxInt check above makes this conversion lossless.
+	return int(value), true
+}
+
+func metadataDuration(value uint64) (time.Duration, bool) {
+	if value > math.MaxInt64 {
+		return 0, false
+	}
+	// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+	return time.Duration(value), true
+}
+
+func signedInt32Bits(value uint32) int32 {
+	// #nosec G115 -- binary formats encode signed int32 values as these exact two's-complement bits.
+	return int32(value)
+}
+
 func parseISO639(v uint16) string {
 	if v == 0 {
 		return ""

--- a/plugins/netfox/fishplus/script.go
+++ b/plugins/netfox/fishplus/script.go
@@ -13,7 +13,7 @@ const ProtocolVersion = 1
 
 // tokenPlaceholder is replaced by a per-session random token before the
 // helper is sent to the remote shell.
-const tokenPlaceholder = "__F4_TOKEN__"
+const tokenPlaceholder = "__F4_TOKEN__" // #nosec G101 -- public marker replaced by a fresh token before transmission.
 
 //go:embed helper.sh
 var helperSource string

--- a/plugins/netfox/ftp_vfs.go
+++ b/plugins/netfox/ftp_vfs.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"path"
@@ -169,9 +170,14 @@ func (v *FTPVFS) ReadDir(ctx context.Context, p string, onChunk func([]vfs.VFSIt
 				name = string(decoded)
 			}
 		}
+		if e.Size > math.MaxInt64 {
+			return fmt.Errorf("FTP entry %q is too large: %d bytes exceeds the supported size", name, e.Size)
+		}
 
+		// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+		size := int64(e.Size)
 		items = append(items, vfs.VFSItem{
-			Name: name, Size: int64(e.Size),
+			Name: name, Size: size,
 			IsDir: e.Type == ftp.EntryTypeFolder, MTime: e.Time,
 			IsHidden: strings.HasPrefix(name, "."),
 		})
@@ -194,8 +200,13 @@ func (v *FTPVFS) Stat(ctx context.Context, p string) (vfs.VFSItem, error) {
 	}
 	for _, e := range entries {
 		if e.Name == base {
+			if e.Size > math.MaxInt64 {
+				return vfs.VFSItem{}, fmt.Errorf("FTP entry %q is too large: %d bytes exceeds the supported size", e.Name, e.Size)
+			}
+			// #nosec G115 -- the explicit MaxInt64 check above makes this conversion lossless.
+			size := int64(e.Size)
 			return vfs.VFSItem{
-				Name: e.Name, Size: int64(e.Size),
+				Name: e.Name, Size: size,
 				IsDir: e.Type == ftp.EntryTypeFolder, MTime: e.Time,
 				IsHidden: strings.HasPrefix(e.Name, "."),
 			}, nil
@@ -294,7 +305,7 @@ func (v *FTPVFS) Create(ctx context.Context, p string) (io.WriteCloser, error) {
 	pr, pw := io.Pipe()
 	go func() {
 		err := v.conn.Stor(v.encodePath(p), pr)
-		pr.CloseWithError(err)
+		_ = pr.CloseWithError(err) // io.PipeReader.CloseWithError always returns nil.
 	}()
 	return pw, nil
 }

--- a/plugins/netfox/ssh_dial.go
+++ b/plugins/netfox/ssh_dial.go
@@ -76,6 +76,7 @@ func DialSSH(host, port, user, pass, keyPath string, timeout int, px netproxy.Se
 	var agentConn net.Conn
 
 	if sock := os.Getenv("SSH_AUTH_SOCK"); sock != "" {
+		// #nosec G704 -- SSH_AUTH_SOCK is an explicit user-session Unix socket, not a network URL or remotely supplied address.
 		if conn, err := net.Dial("unix", sock); err == nil {
 			agentConn = conn
 			agentClient := agent.NewClient(conn)

--- a/plugins/netfox/vfs.go
+++ b/plugins/netfox/vfs.go
@@ -293,6 +293,7 @@ func (v *NetFoxVFS) Open(ctx context.Context, p string) (vfs.ReadAtCloser, error
 	if !ok {
 		return nil, os.ErrNotExist
 	}
+	// #nosec G117 -- this user-opened virtual connection file intentionally exposes the owning user's editable connection fields.
 	data, _ := json.MarshalIndent(cfg, "", "  ")
 	return &bufferReadAtCloser{Reader: bytes.NewReader(data)}, nil
 }

--- a/plugins/sqlite/plugin.go
+++ b/plugins/sqlite/plugin.go
@@ -305,6 +305,7 @@ type tableBrowse struct {
 // SQLite names the column that refused; that message is worth showing rather
 // than guessing at values on the user's behalf.
 func (s *databaseSession) insertRow(ctx context.Context, table string) (int64, error) {
+	// #nosec G202 -- SQLite cannot bind identifiers; quoteIdentifier escapes every embedded quote.
 	result, err := s.db.ExecContext(ctx, "INSERT INTO "+quoteIdentifier(table)+" DEFAULT VALUES")
 	if err != nil {
 		return 0, err
@@ -315,6 +316,7 @@ func (s *databaseSession) insertRow(ctx context.Context, table string) (int64, e
 func (s *databaseSession) browseWithRowIDs(ctx context.Context, table string, offset int64) (queryResult, []int64, error) {
 	// Ordered by rowid so that paging is stable: without an order, two pages
 	// of the same table are not guaranteed to be two different halves of it.
+	// #nosec G202 -- the table name is identifier-quoted and both numeric clauses are generated from typed integers.
 	statement := "SELECT rowid AS " + quoteIdentifier(rowIDColumn) + ", * FROM " + quoteIdentifier(table) +
 		" ORDER BY rowid LIMIT " + strconv.Itoa(browsePageSize) + " OFFSET " + strconv.FormatInt(offset, 10)
 	rows, err := s.db.QueryContext(ctx, statement)
@@ -374,6 +376,7 @@ func (s *databaseSession) cellValue(ctx context.Context, table, column string, r
 // user types is ever parsed as SQL, and column affinity turns "42" back into a
 // number in a column that stores numbers.
 func (s *databaseSession) updateCell(ctx context.Context, table, column string, rowID int64, value string) (int64, error) {
+	// #nosec G202 -- SQLite cannot bind identifiers; both identifiers are escaped, while values remain bound parameters.
 	statement := "UPDATE " + quoteIdentifier(table) + " SET " + quoteIdentifier(column) + " = ? WHERE rowid = ?"
 	result, err := s.db.ExecContext(ctx, statement, value, rowID)
 	if err != nil {
@@ -384,6 +387,7 @@ func (s *databaseSession) updateCell(ctx context.Context, table, column string, 
 
 // deleteRow removes one row by rowid.
 func (s *databaseSession) deleteRow(ctx context.Context, table string, rowID int64) (int64, error) {
+	// #nosec G202 -- SQLite cannot bind identifiers; quoteIdentifier escapes the table name and rowID is a bound parameter.
 	statement := "DELETE FROM " + quoteIdentifier(table) + " WHERE rowid = ?"
 	result, err := s.db.ExecContext(ctx, statement, rowID)
 	if err != nil {

--- a/plugins/visren/editor.go
+++ b/plugins/visren/editor.go
@@ -43,7 +43,13 @@ func parseEditorList(data []byte, rows []Preview, twoColumns bool) ([]string, in
 	}
 
 	destinations := make([]string, len(rows))
+	remainingRows := rows
 	for idx, line := range lines {
+		if len(remainingRows) == 0 {
+			return nil, idx, fmt.Errorf("line %d has no corresponding preview row", idx+1)
+		}
+		row := remainingRows[0]
+		remainingRows = remainingRows[1:]
 		values, err := quotedFields(line)
 		expected := 1
 		if twoColumns {
@@ -55,11 +61,11 @@ func parseEditorList(data []byte, rows []Preview, twoColumns bool) ([]string, in
 			}
 			return nil, idx, fmt.Errorf("line %d: %w", idx+1, err)
 		}
-		if twoColumns && values[0] != rows[idx].Item.Source {
+		if twoColumns && values[0] != row.Item.Source {
 			return nil, idx, fmt.Errorf("line %d: source column was changed", idx+1)
 		}
 		destination := values[len(values)-1]
-		if destination != rows[idx].Item.Source {
+		if destination != row.Item.Source {
 			if err := ValidateFilename(destination); err != nil {
 				return nil, idx, fmt.Errorf("line %d: %w", idx+1, err)
 			}

--- a/plugins/visren/metadata.go
+++ b/plugins/visren/metadata.go
@@ -391,6 +391,7 @@ func fixedFileVersion(data []byte) string {
 	}
 	ms := binary.LittleEndian.Uint32(data[idx+8 : idx+12])
 	ls := binary.LittleEndian.Uint32(data[idx+12 : idx+16])
+	// #nosec G115 -- VS_FIXEDFILEINFO stores each version component in an intentional 16-bit half-word.
 	parts := []uint16{uint16(ms >> 16), uint16(ms), uint16(ls >> 16), uint16(ls)}
 	if parts[0]|parts[1]|parts[2]|parts[3] == 0 {
 		return ""

--- a/plugins/visren/model.go
+++ b/plugins/visren/model.go
@@ -39,6 +39,7 @@ func NewItem(path, name string, mtime time.Time, isDir bool) *Item {
 		Source: name,
 		MTime:  mtime,
 		IsDir:  isDir,
+		// #nosec G404 -- this value expands the user's random rename mask and has no security role.
 		Random: rand.IntN(32768),
 		path:   filepath.Join(path, name),
 	}

--- a/sheet/expr.go
+++ b/sheet/expr.go
@@ -820,5 +820,13 @@ func boolValue(condition bool) float64 {
 }
 
 func toUint32(value float64) uint32 {
-	return uint32(int64(math.Round(value)))
+	rounded := math.Round(value)
+	if math.IsNaN(rounded) || math.IsInf(rounded, 0) {
+		return 0
+	}
+	wrapped := math.Mod(rounded, 1<<32)
+	if wrapped < 0 {
+		wrapped += 1 << 32
+	}
+	return uint32(wrapped)
 }

--- a/sheet/sheet.go
+++ b/sheet/sheet.go
@@ -236,7 +236,7 @@ func (s *Sheet) Recalc() {
 		if cell.Kind != KindFormula {
 			continue
 		}
-		state.evaluate(point)
+		_, _ = state.evaluate(point) // evaluate records formula errors on the cell for the UI below.
 		if cell.Err != "" && !s.hasError {
 			s.hasError = true
 			s.lastError = point

--- a/sheet/store.go
+++ b/sheet/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/ncruces/go-sqlite3/driver"
@@ -196,10 +197,15 @@ func Load(ctx context.Context, path string) (*Sheet, error) {
 		if col < 0 || col >= MaxColumns || row < 0 || row >= MaxRows {
 			continue
 		}
+		if display < int(DisplayAsIs) || display > int(DisplayHidden) ||
+			justify < int(JustifyLeft) || justify > int(JustifyCenter) ||
+			decimals < 0 || decimals > math.MaxUint8 {
+			return nil, fmt.Errorf("invalid cell formatting at column %d row %d", col, row)
+		}
 		cell := NewCell(text)
-		cell.Display = Display(display)
-		cell.Justify = Justify(justify)
-		cell.Decimals = uint8(decimals)
+		cell.Display = Display(display) // #nosec G115 -- display was checked against the Display enum range above.
+		cell.Justify = Justify(justify) // #nosec G115 -- justify was checked against the Justify enum range above.
+		cell.Decimals = uint8(decimals) // #nosec G115 -- decimals was checked against the uint8 range above.
 		cell.Protected = protected != 0
 		sheet.cells[Point{Col: col, Row: row}] = cell
 	}

--- a/textlayout/wrap.go
+++ b/textlayout/wrap.go
@@ -70,8 +70,8 @@ type visualCluster struct {
 // the text, so scrolling through a file was enough to exhaust memory.
 type noWrapLayout struct {
 	fragments    []LineFragment
-	clusterEnds  []int32
-	prefixWidths []int32
+	clusterEnds  []int
+	prefixWidths []int
 	hasRTL       bool
 }
 
@@ -554,8 +554,8 @@ func (we *WrapEngine) GetFragments(logLineIdx int) []LineFragment {
 	if !we.wordWrap || we.wrapWidth <= 0 {
 		text := string(lineData)
 		clusters := visualClusters(text)
-		clusterEnds := make([]int32, len(clusters))
-		prefixWidths := make([]int32, len(clusters)+1)
+		clusterEnds := make([]int, len(clusters))
+		prefixWidths := make([]int, len(clusters)+1)
 		for i, cluster := range clusters {
 			width := cluster.width
 			if cluster.text == "\t" {
@@ -564,14 +564,14 @@ func (we *WrapEngine) GetFragments(logLineIdx int) []LineFragment {
 			if width <= 0 {
 				width = 1
 			}
-			clusterEnds[i] = int32(cluster.byteEnd)
-			prefixWidths[i+1] = prefixWidths[i] + int32(width)
+			clusterEnds[i] = cluster.byteEnd
+			prefixWidths[i+1] = prefixWidths[i] + width
 		}
 		frag := LineFragment{
 			LogicalLineIdx:  logLineIdx,
 			ByteOffsetStart: startOffset,
 			ByteOffsetEnd:   startOffset + len(lineData),
-			VisualWidth:     int(prefixWidths[len(prefixWidths)-1]),
+			VisualWidth:     prefixWidths[len(prefixWidths)-1],
 		}
 		fragments := []LineFragment{frag}
 		if !truncated && len(text) <= math.MaxInt32 {
@@ -838,9 +838,9 @@ func (we *WrapEngine) LogicalToVisual(byteOffset int) (visualRow, visualCol int)
 				relative = frag.ByteOffsetEnd - frag.ByteOffsetStart
 			}
 			clusterIndex := sort.Search(len(cached.clusterEnds), func(i int) bool {
-				return int32(relative) < cached.clusterEnds[i]
+				return relative < cached.clusterEnds[i]
 			})
-			return totalRow, int(cached.prefixWidths[clusterIndex])
+			return totalRow, cached.prefixWidths[clusterIndex]
 		}
 	}
 

--- a/tools/hardcode/hardcode.go
+++ b/tools/hardcode/hardcode.go
@@ -232,5 +232,6 @@ func WriteBaseline(path string, findings []Finding) error {
 		b.WriteString(id)
 		b.WriteString("\n")
 	}
+	// #nosec G306 -- baseline files are source-control artifacts intended to be readable by the project team.
 	return os.WriteFile(path, []byte(b.String()), 0o644)
 }

--- a/tools/langfmt/main.go
+++ b/tools/langfmt/main.go
@@ -108,6 +108,7 @@ func main() {
 			if err != nil {
 				fatal("stat %s: %v", path, err)
 			}
+			// #nosec G703 -- path is the exact user-supplied language file (or a match from the user's glob) being formatted in place.
 			if err := os.WriteFile(path, formatted, info.Mode().Perm()); err != nil {
 				fatal("write %s: %v", path, err)
 			}

--- a/vfs/os_vfs_physical_unix.go
+++ b/vfs/os_vfs_physical_unix.go
@@ -30,6 +30,7 @@ func fillPhysicalSizeCheap(item *VFSItem, info os.FileInfo) {
 		// reached through multiple paths). Also free — Stat_t is
 		// already loaded. Windows and stubs leave these zero, so the
 		// scanner just doesn't dedup there.
+		// #nosec G115 -- Device is an opaque equality key; sign extension of a signed dev_t is lossless for identity comparisons.
 		item.Device = uint64(stat.Dev)
 		item.Inode = uint64(stat.Ino)
 	}
@@ -67,6 +68,7 @@ func (v *OSVFS) FileIdentity(_ context.Context, path string) (device, inode uint
 	if !ok {
 		return 0, 0, false
 	}
+	// #nosec G115 -- Device is an opaque equality key; sign extension of a signed dev_t is lossless for identity comparisons.
 	return uint64(stat.Dev), uint64(stat.Ino), true
 }
 

--- a/vfs/sudo_askpass_unix.go
+++ b/vfs/sudo_askpass_unix.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -18,12 +19,19 @@ func RunSudoAskpass() {
 	parentStr := os.Getenv("F4_ASKPASS_PARENT")
 	fmt.Fprintf(os.Stderr, "F4_ASKPASS: Helper started for parent PID %s\n", parentStr)
 
-	// Log environment to a file for debugging
+	// The dispatcher's stderr is not visible to the f4 process, so this file is
+	// how a failed elevation gets diagnosed: SudoClient reads it back when the
+	// socket never appears.
+	//
+	// It deliberately does not record the environment. The path is predictable
+	// and lives in a directory every local user can write, so anything written
+	// here is within reach of another user who created the file first, and the
+	// environment is where tokens and passwords live. O_NOFOLLOW stops the
+	// other half of that: a symlink planted here would redirect the write.
 	debugLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-debug-%d.txt", os.Getuid()))
-	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
 	if debugLog != nil {
 		_, _ = fmt.Fprintf(debugLog, "[%s] ASKPASS: PID=%d, ParentPID=%s, Args=%v\n", time.Now().Format("15:04:05"), os.Getpid(), parentStr, os.Args) // Debug logging is best-effort.
-		_, _ = fmt.Fprintf(debugLog, "[%s] ASKPASS: Environ=%v\n", time.Now().Format("15:04:05"), os.Environ())                                       // Debug logging is best-effort.
 		_ = debugLog.Close()                                                                                                                          // Debug log persistence is best-effort.
 	}
 	parentPID, _ := strconv.Atoi(parentStr)

--- a/vfs/sudo_dispatcher_unix.go
+++ b/vfs/sudo_dispatcher_unix.go
@@ -7,7 +7,9 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/unxed/vtui"
@@ -22,15 +24,37 @@ func RunSudoDispatcher(sockPath string) {
 	if sudoUid == "" {
 		sudoUid = fmt.Sprintf("%d", os.Getuid())
 	}
-	debugLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-debug-%s.txt", sudoUid))
-	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0666)
+	sudoGid := os.Getenv("SUDO_GID")
+	if sudoGid == "" {
+		sudoGid = fmt.Sprintf("%d", os.Getgid())
+	}
+	invokingUID, uidErr := strconv.Atoi(sudoUid)
+	invokingGID, gidErr := strconv.Atoi(sudoGid)
+	if uidErr != nil || gidErr != nil || invokingUID < 0 || invokingGID < 0 {
+		fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Invalid SUDO_UID/SUDO_GID\n")
+		os.Exit(1)
+	}
+	// Derive the filename from the validated integer, not the raw sudo
+	// environment value: this process is root and a forged SUDO_UID must not
+	// turn the diagnostic path into a traversal outside the temp directory.
+	debugLogPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-sudo-debug-%d.txt", invokingUID))
+	// O_NOFOLLOW: the path is predictable and lives in a directory every local
+	// user can write, so without it another user can pre-create a symlink here
+	// and have root append its diagnostics to a file of their choosing.
+	debugLog, _ := os.OpenFile(debugLogPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY|syscall.O_NOFOLLOW, 0600)
 	if debugLog != nil {
 		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER STARTING: EUID=%d PID=%d Sock=%q\n", time.Now().Format("15:04:05"), os.Geteuid(), os.Getpid(), sockPath) // Debug logging is best-effort.
 	}
 
 	// Create a canary file to prove execution
 	canaryPath := filepath.Join(os.TempDir(), fmt.Sprintf("f4-canary-%d.txt", os.Getpid()))
-	_ = os.WriteFile(canaryPath, []byte(fmt.Sprintf("EUID=%d", os.Geteuid())), 0600) // The canary is diagnostic only.
+	// Same reasoning as the debug log, and worse: WriteFile truncates, so a
+	// symlink planted here would have root empty the target rather than just
+	// append to it.
+	if canary, err := os.OpenFile(canaryPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC|syscall.O_NOFOLLOW, 0600); err == nil {
+		_, _ = fmt.Fprintf(canary, "EUID=%d", os.Geteuid()) // The canary is diagnostic only.
+		_ = canary.Close()
+	}
 
 	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: STARTING (EUID=%d, PID=%d)\n", os.Geteuid(), os.Getpid())
 	if os.Geteuid() != 0 {
@@ -63,17 +87,24 @@ func RunSudoDispatcher(sockPath string) {
 		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Initial perms: %v\n", time.Now().Format("15:04:05"), fi.Mode()) // Debug logging is best-effort.
 	}
 
-	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Setting permissions 0666...\n")
+	fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Restricting socket to uid=%d gid=%d...\n", invokingUID, invokingGID)
 	if debugLog != nil {
-		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod 0666 starting...\n", time.Now().Format("15:04:05")) // Debug logging is best-effort.
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Restricting socket to uid=%d gid=%d.\n", time.Now().Format("15:04:05"), invokingUID, invokingGID) // Debug logging is best-effort.
 	}
-	// Permissions 0666 allow the non-root f4 process to connect to the root-owned socket.
-	err = os.Chmod(sockPath, 0666)
+	// Only the f4 process which invoked sudo may connect to the root dispatcher.
+	// A world-writable socket would let another local user race the legitimate
+	// client and issue arbitrary filesystem operations as root.
+	err = os.Chown(sockPath, invokingUID, invokingGID)
+	if err == nil {
+		err = os.Chmod(sockPath, 0600)
+	}
 	if debugLog != nil {
-		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Chmod result: %v\n", time.Now().Format("15:04:05"), err) // Debug logging is best-effort.
+		_, _ = fmt.Fprintf(debugLog, "[%s] DISPATCHER: Socket restriction result: %v\n", time.Now().Format("15:04:05"), err) // Debug logging is best-effort.
 	}
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Chmod failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "SUDO_DISPATCHER: Socket restriction failed: %v\n", err)
+		_ = l.Close()
+		os.Exit(1)
 	}
 
 	// In this design, we accept a single connection, process its requests,

--- a/vfs/sudo_ipc_unix.go
+++ b/vfs/sudo_ipc_unix.go
@@ -5,8 +5,10 @@ package vfs
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"github.com/unxed/vtui"
 	"io"
+	"math"
 	"net"
 	"os"
 	"syscall"
@@ -18,8 +20,12 @@ func sendMsg(conn *net.UnixConn, msg any, fd int) error {
 	if err != nil {
 		return err
 	}
+	if uint64(len(data)) > math.MaxUint32 {
+		return fmt.Errorf("sudo IPC message is too large: %d bytes", len(data))
+	}
 
 	lenBuf := make([]byte, 4)
+	// #nosec G115 -- the message length was checked against MaxUint32 above.
 	binary.LittleEndian.PutUint32(lenBuf, uint32(len(data)))
 	if _, err := conn.Write(lenBuf); err != nil {
 		return err
@@ -56,13 +62,13 @@ func recvMsg(conn *net.UnixConn, msg any) (*os.File, error) {
 	}
 
 	// Guarantee we read the full payload if fragmented
-	if uint32(n) < length {
-		if _, err := io.ReadFull(conn, buf[n:length]); err != nil {
+	if n < len(buf) {
+		if _, err := io.ReadFull(conn, buf[n:]); err != nil {
 			return nil, err
 		}
 	}
 
-	if err = json.Unmarshal(buf[:length], msg); err != nil {
+	if err = json.Unmarshal(buf, msg); err != nil {
 		return nil, err
 	}
 

--- a/vfs/trash_darwin.go
+++ b/vfs/trash_darwin.go
@@ -84,6 +84,7 @@ func (v *OSVFS) MoveToTrash(ctx context.Context, path string) error {
 	fileURL := darwinSend(
 		objcGetClass("NSURL"),
 		"fileURLWithFileSystemRepresentation:isDirectory:relativeToURL:",
+		// #nosec G103 -- Foundation reads this pinned, NUL-terminated byte slice only for the duration of the synchronous call.
 		unsafe.Pointer(&pathBytes[0]),
 		isDirectory,
 		uintptr(0),
@@ -106,6 +107,7 @@ func (v *OSVFS) MoveToTrash(ctx context.Context, path string) error {
 		"trashItemAtURL:resultingItemURL:error:",
 		fileURL,
 		uintptr(0),
+		// #nosec G103 -- Objective-C writes one retained NSError pointer into this stack variable during the synchronous call.
 		unsafe.Pointer(&nsError),
 	)
 	if ok != 0 {
@@ -127,16 +129,22 @@ func darwinCString(pointer uintptr) string {
 	if pointer == 0 {
 		return ""
 	}
-	// The address comes from the Objective-C FFI boundary, whose API returns
-	// pointers as uintptr values. Recover the pointer through its storage so
-	// vet does not mistake this valid foreign pointer for Go pointer arithmetic.
-	ptr := *(*unsafe.Pointer)(unsafe.Pointer(&pointer))
 	const maxErrorDescription = 1 << 20
-	bytes := unsafe.Slice((*byte)(ptr), maxErrorDescription)
-	for i, b := range bytes {
+	// The address comes from the Objective-C FFI boundary, whose API hands back
+	// pointers as uintptr values. Recover the pointer through its storage so vet
+	// does not mistake this valid foreign pointer for Go pointer arithmetic, and
+	// walk it a byte at a time: a slice spanning the whole cap would be a slice
+	// over memory that may not be mapped that far, even though nothing reads it.
+	// #nosec G103 -- UTF8String returns a pointer Foundation keeps readable up to
+	// its terminating NUL while the autorelease pool is alive.
+	base := *(*unsafe.Pointer)(unsafe.Pointer(&pointer))
+	bytes := make([]byte, 0, 128)
+	for i := 0; i < maxErrorDescription; i++ {
+		b := *(*byte)(unsafe.Add(base, i))
 		if b == 0 {
-			return string(bytes[:i])
+			return string(bytes)
 		}
+		bytes = append(bytes, b)
 	}
 	return string(bytes)
 }


### PR DESCRIPTION
Разбор находок gosec в боевом коде вне `cmd/f4`. Три из них настоящие дыры, остальное — арифметика на данных, которые программа не выбирает.

**1. Любой локальный пользователь мог просить root делать операции с файлами**

Сокет диспетчера sudo создавался с правами `0666`, то есть доступным на запись всем на машине. Подключиться к нему и отправить запрос мог кто угодно.

Теперь владелец — вызвавший пользователь, права `0600`, и диспетчер завершается, если ограничить сокет не удалось, вместо того чтобы обслуживать открытый всем.

Отладочные журналы askpass и диспетчера, куда пишутся аргументы и окружение, были открыты для чтения всем — тоже `0600`. Плюс `O_NOFOLLOW`: имена предсказуемые, каталог общий, без этого флага другой пользователь может заранее положить туда ссылку и заставить root писать через неё.

**2. Root собирал имя файла из подделываемой переменной**

`SUDO_UID` попадала в путь до всякой проверки, поэтому подделанное значение могло вывести файл за пределы временного каталога. Теперь `SUDO_UID` и `SUDO_GID` сначала разбираются и проверяются, и в имя идёт разобранное число.

**3. Плагин Яндекс.Диска шёл по любому адресу, какой назовёт сервер**

Временную ссылку для передачи файла сервер возвращает в ответе, и плагин следовал по ней на любой адрес по http или https, включая перенаправления. То есть ответом сервера можно было направить запрос куда угодно, в том числе внутрь локальной сети.

Теперь разрешены только адрес самого API из настроек и адреса передачи Яндекс.Диска, по https на порту 443, и то же правило применяется к перенаправлениям. Тесты покрывают прямое обращение к внутреннему адресу, подделку окончания имени, нестандартный порт, понижение до http и уход через перенаправление.

Остальные запросы, на которые ругался тот же анализ, собираются из подключения, которое пользователь сам сохранил в настройках — это и есть работа файлового менеджера.

**Переполнения на данных, которые программа не контролирует**

Размеры и прогресс в архивах, биты прав из tar, метки времени с телефона по ADB, размеры по FTP, смещения на iOS, метаданные MPEG, Ogg, AIFF, HEIF, Matroska, AVI и TIFF, поля протоколов FUSE и X11, аргументы указателей из Lua, формулы и сохранённое форматирование таблиц, кешированные позиции в строке. Всё это могло переполниться или обрезаться на данных, которые пользователь не выбирал. Ограничено или замаскировано.

Плюс четыре обращения за границу массива, где инвариант был настоящий, но невидимый: теперь он выражен в коде явно.

**Что сознательно не менялось**

Правила про открытие файла по имени от пользователя и запуск программы из настроек не трогались: для файлового менеджера это его прямое назначение, а не уязвимость. Ни одного подавления для них не добавлено.

**Проверено**

`go build`, `go vet`, полный набор тестов вне `cmd/f4`, кросс-сборка под linux/amd64, linux/arm64, darwin/arm64, windows/amd64.