### PR TITLE
gosec: права на файлы в тестах вне cmd/f4

### DIFF
--- a/internal/ttyx/ttyx_events_test.go
+++ b/internal/ttyx/ttyx_events_test.go
@@ -131,8 +131,10 @@ func TestOverlayIsClippedToTheTerminal(t *testing.T) {
 		t.Fatalf("place: %v", err)
 	}
 	pix := make([]byte, 80*40*4)
-	for i := 0; i < len(pix); i += 4 {
-		pix[i], pix[i+1], pix[i+2], pix[i+3] = 0, 0, 255, 255
+	for i := range pix {
+		if i%4 >= 2 {
+			pix[i] = 255
+		}
 	}
 	if err := ov.Draw(pix, 80, 40, 80*4); err != nil {
 		t.Fatalf("draw: %v", err)
@@ -150,10 +152,10 @@ func TestOverlayIsClippedToTheTerminal(t *testing.T) {
 }
 
 // pixelIsBlue reads one pixel off the screen.
-func (f *xFixture) pixelIsBlue(t *testing.T, x, y int) bool {
+func (f *xFixture) pixelIsBlue(t *testing.T, x, y int16) bool {
 	t.Helper()
 	reply, err := xproto.GetImage(f.conn, xproto.ImageFormatZPixmap,
-		xproto.Drawable(f.root), int16(x), int16(y), 1, 1, 0xFFFFFFFF).Reply()
+		xproto.Drawable(f.root), x, y, 1, 1, 0xFFFFFFFF).Reply()
 	if err != nil || reply == nil || len(reply.Data) < 4 {
 		t.Fatalf("read back at %d,%d: %v", x, y, err)
 	}

--- a/internal/ttyx/ttyx_test.go
+++ b/internal/ttyx/ttyx_test.go
@@ -45,7 +45,7 @@ func TestAncestorPIDsOfThisProcess(t *testing.T) {
 	if len(got) == 0 {
 		t.Skip("no /proc on this system")
 	}
-	if got[0] != uint32(os.Getpid()) {
+	if got[0] != uint32(os.Getpid()) { // #nosec G115 -- OS process IDs are positive and represented as uint32 by the X11 API.
 		t.Errorf("the walk must start at us: %v", got)
 	}
 }
@@ -118,10 +118,11 @@ func newXFixture(t *testing.T) *xFixture {
 	if err != nil {
 		t.Fatalf("window id: %v", err)
 	}
+	const structureNotifyMask uint32 = xproto.EventMaskStructureNotify
 	err = xproto.CreateWindowChecked(conn, screen.RootDepth, win, screen.Root,
 		40, 60, 400, 300, 0, xproto.WindowClassInputOutput, screen.RootVisual,
 		xproto.CwBackPixel|xproto.CwEventMask,
-		[]uint32{0x00202020, uint32(xproto.EventMaskStructureNotify)}).Check()
+		[]uint32{0x00202020, structureNotifyMask}).Check()
 	if err != nil {
 		t.Fatalf("the stand-in terminal window could not be created: %v", err)
 	}
@@ -135,7 +136,7 @@ func newXFixture(t *testing.T) *xFixture {
 
 func (f *xFixture) intern(t *testing.T, name string) xproto.Atom {
 	t.Helper()
-	reply, err := xproto.InternAtom(f.conn, false, uint16(len(name)), name).Reply()
+	reply, err := xproto.InternAtom(f.conn, false, uint16(len(name)), name).Reply() // #nosec G115 -- test atom names are fixed short strings.
 	if err != nil || reply == nil {
 		t.Fatalf("intern %s: %v", name, err)
 	}

--- a/luaplug/runtime_test.go
+++ b/luaplug/runtime_test.go
@@ -273,11 +273,11 @@ func TestLoadStringSkipsShebang(t *testing.T) {
 }
 func TestLoadFileAddsPackagePath(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "helper.lua"), []byte("return { answer = 42 }"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "helper.lua"), []byte("return { answer = 42 }"), 0o600); err != nil {
 		t.Fatalf("write helper: %v", err)
 	}
 	main := filepath.Join(dir, "plugin.lua")
-	if err := os.WriteFile(main, []byte("answer = require('helper').answer"), 0o644); err != nil {
+	if err := os.WriteFile(main, []byte("answer = require('helper').answer"), 0o600); err != nil {
 		t.Fatalf("write plugin: %v", err)
 	}
 

--- a/piecetable/lineindex_equivalence_test.go
+++ b/piecetable/lineindex_equivalence_test.go
@@ -122,7 +122,7 @@ func assertSameIndex(t *testing.T, rng *rand.Rand, step int, got *LineIndex, wan
 // what the blocked layout has to get right: an insert shifts the bases of every
 // later block, and one that adds lines renumbers them as well.
 func TestLineIndex_MatchesDenseImplementation(t *testing.T) {
-	rng := rand.New(rand.NewSource(20260815))
+	rng := rand.New(rand.NewSource(20260815)) // #nosec G404 -- a fixed seed makes this randomized equivalence test reproducible; no security decision uses it.
 
 	for round := 0; round < 20; round++ {
 		li := NewLineIndex()

--- a/plugins/android/adb_sync_test.go
+++ b/plugins/android/adb_sync_test.go
@@ -104,7 +104,7 @@ func (o *syncTestOpener) OpenService(_ context.Context, serial, service string) 
 func syncTestRequest(id, payload string) []byte {
 	var result bytes.Buffer
 	result.WriteString(id)
-	_ = binary.Write(&result, binary.LittleEndian, uint32(len(payload)))
+	_ = binary.Write(&result, binary.LittleEndian, syncTestStringLength(payload))
 	result.WriteString(payload)
 	return result.Bytes()
 }
@@ -122,7 +122,7 @@ func syncTestDentV1(name string, mode, size, mtime uint32) []byte {
 	_ = binary.Write(&result, binary.LittleEndian, mode)
 	_ = binary.Write(&result, binary.LittleEndian, size)
 	_ = binary.Write(&result, binary.LittleEndian, mtime)
-	_ = binary.Write(&result, binary.LittleEndian, uint32(len(name)))
+	_ = binary.Write(&result, binary.LittleEndian, syncTestStringLength(name))
 	result.WriteString(name)
 	return result.Bytes()
 }
@@ -161,9 +161,13 @@ func syncTestDentV2(name string, meta syncTestV2Metadata) []byte {
 	var result bytes.Buffer
 	result.WriteString(syncIDDentV2)
 	result.Write(syncTestV2Body(meta))
-	_ = binary.Write(&result, binary.LittleEndian, uint32(len(name)))
+	_ = binary.Write(&result, binary.LittleEndian, syncTestStringLength(name))
 	result.WriteString(name)
 	return result.Bytes()
+}
+
+func syncTestStringLength(value string) uint32 {
+	return uint32(len(value)) // #nosec G115 -- sync protocol test strings are bounded well below its uint32 length field.
 }
 
 func TestSyncListV1HandlesFragmentedResponses(t *testing.T) {
@@ -270,7 +274,7 @@ func TestSyncListRejectsMalformedResponseAndFAIL(t *testing.T) {
 
 	t.Run("remote fail", func(t *testing.T) {
 		message := "permission denied"
-		response := append(syncTestHeader(syncIDFail, uint32(len(message))), message...)
+		response := append(syncTestHeader(syncIDFail, syncTestStringLength(message)), message...)
 		client := NewSyncClient(&syncTestOpener{conn: &syncTestConn{response: response, readChunk: 1}}, "serial", nil)
 		_, err := client.List(context.Background(), "/root")
 		var remoteErr *SyncRemoteError
@@ -386,7 +390,7 @@ func TestSyncReceiveV1AndV2(t *testing.T) {
 
 	t.Run("v2 request and remote fail", func(t *testing.T) {
 		message := "not a file"
-		response := append(syncTestHeader(syncIDFail, uint32(len(message))), message...)
+		response := append(syncTestHeader(syncIDFail, syncTestStringLength(message)), message...)
 		conn := &syncTestConn{response: response, readChunk: 2}
 		client := NewSyncClient(&syncTestOpener{conn: conn}, "serial", map[string]bool{"sendrecv_v2": true})
 		reader, err := client.Receive(context.Background(), "/dir")
@@ -452,7 +456,7 @@ func TestSyncSendV1SplitsLargeWritesAndFinalizes(t *testing.T) {
 
 func TestSyncSendV2SetupAndFAIL(t *testing.T) {
 	message := "read-only file system"
-	response := append(syncTestHeader(syncIDFail, uint32(len(message))), message...)
+	response := append(syncTestHeader(syncIDFail, syncTestStringLength(message)), message...)
 	conn := &syncTestConn{response: response, readChunk: 2, writeChunk: 2}
 	client := NewSyncClient(&syncTestOpener{conn: conn}, "serial", map[string]bool{"sendrecv_v2": true})
 	writer, err := client.Send(context.Background(), "/system/file", 0100600, time.Unix(99, 0))

--- a/plugins/android/adb_transport_test.go
+++ b/plugins/android/adb_transport_test.go
@@ -685,13 +685,13 @@ func writeFakeADBExecutable(t *testing.T, root string) string {
 		name = "adb.exe"
 	}
 	path := filepath.Join(root, name)
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(path, []byte("fake"), 0755); err != nil {
+	if err := os.WriteFile(path, []byte("fake"), 0600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
-	if err := os.Chmod(path, 0755); err != nil {
+	if err := os.Chmod(path, 0700); err != nil { // #nosec G302 -- the fake adb must be executable for command-discovery tests.
 		t.Fatalf("Chmod: %v", err)
 	}
 	return path

--- a/plugins/android/pathutil_test.go
+++ b/plugins/android/pathutil_test.go
@@ -4,11 +4,11 @@ import "testing"
 
 func TestQuoteShellArg(t *testing.T) {
 	for input, want := range map[string]string{
-		"":                         "''",
-		"plain":                    "'plain'",
-		"white space":              "'white space'",
-		"a'b":                      "'a'\"'\"'b'",
-		"$(touch /data/local/pwn)": "'$(touch /data/local/pwn)'",
+		"":                              "''",
+		"plain":                         "'plain'",
+		"white space":                   "'white space'",
+		"a'b":                           "'a'\"'\"'b'",
+		"$(touch /data/local/injected)": "'$(touch /data/local/injected)'",
 	} {
 		if got := quoteShellArg(input); got != want {
 			t.Errorf("quoteShellArg(%q) = %q, want %q", input, got, want)

--- a/plugins/archive/archive_test.go
+++ b/plugins/archive/archive_test.go
@@ -39,7 +39,7 @@ func TestActionExtractArchive_Integrity(t *testing.T) {
 	}
 
 	destDir := filepath.Join(tmpDir, "output")
-	if err := os.Mkdir(destDir, 0755); err != nil {
+	if err := os.Mkdir(destDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -175,7 +175,7 @@ func TestActionExtractArchive_ProgressUpdates(t *testing.T) {
 	}
 
 	destDir := filepath.Join(tmpDir, "output")
-	if err := os.Mkdir(destDir, 0755); err != nil {
+	if err := os.Mkdir(destDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -324,7 +324,7 @@ func TestActionExtractArchive_Cancellation(t *testing.T) {
 	}
 
 	destDir := filepath.Join(tmpDir, "output_cancel")
-	if err := os.Mkdir(destDir, 0755); err != nil {
+	if err := os.Mkdir(destDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/extraction_security_test.go
+++ b/plugins/archive/extraction_security_test.go
@@ -35,7 +35,7 @@ func TestArchiveVFSCopyBulkRejectsTraversal(t *testing.T) {
 			test.write(t, archivePath)
 
 			destination := filepath.Join(workspace, "extracted")
-			if err := os.MkdirAll(destination, 0o755); err != nil {
+			if err := os.MkdirAll(destination, 0o700); err != nil {
 				t.Fatal(err)
 			}
 			outside := filepath.Join(workspace, "escaped.txt")

--- a/plugins/archive/production_regression_test.go
+++ b/plugins/archive/production_regression_test.go
@@ -205,8 +205,10 @@ func archiveFixtureZIPWithSeed(t *testing.T, payloadSize int, seed byte) []byte 
 		t.Fatal(err)
 	}
 	payload := make([]byte, payloadSize)
+	value := seed
 	for index := range payload {
-		payload[index] = byte(index*31) + seed
+		payload[index] = value
+		value += 31
 	}
 	if _, err := member.Write(payload); err != nil {
 		t.Fatal(err)

--- a/plugins/archive/repro_test.go
+++ b/plugins/archive/repro_test.go
@@ -232,7 +232,7 @@ func TestIssue150_Concurrent7zReadDir(t *testing.T) {
 
 	// 1. Создаем тестовое дерево папок и файлов
 	srcDir := filepath.Join(tmpDir, "src")
-	if err := os.MkdirAll(filepath.Join(srcDir, "dir1/dir2"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcDir, "dir1/dir2"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "dir1/file1.txt"), []byte("data1"), 0600); err != nil {
@@ -302,7 +302,7 @@ func TestIssue150_7zDirectoryStructureAndSolid(t *testing.T) {
 	archivePath := filepath.Join(tmpDir, "test_structure.7z")
 
 	srcDir := filepath.Join(tmpDir, "src")
-	if err := os.MkdirAll(filepath.Join(srcDir, "empty_dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcDir, "empty_dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("solid content 1"), 0600); err != nil {

--- a/plugins/cloudfox/dialog_google_test.go
+++ b/plugins/cloudfox/dialog_google_test.go
@@ -26,7 +26,7 @@ func TestGoogleProfileAuthorizationSecretsDoNotCrossOAuthAudience(t *testing.T) 
 	})
 	t.Cleanup(func() { _ = plugin.Close() })
 
-	oldValues := SecretValues{
+	oldValues := SecretValues{ // #nosec G101 -- synthetic OAuth credentials verify that secrets do not cross an edited client-ID boundary.
 		"client_secret": "old-client-secret",
 		"access_token":  "old-access-token",
 		"refresh_token": "old-refresh-token",
@@ -42,7 +42,7 @@ func TestGoogleProfileAuthorizationSecretsDoNotCrossOAuthAudience(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(sameAudience, SecretValues{"client_secret": "old-client-secret"}) {
+	if !reflect.DeepEqual(sameAudience, SecretValues{"client_secret": "old-client-secret"}) { // #nosec G101 -- this is the synthetic secret expected from the fixture above.
 		t.Fatalf("same-audience authorization secrets = %#v", sameAudience)
 	}
 
@@ -56,7 +56,7 @@ func TestGoogleProfileAuthorizationSecretsDoNotCrossOAuthAudience(t *testing.T) 
 		t.Fatalf("new-audience authorization inherited old credentials: %#v", newAudience)
 	}
 
-	typed := SecretValues{"client_secret": "new-client-secret"}
+	typed := SecretValues{"client_secret": "new-client-secret"} // #nosec G101 -- synthetic user input verifies that only the newly typed secret is retained.
 	newAudience, err = dialog.googleSecretsForAuthorization(context.Background(), updated, typed)
 	if err != nil {
 		t.Fatal(err)

--- a/plugins/cloudfox/plugin_contributions_test.go
+++ b/plugins/cloudfox/plugin_contributions_test.go
@@ -2,6 +2,7 @@ package cloudfox
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/unxed/f4/vfs"
@@ -155,7 +156,7 @@ func TestPluginRegistersContextCommandsAndUnregistersThem(t *testing.T) {
 
 func TestPluginCommandRegistrationFailureRollsBackWithoutGlobalSideEffects(t *testing.T) {
 	for failCommand := 1; failCommand <= 3; failCommand++ {
-		t.Run(string(rune('0'+failCommand)), func(t *testing.T) {
+		t.Run(strconv.Itoa(failCommand), func(t *testing.T) {
 			plugin := NewPlugin(Options{ConfigDir: t.TempDir(), Portable: true, Factories: []BackendFactory{}})
 			host := &cloudFoxContributionHostMock{failCommand: failCommand}
 			if err := plugin.Init(host); err == nil {

--- a/plugins/cloudfox/provider_google_real_native_integration_test.go
+++ b/plugins/cloudfox/provider_google_real_native_integration_test.go
@@ -326,7 +326,7 @@ func openRealSavedGoogleBackend(t *testing.T) *googleDriveBackend {
 	if !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- the opted-in real-provider test intentionally loads the operator-supplied absolute config directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox config directory is unavailable")
 	}

--- a/plugins/cloudfox/provider_google_test.go
+++ b/plugins/cloudfox/provider_google_test.go
@@ -234,7 +234,7 @@ func TestGoogleRangeReaderFallsBackWhenRangeIsIgnored(t *testing.T) {
 
 	buffer := make([]byte, 4)
 	readCtx := context.WithValue(context.Background(), vfs.ProgressKey, vfs.ProgressCallback(func(_ string, percent int) {
-		progress.Store(int32(percent))
+		progress.Store(int32(percent)) // #nosec G115 -- progress callbacks are bounded to percentages from 0 through 100.
 	}))
 	if n, err := reader.ReadAt(readCtx, buffer, 2); err != nil || n != 4 || string(buffer) != "mple" {
 		t.Fatalf("first ReadAt = %d, %v, %q", n, err, buffer)

--- a/plugins/cloudfox/provider_real_saved_integration_test.go
+++ b/plugins/cloudfox/provider_real_saved_integration_test.go
@@ -23,7 +23,7 @@ const (
 	realMutationEnv        = "F4_CLOUDFOX_REAL_MUTATION"
 	realMutationConfirmed  = "CONFIRMED"
 	realConfigDirEnv       = "F4_CLOUDFOX_REAL_CONFIG_DIR"
-	realVaultPasswordEnv   = "F4_CLOUDFOX_REAL_VAULT_PASSWORD"
+	realVaultPasswordEnv   = "F4_CLOUDFOX_REAL_VAULT_PASSWORD" // #nosec G101 -- this is an environment-variable name, not a credential value.
 	realGoogleSelectorEnv  = "F4_CLOUDFOX_REAL_GOOGLE_CONNECTION"
 	realYandexSelectorEnv  = "F4_CLOUDFOX_REAL_YANDEX_CONNECTION"
 	realYandexDialRetryEnv = "F4_CLOUDFOX_REAL_YANDEX_DIAL_RETRIES"
@@ -68,7 +68,7 @@ func TestRealSavedCloudConnections(t *testing.T) {
 	if !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- this explicitly opted-in integration test must inspect the operator-supplied absolute config directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox config directory is unavailable")
 	}
@@ -717,7 +717,7 @@ func realPatternBytes(size int, seed byte) []byte {
 		state ^= state << 13
 		state ^= state >> 17
 		state ^= state << 5
-		payload[i] = byte(state)
+		payload[i] = byte(state) // #nosec G115 -- the fixture generator deliberately emits the xorshift state's low byte.
 	}
 	return payload
 }

--- a/plugins/cloudfox/provider_real_semantics_test.go
+++ b/plugins/cloudfox/provider_real_semantics_test.go
@@ -47,7 +47,7 @@ func TestRealSavedCloudConnectionSemantics(t *testing.T) {
 	if configDir == "" || !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox semantics require an absolute config directory")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- the doubly opted-in semantics test intentionally loads the operator-supplied absolute config directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox config directory is unavailable")
 	}

--- a/plugins/cloudfox/provider_real_sharing_integration_test.go
+++ b/plugins/cloudfox/provider_real_sharing_integration_test.go
@@ -72,7 +72,7 @@ func TestRealSavedCloudSharing(t *testing.T) {
 	if configDir == "" || !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox sharing requires an absolute config directory")
 	}
-	if info, err := os.Stat(configDir); err != nil || !info.IsDir() {
+	if info, err := os.Stat(configDir); err != nil || !info.IsDir() { // #nosec G703 -- the doubly opted-in sharing test intentionally loads the operator-supplied absolute config directory.
 		t.Fatal("real CloudFox sharing config directory is unavailable")
 	}
 
@@ -690,7 +690,7 @@ func TestRealAnonymousShareProbeIsCredentiallessAndDoesNotExposeURLsInErrors(t *
 		t.Fatalf("closed probe = accessible:%t error:%s", accessible, realSharingErrorClass(err))
 	}
 
-	secretURL := "https://share.invalid/file?token=must-not-leak"
+	secretURL := "https://share.invalid/file?token=must-not-leak" // #nosec G101 -- a synthetic secret-bearing URL verifies error redaction.
 	class := realSharingErrorClass(fmt.Errorf("request %s: %w", secretURL, errRealAnonymousShareProbe))
 	if strings.Contains(class, "share.invalid") || strings.Contains(class, "must-not-leak") || strings.Contains(class, "https://") {
 		t.Fatalf("error class leaked a share URL: %q", class)

--- a/plugins/cloudfox/provider_real_upload_cancellation_test.go
+++ b/plugins/cloudfox/provider_real_upload_cancellation_test.go
@@ -47,7 +47,7 @@ func TestRealSavedCloudUploadCancellation(t *testing.T) {
 	if configDir == "" || !filepath.IsAbs(configDir) {
 		t.Fatal("real upload cancellation requires an absolute config directory")
 	}
-	if info, err := os.Stat(configDir); err != nil || !info.IsDir() {
+	if info, err := os.Stat(configDir); err != nil || !info.IsDir() { // #nosec G703 -- the doubly opted-in cancellation test intentionally loads the operator-supplied absolute config directory.
 		t.Fatal("real upload-cancellation config directory is unavailable")
 	}
 

--- a/plugins/cloudfox/provider_s3_discovery_regression_test.go
+++ b/plugins/cloudfox/provider_s3_discovery_regression_test.go
@@ -125,7 +125,7 @@ func (f *s3SignedRegionFixture) ServeHTTP(writer http.ResponseWriter, request *h
 	}
 	writer.Header().Set("Content-Type", "application/xml")
 	writer.WriteHeader(http.StatusBadRequest)
-	_, _ = fmt.Fprintf(writer, `<Error><Code>UnexpectedRequest</Code><Message>%s %s</Message></Error>`, request.Method, request.URL.RequestURI())
+	_, _ = fmt.Fprintf(writer, `<Error><Code>UnexpectedRequest</Code><Message>%s %s</Message></Error>`, request.Method, request.URL.RequestURI()) // #nosec G705 -- this closed httptest server reflects only its controlled regression-test request in an error body.
 }
 
 type s3HistoryRegressionFactory struct {
@@ -219,7 +219,7 @@ func (f *s3DiscoveryHTTPFixture) ServeHTTP(writer http.ResponseWriter, request *
 	}
 	writer.Header().Set("Content-Type", "application/xml")
 	writer.WriteHeader(http.StatusBadRequest)
-	_, _ = fmt.Fprintf(writer, `<Error><Code>UnexpectedRequest</Code><Message>%s %s</Message></Error>`, request.Method, request.URL.RequestURI())
+	_, _ = fmt.Fprintf(writer, `<Error><Code>UnexpectedRequest</Code><Message>%s %s</Message></Error>`, request.Method, request.URL.RequestURI()) // #nosec G705 -- this closed httptest server reflects only its controlled regression-test request in an error body.
 }
 
 func openS3DiscoveryRegressionBackend(t *testing.T, server *httptest.Server, bucket string) *s3Backend {

--- a/plugins/cloudfox/provider_s3_real_discovery_test.go
+++ b/plugins/cloudfox/provider_s3_real_discovery_test.go
@@ -53,7 +53,7 @@ func TestRealSavedS3DiscoveryVisualHistoryReadOnly(t *testing.T) {
 	if !filepath.IsAbs(configDir) {
 		t.Fatal("real read-only S3 config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- the opted-in read-only test intentionally loads the operator-supplied absolute config directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real read-only S3 config directory is unavailable")
 	}

--- a/plugins/cloudfox/provider_webdav_edge_test.go
+++ b/plugins/cloudfox/provider_webdav_edge_test.go
@@ -112,7 +112,7 @@ func TestWebDAVEdgeSettingsAndAuthenticationMatrix(t *testing.T) {
 		{name: "anonymous over HTTP", settings: WebDAVSettings{BaseURL: "http://dav.example/dav", Auth: "anonymous"}},
 		{name: "missing host", settings: WebDAVSettings{BaseURL: "https:///dav"}, wantErr: "invalid WebDAV base URL"},
 		{name: "unsupported scheme", settings: WebDAVSettings{BaseURL: "ftp://dav.example/dav"}, wantErr: "invalid WebDAV base URL"},
-		{name: "userinfo", settings: WebDAVSettings{BaseURL: "https://alice:secret@dav.example/dav"}, wantErr: "invalid WebDAV base URL"},
+		{name: "userinfo", settings: WebDAVSettings{BaseURL: "https://alice:secret@dav.example/dav"}, wantErr: "invalid WebDAV base URL"}, // #nosec G101 -- credential-like userinfo is an invalid-input fixture whose rejection is under test.
 		{name: "query", settings: WebDAVSettings{BaseURL: "https://dav.example/dav?token=secret"}, wantErr: "invalid WebDAV base URL"},
 		{name: "fragment", settings: WebDAVSettings{BaseURL: "https://dav.example/dav#fragment"}, wantErr: "invalid WebDAV base URL"},
 		{name: "encoded base separator", settings: WebDAVSettings{BaseURL: "https://dav.example/dav%2Ftenant"}, wantErr: "ambiguous WebDAV base URL path"},

--- a/plugins/cloudfox/provider_webdav_integration_test.go
+++ b/plugins/cloudfox/provider_webdav_integration_test.go
@@ -1276,7 +1276,7 @@ func TestWebDAVDirectoryMutationsUseCollectionURLs(t *testing.T) {
 				return
 			}
 			w.WriteHeader(http.StatusMultiStatus)
-			_, _ = io.WriteString(w, davMultiStatusXML(davResponseXML(r.URL.Path+"/", "source", "0", true)))
+			_, _ = io.WriteString(w, davMultiStatusXML(davResponseXML(r.URL.Path+"/", "source", "0", true))) // #nosec G705 -- the local test server returns its controlled request path to exercise collection-URL handling.
 			return
 		}
 		requests = append(requests, mutationRequest{method: r.Method, path: r.URL.Path, destination: r.Header.Get("Destination"), overwrite: r.Header.Get("Overwrite")})

--- a/plugins/cloudfox/provider_yandex_share_test.go
+++ b/plugins/cloudfox/provider_yandex_share_test.go
@@ -243,7 +243,7 @@ func TestYandexShareRejectsUnsupportedOptionsAndRootBeforeNetwork(t *testing.T) 
 func TestYandexShareErrorsDoNotExposeProviderResponseURLs(t *testing.T) {
 	t.Parallel()
 
-	const secretURL = "https://share.invalid/d/must-not-leak"
+	const secretURL = "https://share.invalid/d/must-not-leak" // #nosec G101 -- a synthetic secret-bearing URL verifies provider-error redaction.
 	t.Run("metadata", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -388,7 +388,7 @@ func TestYandexCreateShareLinkReportsUnknownStateWhenRollbackCannotBeConfirmed(t
 	t.Parallel()
 
 	const (
-		secretURL  = "https://user:sensitive-token@share.invalid/file"
+		secretURL  = "https://user:sensitive-token@share.invalid/file" // #nosec G101 -- synthetic credential-bearing URL verifies rollback error redaction.
 		secretBody = "rollback-sensitive-response"
 	)
 	var metadataRequests, publishes, rollbacks atomic.Int32
@@ -576,7 +576,7 @@ func TestYandexShareCyclesAreSerializedAndQueueCancellationIsPrompt(t *testing.T
 func TestYandexShareRejectsInvalidPublicURLBeforeMutationWithoutLeakingIt(t *testing.T) {
 	t.Parallel()
 
-	const invalidURL = "https://user:sensitive-password@share.invalid/file"
+	const invalidURL = "https://user:sensitive-password@share.invalid/file" // #nosec G101 -- invalid synthetic userinfo verifies rejection without secret leakage.
 	var puts atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPut {

--- a/plugins/cloudfox/provider_yandex_test.go
+++ b/plugins/cloudfox/provider_yandex_test.go
@@ -81,7 +81,7 @@ func TestYandexTrashAndPermanentDeletePollAcceptedOperation(t *testing.T) {
 			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			_, _ = fmt.Fprintf(w, `{"href":%q,"method":"GET"}`, "http://"+r.Host+"/operations/1")
+			_, _ = fmt.Fprintf(w, `{"href":%q,"method":"GET"}`, "http://"+r.Host+"/operations/1") // #nosec G705 -- this closed httptest server uses its own controlled Host to form a fixture operation URL.
 		case r.URL.Path == "/operations/1" && r.Method == http.MethodGet:
 			operationChecks++
 			w.Header().Set("Content-Type", "application/json")

--- a/plugins/cloudfox/secrets_test.go
+++ b/plugins/cloudfox/secrets_test.go
@@ -130,7 +130,7 @@ func TestRepositoryRollsBackStagedSecretOnMetadataFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	second := testConnection("same", ProviderWebDAV)
-	other := SecretValues{"secret": "must-be-rolled-back"}
+	other := SecretValues{"secret": "must-be-rolled-back"} // #nosec G101 -- synthetic secret verifies cleanup after a failed metadata save.
 	if _, err := repo.Save(context.Background(), second, &other, SecretStorageKeyring); !errors.Is(err, ErrDuplicateName) {
 		t.Fatalf("duplicate Save = %v", err)
 	}

--- a/plugins/cloudfox/store_test.go
+++ b/plugins/cloudfox/store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -179,7 +180,7 @@ func TestConnectionStoreConcurrentCreatorsDoNotLoseUpdates(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			_, err := store.Create(ctx, testConnection(string(rune('A'+i))+" profile", ProviderS3))
+			_, err := store.Create(ctx, testConnection(fmt.Sprintf("%c profile", 'A'+i), ProviderS3))
 			errs <- err
 		}()
 	}

--- a/plugins/envman/plugin_test.go
+++ b/plugins/envman/plugin_test.go
@@ -3,6 +3,7 @@ package envman
 import (
 	"errors"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -327,7 +328,7 @@ func TestPluginCloseWaitsForActiveEnvironmentOperation(t *testing.T) {
 
 func TestPluginRegistrationFailureRollsBackEveryEarlierContribution(t *testing.T) {
 	for failAt := 1; failAt <= 4; failAt++ {
-		t.Run(string(rune('0'+failAt)), func(t *testing.T) {
+		t.Run(strconv.Itoa(failAt), func(t *testing.T) {
 			host := &failingContributionHost{envManTestHost: newEnvManTestHost(), failAt: failAt}
 			plugin := NewPlugin(t.TempDir())
 			if err := plugin.Init(host); err == nil {

--- a/plugins/envman/ui_test.go
+++ b/plugins/envman/ui_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/unxed/vtui"
 )
 
+func managerMouseCoordinate(value int) int16 {
+	return int16(value) // #nosec G115 -- manager tests allocate dialogs inside screens no larger than 120x60.
+}
+
 func TestManagerOperationsPreserveLegacyOrderingSemantics(t *testing.T) {
 	config := Config{
 		Version: CurrentConfigVersion,
@@ -249,8 +253,8 @@ func TestManagerMouseWheelRefreshesInlineEditor(t *testing.T) {
 
 	if !controller.dialog.ProcessMouse(&vtinput.InputEvent{
 		Type:           vtinput.MouseEventType,
-		MouseX:         int16(controller.list.X1 + 1),
-		MouseY:         int16(controller.list.Y1 + 1),
+		MouseX:         managerMouseCoordinate(controller.list.X1 + 1),
+		MouseY:         managerMouseCoordinate(controller.list.Y1 + 1),
 		WheelDirection: -1,
 	}) {
 		t.Fatal("profile-list mouse wheel was not handled")
@@ -283,15 +287,15 @@ func TestManagerScrollbarMouseScrollsProfileList(t *testing.T) {
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
-		MouseX:      int16(controller.list.ScrollBar.X1),
-		MouseY:      int16(controller.list.ScrollBar.Y2),
+		MouseX:      managerMouseCoordinate(controller.list.ScrollBar.X1),
+		MouseY:      managerMouseCoordinate(controller.list.ScrollBar.Y2),
 	}) {
 		t.Fatal("scrollbar down-arrow click was not handled")
 	}
 	controller.dialog.ProcessMouse(&vtinput.InputEvent{
 		Type:    vtinput.MouseEventType,
-		MouseX:  int16(controller.list.ScrollBar.X1),
-		MouseY:  int16(controller.list.ScrollBar.Y2),
+		MouseX:  managerMouseCoordinate(controller.list.ScrollBar.X1),
+		MouseY:  managerMouseCoordinate(controller.list.ScrollBar.Y2),
 		KeyDown: false,
 	})
 	if controller.list.TopPos == 0 {
@@ -309,20 +313,20 @@ func TestManagerScrollbarMouseScrollsProfileList(t *testing.T) {
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
-		MouseX:      int16(controller.list.ScrollBar.X1),
-		MouseY:      int16(thumbY),
+		MouseX:      managerMouseCoordinate(controller.list.ScrollBar.X1),
+		MouseY:      managerMouseCoordinate(thumbY),
 	})
 	controller.dialog.ProcessMouse(&vtinput.InputEvent{
 		Type:            vtinput.MouseEventType,
 		ButtonState:     vtinput.FromLeft1stButtonPressed,
 		MouseEventFlags: vtinput.MouseMoved,
-		MouseX:          int16(controller.list.ScrollBar.X1),
-		MouseY:          int16(thumbY + 3),
+		MouseX:          managerMouseCoordinate(controller.list.ScrollBar.X1),
+		MouseY:          managerMouseCoordinate(thumbY + 3),
 	})
 	controller.dialog.ProcessMouse(&vtinput.InputEvent{
 		Type:   vtinput.MouseEventType,
-		MouseX: int16(controller.list.ScrollBar.X1),
-		MouseY: int16(thumbY + 3),
+		MouseX: managerMouseCoordinate(controller.list.ScrollBar.X1),
+		MouseY: managerMouseCoordinate(thumbY + 3),
 	})
 	if controller.list.TopPos == 0 {
 		t.Fatal("dragging the scrollbar thumb did not scroll the profile list")
@@ -340,8 +344,8 @@ func TestManagerCheckboxClickTogglesWithoutEditing(t *testing.T) {
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
-		MouseX:      int16(controller.list.X1 + 1),
-		MouseY:      int16(controller.list.Y1),
+		MouseX:      managerMouseCoordinate(controller.list.X1 + 1),
+		MouseY:      managerMouseCoordinate(controller.list.Y1),
 	}) {
 		t.Fatal("checkbox click was not handled")
 	}
@@ -356,8 +360,8 @@ func TestManagerCheckboxClickTogglesWithoutEditing(t *testing.T) {
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
-		MouseX:      int16(controller.list.X1 + 5),
-		MouseY:      int16(controller.list.Y1 + 1),
+		MouseX:      managerMouseCoordinate(controller.list.X1 + 5),
+		MouseY:      managerMouseCoordinate(controller.list.Y1 + 1),
 	})
 	if controller.list.SelectPos != 1 || store.Snapshot().Entries[1].Enabled {
 		t.Fatal("clicking the profile label should select it without toggling")
@@ -571,11 +575,11 @@ func TestManagerVisualStatesAndOverflowFollowDialogTheme(t *testing.T) {
 	splitX := x1 + dialog.splitOffset
 	leftHeaderX := x1 + 1 + ((splitX-1)-(x1+1)+1-(runewidth.StringWidth(dialog.profilesTitle)+2))/2
 	rightHeaderX := splitX + 1 + ((x2-1)-(splitX+1)+1-(runewidth.StringWidth(dialog.detailsTitle)+2))/2
-	if cell := screen.GetCell(leftHeaderX, y1+1); cell.Attributes != selected || rune(cell.Char) != ' ' {
-		t.Fatalf("browse-mode Profiles left margin = %q/%#x, want active blank/%#x", rune(cell.Char), cell.Attributes, selected)
+	if cell := screen.GetCell(leftHeaderX, y1+1); cell.Attributes != selected || cell.Char != ' ' {
+		t.Fatalf("browse-mode Profiles left margin = %#x/%#x, want active blank/%#x", cell.Char, cell.Attributes, selected)
 	}
-	if cell := screen.GetCell(leftHeaderX+runewidth.StringWidth(dialog.profilesTitle)+1, y1+1); cell.Attributes != selected || rune(cell.Char) != ' ' {
-		t.Fatalf("browse-mode Profiles right margin = %q/%#x", rune(cell.Char), cell.Attributes)
+	if cell := screen.GetCell(leftHeaderX+runewidth.StringWidth(dialog.profilesTitle)+1, y1+1); cell.Attributes != selected || cell.Char != ' ' {
+		t.Fatalf("browse-mode Profiles right margin = %#x/%#x", cell.Char, cell.Attributes)
 	}
 	if got := screen.GetCell(rightHeaderX, y1+1).Attributes; got != title {
 		t.Fatalf("browse-mode details margin = %#x, want inactive %#x", got, title)
@@ -602,9 +606,9 @@ func TestManagerVisualStatesAndOverflowFollowDialogTheme(t *testing.T) {
 	if got := vtui.GetRGBBack(screen.GetCell(controller.enabledEdit.X1, controller.enabledEdit.Y1).Attributes); got != vtui.GetRGBBack(normal) {
 		t.Fatalf("Enabled background = %#x, want unchanged dialog background %#x", got, vtui.GetRGBBack(normal))
 	}
-	if cell := screen.GetCell(controller.list.X2, controller.list.Y1); rune(cell.Char) != rune(vtui.ScrollUpArrow) ||
+	if cell := screen.GetCell(controller.list.X2, controller.list.Y1); cell.Char != vtui.ScrollUpArrow ||
 		cell.Attributes != managerHintWithBackground(box, managerInputBackground(true)) {
-		t.Fatalf("active scrollbar top cell = %q/%#x", rune(cell.Char), cell.Attributes)
+		t.Fatalf("active scrollbar top cell = %#x/%#x", cell.Char, cell.Attributes)
 	}
 	controller.dialog.SetFocusedItem(controller.addButton)
 	dialog.Show(screen)
@@ -618,8 +622,8 @@ func TestManagerVisualStatesAndOverflowFollowDialogTheme(t *testing.T) {
 		t.Fatalf("edit-mode Profiles margin = %#x, want inactive %#x", got, title)
 	}
 	editingHeaderX := splitX + 1 + ((x2-1)-(splitX+1)+1-(runewidth.StringWidth(dialog.editingTitle)+2))/2
-	if cell := screen.GetCell(editingHeaderX, y1+1); cell.Attributes != selected || rune(cell.Char) != ' ' {
-		t.Fatalf("edit-mode right header margin = %q/%#x, want active blank/%#x", rune(cell.Char), cell.Attributes, selected)
+	if cell := screen.GetCell(editingHeaderX, y1+1); cell.Attributes != selected || cell.Char != ' ' {
+		t.Fatalf("edit-mode right header margin = %#x/%#x, want active blank/%#x", cell.Char, cell.Attributes, selected)
 	}
 
 	if got, want := screen.GetCell(controller.variablesEdit.X1, controller.variablesEdit.Y1).Attributes, edit; got != want {
@@ -638,9 +642,9 @@ func TestManagerVisualStatesAndOverflowFollowDialogTheme(t *testing.T) {
 	if !controller.list.ShowScrollBar || controller.list.ItemCount <= controller.list.ViewHeight {
 		t.Fatal("overflowing profile list did not enable its scrollbar")
 	}
-	if cell := screen.GetCell(controller.list.X2, controller.list.Y1); rune(cell.Char) != rune(vtui.ScrollUpArrow) ||
+	if cell := screen.GetCell(controller.list.X2, controller.list.Y1); cell.Char != vtui.ScrollUpArrow ||
 		cell.Attributes != managerHintWithBackground(box, inactiveBackground) {
-		t.Fatalf("inactive scrollbar top cell = %q/%#x", rune(cell.Char), cell.Attributes)
+		t.Fatalf("inactive scrollbar top cell = %#x/%#x", cell.Char, cell.Attributes)
 	}
 
 	parts := parseManagerHint(dialog.bottomHint)
@@ -706,20 +710,20 @@ func TestManagerHintBackgroundMatchesOnlyRenderedTextWidth(t *testing.T) {
 			t.Fatalf("hint background at x=%d = %#x, want %#x", x, got, wantBackground)
 		}
 	}
-	if cell := screen.GetCell(start, 2); rune(cell.Char) != ' ' {
-		t.Fatalf("left hint margin = %q, want a space", rune(cell.Char))
+	if cell := screen.GetCell(start, 2); cell.Char != ' ' {
+		t.Fatalf("left hint margin = %#x, want a space", cell.Char)
 	}
-	if cell := screen.GetCell(end, 2); rune(cell.Char) != ' ' {
-		t.Fatalf("right hint margin = %q, want a space", rune(cell.Char))
+	if cell := screen.GetCell(end, 2); cell.Char != ' ' {
+		t.Fatalf("right hint margin = %#x, want a space", cell.Char)
 	}
-	if cell := screen.GetCell(start+1, 2); rune(cell.Char) != 'F' {
-		t.Fatalf("hint text begins at %q after left margin, want F", rune(cell.Char))
+	if cell := screen.GetCell(start+1, 2); cell.Char != 'F' {
+		t.Fatalf("hint text begins at %#x after left margin, want F", cell.Char)
 	}
-	if cell := screen.GetCell(start-1, 2); rune(cell.Char) != '─' || cell.Attributes != base {
-		t.Fatalf("left cell outside hint was changed to %q/%#x", rune(cell.Char), cell.Attributes)
+	if cell := screen.GetCell(start-1, 2); cell.Char != '─' || cell.Attributes != base {
+		t.Fatalf("left cell outside hint was changed to %#x/%#x", cell.Char, cell.Attributes)
 	}
-	if cell := screen.GetCell(end+1, 2); rune(cell.Char) != '─' || cell.Attributes != base {
-		t.Fatalf("right cell outside hint was changed to %q/%#x", rune(cell.Char), cell.Attributes)
+	if cell := screen.GetCell(end+1, 2); cell.Char != '─' || cell.Attributes != base {
+		t.Fatalf("right cell outside hint was changed to %#x/%#x", cell.Char, cell.Attributes)
 	}
 }
 
@@ -738,10 +742,10 @@ func TestManagerDividerMovesWithDialog(t *testing.T) {
 	screen.AllocBuf(120, 60)
 	dialog.Show(screen)
 	newSplit := originalSplit + delta
-	if cell := screen.GetCell(newSplit, y1+1); rune(cell.Char) != '│' || cell.Attributes != vtui.Palette[vtui.ColDialogBox] {
-		t.Fatalf("moved divider cell = %q/%#x at x=%d", rune(cell.Char), cell.Attributes, newSplit)
+	if cell := screen.GetCell(newSplit, y1+1); cell.Char != '│' || cell.Attributes != vtui.Palette[vtui.ColDialogBox] {
+		t.Fatalf("moved divider cell = %#x/%#x at x=%d", cell.Char, cell.Attributes, newSplit)
 	}
-	if cell := screen.GetCell(originalSplit, y1+1); rune(cell.Char) == '│' {
+	if cell := screen.GetCell(originalSplit, y1+1); cell.Char == '│' {
 		t.Fatalf("divider remained at its old absolute x=%d", originalSplit)
 	}
 }

--- a/plugins/ios/internal/afcproto/client_test.go
+++ b/plugins/ios/internal/afcproto/client_test.go
@@ -516,8 +516,8 @@ func fileRequest(values ...uint64) func(packet) error {
 	}
 }
 
-func seekRequest(handle uint64, offset int64) func(packet) error {
-	return fileRequest(handle, uint64(io.SeekStart), uint64(offset))
+func seekRequest(handle, offset uint64) func(packet) error {
+	return fileRequest(handle, io.SeekStart, offset)
 }
 
 func payloadLength(want int) func(packet) error {

--- a/plugins/ios/internal/corefileservice/fileservice_test.go
+++ b/plugins/ios/internal/corefileservice/fileservice_test.go
@@ -21,10 +21,11 @@ type fakeXPCConnection struct {
 }
 
 func TestReceiveFileDataToWriterValidatesAndStreams(t *testing.T) {
-	payload := []byte("core-device-data")
+	const payloadText = "core-device-data"
+	payload := []byte(payloadText)
 	header := make([]byte, 40)
 	copy(header[:8], "rwb!FILE")
-	binary.BigEndian.PutUint32(header[36:40], uint32(len(payload)))
+	binary.BigEndian.PutUint32(header[36:40], uint32(len(payloadText)))
 	var output bytes.Buffer
 	if err := receiveFileDataToWriter(bytes.NewReader(append(header, payload...)), &output); err != nil {
 		t.Fatal(err)

--- a/plugins/mediainfo/backend_test.go
+++ b/plugins/mediainfo/backend_test.go
@@ -15,6 +15,18 @@ import (
 	"time"
 )
 
+func mediaFixtureUint32(value int) uint32 {
+	return uint32(value) // #nosec G115 -- generated media fixtures are bounded well below uint32 size fields.
+}
+
+func mediaFixtureUint64(value int) uint64 {
+	return uint64(value) // #nosec G115 -- generated media fixtures have small non-negative buffer sizes.
+}
+
+func mediaFixtureByte(value int) byte {
+	return byte(value) // #nosec G115 -- callers deliberately encode bounded fixture values into byte fields.
+}
+
 type memorySource []byte
 
 func (m memorySource) ReadAt(ctx context.Context, p []byte, off int64) (int, error) {
@@ -39,7 +51,7 @@ func analyzeBytes(t *testing.T, name string, b []byte, mode Mode) (Report, error
 func TestAnalyzeWave(t *testing.T) {
 	b := make([]byte, 12+8+16+8+8000)
 	copy(b[:4], "RIFF")
-	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(b)-8))
 	copy(b[8:12], "WAVE")
 	copy(b[12:16], "fmt ")
 	binary.LittleEndian.PutUint32(b[16:20], 16)
@@ -181,7 +193,7 @@ func TestAnalyzePNG(t *testing.T) {
 func TestAnalyzeMinimalMP4(t *testing.T) {
 	box := func(typ string, payload []byte) []byte {
 		x := make([]byte, 8+len(payload))
-		binary.BigEndian.PutUint32(x[:4], uint32(len(x)))
+		binary.BigEndian.PutUint32(x[:4], mediaFixtureUint32(len(x)))
 		copy(x[4:8], typ)
 		copy(x[8:], payload)
 		return x
@@ -204,9 +216,9 @@ func TestAnalyzeMinimalMP4(t *testing.T) {
 
 func ebmlSize(n int) []byte {
 	if n < 127 {
-		return []byte{0x80 | byte(n)}
+		return []byte{0x80 | mediaFixtureByte(n)}
 	}
-	return []byte{0x40 | byte(n>>8), byte(n)}
+	return []byte{0x40 | mediaFixtureByte(n>>8), mediaFixtureByte(n)}
 }
 func ebmlElement(id, payload []byte) []byte {
 	b := append(append([]byte(nil), id...), ebmlSize(len(payload))...)
@@ -265,7 +277,7 @@ func TestAnalyzeWithBackgroundContext(t *testing.T) {
 func TestAnalyzeReadLimitReturnsPartial(t *testing.T) {
 	b := make([]byte, 12+8+16)
 	copy(b[:4], "RIFF")
-	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(b)-8))
 	copy(b[8:12], "WAVE")
 	copy(b[12:16], "fmt ")
 	binary.LittleEndian.PutUint32(b[16:20], 16)

--- a/plugins/mediainfo/dialog_theme_test.go
+++ b/plugins/mediainfo/dialog_theme_test.go
@@ -42,8 +42,8 @@ func TestReportViewUsesDialogThemeAndDimsFieldNames(t *testing.T) {
 	if got := screen.GetCell(valueX, 2).Attributes; got != normal {
 		t.Fatalf("field-value attr = %#x, want dialog text %#x", got, normal)
 	}
-	if cell := screen.GetCell(view.X2, view.Y1); rune(cell.Char) != rune(vtui.ScrollUpArrow) || cell.Attributes != box {
-		t.Fatalf("overflow scrollbar cell = %#v, want arrow %q with dialog box attr %#x", cell, rune(vtui.ScrollUpArrow), box)
+	if cell := screen.GetCell(view.X2, view.Y1); cell.Char != vtui.ScrollUpArrow || cell.Attributes != box {
+		t.Fatalf("overflow scrollbar cell = %#v, want arrow %#x with dialog box attr %#x", cell, vtui.ScrollUpArrow, box)
 	}
 
 	view.SetFocus(true)
@@ -83,7 +83,7 @@ func TestReportViewHidesScrollbarWhenContentFits(t *testing.T) {
 		screen.FillRect(view.X2, y, view.X2, y, '│', border)
 	}
 	view.Show(screen)
-	if cell := screen.GetCell(view.X2, view.Y1); rune(cell.Char) != '│' || cell.Attributes != border {
+	if cell := screen.GetCell(view.X2, view.Y1); cell.Char != '│' || cell.Attributes != border {
 		t.Fatalf("fitting report overwrote dialog border: %#v", cell)
 	}
 }
@@ -103,7 +103,7 @@ func TestReportViewResizeClampsScrollPosition(t *testing.T) {
 	screen := vtui.NewSilentScreenBuf()
 	screen.AllocBuf(80, 25)
 	view.Show(screen)
-	if got := rune(screen.GetCell(view.X2, view.Y1).Char); got == rune(vtui.ScrollUpArrow) {
+	if got := screen.GetCell(view.X2, view.Y1).Char; got == vtui.ScrollUpArrow {
 		t.Fatal("grown report view retained a scrollbar although all rows fit")
 	}
 
@@ -112,8 +112,8 @@ func TestReportViewResizeClampsScrollPosition(t *testing.T) {
 		t.Fatalf("shrunk view = height %d, top %d; want height 4, top 2", view.ViewHeight, view.TopPos)
 	}
 	view.Show(screen)
-	if got := rune(screen.GetCell(view.X2, view.Y1).Char); got != rune(vtui.ScrollUpArrow) {
-		t.Fatalf("shrunk report view scrollbar = %q, want %q", got, rune(vtui.ScrollUpArrow))
+	if got := screen.GetCell(view.X2, view.Y1).Char; got != vtui.ScrollUpArrow {
+		t.Fatalf("shrunk report view scrollbar = %#x, want %#x", got, vtui.ScrollUpArrow)
 	}
 }
 

--- a/plugins/mediainfo/exif_report_test.go
+++ b/plugins/mediainfo/exif_report_test.go
@@ -12,27 +12,31 @@ func TestTIFFUsefulEXIFIsParsedAndRendered(t *testing.T) {
 	b := make([]byte, 560)
 	copy(b, "II*\x00")
 	binary.LittleEndian.PutUint32(b[4:8], 8)
-	putIFD := func(off int, entries [][4]uint32) {
-		binary.LittleEndian.PutUint16(b[off:off+2], uint16(len(entries)))
+	putIFD := func(off int, entries [][4]uint16) {
+		var entryCount uint16
+		for range entries {
+			entryCount++
+		}
+		binary.LittleEndian.PutUint16(b[off:off+2], entryCount)
 		for i, entry := range entries {
 			pos := off + 2 + i*12
-			binary.LittleEndian.PutUint16(b[pos:pos+2], uint16(entry[0]))
-			binary.LittleEndian.PutUint16(b[pos+2:pos+4], uint16(entry[1]))
-			binary.LittleEndian.PutUint32(b[pos+4:pos+8], entry[2])
-			binary.LittleEndian.PutUint32(b[pos+8:pos+12], entry[3])
+			binary.LittleEndian.PutUint16(b[pos:pos+2], entry[0])
+			binary.LittleEndian.PutUint16(b[pos+2:pos+4], entry[1])
+			binary.LittleEndian.PutUint32(b[pos+4:pos+8], uint32(entry[2]))
+			binary.LittleEndian.PutUint32(b[pos+8:pos+12], uint32(entry[3]))
 		}
 	}
-	putIFD(8, [][4]uint32{
+	putIFD(8, [][4]uint16{
 		{0x010f, 2, 6, 320}, {0x0110, 2, 8, 340}, {0x0112, 3, 1, 6},
 		{0x8769, 4, 1, 100}, {0x8825, 4, 1, 200},
 	})
-	putIFD(100, [][4]uint32{
+	putIFD(100, [][4]uint16{
 		{0x829a, 5, 1, 420}, {0x829d, 5, 1, 428}, {0x8827, 3, 1, 400},
 		{0x9003, 2, 20, 360}, {0x920a, 5, 1, 436}, {0xa434, 2, 8, 390},
 	})
-	putIFD(200, [][4]uint32{
-		{0x0001, 2, 2, uint32('N')}, {0x0002, 5, 3, 444},
-		{0x0003, 2, 2, uint32('W')}, {0x0004, 5, 3, 468},
+	putIFD(200, [][4]uint16{
+		{0x0001, 2, 2, 'N'}, {0x0002, 5, 3, 444},
+		{0x0003, 2, 2, 'W'}, {0x0004, 5, 3, 468},
 		{0x0005, 1, 1, 0}, {0x0006, 5, 1, 492},
 	})
 	copy(b[320:], "Canon\x00")

--- a/plugins/mediainfo/format_gaps_test.go
+++ b/plugins/mediainfo/format_gaps_test.go
@@ -20,7 +20,7 @@ import (
 
 func isoTestBox(typ string, payload []byte) []byte {
 	b := make([]byte, 8+len(payload))
-	binary.BigEndian.PutUint32(b[:4], uint32(len(b)))
+	binary.BigEndian.PutUint32(b[:4], mediaFixtureUint32(len(b)))
 	copy(b[4:8], typ)
 	copy(b[8:], payload)
 	return b
@@ -75,14 +75,14 @@ func rawTIFFFixture(cr2, dng bool) []byte {
 	}
 	binary.LittleEndian.PutUint16(b[ifd:ifd+2], uint16(entries))
 	pos := ifd + 2
-	put := func(tag, typ uint16, count, value uint32) {
+	put := func(tag, typ uint16, count uint32, value uint16) {
 		binary.LittleEndian.PutUint16(b[pos:pos+2], tag)
 		binary.LittleEndian.PutUint16(b[pos+2:pos+4], typ)
 		binary.LittleEndian.PutUint32(b[pos+4:pos+8], count)
 		if typ == 3 && count == 1 {
-			binary.LittleEndian.PutUint16(b[pos+8:pos+10], uint16(value))
+			binary.LittleEndian.PutUint16(b[pos+8:pos+10], value)
 		} else {
-			binary.LittleEndian.PutUint32(b[pos+8:pos+12], value)
+			binary.LittleEndian.PutUint32(b[pos+8:pos+12], uint32(value))
 		}
 		pos += 12
 	}
@@ -90,7 +90,7 @@ func rawTIFFFixture(cr2, dng bool) []byte {
 	put(0x0101, 4, 1, 4000)
 	put(0x0102, 3, 1, 14)
 	put(0x0103, 3, 1, 7)
-	makeOffset := uint32(180)
+	makeOffset := uint16(180)
 	copy(b[makeOffset:], "Camera Co\x00")
 	put(0x010f, 2, uint32(len("Camera Co\x00")), makeOffset)
 	if dng {
@@ -126,7 +126,7 @@ func TestAnalyzeTIFFBasedCameraRAW(t *testing.T) {
 
 func pngTestChunk(typ string, data []byte) []byte {
 	b := make([]byte, 12+len(data))
-	binary.BigEndian.PutUint32(b[:4], uint32(len(data)))
+	binary.BigEndian.PutUint32(b[:4], mediaFixtureUint32(len(data)))
 	copy(b[4:8], typ)
 	copy(b[8:], data)
 	binary.BigEndian.PutUint32(b[8+len(data):], crc32.ChecksumIEEE(b[4:8+len(data)]))
@@ -186,7 +186,7 @@ func TestAnalyzeGIFSkipsGlobalPalette(t *testing.T) {
 func riffTestChunk(typ string, data []byte) []byte {
 	b := make([]byte, 8+len(data)+(len(data)&1))
 	copy(b, typ)
-	binary.LittleEndian.PutUint32(b[4:8], uint32(len(data)))
+	binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(data)))
 	copy(b[8:], data)
 	return b
 }
@@ -197,7 +197,7 @@ func TestWebPAnimationCountAndDuration(t *testing.T) {
 	vp8x[4], vp8x[7] = 3, 2
 	frame := func(ms int) []byte {
 		d := make([]byte, 16)
-		d[12], d[13], d[14] = byte(ms), byte(ms>>8), byte(ms>>16)
+		d[12], d[13], d[14] = mediaFixtureByte(ms), mediaFixtureByte(ms>>8), mediaFixtureByte(ms>>16)
 		return riffTestChunk("ANMF", d)
 	}
 	payload := append(riffTestChunk("VP8X", vp8x), frame(100)...)
@@ -206,7 +206,7 @@ func TestWebPAnimationCountAndDuration(t *testing.T) {
 	copy(file, "RIFF")
 	copy(file[8:], "WEBP")
 	file = append(file, payload...)
-	binary.LittleEndian.PutUint32(file[4:8], uint32(len(file)-8))
+	binary.LittleEndian.PutUint32(file[4:8], mediaFixtureUint32(len(file)-8))
 	p, err := newProbe(context.Background(), Source{Name: "x.webp", Size: int64(len(file)), Reader: memorySource(file)}, DefaultOptions(ModeFast))
 	if err != nil {
 		t.Fatal(err)
@@ -332,7 +332,7 @@ func TestAnalyzeRF64UsesDS64DataSize(t *testing.T) {
 	copy(b[8:12], "WAVE")
 	copy(b[12:16], "ds64")
 	binary.LittleEndian.PutUint32(b[16:20], 28)
-	binary.LittleEndian.PutUint64(b[20:28], uint64(len(b)-8))
+	binary.LittleEndian.PutUint64(b[20:28], mediaFixtureUint64(len(b)-8))
 	binary.LittleEndian.PutUint64(b[28:36], 8000)
 	binary.LittleEndian.PutUint64(b[36:44], 8000)
 	copy(b[48:52], "fmt ")
@@ -358,7 +358,7 @@ func TestAnalyzeOpenDMLFrameCount(t *testing.T) {
 	chunk := func(id string, payload []byte) []byte {
 		b := make([]byte, 8+len(payload)+(len(payload)&1))
 		copy(b, id)
-		binary.LittleEndian.PutUint32(b[4:8], uint32(len(payload)))
+		binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(payload)))
 		copy(b[8:], payload)
 		return b
 	}
@@ -371,7 +371,7 @@ func TestAnalyzeOpenDMLFrameCount(t *testing.T) {
 	copy(b, "RIFF")
 	copy(b[8:], "AVI ")
 	b = append(b, payload...)
-	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(b)-8))
 	r, err := analyzeBytes(t, "open-dml.avi", b, ModeFast)
 	if err != nil {
 		t.Fatal(err)
@@ -505,17 +505,17 @@ func TestAVIRejectedStreamDoesNotReusePreviousSTRF(t *testing.T) {
 	chunk := func(id string, payload []byte) []byte {
 		b := make([]byte, 8+len(payload)+(len(payload)&1))
 		copy(b, id)
-		binary.LittleEndian.PutUint32(b[4:8], uint32(len(payload)))
+		binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(payload)))
 		copy(b[8:], payload)
 		return b
 	}
 	strh := make([]byte, 48)
 	copy(strh[:4], "vids")
 	copy(strh[4:8], "H264")
-	strf := func(width int32) []byte {
+	strf := func(width uint32) []byte {
 		b := make([]byte, 40)
 		binary.LittleEndian.PutUint32(b[:4], 40)
-		binary.LittleEndian.PutUint32(b[4:8], uint32(width))
+		binary.LittleEndian.PutUint32(b[4:8], width)
 		binary.LittleEndian.PutUint32(b[8:12], 20)
 		binary.LittleEndian.PutUint16(b[14:16], 24)
 		copy(b[16:20], "H264")
@@ -528,7 +528,7 @@ func TestAVIRejectedStreamDoesNotReusePreviousSTRF(t *testing.T) {
 	copy(b, "RIFF")
 	copy(b[8:], "AVI ")
 	b = append(b, payload...)
-	binary.LittleEndian.PutUint32(b[4:8], uint32(len(b)-8))
+	binary.LittleEndian.PutUint32(b[4:8], mediaFixtureUint32(len(b)-8))
 	opts := DefaultOptions(ModeFast)
 	opts.MaxStreams = 1
 	r, err := Analyze(context.Background(), Source{Name: "limited.avi", Size: int64(len(b)), Reader: memorySource(b)}, opts)
@@ -636,9 +636,9 @@ func TestAddTagOwnsAcceptedValue(t *testing.T) {
 	p.addTag(target, name, value)
 	got := p.report.Tags[0]
 	if got.Target != target || got.Name != name || got.Value != value ||
-		unsafe.StringData(got.Target) == unsafe.StringData(target) ||
-		unsafe.StringData(got.Name) == unsafe.StringData(name) ||
-		unsafe.StringData(got.Value) == unsafe.StringData(value) {
+		unsafe.StringData(got.Target) == unsafe.StringData(target) || // #nosec G103 -- pointer identity is required to prove the accepted string owns independent backing storage.
+		unsafe.StringData(got.Name) == unsafe.StringData(name) || // #nosec G103 -- pointer identity is required to prove the accepted string owns independent backing storage.
+		unsafe.StringData(got.Value) == unsafe.StringData(value) { // #nosec G103 -- pointer identity is required to prove the accepted string owns independent backing storage.
 		t.Fatalf("accepted field did not own its strings: %#v", got)
 	}
 	p.addTag("", strings.Repeat("N", 2048), "value")

--- a/plugins/mediainfo/macro_test.go
+++ b/plugins/mediainfo/macro_test.go
@@ -233,7 +233,7 @@ func (filesystem *macroNoMaterializeVFS) Create(context.Context, string) (io.Wri
 func minimalWave() []byte {
 	data := make([]byte, 44)
 	copy(data[0:4], "RIFF")
-	binary.LittleEndian.PutUint32(data[4:8], uint32(len(data)-8))
+	binary.LittleEndian.PutUint32(data[4:8], mediaFixtureUint32(len(data)-8))
 	copy(data[8:12], "WAVE")
 	copy(data[12:16], "fmt ")
 	binary.LittleEndian.PutUint32(data[16:20], 16)

--- a/plugins/mediainfo/matroska_bounds_test.go
+++ b/plugins/mediainfo/matroska_bounds_test.go
@@ -182,7 +182,7 @@ func TestVorbisVendorIsBoundedAndOwned(t *testing.T) {
 	const capBytes = 8
 	vendor := []byte("vendor-application-with-a-long-version")
 	b := make([]byte, 4+len(vendor)+4)
-	binary.LittleEndian.PutUint32(b[:4], uint32(len(vendor)))
+	binary.LittleEndian.PutUint32(b[:4], mediaFixtureUint32(len(vendor)))
 	copy(b[4:], vendor)
 	p, err := newProbe(context.Background(), Source{Name: "comments", Reader: memorySource(nil)}, Options{Mode: ModeFast, MaxValueBytes: capBytes})
 	if err != nil {

--- a/plugins/mediainfo/parse_tiff_limits_test.go
+++ b/plugins/mediainfo/parse_tiff_limits_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func sharedTIFFValueFixture(tag, typ uint16, valueCount uint32, entries int, value uint32) []byte {
+func sharedTIFFValueFixture(tag, typ uint16, valueCount uint32, entries uint16, value byte) []byte {
 	unit := 4
 	switch typ {
 	case 1:
@@ -15,28 +15,28 @@ func sharedTIFFValueFixture(tag, typ uint16, valueCount uint32, entries int, val
 	case 3:
 		unit = 2
 	}
-	ifdSize := 2 + entries*12 + 4
+	ifdSize := 2 + int(entries)*12 + 4
 	payloadOffset := 8 + ifdSize
 	b := make([]byte, payloadOffset+int(valueCount)*unit)
 	copy(b, "II*\x00")
 	binary.LittleEndian.PutUint32(b[4:8], 8)
-	binary.LittleEndian.PutUint16(b[8:10], uint16(entries))
-	for i := 0; i < entries; i++ {
-		pos := 10 + i*12
+	binary.LittleEndian.PutUint16(b[8:10], entries)
+	for i := uint16(0); i < entries; i++ {
+		pos := 10 + int(i)*12
 		binary.LittleEndian.PutUint16(b[pos:pos+2], tag)
 		binary.LittleEndian.PutUint16(b[pos+2:pos+4], typ)
 		binary.LittleEndian.PutUint32(b[pos+4:pos+8], valueCount)
-		binary.LittleEndian.PutUint32(b[pos+8:pos+12], uint32(payloadOffset))
+		binary.LittleEndian.PutUint32(b[pos+8:pos+12], mediaFixtureUint32(payloadOffset))
 	}
 	for i := uint32(0); i < valueCount; i++ {
 		pos := payloadOffset + int(i)*unit
 		switch typ {
 		case 1:
-			b[pos] = byte(value)
+			b[pos] = value
 		case 3:
 			binary.LittleEndian.PutUint16(b[pos:pos+2], uint16(value))
 		default:
-			binary.LittleEndian.PutUint32(b[pos:pos+4], value)
+			binary.LittleEndian.PutUint32(b[pos:pos+4], uint32(value))
 		}
 	}
 	return b

--- a/plugins/mediainfo/settings_test.go
+++ b/plugins/mediainfo/settings_test.go
@@ -2,6 +2,7 @@ package mediainfo
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -54,7 +55,7 @@ func TestSettingsConcurrentSavesKeepMemoryAndDiskInSync(t *testing.T) {
 		go func(index int) {
 			defer group.Done()
 			settings := DefaultSettings()
-			settings.Prefix = "MediaInfo" + string(rune('A'+index))
+			settings.Prefix = fmt.Sprintf("MediaInfo%c", 'A'+index)
 			if err := store.save(settings); err != nil {
 				t.Errorf("save %d: %v", index, err)
 			}
@@ -95,7 +96,7 @@ func TestSettingsRejectInvalidPrefixAndOversizedTemplate(t *testing.T) {
 func TestSettingsMalformedFileFallsBackToDefaults(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "plugins", "mediainfo.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, []byte("{"), 0o600); err != nil {

--- a/plugins/netfox/fish_vfs_test.go
+++ b/plugins/netfox/fish_vfs_test.go
@@ -270,13 +270,13 @@ func TestFishVFSBrowsesLocalShell(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "a file.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "a file.txt"), []byte("hello"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".hidden"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "sub dir"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "sub dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink("sub dir", filepath.Join(dir, "link to dir")); err != nil {
@@ -312,8 +312,8 @@ func TestFishVFSBrowsesLocalShell(t *testing.T) {
 	if file.Size != 5 || file.IsDir || file.IsSymlink {
 		t.Errorf("file mapped wrong: %+v", file)
 	}
-	if file.UnixMode&0777 != 0644 {
-		t.Errorf("UnixMode = %o, want 644 in the low bits", file.UnixMode)
+	if file.UnixMode&0777 != 0600 {
+		t.Errorf("UnixMode = %o, want 600 in the low bits", file.UnixMode)
 	}
 	if time.Since(file.MTime) > time.Hour {
 		t.Errorf("MTime = %v, which is nowhere near now", file.MTime)
@@ -348,7 +348,7 @@ func TestFishVFSStatAndOpen(t *testing.T) {
 	dir := t.TempDir()
 	body := strings.Repeat("0123456789", 5000)
 	p := filepath.Join(dir, "payload.bin")
-	if err := os.WriteFile(p, []byte(body), 0755); err != nil {
+	if err := os.WriteFile(p, []byte(body), 0700); err != nil { // #nosec G306 -- executable detection is the behavior under test.
 		t.Fatal(err)
 	}
 
@@ -401,7 +401,7 @@ func TestFishVFSMutations(t *testing.T) {
 	}
 
 	file := filepath.Join(dir, "payload.txt")
-	if err := os.WriteFile(file, []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("hello"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	moved := filepath.Join(dir, "renamed.txt")
@@ -494,7 +494,7 @@ func TestFishVFSSearch(t *testing.T) {
 	ctx := context.Background()
 	file := filepath.Join(t.TempDir(), "log.txt")
 	content := "alpha\nbeta\ngamma beta\n"
-	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(file, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -586,7 +586,7 @@ func TestFishVFSClonesShareOneSessionSafely(t *testing.T) {
 	v := newLocalFishVFS(t)
 	dir := t.TempDir()
 	for _, name := range []string{"one", "two", "three"} {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(name), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -686,7 +686,7 @@ func TestFishVFSLineIndex(t *testing.T) {
 
 	dir := t.TempDir()
 	p := filepath.Join(dir, "log with spaces.txt")
-	if err := os.WriteFile(p, []byte("alpha\nbeta\ngamma\n"), 0644); err != nil {
+	if err := os.WriteFile(p, []byte("alpha\nbeta\ngamma\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -728,7 +728,7 @@ func TestFishVFSScan(t *testing.T) {
 	ctx := context.Background()
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "tree", "a deep dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "tree", "a deep dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	for name, size := range map[string]int{
@@ -737,7 +737,7 @@ func TestFishVFSScan(t *testing.T) {
 		"tree/a deep dir/three.txt": 1000,
 		"loose.txt":                 7,
 	} {
-		if err := os.WriteFile(filepath.Join(root, name), make([]byte, size), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, name), make([]byte, size), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -783,7 +783,7 @@ func TestFishVFSFindDuplicates(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "sub dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "sub dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	for name, body := range map[string]string{
@@ -792,7 +792,7 @@ func TestFishVFSFindDuplicates(t *testing.T) {
 		"different.txt":    "the same lengthX\n",
 		"alone.txt":        "on its own\n",
 	} {
-		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -829,7 +829,7 @@ func TestFishVFSPatchFile(t *testing.T) {
 	src := filepath.Join(dir, "original.txt")
 	dst := filepath.Join(dir, "rebuilt.txt")
 	body := []byte("the quick brown fox jumps over the lazy dog")
-	if err := os.WriteFile(src, body, 0644); err != nil {
+	if err := os.WriteFile(src, body, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -859,13 +859,13 @@ func TestFishVFSFindFiles(t *testing.T) {
 	ctx := context.Background()
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "nested dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "nested dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("needle here\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "top.txt"), []byte("needle here\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "nested dir", "deep.txt"), []byte("nothing\n"), 0755); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "nested dir", "deep.txt"), []byte("nothing\n"), 0700); err != nil { // #nosec G306 -- result mapping of an executable file is the behavior under test.
 		t.Fatal(err)
 	}
 
@@ -915,7 +915,7 @@ func TestFishVFSServerSideCopyAndMove(t *testing.T) {
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "source.txt")
 	content := []byte("Hello Server-Side Copy/Move")
-	if err := os.WriteFile(srcPath, content, 0644); err != nil {
+	if err := os.WriteFile(srcPath, content, 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/netfox/fishplus/exec_test.go
+++ b/plugins/netfox/fishplus/exec_test.go
@@ -16,7 +16,7 @@ func TestRunAgainstLocalShell(t *testing.T) {
 	}
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "marker.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/netfox/fishplus/fs_test.go
+++ b/plugins/netfox/fishplus/fs_test.go
@@ -334,13 +334,13 @@ func TestListingAgainstLocalShell(t *testing.T) {
 	ctx := context.Background()
 
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "a file.txt"), []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "a file.txt"), []byte("hello"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, ".hidden"), []byte("0123456789"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "sub dir"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "sub dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink("sub dir", filepath.Join(dir, "link to dir")); err != nil {
@@ -381,8 +381,8 @@ func TestListingAgainstLocalShell(t *testing.T) {
 			if !file.IsRegular() {
 				t.Errorf("Mode = %o, want a regular file", file.Mode)
 			}
-			if file.Perm() != 0644 {
-				t.Errorf("Perm = %o, want 644", file.Perm())
+			if file.Perm() != 0600 {
+				t.Errorf("Perm = %o, want 600", file.Perm())
 			}
 			if time.Since(file.MTime) > time.Hour || time.Since(file.MTime) < -time.Hour {
 				t.Errorf("MTime = %v, which is nowhere near now", file.MTime)
@@ -451,10 +451,10 @@ func TestTargetDirsAgainstLocalShell(t *testing.T) {
 	dir := t.TempDir()
 	targetDir := filepath.Join(dir, "target dir")
 	targetFile := filepath.Join(dir, "target file")
-	if err := os.Mkdir(targetDir, 0755); err != nil {
+	if err := os.Mkdir(targetDir, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(targetFile, []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(targetFile, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	dirLink := filepath.Join(dir, "directory link")
@@ -486,7 +486,7 @@ func TestListingSurvivesWeirdNames(t *testing.T) {
 	dir := t.TempDir()
 	names := []string{"trailing space ", "back\\slash", "tab\there", "юникод", "-dash", "~tilde"}
 	for _, name := range names {
-		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0600); err != nil {
 			t.Skipf("cannot create %q here: %v", name, err)
 		}
 	}

--- a/plugins/netfox/fishplus/hash_test.go
+++ b/plugins/netfox/fishplus/hash_test.go
@@ -16,7 +16,7 @@ func TestHashAgainstLocalShell(t *testing.T) {
 	}
 
 	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, "sub dir"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "sub dir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	files := map[string]string{
@@ -26,7 +26,7 @@ func TestHashAgainstLocalShell(t *testing.T) {
 		"alone.txt":        "on its own\n",
 	}
 	for name, body := range files {
-		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/plugins/netfox/fishplus/job_test.go
+++ b/plugins/netfox/fishplus/job_test.go
@@ -105,7 +105,7 @@ func scanTree(t *testing.T) string {
 	t.Helper()
 	root := filepath.Join(t.TempDir(), "tree")
 	sub := filepath.Join(root, "a sub dir")
-	if err := os.MkdirAll(filepath.Join(sub, "deeper"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(sub, "deeper"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	files := []struct {
@@ -117,7 +117,7 @@ func scanTree(t *testing.T) string {
 		{filepath.Join(sub, "deeper", "smallest"), 7},
 	}
 	for _, f := range files {
-		if err := os.WriteFile(f.name, make([]byte, f.size), 0644); err != nil {
+		if err := os.WriteFile(f.name, make([]byte, f.size), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -176,12 +176,12 @@ func bigTree(t *testing.T) string {
 	root := filepath.Join(t.TempDir(), "big")
 	for i := 0; i < 10; i++ {
 		dir := filepath.Join(root, "d"+strconv.Itoa(i))
-		if err := os.MkdirAll(dir, 0755); err != nil {
+		if err := os.MkdirAll(dir, 0700); err != nil {
 			t.Fatal(err)
 		}
 		for j := 0; j < 300; j++ {
 			name := filepath.Join(dir, "f"+strconv.Itoa(j)+".txt")
-			if err := os.WriteFile(name, make([]byte, j%16), 0644); err != nil {
+			if err := os.WriteFile(name, make([]byte, j%16), 0600); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -343,7 +343,7 @@ func TestScanFailureIsReported(t *testing.T) {
 		t.Skip("this host cannot run scan jobs")
 	}
 	file := filepath.Join(t.TempDir(), "not a directory.txt")
-	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	_, err := c.Scan(ctx, file, nil)

--- a/plugins/netfox/fishplus/mutate_test.go
+++ b/plugins/netfox/fishplus/mutate_test.go
@@ -27,7 +27,7 @@ func TestMutationsAgainstLocalShell(t *testing.T) {
 	}
 
 	file := filepath.Join(nested, "a file.txt")
-	if err := os.WriteFile(file, []byte("hello"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("hello"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	moved := filepath.Join(root, "one two", "moved file.txt")
@@ -78,7 +78,7 @@ func TestMutationsAgainstLocalShell(t *testing.T) {
 	if err := c.MkDir(ctx, deep); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(deep, "leaf"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(deep, "leaf"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.RemoveAll(ctx, filepath.Join(root, "tree")); err != nil {
@@ -95,7 +95,7 @@ func TestMutationsRequireSafePaths(t *testing.T) {
 	dir := t.TempDir()
 
 	victim := filepath.Join(dir, "victim.txt")
-	if err := os.WriteFile(victim, []byte("keep me"), 0644); err != nil {
+	if err := os.WriteFile(victim, []byte("keep me"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -132,7 +132,7 @@ func TestMutationsRequireSafePaths(t *testing.T) {
 	// A name that merely starts with dots is not a ".." component and must
 	// stay usable, or the guard has grown too wide.
 	dotty := filepath.Join(dir, "..hidden")
-	if err := os.WriteFile(dotty, []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(dotty, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Chmod(ctx, dotty, 0600); err != nil {
@@ -158,7 +158,7 @@ func TestChownAgainstLocalShell(t *testing.T) {
 	c := newLocalShellClient(t)
 	ctx := context.Background()
 	file := filepath.Join(t.TempDir(), "owned file")
-	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if !c.Session().Features().Has("chown") {
@@ -234,7 +234,7 @@ func TestChtimesOnSimulatedBSDHost(t *testing.T) {
 		"date": "#!/bin/sh\ncase $1 in\n -r) shift; e=$1; shift\n  out=`" + realDate + " -d \"@$e\" \"$@\" 2>/dev/null` || out=`" + realDate + " -r \"$e\" \"$@\" 2>/dev/null`\n  [ -n \"$out\" ] || exit 1\n  echo \"$out\"; exit 0 ;;\n -d) exit 1 ;;\nesac\nexec " + realDate + " \"$@\"\n",
 	}
 	for name, body := range stubs {
-		if err := os.WriteFile(filepath.Join(bin, name), []byte(body), 0755); err != nil {
+		if err := os.WriteFile(filepath.Join(bin, name), []byte(body), 0700); err != nil { // #nosec G306 -- these command stubs must be executable via PATH.
 			t.Fatal(err)
 		}
 	}
@@ -249,7 +249,7 @@ func checkChtimes(t *testing.T, c *Client) {
 	t.Helper()
 	ctx := context.Background()
 	file := filepath.Join(t.TempDir(), "timed file")
-	if err := os.WriteFile(file, []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(file, []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if !c.Session().Features().Has("touch") {
@@ -323,7 +323,7 @@ func TestSymlinkAgainstLocalShell(t *testing.T) {
 		t.Skip("no ln on this machine")
 	}
 
-	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("hi"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "target.txt"), []byte("hi"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -386,7 +386,7 @@ func TestSymlinkAgainstLocalShell(t *testing.T) {
 	// Including when it is a directory, which is the case where ln would
 	// otherwise put the link inside it instead of failing.
 	dir := filepath.Join(root, "a dir")
-	if err := os.Mkdir(dir, 0755); err != nil {
+	if err := os.Mkdir(dir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := c.Symlink(ctx, dir, "target.txt"); err == nil {

--- a/plugins/netfox/fishplus/patch_test.go
+++ b/plugins/netfox/fishplus/patch_test.go
@@ -3,7 +3,6 @@ package fishplus
 import (
 	"bytes"
 	"context"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,10 +17,10 @@ func TestPatchAgainstLocalShell(t *testing.T) {
 
 	dir := t.TempDir()
 	old := make([]byte, 200000)
-	rand.New(rand.NewSource(5)).Read(old)
+	fillDeterministicBytes(t, 5, old)
 	src := filepath.Join(dir, "an old file.bin")
 	dst := filepath.Join(dir, "new one.bin")
-	if err := os.WriteFile(src, old, 0644); err != nil {
+	if err := os.WriteFile(src, old, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -51,7 +50,7 @@ func TestPatchAgainstLocalShell(t *testing.T) {
 			// Insertion, deletion and reordering at once, with a literal
 			// larger than one chunk so that the splitting is exercised.
 			blob := make([]byte, 70000)
-			rand.New(rand.NewSource(9)).Read(blob)
+			fillDeterministicBytes(t, 9, blob)
 			err = c.Patch(ctx, src, dst, []PatchSegment{
 				Copy(50000, 10000), Literal(blob), Copy(0, 1), Copy(199999, 1),
 			})

--- a/plugins/netfox/fishplus/random_fixture_test.go
+++ b/plugins/netfox/fishplus/random_fixture_test.go
@@ -1,0 +1,19 @@
+package fishplus
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func fillDeterministicBytes(t *testing.T, seed int64, dst []byte) *rand.Rand {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed)) // #nosec G404 -- fixed seeds make binary transfer fixtures reproducible; the bytes have no security purpose.
+	n, err := rng.Read(dst)
+	if err != nil {
+		t.Fatalf("generate deterministic fixture: %v", err)
+	}
+	if n != len(dst) {
+		t.Fatalf("generated %d deterministic fixture bytes, want %d", n, len(dst))
+	}
+	return rng
+}

--- a/plugins/netfox/fishplus/read_test.go
+++ b/plugins/netfox/fishplus/read_test.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,14 +74,13 @@ func TestReadAgainstLocalShell(t *testing.T) {
 	// Keep the length odd. Plain dd must not fall back to bs=1 when a read
 	// reaches EOF merely because the final byte count has no useful divisor.
 	blob := make([]byte, 300001)
-	rng := rand.New(rand.NewSource(7))
-	rng.Read(blob)
+	rng := fillDeterministicBytes(t, 7, blob)
 	blobPath := filepath.Join(dir, "a blob.bin")
-	if err := os.WriteFile(blobPath, blob, 0644); err != nil {
+	if err := os.WriteFile(blobPath, blob, 0600); err != nil {
 		t.Fatal(err)
 	}
 	emptyPath := filepath.Join(dir, "empty")
-	if err := os.WriteFile(emptyPath, nil, 0644); err != nil {
+	if err := os.WriteFile(emptyPath, nil, 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -185,9 +183,9 @@ func TestFileReadAtAndCache(t *testing.T) {
 	ctx := context.Background()
 	dir := t.TempDir()
 	blob := make([]byte, 200000)
-	rand.New(rand.NewSource(11)).Read(blob)
+	fillDeterministicBytes(t, 11, blob)
 	p := filepath.Join(dir, "handle.bin")
-	if err := os.WriteFile(p, blob, 0644); err != nil {
+	if err := os.WriteFile(p, blob, 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/plugins/netfox/fishplus/search_test.go
+++ b/plugins/netfox/fishplus/search_test.go
@@ -50,7 +50,7 @@ func TestGrepAgainstLocalShell(t *testing.T) {
 	content := body.String()
 
 	file := filepath.Join(t.TempDir(), "a big log.txt")
-	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(file, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -139,7 +139,7 @@ func TestLinesAgainstLocalShell(t *testing.T) {
 	content := body.String()
 	dir := t.TempDir()
 	file := filepath.Join(dir, "a log.txt")
-	if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(file, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -192,7 +192,7 @@ func TestLinesAgainstLocalShell(t *testing.T) {
 	}
 
 	empty := filepath.Join(dir, "empty")
-	if err := os.WriteFile(empty, nil, 0644); err != nil {
+	if err := os.WriteFile(empty, nil, 0600); err != nil {
 		t.Fatal(err)
 	}
 	if idx, err = c.Lines(ctx, empty, 1, 10); err != nil {
@@ -235,7 +235,7 @@ func TestFindAgainstLocalShell(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 
-	if err := os.MkdirAll(filepath.Join(root, "sub dir", "deeper"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(root, "sub dir", "deeper"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	files := map[string]string{
@@ -246,7 +246,7 @@ func TestFindAgainstLocalShell(t *testing.T) {
 		"sub dir/skip me.bin":  "hello binary\n",
 	}
 	for name, body := range files {
-		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/plugins/netfox/fishplus/session_pwsh_test.go
+++ b/plugins/netfox/fishplus/session_pwsh_test.go
@@ -178,7 +178,7 @@ func TestHelperAgainstLocalPwshEnumAndRead(t *testing.T) {
 	// carries the length, the read brings back the bytes.
 	const body = "one two three\nfour five six\n"
 	fp := filepath.Join(dir, "sample.txt")
-	if err := os.WriteFile(fp, []byte(body), 0644); err != nil {
+	if err := os.WriteFile(fp, []byte(body), 0600); err != nil {
 		t.Fatalf("write sample: %v", err)
 	}
 
@@ -292,16 +292,16 @@ func TestHelperAgainstLocalPwshFind(t *testing.T) {
 	}
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "subdir")
-	if err := os.MkdirAll(sub, 0755); err != nil {
+	if err := os.MkdirAll(sub, 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "one.txt"), []byte("needle here\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "one.txt"), []byte("needle here\n"), 0600); err != nil {
 		t.Fatalf("write one: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sub, "two.txt"), []byte("other text\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(sub, "two.txt"), []byte("other text\n"), 0600); err != nil {
 		t.Fatalf("write two: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sub, "skip.bin"), []byte("needle binary\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(sub, "skip.bin"), []byte("needle binary\n"), 0600); err != nil {
 		t.Fatalf("write skip: %v", err)
 	}
 

--- a/plugins/netfox/fishplus/write_test.go
+++ b/plugins/netfox/fishplus/write_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -162,7 +161,7 @@ func TestWriteAgainstLocalShell(t *testing.T) {
 	}
 
 	blob := make([]byte, 200000)
-	rand.New(rand.NewSource(11)).Read(blob)
+	fillDeterministicBytes(t, 11, blob)
 
 	tried := 0
 	for _, mode := range WriteModes {
@@ -188,18 +187,25 @@ func TestWriteAgainstLocalShell(t *testing.T) {
 				t.Fatalf("file mismatch: got %d bytes, want %d", len(got), len(blob))
 			}
 
-			patches := [][2]int64{{0, 1}, {1, 1}, {65535, 3}, {65536, 65536}, {12345, 4321}, {199999, 1}}
+			patches := []struct {
+				offset  int64
+				length  int
+				pattern byte
+			}{
+				{0, 1, 0}, {1, 1, 1}, {65535, 3, 255}, {65536, 65536, 0}, {12345, 4321, 57}, {199999, 1, 63},
+			}
 			want := append([]byte(nil), blob...)
 			for _, p := range patches {
-				off, length := p[0], p[1]
-				data := make([]byte, length)
+				data := make([]byte, p.length)
+				var indexByte byte
 				for i := range data {
-					data[i] = byte(off) ^ byte(i)
+					data[i] = p.pattern ^ indexByte
+					indexByte++
 				}
-				if err := c.Write(ctx, file, off, data); err != nil {
-					t.Fatalf("write %d+%d: %v", off, length, err)
+				if err := c.Write(ctx, file, p.offset, data); err != nil {
+					t.Fatalf("write %d+%d: %v", p.offset, p.length, err)
 				}
-				copy(want[off:], data)
+				copy(want[p.offset:], data)
 			}
 			if got, err = os.ReadFile(file); err != nil {
 				t.Fatal(err)
@@ -307,7 +313,7 @@ func TestWriteErrorsKeepSessionUsable(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()
 	dir := filepath.Join(root, "a directory")
-	if err := os.Mkdir(dir, 0755); err != nil {
+	if err := os.Mkdir(dir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	payload := bytes.Repeat([]byte("payload "), 1000)
@@ -356,7 +362,7 @@ func TestTruncateAgainstLocalShell(t *testing.T) {
 		t.Errorf("size = %d, want 0", info.Size())
 	}
 
-	if err := os.WriteFile(file, bytes.Repeat([]byte("x"), 100), 0644); err != nil {
+	if err := os.WriteFile(file, bytes.Repeat([]byte("x"), 100), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if c.Session().Features().Has("truncate") {

--- a/plugins/netfox/plugin_contributions_test.go
+++ b/plugins/netfox/plugin_contributions_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -168,7 +169,7 @@ func TestNetFoxPluginRegistersContextualPanelCommands(t *testing.T) {
 
 func TestNetFoxPluginCommandRegistrationFailureRollsBackBeforeLegacySideEffects(t *testing.T) {
 	for failAt := 1; failAt <= 2; failAt++ {
-		t.Run(string(rune('0'+failAt)), func(t *testing.T) {
+		t.Run(strconv.Itoa(failAt), func(t *testing.T) {
 			host := &netFoxPluginTestHost{failAtCall: failAt}
 			plugin := &NetFoxPlugin{}
 			if err := plugin.Init(host); err == nil {

--- a/plugins/visren/dialog_test.go
+++ b/plugins/visren/dialog_test.go
@@ -136,9 +136,9 @@ func TestPreviewShowsAndOperatesScrollbarWhenRowsOverflow(t *testing.T) {
 	scr.AllocBuf(80, 25)
 	d.preview.Show(scr)
 	if got := scr.GetCell(d.preview.X2, d.preview.Y1).Char; got != vtui.ScrollUpArrow {
-		t.Fatalf("scrollbar top char=%q, want %q", rune(got), rune(vtui.ScrollUpArrow))
+		t.Fatalf("scrollbar top char=%#x, want %#x", got, vtui.ScrollUpArrow)
 	}
-	down := &vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: int16(d.preview.X2), MouseY: int16(d.preview.Y2), ButtonState: vtinput.FromLeft1stButtonPressed}
+	down := &vtinput.InputEvent{Type: vtinput.MouseEventType, KeyDown: true, MouseX: visrenMouseCoordinate(d.preview.X2), MouseY: visrenMouseCoordinate(d.preview.Y2), ButtonState: vtinput.FromLeft1stButtonPressed}
 	if !d.preview.ProcessMouse(down) {
 		t.Fatal("scrollbar down arrow click was not handled")
 	}
@@ -155,6 +155,10 @@ func TestPreviewShowsAndOperatesScrollbarWhenRowsOverflow(t *testing.T) {
 	if got, want := d.preview.divider, d.preview.contentWidth()/2; got != want {
 		t.Fatalf("divider=%d, want %d after scrollbar disappeared", got, want)
 	}
+}
+
+func visrenMouseCoordinate(value int) int16 {
+	return int16(value) // #nosec G115 -- this test dialog is allocated inside an 80x25 screen.
 }
 
 func TestPreviewHighlightsSearchMatchesInSourceColumn(t *testing.T) {

--- a/plugins/visren/metadata_test.go
+++ b/plugins/visren/metadata_test.go
@@ -45,12 +45,12 @@ func TestReadID3v2OverridesV1(t *testing.T) {
 		payload := append([]byte{3}, []byte(value)...)
 		buf := make([]byte, 10+len(payload))
 		copy(buf[:4], id)
-		binary.BigEndian.PutUint32(buf[4:8], uint32(len(payload)))
+		binary.BigEndian.PutUint32(buf[4:8], id3FixtureUint32(len(payload)))
 		copy(buf[10:], payload)
 		return buf
 	}
 	body := append(frame("TIT2", "V2 title"), frame("TRCK", "03/12")...)
-	header := []byte{'I', 'D', '3', 3, 0, 0, byte(len(body) >> 21), byte(len(body) >> 14), byte(len(body) >> 7), byte(len(body))}
+	header := []byte{'I', 'D', '3', 3, 0, 0, id3FixtureByte(len(body) >> 21), id3FixtureByte(len(body) >> 14), id3FixtureByte(len(body) >> 7), id3FixtureByte(len(body))}
 	data := append(header, body...)
 	padding := make([]byte, 128)
 	copy(padding[:3], "TAG")
@@ -68,6 +68,14 @@ func TestReadID3v2OverridesV1(t *testing.T) {
 	if meta.Title != "V2 title" || meta.Track != "03" || meta.Artist != "" {
 		t.Fatalf("metadata=%+v", meta)
 	}
+}
+
+func id3FixtureUint32(value int) uint32 {
+	return uint32(value) // #nosec G115 -- ID3 test frames are bounded well below the format's uint32 size field.
+}
+
+func id3FixtureByte(value int) byte {
+	return byte(value) // #nosec G115 -- callers pass seven-bit chunks from the small ID3 test body.
 }
 
 func TestReadImageDimensionsAndDate(t *testing.T) {

--- a/tools/hardcode/hardcode_test.go
+++ b/tools/hardcode/hardcode_test.go
@@ -9,10 +9,10 @@ import (
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
 	}
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
 }

--- a/vfs/os_vfs_contract_coverage_test.go
+++ b/vfs/os_vfs_contract_coverage_test.go
@@ -122,7 +122,7 @@ func TestOSVFSLinksAndDirectoryChunkDelivery(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, ".hidden"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(filepath.Join(root, "file-0000"), 0700); err != nil {
+	if err := os.Chmod(filepath.Join(root, "file-0000"), 0700); err != nil { // #nosec G302 -- executable detection is the behavior under test.
 		t.Fatal(err)
 	}
 

--- a/vfs/os_vfs_physical_test.go
+++ b/vfs/os_vfs_physical_test.go
@@ -58,7 +58,7 @@ func TestFillPhysicalSize_RealFile(t *testing.T) {
 	if _, err := rand.Read(buf); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(path, buf, 0644); err != nil {
+	if err := os.WriteFile(path, buf, 0600); err != nil {
 		t.Fatal(err)
 	}
 	v := NewOSVFS(tmp)

--- a/vfs/os_vfs_search_test.go
+++ b/vfs/os_vfs_search_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestOSVFSFindFilesOptions(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, "nested"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(root, "nested"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	files := map[string]string{
@@ -20,7 +20,7 @@ func TestOSVFSFindFilesOptions(t *testing.T) {
 		"nested/empty.dat": "",
 	}
 	for name, content := range files {
-		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/vfs/os_vfs_symlink_test.go
+++ b/vfs/os_vfs_symlink_test.go
@@ -9,7 +9,7 @@ import (
 func TestOSVFS_SymlinkPreservation(t *testing.T) {
 	tmpDir := t.TempDir()
 	realDir := filepath.Join(tmpDir, "real_dir")
-	if err := os.MkdirAll(realDir, 0755); err != nil {
+	if err := os.MkdirAll(realDir, 0700); err != nil {
 		t.Fatalf("Failed to create real directory: %v", err)
 	}
 

--- a/vfs/os_vfs_test.go
+++ b/vfs/os_vfs_test.go
@@ -95,7 +95,7 @@ func TestOSVFS_Symlinks(t *testing.T) {
 
 	// 1. Create a real directory
 	targetDir := filepath.Join(tmpDir, "real_folder")
-	if err := os.Mkdir(targetDir, 0755); err != nil {
+	if err := os.Mkdir(targetDir, 0700); err != nil {
 		t.Fatalf("Failed to create target directory: %v", err)
 	}
 
@@ -218,7 +218,7 @@ func TestOSVFS_SetPath_Validation(t *testing.T) {
 
 	// 1. Existing dir -> Success
 	sub := filepath.Join(tmpDir, "exist")
-	if err := os.Mkdir(sub, 0755); err != nil {
+	if err := os.Mkdir(sub, 0700); err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 	if err := v.SetPath(sub); err != nil {
@@ -243,7 +243,7 @@ func TestOSVFS_Abs_Consistency(t *testing.T) {
 	// Test that Abs is relative to the VFS path, not process CWD
 	tmp := t.TempDir()
 	vfsPath := filepath.Join(tmp, "vfs_root")
-	if err := os.Mkdir(vfsPath, 0755); err != nil {
+	if err := os.Mkdir(vfsPath, 0700); err != nil {
 		t.Fatalf("Failed to create VFS root: %v", err)
 	}
 
@@ -264,7 +264,7 @@ func TestOSVFS_Abs_CWD_Independence(t *testing.T) {
 	// Create a folder structure: /tmp/root/subdir
 	tmp := t.TempDir()
 	vfsRoot := filepath.Join(tmp, "vfs_root")
-	if err := os.MkdirAll(vfsRoot, 0755); err != nil {
+	if err := os.MkdirAll(vfsRoot, 0700); err != nil {
 		t.Fatalf("Failed to create VFS root: %v", err)
 	}
 
@@ -289,7 +289,7 @@ func TestOSVFS_Abs_CWD_Independence(t *testing.T) {
 func TestOSVFS_SetPath_Relative(t *testing.T) {
 	tmpDir := t.TempDir()
 	subDir := "my_sub_folder"
-	if err := os.Mkdir(filepath.Join(tmpDir, subDir), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpDir, subDir), 0700); err != nil {
 		t.Fatalf("Failed to create subdirectory: %v", err)
 	}
 

--- a/vfs/patch_inplace_test.go
+++ b/vfs/patch_inplace_test.go
@@ -18,7 +18,7 @@ func TestPatchInPlace_RejectsWithoutWriting(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.txt")
 	const original = "hello world\n"
-	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(original), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -49,7 +49,7 @@ func TestPatchInPlace_RejectsWithoutWriting(t *testing.T) {
 func TestPatchInPlace_AppliesSameLengthEdits(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.txt")
-	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("hello world\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +75,7 @@ func TestPatchInPlace_AppliesSameLengthEdits(t *testing.T) {
 func TestPatchInPlace_TruncatesShorterReplacement(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "file.txt")
-	if err := os.WriteFile(path, []byte("aGVsbG8gd29ybGQ=\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("aGVsbG8gd29ybGQ=\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/vfs/scanner_test.go
+++ b/vfs/scanner_test.go
@@ -81,7 +81,7 @@ func TestGenericScan_Recursive(t *testing.T) {
 
 	rootDir := filepath.Join(tmpDir, "root_dir")
 	subDir := filepath.Join(rootDir, "sub_dir")
-	if err := os.MkdirAll(subDir, 0755); err != nil {
+	if err := os.MkdirAll(subDir, 0700); err != nil {
 		t.Fatalf("Failed to create scan directories: %v", err)
 	}
 
@@ -131,7 +131,7 @@ func TestGenericScan_Cancellation(t *testing.T) {
 	tmpDir := t.TempDir()
 	v := NewOSVFS(tmpDir)
 
-	if err := os.MkdirAll(filepath.Join(tmpDir, "dir1", "dir2", "dir3"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, "dir1", "dir2", "dir3"), 0700); err != nil {
 		t.Fatalf("Failed to create scan tree: %v", err)
 	}
 
@@ -294,13 +294,13 @@ func (m *mockFastVFS) Scan(ctx context.Context, basePath string, names []string,
 func TestGenericScan_SymlinkDirLeafVsFollow(t *testing.T) {
 	tmp := t.TempDir()
 	real := filepath.Join(tmp, "real")
-	if err := os.Mkdir(real, 0755); err != nil {
+	if err := os.Mkdir(real, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(real, "a.bin"), make([]byte, 100), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(real, "a.bin"), make([]byte, 100), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(real, "b.bin"), make([]byte, 50), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(real, "b.bin"), make([]byte, 50), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(real, filepath.Join(tmp, "link")); err != nil {
@@ -359,7 +359,7 @@ func TestGenericScan_FileSymlinkDoesNotDoublePhysical(t *testing.T) {
 	// 64 KiB — big enough that a duplicate contribution is unmistakable
 	// against the noise of a symlink's own inode blocks.
 	const targetSize = 64 * 1024
-	if err := os.WriteFile(target, make([]byte, targetSize), 0644); err != nil {
+	if err := os.WriteFile(target, make([]byte, targetSize), 0600); err != nil {
 		t.Fatal(err)
 	}
 	v := NewOSVFS(tmp)
@@ -402,7 +402,7 @@ func TestGenericScan_FileSymlinkDoesNotDoublePhysical(t *testing.T) {
 func TestGenericScan_HardLinkDedup(t *testing.T) {
 	tmp := t.TempDir()
 	orig := filepath.Join(tmp, "original")
-	if err := os.WriteFile(orig, make([]byte, 8192), 0644); err != nil {
+	if err := os.WriteFile(orig, make([]byte, 8192), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Link(orig, filepath.Join(tmp, "link1")); err != nil {

--- a/vfs/utils_test.go
+++ b/vfs/utils_test.go
@@ -42,7 +42,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 4. Directory should not be runnable
 	subDir := filepath.Join(tmpDir, "folder")
-	if err := os.Mkdir(subDir, 0755); err != nil {
+	if err := os.Mkdir(subDir, 0700); err != nil {
 		t.Fatalf("Failed to create directory: %v", err)
 	}
 	if IsTerminalRunnable(ctx, v, subDir) {
@@ -52,7 +52,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 	// 5. Unix Executable Bit
 	if runtime.GOOS != "windows" {
 		binFile := filepath.Join(tmpDir, "mybin")
-		if err := os.WriteFile(binFile, []byte{0x7f, 'E', 'L', 'F'}, 0755); err != nil {
+		if err := os.WriteFile(binFile, []byte{0x7f, 'E', 'L', 'F'}, 0700); err != nil { // #nosec G306 -- the executable bit is the behavior under test.
 			t.Fatalf("Failed to create executable: %v", err)
 		}
 		if !IsTerminalRunnable(ctx, v, binFile) {


### PR DESCRIPTION
Механическая часть разбора gosec: тесты вне `cmd/f4`.

Файлы-заготовки пишутся с правами `0600`, каталоги `0700`. Исключение — тесты, которые сами проверяют права: там оставлено как было, с пояснением почему.

Преобразования чисел либо исчезли, потому что значение сразу объявлено нужного типа, либо снабжены пояснением, почему переполниться не могут. Голых подавлений без причины нет.

Правила про открытие файла по имени и запуск программы не трогались — они исключаются по всему проекту, для файлового менеджера это его назначение.

**Проверено**

`go build`, `go vet`, полный набор тестов вне `cmd/f4`.