### PR TITLE
gosec: права на заготовки и проверка чисел в тестах cmd/f4

### DIFF
--- a/cmd/f4/action_copyname_parent_test.go
+++ b/cmd/f4/action_copyname_parent_test.go
@@ -50,7 +50,7 @@ func seedPanelForCopyName(t *testing.T, path string) *PanelsFrame {
 
 func TestAction_PanelCopyName_CursorOnFile(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, tmp)
@@ -68,7 +68,7 @@ func TestAction_PanelCopyName_CursorOnFile(t *testing.T) {
 
 func TestAction_PanelCopyName_CopiesCommandLineWhenNotEmpty(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, tmp)
@@ -87,7 +87,7 @@ func TestAction_PanelCopyName_CopiesCommandLineWhenNotEmpty(t *testing.T) {
 
 func TestAction_PanelCopyPath_CursorOnFile(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, tmp)
@@ -107,7 +107,7 @@ func TestAction_PanelCopyPath_CursorOnFile(t *testing.T) {
 func TestAction_PanelCopyPath_CursorOnParentUsesCurrentFolderPath(t *testing.T) {
 	tmp := t.TempDir()
 	inner := filepath.Join(tmp, "some-folder")
-	if err := os.Mkdir(inner, 0755); err != nil {
+	if err := os.Mkdir(inner, 0700); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, inner)
@@ -125,7 +125,7 @@ func TestAction_PanelCopyPath_CursorOnParentUsesCurrentFolderPath(t *testing.T) 
 
 func TestAction_PanelInsertPath_CursorOnFile(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, tmp)
@@ -150,7 +150,7 @@ func TestAction_PanelCopyName_CursorOnParentUsesCurrentFolderName(t *testing.T) 
 	// what the far2l "cursor on .. = current folder name" rule should yield.
 	tmp := t.TempDir()
 	inner := filepath.Join(tmp, "some-folder")
-	if err := os.Mkdir(inner, 0755); err != nil {
+	if err := os.Mkdir(inner, 0700); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedPanelForCopyName(t, inner)

--- a/cmd/f4/action_marked_clipboard_test.go
+++ b/cmd/f4/action_marked_clipboard_test.go
@@ -63,7 +63,7 @@ func seedMarkedPanel(t *testing.T, path string, names []string, markCount int) *
 func TestAction_PanelCopySelectedNames(t *testing.T) {
 	tmp := t.TempDir()
 	for _, n := range []string{"a.txt", "b.txt", "c.txt"} {
-		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -82,7 +82,7 @@ func TestAction_PanelCopySelectedNames(t *testing.T) {
 func TestAction_PanelCopySelectedNames_NoMarkedFallsBackToCursor(t *testing.T) {
 	tmp := t.TempDir()
 	for _, n := range []string{"a.txt", "b.txt"} {
-		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -104,7 +104,7 @@ func TestAction_PanelCopySelectedNames_NoMarkedFallsBackToCursor(t *testing.T) {
 func TestAction_PanelCopySelectedPaths(t *testing.T) {
 	tmp := t.TempDir()
 	for _, n := range []string{"a.txt", "b.txt"} {
-		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tmp, n), []byte("x"), 0600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -125,7 +125,7 @@ func TestAction_PanelCopySelectedPaths(t *testing.T) {
 
 func TestAction_PanelCopySelectedPaths_CursorOnParentUsesCurrentDir(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pf := seedMarkedPanel(t, tmp, []string{"a.txt"}, 0)
@@ -150,7 +150,7 @@ func TestAction_PanelCopySelectedRealPaths_CursorOnParentUsesCurrentDir(t *testi
 	tmp := t.TempDir()
 	realDir := filepath.Join(tmp, "real")
 	linkDir := filepath.Join(tmp, "link")
-	if err := os.Mkdir(realDir, 0755); err != nil {
+	if err := os.Mkdir(realDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(realDir, linkDir); err != nil {
@@ -182,10 +182,10 @@ func TestAction_PanelCopySelectedRealPaths_ResolvesSymlink(t *testing.T) {
 	tmp := t.TempDir()
 	realDir := filepath.Join(tmp, "real")
 	linkDir := filepath.Join(tmp, "link")
-	if err := os.Mkdir(realDir, 0755); err != nil {
+	if err := os.Mkdir(realDir, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(realDir, "target.txt"), []byte("x"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(realDir, "target.txt"), []byte("x"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.Symlink(realDir, linkDir); err != nil {

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -971,7 +971,7 @@ func TestActionCopy_ShiftF5_Prefill(t *testing.T) {
 	// Setup actual existing paths using t.TempDir()
 	tmpDir := t.TempDir()
 	srcPath := filepath.Join(tmpDir, "src")
-	if err := os.MkdirAll(srcPath, 0755); err != nil {
+	if err := os.MkdirAll(srcPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1556,7 +1556,7 @@ func TestSession_OldFileDefaultsWideOff(t *testing.T) {
 	getSessionIniPath = func() string { return filepath.Join(tmpDir, "session.ini") }
 	defer func() { getSessionIniPath = origPathFunc }()
 
-	if err := os.WriteFile(getSessionIniPath(), []byte("[Session]\nActivePanel = 0\n"), 0644); err != nil {
+	if err := os.WriteFile(getSessionIniPath(), []byte("[Session]\nActivePanel = 0\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	LastWidePanel = 1
@@ -2680,7 +2680,7 @@ func TestActionEditFile_DirectoryRedirectsToAttributes(t *testing.T) {
 	tmpDir := t.TempDir()
 	subDirName := "sub_folder"
 	subDirPath := filepath.Join(tmpDir, subDirName)
-	if err := os.Mkdir(subDirPath, 0755); err != nil {
+	if err := os.Mkdir(subDirPath, 0700); err != nil {
 		t.Fatalf("Failed to create sub directory: %v", err)
 	}
 
@@ -2738,10 +2738,10 @@ func TestActionCreateLink_Flow(t *testing.T) {
 
 	srcDir := filepath.Join(tmpDir, "src")
 	dstDir := filepath.Join(tmpDir, "dst")
-	if err := os.MkdirAll(srcDir, 0755); err != nil {
+	if err := os.MkdirAll(srcDir, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
+	if err := os.MkdirAll(dstDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/ansi_parser_sync_test.go
+++ b/cmd/f4/ansi_parser_sync_test.go
@@ -20,7 +20,7 @@ func syncEnv(t *testing.T) (*TerminalView, *AnsiParser, *mockPty) {
 func syncRow(tv *TerminalView, row int) string {
 	var sb strings.Builder
 	for _, c := range tv.Lines[row] {
-		sb.WriteRune(rune(c.Char))
+		sb.WriteRune(testRune(c.Char))
 	}
 	return strings.TrimRight(sb.String(), " ")
 }

--- a/cmd/f4/ansi_parser_test.go
+++ b/cmd/f4/ansi_parser_test.go
@@ -242,7 +242,7 @@ func TestAnsiParser_REP_ECH(t *testing.T) {
 	line := tv.Lines[tv.CursorY]
 	for i := 0; i < 6; i++ {
 		if line[i].Char != 'A' {
-			t.Errorf("REP failed at pos %d: expected 'A', got %c", i, rune(line[i].Char))
+			t.Errorf("REP failed at pos %d: expected 'A', got %c", i, testRune(line[i].Char))
 		}
 	}
 
@@ -251,7 +251,7 @@ func TestAnsiParser_REP_ECH(t *testing.T) {
 	p.Process([]byte("\x1b[3X"))
 	for i := 0; i < 3; i++ {
 		if line[i].Char != ' ' {
-			t.Errorf("ECH failed at pos %d: expected space, got %c", i, rune(line[i].Char))
+			t.Errorf("ECH failed at pos %d: expected space, got %c", i, testRune(line[i].Char))
 		}
 	}
 }
@@ -268,7 +268,7 @@ func TestAnsiParser_SplitUTF8(t *testing.T) {
 
 	p.Process([]byte{0x9F})
 	if tv.Lines[tv.CursorY][0].Char != 'П' {
-		t.Errorf("Parser failed to assemble split UTF-8: expected 'П', got %c", rune(tv.Lines[tv.CursorY][0].Char))
+		t.Errorf("Parser failed to assemble split UTF-8: expected 'П', got %c", testRune(tv.Lines[tv.CursorY][0].Char))
 	}
 }
 func TestAnsiParser_MovementAndErase(t *testing.T) {
@@ -361,7 +361,7 @@ func TestAnsiParser_AdvancedCSI(t *testing.T) {
 	p.Process([]byte("\x1b[2P")) // Delete 2 characters ('2' and '3')
 	// Result should be "145" at index 0, 1, 2 of line 0
 	if tv.Lines[0][1].Char != '4' || tv.Lines[0][2].Char != '5' {
-		t.Errorf("Delete characters failed. Found %c (U+%04X) at [0][1]", rune(tv.Lines[0][1].Char), tv.Lines[0][1].Char)
+		t.Errorf("Delete characters failed. Found %c (U+%04X) at [0][1]", testRune(tv.Lines[0][1].Char), tv.Lines[0][1].Char)
 	}
 
 	// Test Insert Blank Characters (@)
@@ -369,7 +369,7 @@ func TestAnsiParser_AdvancedCSI(t *testing.T) {
 	p.Process([]byte("\x1b[2@")) // Insert 2 blanks at pos 1
 	// Result should be "1  45"
 	if tv.Lines[0][1].Char != ' ' || tv.Lines[0][2].Char != ' ' || tv.Lines[0][3].Char != '4' {
-		t.Errorf("Insert blank characters failed. Found %c at [0][3]", rune(tv.Lines[0][3].Char))
+		t.Errorf("Insert blank characters failed. Found %c at [0][3]", testRune(tv.Lines[0][3].Char))
 	}
 }
 
@@ -900,7 +900,7 @@ func TestAnsiParser_Excision_UTF8_Safety(t *testing.T) {
 	// Completing the sequence: sending 0x9F (second byte of 'П')
 	p.Process([]byte{0x9F})
 	if tv.Lines[tv.CursorY][0].Char != 'П' {
-		t.Errorf("UTF-8 sequence was not correctly assembled after excision. Got: %c", rune(tv.Lines[tv.CursorY][0].Char))
+		t.Errorf("UTF-8 sequence was not correctly assembled after excision. Got: %c", testRune(tv.Lines[tv.CursorY][0].Char))
 	}
 }
 

--- a/cmd/f4/archive_index_test.go
+++ b/cmd/f4/archive_index_test.go
@@ -50,7 +50,7 @@ func TestArchiveIndex_AutoOp(t *testing.T) {
 	oldIdx, _ := tar.GetStandardIndexPath(absOld)
 
 	// Ensure cache directory exists and create dummy index
-	if err := os.MkdirAll(filepath.Dir(oldIdx), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(oldIdx), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(oldIdx, []byte("fake index"), 0600); err != nil {
@@ -119,7 +119,7 @@ func TestArchiveIndex_AutoDelete(t *testing.T) {
 		}
 		abs, _ := v.Abs(name)
 		idx, _ := tar.GetStandardIndexPath(abs)
-		if err := os.MkdirAll(filepath.Dir(idx), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(idx), 0700); err != nil {
 			t.Fatal(err)
 		}
 		if err := os.WriteFile(idx, []byte("idx"), 0600); err != nil {
@@ -134,7 +134,7 @@ func TestArchiveIndex_AutoDelete(t *testing.T) {
 	})
 
 	t.Run("Recursive delete index", func(t *testing.T) {
-		if err := os.MkdirAll(filepath.Join(tmp, "subdir"), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(tmp, "subdir"), 0700); err != nil {
 			t.Fatal(err)
 		}
 		name := "subdir/nested.tar.zst"
@@ -168,7 +168,7 @@ func TestExecuteFileOp_ArchiveIndexMigration(t *testing.T) {
 	}
 	absOld, _ := srcVfs.Abs(name)
 	oldIdx, _ := tar.GetStandardIndexPath(absOld)
-	if err := os.MkdirAll(filepath.Dir(oldIdx), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(oldIdx), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(oldIdx, []byte("index-data"), 0600); err != nil {

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -960,7 +960,7 @@ func TestAttributesDialog_SymlinkToDirectoryIsIdentifiedAsLink(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	targetName := "target-dir"
-	if err := os.Mkdir(filepath.Join(tmpDir, targetName), 0o755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpDir, targetName), 0o700); err != nil {
 		t.Fatalf("create target directory: %v", err)
 	}
 	linkPath := filepath.Join(tmpDir, "link-dir")

--- a/cmd/f4/bookmarks_dialog_test.go
+++ b/cmd/f4/bookmarks_dialog_test.go
@@ -85,7 +85,7 @@ func TestNewBookmarksDialog_LoadFailureReturnsError(t *testing.T) {
 	// A directory where the INI is expected: opening succeeds, reading
 	// does not. The dialog must report that instead of crashing.
 	path := filepath.Join(t.TempDir(), "bookmarks.ini")
-	if err := os.Mkdir(path, 0o755); err != nil {
+	if err := os.Mkdir(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	d, err := newBookmarksDialog(nil, path)

--- a/cmd/f4/bookmarks_test.go
+++ b/cmd/f4/bookmarks_test.go
@@ -13,7 +13,7 @@ func writeTempBookmarks(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "bookmarks.ini")
-	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatalf("write temp: %v", err)
 	}
 	return p

--- a/cmd/f4/child_env_test.go
+++ b/cmd/f4/child_env_test.go
@@ -89,10 +89,10 @@ func TestTerminfoExists(t *testing.T) {
 	}
 
 	// The database keeps an entry under the first letter of its name.
-	if err := os.MkdirAll(filepath.Join(dir, "x"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dir, "x"), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "x", "xterm-kitty"), []byte("x"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "x", "xterm-kitty"), []byte("x"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	if !terminfoExists("xterm-kitty") {
@@ -102,10 +102,10 @@ func TestTerminfoExists(t *testing.T) {
 	// And on some systems under the hexadecimal code of that letter.
 	other := t.TempDir()
 	t.Setenv("TERMINFO", other)
-	if err := os.MkdirAll(filepath.Join(other, "78"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(other, "78"), 0o700); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(other, "78", "xterm-kitty"), []byte("x"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(other, "78", "xterm-kitty"), []byte("x"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	if !terminfoExists("xterm-kitty") {

--- a/cmd/f4/cloudfox_real_archive_test.go
+++ b/cmd/f4/cloudfox_real_archive_test.go
@@ -159,7 +159,7 @@ func loadRealCloudFoxArchiveFixture(t *testing.T) realCloudFoxArchiveFixture {
 	if !strings.EqualFold(filepath.Ext(localPath), ".7z") {
 		t.Fatal("real CloudFox archive fixture must have the .7z extension")
 	}
-	info, err := os.Stat(localPath)
+	info, err := os.Stat(localPath) // #nosec G703 -- this opt-in integration fixture must be an operator-supplied absolute path.
 	if err != nil || !info.Mode().IsRegular() || info.Size() <= 0 {
 		t.Fatal("real CloudFox archive fixture is not an available non-empty regular file")
 	}
@@ -200,7 +200,7 @@ func requireRealCloudFoxArchiveConfigDir(t *testing.T) string {
 	if configDir == "" || !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox archive config directory must be an explicit absolute path")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- this opt-in integration config must be an operator-supplied absolute directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox archive config directory is unavailable")
 	}

--- a/cmd/f4/cloudfox_real_cross_cloud_test.go
+++ b/cmd/f4/cloudfox_real_cross_cloud_test.go
@@ -51,7 +51,7 @@ func TestRealSavedCloudCrossProviderF5(t *testing.T) {
 	if !filepath.IsAbs(configDir) {
 		t.Fatal("real cross-cloud config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- this opt-in integration config must be an operator-supplied absolute directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real cross-cloud config directory is unavailable")
 	}

--- a/cmd/f4/cloudfox_real_large_f5_test.go
+++ b/cmd/f4/cloudfox_real_large_f5_test.go
@@ -52,7 +52,7 @@ func TestRealSavedCloudLargeF5RoundTrip(t *testing.T) {
 	if configDir == "" || !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox large F5 config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- this opt-in integration config must be an operator-supplied absolute directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox large F5 config directory is unavailable")
 	}
@@ -124,7 +124,7 @@ func loadRealCloudFoxLargeF5Fixture(t *testing.T) (string, int64, string) {
 	if fixturePath == "" || !filepath.IsAbs(fixturePath) {
 		t.Fatal("real CloudFox large F5 fixture path must be absolute")
 	}
-	info, err := os.Stat(fixturePath)
+	info, err := os.Stat(fixturePath) // #nosec G703 -- this opt-in integration fixture must be an operator-supplied absolute path.
 	if err != nil || !info.Mode().IsRegular() {
 		t.Fatal("real CloudFox large F5 fixture is unavailable or is not a regular file")
 	}

--- a/cmd/f4/cloudfox_real_ui_test.go
+++ b/cmd/f4/cloudfox_real_ui_test.go
@@ -68,7 +68,7 @@ func TestRealSavedCloudConnectionsUI(t *testing.T) {
 	if !filepath.IsAbs(configDir) {
 		t.Fatal("real CloudFox UI config directory must be absolute")
 	}
-	info, err := os.Stat(configDir)
+	info, err := os.Stat(configDir) // #nosec G703 -- this opt-in integration config must be an operator-supplied absolute directory.
 	if err != nil || !info.IsDir() {
 		t.Fatal("real CloudFox UI config directory is unavailable")
 	}

--- a/cmd/f4/colorer_plugin_test.go
+++ b/cmd/f4/colorer_plugin_test.go
@@ -23,16 +23,16 @@ func TestColorer_EnsureRadiolaSchema(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	baseDir := filepath.Join(tmpDir, "base")
-	_ = os.MkdirAll(baseDir, 0755)
-	_ = os.WriteFile(filepath.Join(baseDir, "catalog.xml"), []byte("<catalog/>"), 0644)
+	_ = os.MkdirAll(baseDir, 0700)
+	_ = os.WriteFile(filepath.Join(baseDir, "catalog.xml"), []byte("<catalog/>"), 0600)
 
 	hrdDir := filepath.Join(baseDir, "hrd")
-	_ = os.MkdirAll(hrdDir, 0755)
+	_ = os.MkdirAll(hrdDir, 0700)
 
 	catalogRGBContent := `        <hrd class="rgb" name="default" description="far2l default">
             <location link="&hrd;/rgb/default.hrd"/>
         </hrd>`
-	_ = os.WriteFile(filepath.Join(hrdDir, "catalog-rgb.xml"), []byte(catalogRGBContent), 0644)
+	_ = os.WriteFile(filepath.Join(hrdDir, "catalog-rgb.xml"), []byte(catalogRGBContent), 0600)
 
 	ensureRadiolaSchema(tmpDir)
 
@@ -317,7 +317,7 @@ Loop:
 
 func TestColorer_StagedInstallRejectsTraversalAndPreservesExistingTree(t *testing.T) {
 	dest := filepath.Join(t.TempDir(), "colorer", "configs")
-	if err := os.MkdirAll(filepath.Join(dest, "base"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(dest, "base"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	catalog := filepath.Join(dest, "base", "catalog.xml")

--- a/cmd/f4/colorer_settings_test.go
+++ b/cmd/f4/colorer_settings_test.go
@@ -72,10 +72,10 @@ func TestColorerSchemasExist_FollowsTheConfiguredCatalog(t *testing.T) {
 	if SchemasExist() {
 		t.Fatal("Expected no schemas in an empty folder")
 	}
-	if err := os.MkdirAll(filepath.Join(custom, "base"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(custom, "base"), 0700); err != nil {
 		t.Fatalf("Cannot create the fixture directory: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(custom, "base", "catalog.xml"), []byte("<catalog/>"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(custom, "base", "catalog.xml"), []byte("<catalog/>"), 0600); err != nil {
 		t.Fatalf("Cannot write the catalog: %v", err)
 	}
 	if !SchemasExist() {

--- a/cmd/f4/colors_test.go
+++ b/cmd/f4/colors_test.go
@@ -68,7 +68,7 @@ CommandLine.Prompt = foreground:#00FF00
 CommandLine.UserScreen = foreground:#D0D0D0 | background:#010203
 Editor.Text = foreground:#A0A0A0 | background:#232323
 `
-	if err := os.WriteFile(iniPath, []byte(iniContent), 0644); err != nil {
+	if err := os.WriteFile(iniPath, []byte(iniContent), 0600); err != nil {
 		t.Fatalf("Failed to write mock INI: %v", err)
 	}
 
@@ -230,7 +230,7 @@ func TestColors_AliasesAndCanonicalPrecedence(t *testing.T) {
 CommandLine.Prompt = foreground:#FF0000
 CommandLine.Prefix = foreground:#00FF00
 `
-	if err := os.WriteFile(iniPath, []byte(iniContent), 0644); err != nil {
+	if err := os.WriteFile(iniPath, []byte(iniContent), 0600); err != nil {
 		t.Fatalf("Failed to write mock INI: %v", err)
 	}
 
@@ -279,7 +279,7 @@ func TestColors_GenerateDocumentation(t *testing.T) {
 	if os.Getenv("F4_GENERATE_DOCS") != "1" {
 		targetPath = filepath.Join(t.TempDir(), "COLORS.md")
 	}
-	_ = os.WriteFile(targetPath, []byte(sb.String()), 0644)
+	_ = os.WriteFile(targetPath, []byte(sb.String()), 0600)
 }
 func TestColors_ContrastCorrection(t *testing.T) {
 	// Dark grey on black is well below the ΔE2000 floor far2l enforces, so the

--- a/cmd/f4/command_palette_ui_test.go
+++ b/cmd/f4/command_palette_ui_test.go
@@ -167,7 +167,7 @@ func TestCommandPaletteMouseScrollRefreshesDescriptionAndHeaderClickIsConsumed(t
 		t.Fatalf("initial description = %q", got)
 	}
 	if !dialog.ProcessMouse(&vtinput.InputEvent{
-		Type: vtinput.MouseEventType, MouseX: int16(dialog.table.X1), MouseY: int16(dialog.table.Y1 + 1),
+		Type: vtinput.MouseEventType, MouseX: testInt16(dialog.table.X1), MouseY: testInt16(dialog.table.Y1 + 1),
 		WheelDirection: -1,
 	}) {
 		t.Fatal("mouse wheel inside the result table was not consumed")
@@ -179,14 +179,14 @@ func TestCommandPaletteMouseScrollRefreshesDescriptionAndHeaderClickIsConsumed(t
 	originalX, originalY := dialog.X1, dialog.Y1
 	if !dialog.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(dialog.table.X1), MouseY: int16(dialog.table.Y1),
+		MouseX: testInt16(dialog.table.X1), MouseY: testInt16(dialog.table.Y1),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) {
 		t.Fatal("table header click was not consumed")
 	}
 	dialog.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(dialog.table.X1 + 5), MouseY: int16(dialog.table.Y1 + 2),
+		MouseX: testInt16(dialog.table.X1 + 5), MouseY: testInt16(dialog.table.Y1 + 2),
 		ButtonState: vtinput.FromLeft1stButtonPressed, MouseEventFlags: vtinput.MouseMoved,
 	})
 	if dialog.X1 != originalX || dialog.Y1 != originalY {

--- a/cmd/f4/config_test.go
+++ b/cmd/f4/config_test.go
@@ -203,7 +203,7 @@ func TestSaveSettingsGroupsKeepUnselectedValues(t *testing.T) {
 		t.Fatal(err)
 	}
 	data = append(data, []byte("\n[ThirdParty]\nKeep=1\n")...)
-	if err := os.WriteFile(settingsPath, data, 0644); err != nil {
+	if err := os.WriteFile(settingsPath, data, 0600); err != nil { // #nosec G703 -- settingsPath is a fixed fixture name beneath t.TempDir().
 		t.Fatal(err)
 	}
 	AppConfig.ColorStyle = "Not persisted"
@@ -465,7 +465,7 @@ func TestConfig_PanelFileInfoDefaultsHiddenWhenKeyIsAbsent(t *testing.T) {
 func TestConfig_ApplyCommandParallelismDefaultsToLogicalCPUs(t *testing.T) {
 	tmpDir := t.TempDir()
 	userIniPath := filepath.Join(tmpDir, "settings.ini")
-	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0o644); err != nil {
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	origPathsFunc := getConfigIniPaths
@@ -482,7 +482,7 @@ func TestConfig_ApplyCommandParallelismDefaultsToLogicalCPUs(t *testing.T) {
 func TestConfig_MinimalPanelScrollbarsByDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 	userIniPath := filepath.Join(tmpDir, "settings.ini")
-	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0644); err != nil {
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -507,7 +507,7 @@ func TestConfig_MinimalPanelScrollbarsByDefault(t *testing.T) {
 func TestConfig_PanelScrollbarBooleanMigration(t *testing.T) {
 	tmpDir := t.TempDir()
 	userIniPath := filepath.Join(tmpDir, "settings.ini")
-	if err := os.WriteFile(userIniPath, []byte("[Panel]\nShowPanelScrollbars = 1\n"), 0644); err != nil {
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\nShowPanelScrollbars = 1\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -531,7 +531,7 @@ func TestConfig_PanelScrollbarBooleanMigration(t *testing.T) {
 func TestConfig_DisabledPanelScrollbarBooleanMigration(t *testing.T) {
 	tmpDir := t.TempDir()
 	userIniPath := filepath.Join(tmpDir, "settings.ini")
-	if err := os.WriteFile(userIniPath, []byte("[Panel]\nShowPanelScrollbars = 0\n"), 0644); err != nil {
+	if err := os.WriteFile(userIniPath, []byte("[Panel]\nShowPanelScrollbars = 0\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -766,7 +766,7 @@ func TestConfig_LayoutRoundTrip(t *testing.T) {
 		"RightHeightDecrement=7\n" +
 		"FullscreenHelp=1\n" +
 		"PanelsDisposition=2\n"
-	if err := os.WriteFile(iniPath, []byte(seed), 0644); err != nil {
+	if err := os.WriteFile(iniPath, []byte(seed), 0600); err != nil {
 		t.Fatalf("write seed: %v", err)
 	}
 

--- a/cmd/f4/editor_binary_open_test.go
+++ b/cmd/f4/editor_binary_open_test.go
@@ -62,7 +62,7 @@ func TestShowEditorBinaryOpensInHex(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sample.bin")
-	if err := os.WriteFile(path, []byte{0, 0, 0, 0x20, 'f', 't', 'y', 'p', 0x0A, 'x'}, 0644); err != nil {
+	if err := os.WriteFile(path, []byte{0, 0, 0, 0x20, 'f', 't', 'y', 'p', 0x0A, 'x'}, 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/editor_find_all_test.go
+++ b/cmd/f4/editor_find_all_test.go
@@ -697,8 +697,8 @@ func TestEditorFindAll_MouseClickJumps(t *testing.T) {
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
 		ButtonState: vtinput.FromLeft1stButtonPressed,
-		MouseX:      int16(x1 + 2),
-		MouseY:      int16(y1 + 2), // second row
+		MouseX:      testInt16(x1 + 2),
+		MouseY:      testInt16(y1 + 2), // second row
 	}
 	if !frame.ProcessMouse(click) {
 		t.Fatal("click on an occurrence was not handled")
@@ -755,7 +755,7 @@ func openMappedFindAllEditor(t *testing.T, content string) *EditorView {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "occurrences.txt")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	ev := openMappedEditor(t, dir, path)
@@ -1017,7 +1017,7 @@ func TestCollectMatchSpans_ReadsTheFileNotTheMapping(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "occurrences.txt")
 	content := strings.Repeat("a line with needle in it\n", 20000)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	ev := openMappedEditor(t, dir, path)

--- a/cmd/f4/editor_mmap_test.go
+++ b/cmd/f4/editor_mmap_test.go
@@ -52,7 +52,7 @@ func TestMappedEditor_SearchAllocatesNothing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "big.txt")
 	content := strings.Repeat("the quick brown fox\n", 200000) // ~4 MB
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -102,7 +102,7 @@ func TestMappedEditor_IndexesWithoutAnAsyncBuffer(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "lines.txt")
 	const lines = 5000
-	if err := os.WriteFile(path, []byte(strings.Repeat("a line of text\n", lines)), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(strings.Repeat("a line of text\n", lines)), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -138,7 +138,7 @@ func TestMappedEditor_EditsAndSaves(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "edit.txt")
-	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("hello world\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -204,7 +204,7 @@ func TestMappedEditor_IndexReadsTheFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "lines.txt")
 	const lines = 20000
-	if err := os.WriteFile(path, []byte(strings.Repeat("a line of text\n", lines)), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(strings.Repeat("a line of text\n", lines)), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -249,7 +249,7 @@ func TestMappedEditor_EditedTextIsScannedFromTheBuffer(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "edited.txt")
 	const lines = 5000
-	if err := os.WriteFile(path, []byte(strings.Repeat("original line\n", lines)), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(strings.Repeat("original line\n", lines)), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -318,7 +318,7 @@ func TestMappedEditor_SwappedBufferIsNotReadFromTheFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "reload.txt")
 	content := strings.Repeat("a line of the file\n", 500)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/editor_save_inplace_test.go
+++ b/cmd/f4/editor_save_inplace_test.go
@@ -49,7 +49,7 @@ func TestEditorSave_InPlacePatchDoesNotRenameAMissingStage(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "aa.txt")
-	if err := os.WriteFile(path, []byte("hello world\nsecond line\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("hello world\nsecond line\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -89,7 +89,7 @@ func TestEditorSave_UnmodifiedBufferCompletes(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "untouched.txt")
 	content := strings.Repeat("line of text\n", 100)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -123,7 +123,7 @@ func TestEditorSave_InsertionStillStages(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "grown.txt")
-	if err := os.WriteFile(path, []byte("hello world\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("hello world\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -156,7 +156,7 @@ func TestEditorSave_ShrinkingEditStillTruncates(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shrunk.txt")
-	if err := os.WriteFile(path, []byte("aGVsbG8gd29ybGQ=\n"), 0644); err != nil {
+	if err := os.WriteFile(path, []byte("aGVsbG8gd29ybGQ=\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/editor_search_lazy_test.go
+++ b/cmd/f4/editor_search_lazy_test.go
@@ -52,7 +52,7 @@ func lazyEditorBuffer(t *testing.T, content string) (*piecetable.PieceTable, *As
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "big.txt")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/cmd/f4/editor_target_line_test.go
+++ b/cmd/f4/editor_target_line_test.go
@@ -70,7 +70,7 @@ func TestEditorView_IndexerRestoresTargetLineAfterLateDrain(t *testing.T) {
 	}
 	dir := t.TempDir()
 	path := filepath.Join(dir, "restore.txt")
-	if err := os.WriteFile(path, []byte(sb.String()), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(sb.String()), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -145,7 +145,7 @@ func TestEditorView_IndexerAppliesTargetLineWhenFileShrank(t *testing.T) {
 	content := "one\ntwo\nthree\n"
 	dir := t.TempDir()
 	path := filepath.Join(dir, "shrank.txt")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -450,7 +450,7 @@ func TestEditorView_SaveFile(t *testing.T) {
 			t.Errorf("remove temporary save file: %v", err)
 		}
 	})
-	err := os.WriteFile(tmpFile, []byte("Original"), 0644)
+	err := os.WriteFile(tmpFile, []byte("Original"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1620,7 +1620,7 @@ func TestViewerView_CodepageSwitch_Crash(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	tmpFile := filepath.Join(t.TempDir(), "test_viewer_cp.txt")
-	err := os.WriteFile(tmpFile, []byte("Hello World\nLine 2\nLine 3"), 0644)
+	err := os.WriteFile(tmpFile, []byte("Hello World\nLine 2\nLine 3"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3113,7 +3113,7 @@ type editorStageModeWriter struct {
 }
 
 func (w *editorStageModeWriter) Write(p []byte) (int, error) {
-	info, err := os.Stat(w.path)
+	info, err := os.Stat(w.path) // #nosec G703 -- the wrapped VFS supplies a generated staging path beneath the test temp directory.
 	if err != nil {
 		return 0, err
 	}
@@ -4847,13 +4847,13 @@ func TestEditorView_ZeroAndDoubleWidthConsistency(t *testing.T) {
 		t.Errorf("Expected cells[0] to be the combining cluster, got %q", got)
 	}
 	if cells[1].Char != '世' {
-		t.Errorf("Expected cells[1] to be '世', got %c", rune(cells[1].Char))
+		t.Errorf("Expected cells[1] to be '世', got %c", testRune(cells[1].Char))
 	}
 	if cells[2].Char != uint64(vtui.WideCharFiller) {
 		t.Errorf("Expected cells[2] to be WideCharFiller, got %d", cells[2].Char)
 	}
 	if cells[3].Char != 'b' {
-		t.Errorf("Expected cells[3] to be 'b', got %c", rune(cells[3].Char))
+		t.Errorf("Expected cells[3] to be 'b', got %c", testRune(cells[3].Char))
 	}
 }
 

--- a/cmd/f4/farmenu_file_test.go
+++ b/cmd/f4/farmenu_file_test.go
@@ -211,7 +211,7 @@ func TestParseFarMenu_UTF32LEWithBOM(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range body {
-		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+		_ = binary.Write(&buf, binary.LittleEndian, testUint32Rune(r))
 	}
 	got, err := ParseFarMenu(&buf)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestParseFarMenu_UTF32LEWithCyrillic(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range body {
-		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+		_ = binary.Write(&buf, binary.LittleEndian, testUint32Rune(r))
 	}
 	got, _ := ParseFarMenu(&buf)
 	if len(got) != 1 || got[0].Label != "Яблоко" {
@@ -245,7 +245,7 @@ func TestParseFarMenu_UTF32BEWithBOM(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range body {
-		_ = binary.Write(&buf, binary.BigEndian, uint32(r))
+		_ = binary.Write(&buf, binary.BigEndian, testUint32Rune(r))
 	}
 	got, _ := ParseFarMenu(&buf)
 	if len(got) != 1 || got[0].HotKey != "a" || got[0].Label != "X" {
@@ -265,7 +265,7 @@ func TestParseFarMenu_UTF32LE_NotMistakenForUTF16LE(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, r := range body {
-		_ = binary.Write(&buf, binary.LittleEndian, uint32(r))
+		_ = binary.Write(&buf, binary.LittleEndian, testUint32Rune(r))
 	}
 	got, _ := ParseFarMenu(&buf)
 	if len(got) != 1 || got[0].Label != "Apple" {

--- a/cmd/f4/file_associations_dispatch_test.go
+++ b/cmd/f4/file_associations_dispatch_test.go
@@ -50,9 +50,9 @@ func setupPanelWithFile(t *testing.T, name string) (*PanelsFrame, *mockPty) {
 	if name != ".." && name != "" {
 		fullPath := filepath.Join(tmpDir, name)
 		if name == "some_subdir" {
-			_ = os.MkdirAll(fullPath, 0755)
+			_ = os.MkdirAll(fullPath, 0700)
 		} else {
-			_ = os.WriteFile(fullPath, []byte("mock"), 0644)
+			_ = os.WriteFile(fullPath, []byte("mock"), 0600)
 		}
 	}
 

--- a/cmd/f4/file_associations_test.go
+++ b/cmd/f4/file_associations_test.go
@@ -157,7 +157,7 @@ Description=Markdown
 Execute=less !.!
 State=1
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	out, err := LoadAssociations(path)
@@ -187,7 +187,7 @@ Edit=
 AltEdit=
 State=5
 `
-	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	out, err := LoadAssociations(path)

--- a/cmd/f4/file_ops_safety_test.go
+++ b/cmd/f4/file_ops_safety_test.go
@@ -71,10 +71,10 @@ func TestRecursiveCopyAbortsWhenDestinationStatIsInconclusive(t *testing.T) {
 			sourceRoot, destinationRoot := t.TempDir(), t.TempDir()
 			sourcePath := filepath.Join(sourceRoot, "source")
 			if directory {
-				if err := os.Mkdir(sourcePath, 0o755); err != nil {
+				if err := os.Mkdir(sourcePath, 0o700); err != nil {
 					t.Fatal(err)
 				}
-			} else if err := os.WriteFile(sourcePath, []byte("content"), 0o644); err != nil {
+			} else if err := os.WriteFile(sourcePath, []byte("content"), 0o600); err != nil {
 				t.Fatal(err)
 			}
 			destinationPath := filepath.Join(destinationRoot, "target")
@@ -203,7 +203,7 @@ func (w *stagedAbortWriter) Write(p []byte) (int, error) {
 
 func (w *stagedAbortWriter) Close() error {
 	w.closeCalls++
-	return os.WriteFile(w.path, w.staged, 0o644)
+	return os.WriteFile(w.path, w.staged, 0o600)
 }
 
 func (w *stagedAbortWriter) Abort() error {
@@ -219,11 +219,11 @@ func TestRecursiveCopyAbortsStagedReplacementAfterSourceReadError(t *testing.T) 
 	sourceRoot, destinationRoot := t.TempDir(), t.TempDir()
 	sourcePath := filepath.Join(sourceRoot, "source.bin")
 	destinationPath := filepath.Join(destinationRoot, "existing.bin")
-	if err := os.WriteFile(sourcePath, []byte("declared source"), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte("declared source"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	const original = "existing destination must survive"
-	if err := os.WriteFile(destinationPath, []byte(original), 0o644); err != nil {
+	if err := os.WriteFile(destinationPath, []byte(original), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	readErr := errors.New("source failed after returning a prefix")
@@ -262,7 +262,7 @@ func TestRecursiveCopySurfacesSourceAndAbortFailures(t *testing.T) {
 	sourceRoot, destinationRoot := t.TempDir(), t.TempDir()
 	sourcePath := filepath.Join(sourceRoot, "source.bin")
 	destinationPath := filepath.Join(destinationRoot, "new.bin")
-	if err := os.WriteFile(sourcePath, []byte("declared source"), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte("declared source"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	readErr := errors.New("source failed after returning a prefix")
@@ -338,7 +338,7 @@ func TestRecursiveCopyResetsProviderProgressThroughProductionStartPath(t *testin
 	first := filepath.Join(sourceRoot, "first.bin")
 	second := filepath.Join(sourceRoot, "second.bin")
 	for _, path := range []string{first, second} {
-		if err := os.WriteFile(path, []byte{'x'}, 0o644); err != nil {
+		if err := os.WriteFile(path, []byte{'x'}, 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -388,7 +388,7 @@ func (w *phaseUploadWriter) Close() error {
 			reporter.UpdateTransfer("Uploading", filepath.Base(w.path), percent, "", percent, "")
 		}
 	}
-	return os.WriteFile(w.path, w.staged, 0o644)
+	return os.WriteFile(w.path, w.staged, 0o600)
 }
 
 func (w *phaseUploadWriter) Abort() error {
@@ -405,7 +405,7 @@ func TestRecursiveCopyWeightsDownloadAndManagedUploadPhases(t *testing.T) {
 	for i := range payload {
 		payload[i] = byte(i)
 	}
-	if err := os.WriteFile(sourcePath, payload, 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	source := &reportingOpenVFS{VFS: vfs.NewOSVFS(sourceRoot), reportPath: sourcePath}
@@ -452,7 +452,7 @@ func TestRecursiveCopyWeightsMaterializedDownloadAndStreamingCloudWrite(t *testi
 	sourcePath := filepath.Join(sourceRoot, "materialized-source.bin")
 	destinationPath := filepath.Join(destinationRoot, "streaming-destination.bin")
 	payload := make([]byte, 100)
-	if err := os.WriteFile(sourcePath, payload, 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	source := &reportingOpenVFS{VFS: vfs.NewOSVFS(sourceRoot), reportPath: sourcePath}
@@ -494,7 +494,7 @@ func TestRecursiveCopyLearnsUnknownMaterializedSizeForManagedPhases(t *testing.T
 	sourcePath := filepath.Join(sourceRoot, "unknown-export.bin")
 	destinationPath := filepath.Join(destinationRoot, "managed-upload.bin")
 	payload := make([]byte, 100)
-	if err := os.WriteFile(sourcePath, payload, 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, payload, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	source := &reportingOpenVFS{VFS: vfs.NewOSVFS(sourceRoot), reportPath: sourcePath, unknownSize: true}
@@ -534,7 +534,7 @@ func TestRecursiveCopyZeroByteManagedUploadWaitsForCommitPhase(t *testing.T) {
 	sourceRoot, destinationRoot := t.TempDir(), t.TempDir()
 	sourcePath := filepath.Join(sourceRoot, "empty.bin")
 	destinationPath := filepath.Join(destinationRoot, "empty.bin")
-	if err := os.WriteFile(sourcePath, nil, 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, nil, 0o600); err != nil {
 		t.Fatal(err)
 	}
 	destination := &fileOpSafetyProbeVFS{
@@ -566,7 +566,7 @@ func TestRecursiveCopyDoesNotDeleteConcurrentDestinationAfterConditionalCloseFai
 	sourceRoot, destinationRoot := t.TempDir(), t.TempDir()
 	sourcePath := filepath.Join(sourceRoot, "source.txt")
 	destinationPath := filepath.Join(destinationRoot, "target.txt")
-	if err := os.WriteFile(sourcePath, []byte("payload"), 0o644); err != nil {
+	if err := os.WriteFile(sourcePath, []byte("payload"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	probe := &fileOpSafetyProbeVFS{

--- a/cmd/f4/file_ops_test.go
+++ b/cmd/f4/file_ops_test.go
@@ -23,7 +23,7 @@ func TestRecursiveCopy(t *testing.T) {
 	// 1. Create source structure:
 	// /folder1/file1.txt
 	// /file2.txt
-	if err := os.Mkdir(filepath.Join(tmpSrc, "folder1"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpSrc, "folder1"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpSrc, "file2.txt"), []byte("file2 content"), 0600); err != nil {
@@ -90,7 +90,7 @@ func TestRecursiveCopy_Cancel(t *testing.T) {
 
 func TestRecursiveCopy_SelfCopy(t *testing.T) {
 	tmp := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmp, "src_folder"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, "src_folder"), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -115,7 +115,7 @@ func TestRecursiveCopy_ConflictTypeMismatch(t *testing.T) {
 
 	// Create folder in source, file with same name in destination
 	name := "mismatch"
-	if err := os.Mkdir(filepath.Join(tmpSrc, name), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpSrc, name), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmpDst, name), []byte("i am a file"), 0600); err != nil {
@@ -181,7 +181,7 @@ func TestRecursiveCopy_FileOverFolderMismatch(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(tmpSrc, name), []byte("file"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(tmpDst, name), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpDst, name), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -539,10 +539,10 @@ func TestExecuteFileOp_RenameMaskUsesBasenameForPathSelection(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	srcRoot := t.TempDir()
 	dstRoot := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(srcRoot, "nested"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcRoot, "nested"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(srcRoot, "nested", "source.txt"), []byte("payload"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(srcRoot, "nested", "source.txt"), []byte("payload"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -619,7 +619,7 @@ func TestExecuteFileOp_DirFileConflict(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
 	// Source: folder 'item'
-	if err := os.Mkdir(filepath.Join(tmpSrc, "item"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmpSrc, "item"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	// Destination: file 'item'
@@ -811,7 +811,7 @@ func TestExecuteFileOp_Move_Skip_NoDataLoss(t *testing.T) {
 	tmpDst := t.TempDir()
 
 	srcFolder := filepath.Join(tmpSrc, "my_folder")
-	if err := os.Mkdir(srcFolder, 0755); err != nil {
+	if err := os.Mkdir(srcFolder, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(srcFolder, "f1.txt"), []byte("src1"), 0600); err != nil {
@@ -823,7 +823,7 @@ func TestExecuteFileOp_Move_Skip_NoDataLoss(t *testing.T) {
 
 	// Pre-create destination to cause conflict and skip
 	dstFolder := filepath.Join(tmpDst, "my_folder")
-	if err := os.Mkdir(dstFolder, 0755); err != nil {
+	if err := os.Mkdir(dstFolder, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dstFolder, "f1.txt"), []byte("dst1"), 0600); err != nil {
@@ -959,7 +959,7 @@ func TestExecuteFileOp_DeepIntegrity(t *testing.T) {
 	// /root/file1.txt
 	// /root/sub1/file2.txt
 	// /root/sub1/sub2/large.bin (4MB)
-	if err := os.MkdirAll(filepath.Join(srcBase, "root", "sub1", "sub2"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(srcBase, "root", "sub1", "sub2"), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1041,11 +1041,11 @@ func TestExecuteFileOp_Move_PermissionDenied_Recovery(t *testing.T) {
 	}
 
 	// Make destination dir read-only
-	if err := os.Chmod(dstDir, 0444); err != nil {
+	if err := os.Chmod(dstDir, 0444); err != nil { // #nosec G302 -- a non-writable destination is the behavior under test.
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		if err := os.Chmod(dstDir, 0755); err != nil {
+		if err := os.Chmod(dstDir, 0755); err != nil { // #nosec G302 -- cleanup must restore access to the deliberately locked directory.
 			t.Errorf("restore destination directory permissions: %v", err)
 		}
 	})
@@ -1089,7 +1089,7 @@ func TestExecuteFileOp_MoveIntoSelf_Circular(t *testing.T) {
 	tmp := t.TempDir()
 	parent := filepath.Join(tmp, "parent")
 	child := filepath.Join(parent, "child")
-	if err := os.MkdirAll(child, 0755); err != nil {
+	if err := os.MkdirAll(child, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1110,7 +1110,7 @@ func TestRecursiveCopy_SelfAndSubfolderProtection(t *testing.T) {
 
 	// 1. Folder self-copy
 	folderPath := filepath.Join(tmpDir, "myfolder")
-	if err := os.MkdirAll(folderPath, 0755); err != nil {
+	if err := os.MkdirAll(folderPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1152,7 +1152,7 @@ func TestRecursiveCopy_SubfolderDeepRecursion(t *testing.T) {
 	// Create /parent/child
 	parent := filepath.Join(tmp, "parent")
 	child := filepath.Join(parent, "child")
-	if err := os.MkdirAll(child, 0755); err != nil {
+	if err := os.MkdirAll(child, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(parent, "file.txt"), []byte("data"), 0600); err != nil {
@@ -1192,7 +1192,7 @@ func TestRecursiveCopy_SymlinkLoop(t *testing.T) {
 	tmp := t.TempDir()
 
 	src := filepath.Join(tmp, "source")
-	if err := os.Mkdir(src, 0755); err != nil {
+	if err := os.Mkdir(src, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(src, "data.txt"), []byte("hi"), 0600); err != nil {
@@ -1965,7 +1965,7 @@ func TestFileOps_PathDisplay(t *testing.T) {
 func TestFileOps_CalculateStats_Integration(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	tmp := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(tmp, "a/b"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmp, "a/b"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmp, "a/f1.txt"), []byte("123"), 0600); err != nil {
@@ -2194,7 +2194,7 @@ func TestRecursiveCopyFailsWhenTheDestinationCloseFails(t *testing.T) {
 	tmpSrc := t.TempDir()
 	tmpDst := t.TempDir()
 	srcFile := filepath.Join(tmpSrc, "file.txt")
-	if err := os.WriteFile(srcFile, []byte("some content"), 0644); err != nil {
+	if err := os.WriteFile(srcFile, []byte("some content"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	dstFile := filepath.Join(tmpDst, "file.txt")
@@ -2221,7 +2221,7 @@ func TestRecursiveCopyClosesTheDestinationBeforeSucceeding(t *testing.T) {
 	tmpDst := t.TempDir()
 	srcFile := filepath.Join(tmpSrc, "file.txt")
 	content := []byte("some content")
-	if err := os.WriteFile(srcFile, content, 0644); err != nil {
+	if err := os.WriteFile(srcFile, content, 0600); err != nil {
 		t.Fatal(err)
 	}
 	dstFile := filepath.Join(tmpDst, "file.txt")

--- a/cmd/f4/file_ops_transfer_name_test.go
+++ b/cmd/f4/file_ops_transfer_name_test.go
@@ -117,13 +117,13 @@ func TestRecursiveCopyAppliesTransferNamesAtEveryDepth(t *testing.T) {
 	sourceRoot := t.TempDir()
 	destinationRoot := t.TempDir()
 	sourceDir := filepath.Join(sourceRoot, "root")
-	if err := os.MkdirAll(filepath.Join(sourceDir, "nested [c3d4]"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(sourceDir, "nested [c3d4]"), 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(sourceDir, "document.gdoc [a1b2]"), []byte("doc"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sourceDir, "document.gdoc [a1b2]"), []byte("doc"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(sourceDir, "nested [c3d4]", "sheet.gsheet [e5f6]"), []byte("sheet"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(sourceDir, "nested [c3d4]", "sheet.gsheet [e5f6]"), []byte("sheet"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -606,7 +606,7 @@ func TestFileSystemPanel_NavigateUp_Selection(t *testing.T) {
 
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "target_folder")
-	if err := os.Mkdir(sub, 0755); err != nil {
+	if err := os.Mkdir(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(tmp, "other.txt"), []byte(""), 0600); err != nil {
@@ -784,7 +784,7 @@ func TestFileSystemPanel_HiddenInfoShowsCursorFileSizeOnMulticolumnBorder(t *tes
 		runes := make([]rune, width)
 		for i := range runes {
 			cell := scr.GetCell(x+i, y)
-			runes[i] = rune(cell.Char)
+			runes[i] = testRune(cell.Char)
 			if runes[i] == 0 {
 				runes[i] = ' '
 			}
@@ -1401,10 +1401,10 @@ func TestFileSystemPanel_SelectionClearedOnDirChange(t *testing.T) {
 	parent := t.TempDir()
 	a := filepath.Join(parent, "a")
 	b := filepath.Join(parent, "b")
-	if err := os.MkdirAll(a, 0755); err != nil {
+	if err := os.MkdirAll(a, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(b, 0755); err != nil {
+	if err := os.MkdirAll(b, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(a, "same"), []byte("a"), 0600); err != nil {
@@ -1813,7 +1813,7 @@ func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 	scr.AllocBuf(40, 12)
 	fp.drawScrollBar(scr)
 	if got := scr.GetCell(fp.X2, fp.scrollBar.Y1); got.Char != vtui.ScrollUpArrow {
-		t.Fatalf("scrollbar top cell = %q, want %q", rune(got.Char), rune(vtui.ScrollUpArrow))
+		t.Fatalf("scrollbar top cell = %q, want %q", testRune(got.Char), testRune(vtui.ScrollUpArrow))
 	} else if got.Attributes != vtui.Palette[ColPanelScrollbar] {
 		t.Fatalf("scrollbar attr = %#x, want Panel.Scrollbar %#x", got.Attributes, vtui.Palette[ColPanelScrollbar])
 	}
@@ -1822,7 +1822,7 @@ func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 	// visual slot.
 	if !fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.X2), MouseY: int16(fp.scrollBar.Y2),
+		MouseX: testInt16(fp.X2), MouseY: testInt16(fp.scrollBar.Y2),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) {
 		t.Fatal("scrollbar down arrow was not handled")
@@ -1837,7 +1837,7 @@ func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 	fp.setPanelScrollTop(0)
 	fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.X2), MouseY: int16(fp.scrollBar.Y2),
+		MouseX: testInt16(fp.X2), MouseY: testInt16(fp.scrollBar.Y2),
 		ButtonState:     vtinput.FromLeft1stButtonPressed,
 		MouseEventFlags: vtinput.MouseMoved,
 	})
@@ -1852,12 +1852,12 @@ func TestFileSystemPanel_ScrollBarDrawAndMouse(t *testing.T) {
 	thumbY := fp.scrollBar.Y1 + 1
 	fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.X2), MouseY: int16(thumbY),
+		MouseX: testInt16(fp.X2), MouseY: testInt16(thumbY),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 	fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: 0, MouseY: int16(fp.scrollBar.Y2 - 1),
+		MouseX: 0, MouseY: testInt16(fp.scrollBar.Y2 - 1),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 	fp.ProcessMouse(&vtinput.InputEvent{Type: vtinput.MouseEventType})
@@ -1889,7 +1889,7 @@ func TestFileSystemPanel_ScrollBarHiddenWhenGridFits(t *testing.T) {
 	fp.drawScrollBar(scr)
 	dataY := fp.table.Y1 + fp.table.MarginTop
 	if got := scr.GetCell(fp.X2, dataY).Char; got != 0 {
-		t.Fatalf("scrollbar drawn for fitting Brief grid: %q", rune(got))
+		t.Fatalf("scrollbar drawn for fitting Brief grid: %q", testRune(got))
 	}
 }
 
@@ -1907,11 +1907,11 @@ func TestFileSystemPanel_ScrollBarDisabled(t *testing.T) {
 	fp.drawScrollBar(scr)
 	y := fp.table.Y1 + fp.table.MarginTop
 	if got := scr.GetCell(fp.X2, y).Char; got != 0 {
-		t.Fatalf("disabled panel scrollbar drew %q", rune(got))
+		t.Fatalf("disabled panel scrollbar drew %q", testRune(got))
 	}
 	if fp.processScrollBarMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.X2), MouseY: int16(y),
+		MouseX: testInt16(fp.X2), MouseY: testInt16(y),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) {
 		t.Fatal("disabled panel scrollbar handled mouse input")
@@ -1951,31 +1951,31 @@ func TestFileSystemPanel_MinimalScrollBarDrawAndMouse(t *testing.T) {
 		inHandle := offset >= caretPos && offset < caretPos+caretLength
 		if inHandle {
 			if cell.Char != '│' || cell.Attributes != vtui.Palette[ColPanelMinimalScrollbar] {
-				t.Fatalf("minimal handle cell %d = %q/%#x, want bright border", offset, rune(cell.Char), cell.Attributes)
+				t.Fatalf("minimal handle cell %d = %q/%#x, want bright border", offset, testRune(cell.Char), cell.Attributes)
 			}
 		} else if cell.Char != 0 {
-			t.Fatalf("minimal scrollbar drew track or arrow at offset %d: %q", offset, rune(cell.Char))
+			t.Fatalf("minimal scrollbar drew track or arrow at offset %d: %q", offset, testRune(cell.Char))
 		}
 	}
 
 	outsideHandleY := fp.scrollBar.Y1 + caretPos + caretLength
 	if outsideHandleY <= fp.scrollBar.Y2 && fp.processScrollBarMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.scrollBar.X1), MouseY: int16(outsideHandleY),
+		MouseX: testInt16(fp.scrollBar.X1), MouseY: testInt16(outsideHandleY),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) {
 		t.Fatal("minimal scrollbar handled a click on the invisible track")
 	}
 	if !fp.processScrollBarMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(fp.scrollBar.X1), MouseY: int16(fp.scrollBar.Y1 + caretPos),
+		MouseX: testInt16(fp.scrollBar.X1), MouseY: testInt16(fp.scrollBar.Y1 + caretPos),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) {
 		t.Fatal("minimal scrollbar did not capture its handle")
 	}
 	if !fp.processScrollBarMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: 0, MouseY: int16(fp.scrollBar.Y2),
+		MouseX: 0, MouseY: testInt16(fp.scrollBar.Y2),
 		ButtonState: vtinput.FromLeft1stButtonPressed, MouseEventFlags: vtinput.MouseMoved,
 	}) {
 		t.Fatal("minimal scrollbar did not drag its captured handle")
@@ -2060,7 +2060,7 @@ func TestFileSystemPanel_CursorColorsColumnSeparators(t *testing.T) {
 				x += fp.table.Columns[column].Width
 				cell := scr.GetCell(x, y)
 				if cell.Char != '│' {
-					t.Fatalf("separator %d char = %q, want │", column, rune(cell.Char))
+					t.Fatalf("separator %d char = %q, want │", column, testRune(cell.Char))
 				}
 				boxAttr := vtui.Palette[ColPanelBox]
 				cursorAttr := vtui.Palette[ColPanelSelectedCursor]
@@ -2153,14 +2153,14 @@ func TestFileSystemPanel_RightDragAppliesToSkippedRows(t *testing.T) {
 	rightDown := func(idx int) {
 		fp.ProcessMouse(&vtinput.InputEvent{
 			Type: vtinput.MouseEventType, KeyDown: true,
-			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			MouseX: testInt16(fp.table.X1), MouseY: testInt16(dataY + idx),
 			ButtonState: vtinput.RightmostButtonPressed,
 		})
 	}
 	release := func(idx int) {
 		fp.ProcessMouse(&vtinput.InputEvent{
 			Type:   vtinput.MouseEventType,
-			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			MouseX: testInt16(fp.table.X1), MouseY: testInt16(dataY + idx),
 		})
 	}
 
@@ -2206,12 +2206,12 @@ func TestFileSystemPanel_RightDragTracksGridColumn(t *testing.T) {
 
 	fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(leftX), MouseY: int16(dataY + height - 2),
+		MouseX: testInt16(leftX), MouseY: testInt16(dataY + height - 2),
 		ButtonState: vtinput.RightmostButtonPressed,
 	})
 	fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(rightX), MouseY: int16(dataY + 1),
+		MouseX: testInt16(rightX), MouseY: testInt16(dataY + 1),
 		ButtonState: vtinput.RightmostButtonPressed,
 	})
 
@@ -2241,14 +2241,14 @@ func TestFileSystemPanel_RightDoubleClickAppliesToWholePanel(t *testing.T) {
 	rightClick := func(idx int, flags uint32) {
 		fp.ProcessMouse(&vtinput.InputEvent{
 			Type: vtinput.MouseEventType, KeyDown: true,
-			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			MouseX: testInt16(fp.table.X1), MouseY: testInt16(dataY + idx),
 			ButtonState: vtinput.RightmostButtonPressed, MouseEventFlags: flags,
 		})
 	}
 	release := func(idx int) {
 		fp.ProcessMouse(&vtinput.InputEvent{
 			Type:   vtinput.MouseEventType,
-			MouseX: int16(fp.table.X1), MouseY: int16(dataY + idx),
+			MouseX: testInt16(fp.table.X1), MouseY: testInt16(dataY + idx),
 		})
 	}
 
@@ -2480,7 +2480,7 @@ func TestFileSystemPanel_NavigateDown_CursorReset(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "subdir")
-	if err := os.Mkdir(sub, 0755); err != nil {
+	if err := os.Mkdir(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2719,10 +2719,10 @@ func TestFileSystemPanel_FastFind_Rendering(t *testing.T) {
 	fp.fastFindStr = "*test"
 	fp.Show(scr)
 	if got := scr.GetCell(inputX, inputY).Char; got != '*' {
-		t.Fatalf("anywhere-mode marker = %q, want '*'", rune(got))
+		t.Fatalf("anywhere-mode marker = %q, want '*'", testRune(got))
 	}
 	if got := scr.GetCell(inputX+1, inputY).Char; got != 't' {
-		t.Fatalf("query after anywhere-mode marker starts with %q, want 't'", rune(got))
+		t.Fatalf("query after anywhere-mode marker starts with %q, want 't'", testRune(got))
 	}
 
 	fp.fastFindStr = "missing"
@@ -3115,20 +3115,20 @@ func TestFileSystemPanel_TitleDoesNotContainSortIndicator(t *testing.T) {
 	fp.sortReverse = true
 	fp.Show(scr)
 
-	if got := rune(scr.GetCell(2, 0).Char); got != ' ' {
+	if got := testRune(scr.GetCell(2, 0).Char); got != ' ' {
 		t.Fatalf("title decoration starts with %q; want a space", got)
 	}
-	if got := rune(scr.GetCell(3, 0).Char); got != 'C' {
+	if got := testRune(scr.GetCell(3, 0).Char); got != 'C' {
 		t.Fatalf("first title character = %q; sort indicator still occupies the title", got)
 	}
-	if got := rune(scr.GetCell(10, 0).Char); got != ' ' {
+	if got := testRune(scr.GetCell(10, 0).Char); got != ' ' {
 		t.Fatalf("title decoration ends with %q; want a space", got)
 	}
 
 	fp.sortMode = SortSize
 	fp.sortReverse = false
 	fp.Show(scr)
-	if got := rune(scr.GetCell(3, 0).Char); got != 'C' {
+	if got := testRune(scr.GetCell(3, 0).Char); got != 'C' {
 		t.Fatalf("changing sort mode changed the path title prefix to %q", got)
 	}
 }
@@ -3352,7 +3352,7 @@ func TestFileSystemPanel_HeaderClickSortsAndToggles(t *testing.T) {
 	clickName := func(flags uint32) bool {
 		return fp.ProcessMouse(&vtinput.InputEvent{
 			Type: vtinput.MouseEventType, KeyDown: true,
-			MouseX: int16(fp.table.X1), MouseY: int16(fp.table.Y1),
+			MouseX: testInt16(fp.table.X1), MouseY: testInt16(fp.table.Y1),
 			ButtonState: vtinput.FromLeft1stButtonPressed, MouseEventFlags: flags,
 		})
 	}
@@ -3385,7 +3385,7 @@ func TestFileSystemPanel_HeaderClickSortsAndToggles(t *testing.T) {
 	hiddenX := fp.table.X1 + fp.table.Columns[0].Width - runewidth.StringWidth(hiddenTitle)
 	if !fp.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(hiddenX), MouseY: int16(fp.table.Y1),
+		MouseX: testInt16(hiddenX), MouseY: testInt16(fp.table.Y1),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	}) || fp.sortMode != SortExt || !fp.sortReverse {
 		t.Fatalf("hidden Extension header click: mode=%v reverse=%v title=%q", fp.sortMode, fp.sortReverse, fp.table.Columns[0].Title)
@@ -4821,7 +4821,7 @@ func TestFileSystemPanel_SelectionColorInMultiColumnViewMode(t *testing.T) {
 	}
 
 	tmp := t.TempDir()
-	if err := os.Mkdir(filepath.Join(tmp, "adir"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmp, "adir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/folder_history_navigation_test.go
+++ b/cmd/f4/folder_history_navigation_test.go
@@ -163,5 +163,5 @@ func TestFolderHistoryNavigationAndMenuDoNotReorderHistory(t *testing.T) {
 }
 
 func ensureDir(path string) error {
-	return os.Mkdir(path, 0o755)
+	return os.Mkdir(path, 0o700)
 }

--- a/cmd/f4/grabber_test.go
+++ b/cmd/f4/grabber_test.go
@@ -66,7 +66,7 @@ func TestGrabber_SnapshotOnFirstShow(t *testing.T) {
 	if g.snapW != testGrabberW || g.snapH != testGrabberH {
 		t.Fatalf("snapshot dims %dx%d, want %dx%d", g.snapW, g.snapH, testGrabberW, testGrabberH)
 	}
-	if rune(g.snap[0][0].Char) != 'h' {
+	if testRune(g.snap[0][0].Char) != 'h' {
 		t.Fatalf("snap[0][0]=%v, want 'h'", g.snap[0][0].Char)
 	}
 	// Cursor starts collapsed at (0,0) — anchor==cur.

--- a/cmd/f4/help_lang_test.go
+++ b/cmd/f4/help_lang_test.go
@@ -18,13 +18,13 @@ func TestHelpLanguageSwitch(t *testing.T) {
 		helpActionStrings = oldHelpActionStrings
 	})
 
-	err := os.MkdirAll(filepath.Join(tempDir, "help"), 0755)
+	err := os.MkdirAll(filepath.Join(tempDir, "help"), 0700)
 	if err != nil {
 		t.Fatalf("failed to create help dir: %v", err)
 	}
 
 	ruHelpContent := "@TestTopic\n$RU Title\nRussian Help Content\n"
-	err = os.WriteFile(filepath.Join(tempDir, "help", "ru.hlf"), []byte(ruHelpContent), 0644)
+	err = os.WriteFile(filepath.Join(tempDir, "help", "ru.hlf"), []byte(ruHelpContent), 0600)
 	if err != nil {
 		t.Fatalf("failed to write test hlf: %v", err)
 	}

--- a/cmd/f4/help_search_test.go
+++ b/cmd/f4/help_search_test.go
@@ -87,7 +87,7 @@ func TestHelpSearchRendersHighlightAndHint(t *testing.T) {
 	}
 	foundHint := false
 	for x := x1 + 2; x < view.X2-1; x++ {
-		if rune(scr.GetCell(x, y2).Char) == 'F' && rune(scr.GetCell(x+1, y2).Char) == '3' {
+		if testRune(scr.GetCell(x, y2).Char) == 'F' && testRune(scr.GetCell(x+1, y2).Char) == '3' {
 			foundHint = true
 			break
 		}
@@ -101,7 +101,7 @@ func TestHelpSearchRendersHighlightAndHint(t *testing.T) {
 	foundHighlightedQuery := false
 	for x := x1 + 2; x < view.X2; x++ {
 		cell := scr.GetCell(x, y1)
-		if rune(cell.Char) == 'n' && vtui.GetRGBFore(cell.Attributes) == vtui.GetRGBFore(vtui.Palette[vtui.ColHelpLink]) {
+		if testRune(cell.Char) == 'n' && vtui.GetRGBFore(cell.Attributes) == vtui.GetRGBFore(vtui.Palette[vtui.ColHelpLink]) {
 			if got := vtui.GetRGBBack(cell.Attributes); got != titleBackground {
 				t.Fatalf("query changed title background to %#x, want %#x", got, titleBackground)
 			}
@@ -265,12 +265,12 @@ func TestHelpShowsZoomButtonAndRestoresPreviousBounds(t *testing.T) {
 		t.Fatal("Help zoom support was not enabled")
 	}
 	x1, y1, x2, y2 := view.GetPosition()
-	if got := rune(scr.GetCell(x2-6, y1).Char); got != vtui.UIStrings.ZoomSymbol {
+	if got := testRune(scr.GetCell(x2-6, y1).Char); got != vtui.UIStrings.ZoomSymbol {
 		t.Fatalf("zoom button symbol = %q, want %q", got, vtui.UIStrings.ZoomSymbol)
 	}
 	if !handleHelpSearchHotkey(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		ButtonState: vtinput.FromLeft1stButtonPressed, MouseX: int16(x2 - 6), MouseY: int16(y1),
+		ButtonState: vtinput.FromLeft1stButtonPressed, MouseX: testInt16(x2 - 6), MouseY: testInt16(y1),
 	}) {
 		t.Fatal("zoom button click was not handled")
 	}
@@ -281,7 +281,7 @@ func TestHelpShowsZoomButtonAndRestoresPreviousBounds(t *testing.T) {
 	_, _, zoomedX2, _ := view.GetPosition()
 	if !handleHelpSearchHotkey(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		ButtonState: vtinput.FromLeft1stButtonPressed, MouseX: int16(zoomedX2 - 6), MouseY: 0,
+		ButtonState: vtinput.FromLeft1stButtonPressed, MouseX: testInt16(zoomedX2 - 6), MouseY: 0,
 	}) {
 		t.Fatal("restore button click was not handled")
 	}

--- a/cmd/f4/history_dialog_test.go
+++ b/cmd/f4/history_dialog_test.go
@@ -106,7 +106,7 @@ func TestHistorySearchDrawHighlightsMatchAndSearchTitle(t *testing.T) {
 	foundBracket := false
 	foundStar := false
 	for x := menu.X1 + 1; x < menu.X2; x++ {
-		char := rune(scr.GetCell(x, menu.Y1).Char)
+		char := testRune(scr.GetCell(x, menu.Y1).Char)
 		if char == '[' {
 			foundBracket = true
 		}
@@ -120,7 +120,7 @@ func TestHistorySearchDrawHighlightsMatchAndSearchTitle(t *testing.T) {
 	foundHighlightedQuery := false
 	for x := menu.X1 + 1; x < menu.X2; x++ {
 		cell := scr.GetCell(x, menu.Y1)
-		if rune(cell.Char) == 'm' && cell.Attributes == vtui.Palette[vtui.ColDialogHighlightText] {
+		if testRune(cell.Char) == 'm' && cell.Attributes == vtui.Palette[vtui.ColDialogHighlightText] {
 			foundHighlightedQuery = true
 			break
 		}
@@ -130,7 +130,7 @@ func TestHistorySearchDrawHighlightsMatchAndSearchTitle(t *testing.T) {
 	}
 	foundF2Hint := false
 	for x := menu.X1 + 1; x < menu.X2-1; x++ {
-		if rune(scr.GetCell(x, menu.Y2).Char) == 'F' && rune(scr.GetCell(x+1, menu.Y2).Char) == '2' {
+		if testRune(scr.GetCell(x, menu.Y2).Char) == 'F' && testRune(scr.GetCell(x+1, menu.Y2).Char) == '2' {
 			foundF2Hint = true
 			break
 		}
@@ -164,10 +164,10 @@ func TestHistorySearchLockColumnAndDetailsAreCapabilityGated(t *testing.T) {
 	}
 	menu.Show(scr)
 	search.draw(scr)
-	if got := rune(scr.GetCell(menu.X1+1, menu.Y1+1).Char); got != '*' {
+	if got := testRune(scr.GetCell(menu.X1+1, menu.Y1+1).Char); got != '*' {
 		t.Fatalf("lock marker = %q, want *", got)
 	}
-	if got := rune(scr.GetCell(menu.X1+2, menu.Y1+1).Char); got != 'e' {
+	if got := testRune(scr.GetCell(menu.X1+2, menu.Y1+1).Char); got != 'e' {
 		t.Fatalf("text after lock marker = %q, want e with no spacer", got)
 	}
 	search.showDetails = true
@@ -209,7 +209,7 @@ func TestHistorySearchResolvesDialogThemeAtRenderTime(t *testing.T) {
 		menu.Show(scr)
 		search.draw(scr)
 		y := menu.Y1 + 1 + (menu.SelectPos - menu.TopPos)
-		if got := rune(scr.GetCell(menu.X1+1, y).Char); got != '*' {
+		if got := testRune(scr.GetCell(menu.X1+1, y).Char); got != '*' {
 			t.Fatalf("selected lock marker = %q, want * at the first inner cell", got)
 		}
 		if got := scr.GetCell(menu.X1+2, y).Attributes; got != selected {

--- a/cmd/f4/history_hint_test.go
+++ b/cmd/f4/history_hint_test.go
@@ -377,8 +377,8 @@ func TestActionCommandHistory_MouseClickPastesEntry(t *testing.T) {
 	menu.ProcessMouse(&vtinput.InputEvent{
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
-		MouseX:      int16(x1 + 2),
-		MouseY:      int16(rowY),
+		MouseX:      testInt16(x1 + 2),
+		MouseY:      testInt16(rowY),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 
@@ -398,7 +398,7 @@ func TestActionCommandHistory_PathColumnAndInsertion(t *testing.T) {
 	t.Cleanup(func() { vtui.GlobalHistoryProvider = previous })
 
 	path := filepath.Join(t.TempDir(), "folder with space")
-	if err := os.Mkdir(path, 0o755); err != nil {
+	if err := os.Mkdir(path, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	rememberCommandHistoryPath("echo newest", path, provider["cmdline"])
@@ -510,8 +510,8 @@ func TestActionFoldersHistory_MouseClickNavigates(t *testing.T) {
 	menu.ProcessMouse(&vtinput.InputEvent{
 		Type:        vtinput.MouseEventType,
 		KeyDown:     true,
-		MouseX:      int16(x1 + 2),
-		MouseY:      int16(rowY),
+		MouseX:      testInt16(x1 + 2),
+		MouseY:      testInt16(rowY),
 		ButtonState: vtinput.FromLeft1stButtonPressed,
 	})
 

--- a/cmd/f4/image_formats_test.go
+++ b/cmd/f4/image_formats_test.go
@@ -61,11 +61,11 @@ func bmpFile(width, height, bits int, palette [][3]byte, rows [][]byte) []byte {
 	info := make([]byte, bmpInfoHeaderSize)
 	le := binary.LittleEndian
 	le.PutUint32(info[0:4], bmpInfoHeaderSize)
-	le.PutUint32(info[4:8], uint32(int32(width)))
-	le.PutUint32(info[8:12], uint32(int32(height)))
+	le.PutUint32(info[4:8], testUint32Int32Bits(width))
+	le.PutUint32(info[8:12], testUint32Int32Bits(height))
 	le.PutUint16(info[12:14], 1)
-	le.PutUint16(info[14:16], uint16(bits))
-	le.PutUint32(info[32:36], uint32(len(palette)))
+	le.PutUint16(info[14:16], testUint16(bits))
+	le.PutUint32(info[32:36], testUint32(len(palette)))
 
 	var pal []byte
 	for _, c := range palette {
@@ -79,9 +79,9 @@ func bmpFile(width, height, bits int, palette [][3]byte, rows [][]byte) []byte {
 	}
 
 	out := []byte{'B', 'M'}
-	out = le.AppendUint32(out, uint32(offset+len(pixels)))
+	out = le.AppendUint32(out, testUint32(offset+len(pixels)))
 	out = le.AppendUint32(out, 0)
-	out = le.AppendUint32(out, uint32(offset))
+	out = le.AppendUint32(out, testUint32(offset))
 	out = append(out, info...)
 	out = append(out, pal...)
 	return append(out, pixels...)

--- a/cmd/f4/image_preview_test.go
+++ b/cmd/f4/image_preview_test.go
@@ -63,7 +63,7 @@ func jpegWithThumbnail(t *testing.T, outer, thumb []byte) []byte {
 	put16(0x0202)
 	put16(4)
 	put32(1)
-	put32(uint32(len(thumb)))
+	put32(testUint32(len(thumb)))
 	put32(0) // no further directories
 
 	if tiff.Len() != thumbOffset {
@@ -76,7 +76,7 @@ func jpegWithThumbnail(t *testing.T, outer, thumb []byte) []byte {
 	payload := append([]byte("Exif\x00\x00"), tiff.Bytes()...)
 
 	out := []byte{0xFF, 0xD8, 0xFF, 0xE1}
-	out = binary.BigEndian.AppendUint16(out, uint16(len(payload)+2))
+	out = binary.BigEndian.AppendUint16(out, testUint16(len(payload)+2))
 	out = append(out, payload...)
 	return append(out, outer[2:]...)
 }

--- a/cmd/f4/image_transform_test.go
+++ b/cmd/f4/image_transform_test.go
@@ -13,7 +13,7 @@ func gradientSurface(w, h int) *vtui.ImageSurface {
 	s := vtui.NewImageSurface(w, h)
 	for y := 0; y < h; y++ {
 		for x := 0; x < w; x++ {
-			s.SetPixel(x, y, byte(x+1), byte(y+1), byte(x*h+y+1), 255)
+			s.SetPixel(x, y, testUint8(x+1), testUint8(y+1), testUint8(x*h+y+1), 255)
 		}
 	}
 	return s

--- a/cmd/f4/info_panel_test.go
+++ b/cmd/f4/info_panel_test.go
@@ -781,7 +781,7 @@ func TestInfoPanel_RendersUsageAsTwoLineMeter(t *testing.T) {
 				cell := scr.GetCell(ip.X1+1+percentStart+offset, first.y)
 				if cell.Attributes != wantAttr {
 					t.Fatalf("percentage cell %q at bar offset %d: attr=%#x, want %#x",
-						rune(cell.Char), insideOffset, cell.Attributes, wantAttr)
+						testRune(cell.Char), insideOffset, cell.Attributes, wantAttr)
 				}
 			}
 			unfilledCell := scr.GetCell(ip.X1+1+first.usageBarStart+first.usageBarWidth-1, first.y)

--- a/cmd/f4/issue149_test.go
+++ b/cmd/f4/issue149_test.go
@@ -483,7 +483,7 @@ func TestIssue149_F5_Extraction_Integrity(t *testing.T) {
 	defer func() { _ = arcVFS.Close() }()
 
 	dstDir := filepath.Join(tmpDir, "out")
-	if err := os.MkdirAll(dstDir, 0755); err != nil {
+	if err := os.MkdirAll(dstDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	dstVFS := vfs.NewOSVFS(dstDir)
@@ -607,21 +607,21 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 
 	for _, spec := range fileSpecs {
 		fullPath := filepath.Join(srcDir, filepath.FromSlash(spec.relPath))
-		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0700); err != nil {
 			t.Fatalf("Failed to create dir for %s: %v", spec.relPath, err)
 		}
 
 		// Generate uncompressible pseudo-random data to force multi-block solid LZMA2 stream
 		data := make([]byte, spec.size)
 		for i := range data {
-			data[i] = byte((int64(i)*13 + spec.seed*37) % 251)
+			data[i] = testByteInt64((int64(i)*13 + spec.seed*37) % 251)
 			if data[i] == 0 {
 				data[i] = 1
 			}
 		}
 		originalData[spec.relPath] = data
 
-		if err := os.WriteFile(fullPath, data, 0644); err != nil {
+		if err := os.WriteFile(fullPath, data, 0600); err != nil {
 			t.Fatalf("Failed to write test file %s: %v", spec.relPath, err)
 		}
 	}
@@ -664,7 +664,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 		defer func() { _ = arcVFS.Close() }()
 
 		dstDir := filepath.Join(tmpDir, "out_f5_nested")
-		if err := os.MkdirAll(dstDir, 0755); err != nil {
+		if err := os.MkdirAll(dstDir, 0700); err != nil {
 			t.Fatalf("Failed to create out_f5_nested: %v", err)
 		}
 		dstVFS := vfs.NewOSVFS(dstDir)
@@ -694,7 +694,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 		defer func() { _ = arcVFS.Close() }()
 
 		dstDir := filepath.Join(tmpDir, "out_f5_root")
-		if err := os.MkdirAll(dstDir, 0755); err != nil {
+		if err := os.MkdirAll(dstDir, 0700); err != nil {
 			t.Fatalf("Failed to create out_f5_root: %v", err)
 		}
 		dstVFS := vfs.NewOSVFS(dstDir)
@@ -722,7 +722,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 		defer func() { _ = arcVFS.Close() }()
 
 		dstDir := filepath.Join(tmpDir, "out_seq_open")
-		if err := os.MkdirAll(dstDir, 0755); err != nil {
+		if err := os.MkdirAll(dstDir, 0700); err != nil {
 			t.Fatalf("Failed to create out_seq_open: %v", err)
 		}
 
@@ -736,7 +736,7 @@ func TestIssue149_7z_MultiBlock_Solid_Integrity(t *testing.T) {
 			}
 
 			outPath := filepath.Join(dstDir, filepath.FromSlash(spec.relPath))
-			if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+			if err := os.MkdirAll(filepath.Dir(outPath), 0700); err != nil {
 				_ = reader.Close() // Reader cleanup is secondary to the setup failure.
 				t.Fatalf("Failed to create out dir: %v", err)
 			}

--- a/cmd/f4/lang_consistency_test.go
+++ b/cmd/f4/lang_consistency_test.go
@@ -68,7 +68,7 @@ func writeLangCoverageBaseline(path string, coverage map[string]int) error {
 			return err
 		}
 	}
-	return os.WriteFile(path, []byte(builder.String()), 0644)
+	return os.WriteFile(path, []byte(builder.String()), 0600)
 }
 
 func TestLangConsistency(t *testing.T) {

--- a/cmd/f4/lua_plugin_test.go
+++ b/cmd/f4/lua_plugin_test.go
@@ -48,7 +48,7 @@ func (h *luaTestHostAPI) RunAction(name string) bool {
 func writeLuaPlugin(t *testing.T, source string) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), "plugin.lua")
-	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
 		t.Fatalf("writing plugin: %v", err)
 	}
 	return path

--- a/cmd/f4/macro_lua_test.go
+++ b/cmd/f4/macro_lua_test.go
@@ -522,12 +522,12 @@ func TestMacroFailingActionIsContained(t *testing.T) {
 func TestMacroLoadDir(t *testing.T) {
 	dir := t.TempDir()
 	nested := filepath.Join(dir, "user")
-	if err := os.MkdirAll(nested, 0o755); err != nil {
+	if err := os.MkdirAll(nested, 0o700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
 	write := func(path, content string) {
 		t.Helper()
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatalf("write %s: %v", path, err)
 		}
 	}

--- a/cmd/f4/macro_reload_test.go
+++ b/cmd/f4/macro_reload_test.go
@@ -23,7 +23,7 @@ func TestMacroManagerReloadLuaMacros(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "debug.lua")
 	const first = `Macro { area = "Shell"; key = "CtrlJ"; action = function() end }`
-	if err := os.WriteFile(path, []byte(first), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(first), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -50,7 +50,7 @@ func TestMacroManagerReloadLuaMacros(t *testing.T) {
 		t.Fatalf("rename loaded script: %v", err)
 	}
 	const second = `Macro { area = "Shell"; key = "CtrlK"; action = function() end }`
-	if err := os.WriteFile(renamed, []byte(second), 0o644); err != nil {
+	if err := os.WriteFile(renamed, []byte(second), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/macro_test.go
+++ b/cmd/f4/macro_test.go
@@ -897,7 +897,7 @@ func TestMacro_ReassignAndCleanup(t *testing.T) {
 	mgr.Lua = engine
 
 	scriptDir := filepath.Join(GetF4ConfigDir(), "Macros", "scripts")
-	if err := os.MkdirAll(scriptDir, 0755); err != nil {
+	if err := os.MkdirAll(scriptDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	scriptPath := filepath.Join(scriptDir, RecordedMacroFileName("Common", key))

--- a/cmd/f4/mapped_file_test.go
+++ b/cmd/f4/mapped_file_test.go
@@ -18,7 +18,7 @@ func mapTestFile(t *testing.T, content string) (*MappedFile, string, vfs.VFS, vf
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "mapped.txt")
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 	v := vfs.NewOSVFS(dir)
@@ -61,7 +61,7 @@ func TestMapEditorFile_DeclinesWhatItShouldNotMap(t *testing.T) {
 
 	t.Run("empty file", func(t *testing.T) {
 		path := filepath.Join(dir, "empty.txt")
-		if err := os.WriteFile(path, nil, 0644); err != nil {
+		if err := os.WriteFile(path, nil, 0600); err != nil {
 			t.Fatal(err)
 		}
 		v := vfs.NewOSVFS(dir)
@@ -95,7 +95,7 @@ func TestMapEditorFile_DeclinesWhatItShouldNotMap(t *testing.T) {
 	})
 	t.Run("osvfs file exposes valid descriptor", func(t *testing.T) {
 		path := filepath.Join(dir, "desc_check.txt")
-		if err := os.WriteFile(path, []byte("data"), 0644); err != nil {
+		if err := os.WriteFile(path, []byte("data"), 0600); err != nil {
 			t.Fatal(err)
 		}
 		v := vfs.NewOSVFS(dir)

--- a/cmd/f4/navigation_mode_test.go
+++ b/cmd/f4/navigation_mode_test.go
@@ -45,7 +45,7 @@ func TestPanelNavigationModeConfigRoundTripAndMigration(t *testing.T) {
 		t.Fatalf("round trip got mode=%v stay=%v", AppConfig.NavigationMode, AppConfig.SearchCommandStayFocused)
 	}
 
-	if err := os.WriteFile(iniPath, []byte("[Panel]\nVimHotkeys = 1\n"), 0644); err != nil {
+	if err := os.WriteFile(iniPath, []byte("[Panel]\nVimHotkeys = 1\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	LoadConfig()
@@ -53,7 +53,7 @@ func TestPanelNavigationModeConfigRoundTripAndMigration(t *testing.T) {
 		t.Fatalf("legacy VimHotkeys migration got %v", AppConfig.NavigationMode)
 	}
 
-	if err := os.WriteFile(iniPath, []byte("[Panel]\nNavigationMode = classic\nVimHotkeys = 1\n"), 0644); err != nil {
+	if err := os.WriteFile(iniPath, []byte("[Panel]\nNavigationMode = classic\nVimHotkeys = 1\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	LoadConfig()
@@ -486,7 +486,7 @@ func TestDetailedArrowRoutingByNavigationFocus(t *testing.T) {
 		return &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vk}
 	}
 	typeChar := func(r rune) *vtinput.InputEvent {
-		return &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, Char: r, VirtualKeyCode: uint16(r)}
+		return &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, Char: r, VirtualKeyCode: testUint16Rune(r)}
 	}
 
 	AppConfig.NavigationMode = NavigationClassic

--- a/cmd/f4/numeric_conversions_test.go
+++ b/cmd/f4/numeric_conversions_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"math"
+	"unicode"
+)
+
+// These helpers keep test-fixture conversions checked without obscuring the
+// assertions that use them. An out-of-range fixture is a test bug, so panic is
+// preferable to silently truncating it.
+func testRune(value uint64) rune {
+	if value > unicode.MaxRune {
+		panic("test character is outside the Unicode range")
+	}
+	return rune(value) // #nosec G115 -- value is bounded by unicode.MaxRune above.
+}
+
+func testInt16(value int) int16 {
+	if value < math.MinInt16 || value > math.MaxInt16 {
+		panic("test coordinate is outside the int16 range")
+	}
+	return int16(value) // #nosec G115 -- value is bounded to the int16 range above.
+}
+
+func testInt32(value int) int32 {
+	if int64(value) < math.MinInt32 || int64(value) > math.MaxInt32 {
+		panic("test value is outside the int32 range")
+	}
+	return int32(value) // #nosec G115 -- value is bounded to the int32 range above.
+}
+
+func testUint8(value int) uint8 {
+	if value < 0 || value > math.MaxUint8 {
+		panic("test value is outside the uint8 range")
+	}
+	return uint8(value) // #nosec G115 -- value is bounded to the uint8 range above.
+}
+
+func testUint16(value int) uint16 {
+	if value < 0 || value > math.MaxUint16 {
+		panic("test value is outside the uint16 range")
+	}
+	return uint16(value) // #nosec G115 -- value is bounded to the uint16 range above.
+}
+
+func testUint32(value int) uint32 {
+	// int is 32 bits on the platforms this project still vets, where the
+	// untyped MaxUint32 does not fit in one, so widen before comparing.
+	if value < 0 || int64(value) > math.MaxUint32 {
+		panic("test value is outside the uint32 range")
+	}
+	return uint32(value) // #nosec G115 -- value is bounded to the uint32 range above.
+}
+
+func testUint32Int32Bits(value int) uint32 {
+	signed := testInt32(value)
+	return uint32(signed) // #nosec G115 -- BMP fixtures intentionally encode a checked signed int32 as raw bits.
+}
+
+func testUint16Rune(value rune) uint16 {
+	if value < 0 || value > math.MaxUint16 {
+		panic("test character is outside the uint16 range")
+	}
+	return uint16(value) // #nosec G115 -- value is bounded to the uint16 range above.
+}
+
+func testUint32Rune(value rune) uint32 {
+	if value < 0 {
+		panic("test character is negative")
+	}
+	return uint32(value) // #nosec G115 -- non-negative runes fit in uint32.
+}
+
+func testUint64Rune(value rune) uint64 {
+	if value < 0 {
+		panic("test character is negative")
+	}
+	return uint64(value) // #nosec G115 -- value is checked to be non-negative above.
+}
+
+func testByteInt64(value int64) byte {
+	if value < 0 || value > math.MaxUint8 {
+		panic("test value is outside the byte range")
+	}
+	return byte(value) // #nosec G115 -- value is bounded to the byte range above.
+}
+
+func testInt64Uint64(value uint64) int64 {
+	if value > math.MaxInt64 {
+		panic("test value is outside the int64 range")
+	}
+	return int64(value) // #nosec G115 -- value is bounded to the int64 range above.
+}
+
+func testInt64Uint(value uint) int64 {
+	// uint is 32 bits on the platforms this project still vets, where the
+	// untyped MaxInt64 does not fit in one, so widen before comparing.
+	if uint64(value) > math.MaxInt64 {
+		panic("test value is outside the int64 range")
+	}
+	return int64(value) // #nosec G115 -- value is bounded to the int64 range above.
+}

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -44,10 +44,10 @@ func TestPanelsFrame_WorkspaceTabTitleUsesFolderNames(t *testing.T) {
 	root := t.TempDir()
 	leftPath := filepath.Join(root, "left-leaf")
 	rightPath := filepath.Join(root, "right-leaf")
-	if err := os.MkdirAll(leftPath, 0755); err != nil {
+	if err := os.MkdirAll(leftPath, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(rightPath, 0755); err != nil {
+	if err := os.MkdirAll(rightPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,10 +70,10 @@ func TestPanelsFrame_WorkspaceMenuInfoUsesFullPanelPaths(t *testing.T) {
 	root := t.TempDir()
 	leftPath := filepath.Join(root, "left", "nested")
 	rightPath := filepath.Join(root, "right", "nested")
-	if err := os.MkdirAll(leftPath, 0755); err != nil {
+	if err := os.MkdirAll(leftPath, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(rightPath, 0755); err != nil {
+	if err := os.MkdirAll(rightPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -423,12 +423,12 @@ func TestPanelsFrame_DriveMenuListsAssignedBookmarks(t *testing.T) {
 	oldUserConfigDir := userConfigDir
 	userConfigDir = func() (string, error) { return cfg, nil }
 	t.Cleanup(func() { userConfigDir = oldUserConfigDir })
-	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	target := t.TempDir()
 	if err := os.WriteFile(filepath.Join(cfg, "f4", "settings", "bookmarks.ini"),
-		[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+		[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -485,7 +485,7 @@ func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
 	oldUserConfigDir := userConfigDir
 	userConfigDir = func() (string, error) { return cfg, nil }
 	t.Cleanup(func() { userConfigDir = oldUserConfigDir })
-	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -497,7 +497,7 @@ func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
 		filepath.Join(home, "sub"),
 		filepath.Join(home, "literal"),
 	} {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -526,7 +526,7 @@ func TestPanelsFrame_DriveMenuExpandsBookmarkPath(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := os.WriteFile(BookmarksFilePath(),
-				[]byte("[6]\nPath="+tc.path+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+				[]byte("[6]\nPath="+tc.path+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o600); err != nil {
 				t.Fatal(err)
 			}
 
@@ -618,14 +618,14 @@ func TestPanelsFrame_DriveMenuBookmarkKeys(t *testing.T) {
 	oldUserConfigDir := userConfigDir
 	userConfigDir = func() (string, error) { return cfg, nil }
 	t.Cleanup(func() { userConfigDir = oldUserConfigDir })
-	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(cfg, "f4", "settings"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 	ini := filepath.Join(cfg, "f4", "settings", "bookmarks.ini")
 	target := t.TempDir()
 	write := func() {
 		if err := os.WriteFile(ini,
-			[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o644); err != nil {
+			[]byte("[6]\nPath="+target+"\nPlugin=\nPluginData=\nPluginFile=\n"), 0o600); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1264,7 +1264,7 @@ func TestPanelsFrame_RightClickHeaderOpensPanelCenteredSortMenu(t *testing.T) {
 
 	if !pf.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(left.table.X1), MouseY: int16(left.table.Y1),
+		MouseX: testInt16(left.table.X1), MouseY: testInt16(left.table.Y1),
 		ButtonState: vtinput.RightmostButtonPressed,
 	}) {
 		t.Fatal("right click on column header was not handled")
@@ -1314,7 +1314,7 @@ func TestPanelsFrame_RightClickPanelPathOpensDriveMenuForThatPanel(t *testing.T)
 
 	if !pf.ProcessMouse(&vtinput.InputEvent{
 		Type: vtinput.MouseEventType, KeyDown: true,
-		MouseX: int16(right.X1 + 3), MouseY: int16(right.Y1),
+		MouseX: testInt16(right.X1 + 3), MouseY: testInt16(right.Y1),
 		ButtonState: vtinput.RightmostButtonPressed,
 	}) {
 		t.Fatal("right click on the panel path was not handled")
@@ -1460,10 +1460,10 @@ func TestPanelsFrame_CtrlBrackets_Insertion(t *testing.T) {
 	tmp := t.TempDir()
 	leftPath := filepath.Join(tmp, "left")
 	rightPath := filepath.Join(tmp, "right")
-	if err := os.MkdirAll(leftPath, 0755); err != nil {
+	if err := os.MkdirAll(leftPath, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(rightPath, 0755); err != nil {
+	if err := os.MkdirAll(rightPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1514,10 +1514,10 @@ func TestCtrlBracketsInsertPanelPathsIntoFocusedEdit(t *testing.T) {
 	pf.ResizeConsole(80, 25)
 	leftPath := filepath.Join(t.TempDir(), "left path")
 	rightPath := filepath.Join(t.TempDir(), "right path")
-	if err := os.MkdirAll(leftPath, 0o755); err != nil {
+	if err := os.MkdirAll(leftPath, 0o700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(rightPath, 0o755); err != nil {
+	if err := os.MkdirAll(rightPath, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	if err := pf.panels[0].(*FileSystemPanel).vfs.SetPath(leftPath); err != nil {
@@ -2112,10 +2112,10 @@ func TestPanelsFrame_SwapPanels(t *testing.T) {
 
 	pathL := filepath.Join(t.TempDir(), "left")
 	pathR := filepath.Join(t.TempDir(), "right")
-	if err := os.MkdirAll(pathL, 0755); err != nil {
+	if err := os.MkdirAll(pathL, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(pathR, 0755); err != nil {
+	if err := os.MkdirAll(pathR, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2169,10 +2169,10 @@ func TestPanelsFrame_VisualLeftRightFollowSwap(t *testing.T) {
 
 	pathL := filepath.Join(t.TempDir(), "left")
 	pathR := filepath.Join(t.TempDir(), "right")
-	if err := os.MkdirAll(pathL, 0755); err != nil {
+	if err := os.MkdirAll(pathL, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(pathR, 0755); err != nil {
+	if err := os.MkdirAll(pathR, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2325,7 +2325,7 @@ func TestPanelsFrame_Prompt_WithProvider(t *testing.T) {
 	promptStr := ""
 	for _, c := range prompt {
 		if c.Char != vtui.WideCharFiller {
-			promptStr += string(rune(c.Char))
+			promptStr += string(testRune(c.Char))
 		}
 	}
 
@@ -2420,10 +2420,10 @@ func TestPanelsFrame_GetPaths(t *testing.T) {
 	tmp := t.TempDir()
 	pathL := filepath.Join(tmp, "left")
 	pathR := filepath.Join(tmp, "right")
-	if err := os.MkdirAll(pathL, 0755); err != nil {
+	if err := os.MkdirAll(pathL, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(pathR, 0755); err != nil {
+	if err := os.MkdirAll(pathR, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2715,7 +2715,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 
 	// 4. Директория -> false
 	subDir := filepath.Join(tmpDir, "folder")
-	if err := os.Mkdir(subDir, 0755); err != nil {
+	if err := os.Mkdir(subDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if vfs.IsTerminalRunnable(context.Background(), v, subDir) {
@@ -2728,7 +2728,7 @@ func TestIsTerminalRunnable(t *testing.T) {
 		if err := os.WriteFile(execFile, []byte{0x7f, 'E', 'L', 'F'}, 0600); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Chmod(execFile, 0700); err != nil {
+		if err := os.Chmod(execFile, 0700); err != nil { // #nosec G302 -- the executable bit is the behavior under test.
 			t.Fatal(err)
 		}
 		if !vfs.IsTerminalRunnable(context.Background(), v, execFile) {
@@ -2990,7 +2990,7 @@ func TestPanelsFrame_DirectoryEnter(t *testing.T) {
 	pf.ResizeConsole(80, 25)
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "work_dir")
-	if err := os.Mkdir(sub, 0755); err != nil {
+	if err := os.Mkdir(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3808,7 +3808,7 @@ func TestPanelsFrame_DriveMenu_OtherPanel(t *testing.T) {
 	pf.ResizeConsole(80, 25)
 
 	pathR := filepath.Join(t.TempDir(), "right")
-	if err := os.MkdirAll(pathR, 0755); err != nil {
+	if err := os.MkdirAll(pathR, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := pf.panels[1].(*FileSystemPanel).vfs.SetPath(pathR); err != nil {
@@ -4066,7 +4066,7 @@ func TestPanelsFrame_PromptTruncation(t *testing.T) {
 		promptStr := ""
 		for _, c := range prompt {
 			if c.Char != vtui.WideCharFiller {
-				promptStr += string(rune(c.Char))
+				promptStr += string(testRune(c.Char))
 			}
 		}
 		if strings.Contains(promptStr, "home") {
@@ -4096,7 +4096,7 @@ func TestPanelsFrame_PromptTruncation(t *testing.T) {
 		for _, c := range prompt {
 			if c.Char != vtui.WideCharFiller {
 				visibleLen++
-				promptStr += string(rune(c.Char))
+				promptStr += string(testRune(c.Char))
 			}
 		}
 		if visibleLen > 45 {
@@ -4118,7 +4118,7 @@ func TestPanelsFrame_PromptTruncation(t *testing.T) {
 		for _, c := range prompt {
 			if c.Char != vtui.WideCharFiller {
 				visibleLen++
-				promptStr += string(rune(c.Char))
+				promptStr += string(testRune(c.Char))
 			}
 		}
 
@@ -4509,7 +4509,7 @@ func TestArchiveBulkExtract_ProgressTracking(t *testing.T) {
 	defer func() { _ = arcVFS.Close() }()
 
 	destDir := filepath.Join(tmpDir, "extracted")
-	if err := os.MkdirAll(destDir, 0755); err != nil {
+	if err := os.MkdirAll(destDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	dstVFS := vfs.NewOSVFS(destDir)
@@ -4787,8 +4787,8 @@ func TestPanelsFrame_MiddleClick_LaunchesFile(t *testing.T) {
 	// Симулируем клик колесом мыши по первой строке
 	ev := &vtinput.InputEvent{
 		Type:        vtinput.MouseEventType,
-		MouseX:      int16(fsp.X1 + 5),
-		MouseY:      int16(fsp.Y1 + 1), // Клик по первой строке
+		MouseX:      testInt16(fsp.X1 + 5),
+		MouseY:      testInt16(fsp.Y1 + 1), // Клик по первой строке
 		ButtonState: vtinput.FromLeft2ndButtonPressed,
 		KeyDown:     true,
 	}
@@ -4821,7 +4821,7 @@ func TestPanelsFrame_CtrlBackslash_GoesToRoot(t *testing.T) {
 	fsp := pf.panels[pf.activeIdx].(*FileSystemPanel)
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "a", "b", "c")
-	if err := os.MkdirAll(sub, 0755); err != nil {
+	if err := os.MkdirAll(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := fsp.vfs.SetPath(sub); err != nil {
@@ -4863,7 +4863,7 @@ func TestPanelsFrame_CtrlPgUp_GoesToParentOrDriveMenu(t *testing.T) {
 	fsp := pf.panels[pf.activeIdx].(*FileSystemPanel)
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "sub")
-	if err := os.MkdirAll(sub, 0755); err != nil {
+	if err := os.MkdirAll(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := fsp.vfs.SetPath(sub); err != nil {
@@ -4921,7 +4921,7 @@ func TestPanelsFrame_CtrlPgDn_EntersDir(t *testing.T) {
 	fsp := pf.panels[pf.activeIdx].(*FileSystemPanel)
 	tmp := t.TempDir()
 	sub := filepath.Join(tmp, "sub")
-	if err := os.MkdirAll(sub, 0755); err != nil {
+	if err := os.MkdirAll(sub, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := fsp.vfs.SetPath(tmp); err != nil {
@@ -5112,7 +5112,7 @@ func TestPanelsFrame_ShiftEnter_ExplorerLaunch(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(tmp, "doc.txt"), []byte("data"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(tmp, "sub"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmp, "sub"), 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -5739,8 +5739,8 @@ func TestPanelsFrame_ProcessMouse_HoverWheel(t *testing.T) {
 
 	ev := &vtinput.InputEvent{
 		Type:           vtinput.MouseEventType,
-		MouseX:         int16(lx1 + 2),
-		MouseY:         int16(ly1 + 2),
+		MouseX:         testInt16(lx1 + 2),
+		MouseY:         testInt16(ly1 + 2),
 		WheelDirection: -1, // Down scroll -> should move cursor down
 	}
 
@@ -5801,8 +5801,8 @@ func TestPanelsFrame_ProcessMouse_HoverWheel_AltPanel(t *testing.T) {
 	// Simulate wheel over the left slot (where QuickView is)
 	ev := &vtinput.InputEvent{
 		Type:           vtinput.MouseEventType,
-		MouseX:         int16(lx1 + 2),
-		MouseY:         int16(ly1 + 2),
+		MouseX:         testInt16(lx1 + 2),
+		MouseY:         testInt16(ly1 + 2),
 		WheelDirection: -1, // Down scroll
 	}
 
@@ -5866,8 +5866,8 @@ func TestPanelsFrame_ProcessMouse_HoverWheel_Medium_Boundaries(t *testing.T) {
 	lx1, ly1, _, _ := lp.GetPosition()
 	ev := &vtinput.InputEvent{
 		Type:           vtinput.MouseEventType,
-		MouseX:         int16(lx1 + 2),
-		MouseY:         int16(ly1 + 2),
+		MouseX:         testInt16(lx1 + 2),
+		MouseY:         testInt16(ly1 + 2),
 		WheelDirection: 1, // Up scroll
 	}
 
@@ -5937,8 +5937,8 @@ func TestPanelsFrame_ProcessMouse_HoverWheel_Detailed_Boundaries(t *testing.T) {
 	lx1, ly1, _, _ := lp.GetPosition()
 	ev := &vtinput.InputEvent{
 		Type:           vtinput.MouseEventType,
-		MouseX:         int16(lx1 + 2),
-		MouseY:         int16(ly1 + 2),
+		MouseX:         testInt16(lx1 + 2),
+		MouseY:         testInt16(ly1 + 2),
 		WheelDirection: -1, // Down scroll
 	}
 
@@ -5982,8 +5982,8 @@ func TestFilePanel_WheelScrollSpeed(t *testing.T) {
 	wheel := func(dir int) {
 		ev := &vtinput.InputEvent{
 			Type:           vtinput.MouseEventType,
-			MouseX:         int16(x1 + 2),
-			MouseY:         int16(y1 + 2),
+			MouseX:         testInt16(x1 + 2),
+			MouseY:         testInt16(y1 + 2),
 			WheelDirection: dir,
 		}
 		if !p.ProcessMouse(ev) {

--- a/cmd/f4/path_hints_test.go
+++ b/cmd/f4/path_hints_test.go
@@ -13,10 +13,10 @@ import (
 func setupPathHintDir(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(dir, "subdir1"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "subdir1"), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dir, "subdir2"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "subdir2"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "subdir1", "inner.txt"), []byte("x"), 0600); err != nil {
@@ -224,10 +224,10 @@ func TestPathHintProvider_BothPanels(t *testing.T) {
 
 	dirA := t.TempDir() // active panel
 	dirB := t.TempDir() // passive panel
-	if err := os.Mkdir(filepath.Join(dirA, "sub"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dirA, "sub"), 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Mkdir(filepath.Join(dirB, "sub"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dirB, "sub"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dirA, "sub", "active.txt"), []byte("x"), 0600); err != nil {
@@ -286,7 +286,7 @@ func TestPathHintProvider_DisabledWhenCommandLineAutoCompleteOff(t *testing.T) {
 	SetDefaultF4Palette()
 
 	dir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(dir, "sub"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "sub", "file.txt"), []byte("x"), 0600); err != nil {

--- a/cmd/f4/plughost_ffi_test.go
+++ b/cmd/f4/plughost_ffi_test.go
@@ -97,9 +97,9 @@ func ffiNumber(t *testing.T, value any) int64 {
 	case uint32:
 		return int64(n)
 	case uint64:
-		return int64(n)
+		return testInt64Uint64(n)
 	case uint:
-		return int64(n)
+		return testInt64Uint(n)
 	case float64:
 		return int64(n)
 	}
@@ -190,7 +190,7 @@ func TestFFIPointerResultSurvivesTheWire(t *testing.T) {
 		t.Fatalf("memcpy: %v", err)
 	}
 	// A uintptr has no MessagePack representation; it must arrive as a number.
-	if got := ffiNumber(t, copied.Value); got != int64(dst.Addr) {
+	if got := ffiNumber(t, copied.Value); got != testInt64Uint64(dst.Addr) {
 		t.Fatalf("memcpy returned %#v, want the destination address", copied.Value)
 	}
 

--- a/cmd/f4/plugin_scaffold_test.go
+++ b/cmd/f4/plugin_scaffold_test.go
@@ -57,7 +57,7 @@ func TestScaffoldPluginWritesItsFiles(t *testing.T) {
 
 func TestScaffoldPluginRefusesToOverwrite(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "important.txt"), []byte("mine"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "important.txt"), []byte("mine"), 0o600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 

--- a/cmd/f4/plugring_test.go
+++ b/cmd/f4/plugring_test.go
@@ -169,7 +169,7 @@ func TestGetInstalledPlugRingItems(t *testing.T) {
 	cfgDir := GetF4ConfigDir()
 	plugringDir := filepath.Join(cfgDir, "plugring")
 	pluginPath := filepath.Join(plugringDir, "test-id")
-	if err := os.MkdirAll(pluginPath, 0755); err != nil {
+	if err := os.MkdirAll(pluginPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,7 +200,7 @@ func TestCheckForPluginUpdates(t *testing.T) {
 	cfgDir := GetF4ConfigDir()
 	plugringDir := filepath.Join(cfgDir, "plugring")
 	pluginPath := filepath.Join(plugringDir, "test-plugin")
-	if err := os.MkdirAll(pluginPath, 0755); err != nil {
+	if err := os.MkdirAll(pluginPath, 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/proxy_settings_test.go
+++ b/cmd/f4/proxy_settings_test.go
@@ -68,7 +68,7 @@ func TestProxySettings_DefaultKeepsTheOldBehaviour(t *testing.T) {
 	// http.DefaultClient, which honours the proxy environment variables.
 	// A config file without a [Proxy] section must keep doing exactly that.
 	userIniPath := filepath.Join(t.TempDir(), "settings.ini")
-	if err := os.WriteFile(userIniPath, []byte("[Interface]\nColorStyle = Modern\n"), 0644); err != nil {
+	if err := os.WriteFile(userIniPath, []byte("[Interface]\nColorStyle = Modern\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	origUserPathFunc := getUserConfigIniPath

--- a/cmd/f4/quick_view_panel_test.go
+++ b/cmd/f4/quick_view_panel_test.go
@@ -108,7 +108,7 @@ func TestQuickView_TextFilePreview(t *testing.T) {
 
 	tmp := t.TempDir()
 	filePath := filepath.Join(tmp, "hello.txt")
-	if err := os.WriteFile(filePath, []byte("first line\nsecond line\n"), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte("first line\nsecond line\n"), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -154,7 +154,7 @@ func TestQuickView_ScrollAndWrap(t *testing.T) {
 		}
 	}
 	path := filepath.Join(tmp, "long.txt")
-	if err := os.WriteFile(path, []byte(b.String()), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -299,7 +299,7 @@ func TestQuickView_MouseWheelScrolls(t *testing.T) {
 		}
 	}
 	path := filepath.Join(tmp, "many.txt")
-	if err := os.WriteFile(path, []byte(b.String()), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(b.String()), 0600); err != nil {
 		t.Fatal(err)
 	}
 	fsp := NewFileSystemPanel(0, 0, 40, 20, vfs.NewOSVFS(tmp))
@@ -369,13 +369,13 @@ func TestQuickView_DirScan_PopulatesRecursive(t *testing.T) {
 	// Expected recursive: Folders=1 (sub), Files=2, Bytes=150.
 	dir := filepath.Join(tmp, "dir")
 	sub := filepath.Join(dir, "sub")
-	if err := os.MkdirAll(sub, 0755); err != nil {
+	if err := os.MkdirAll(sub, 0700); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "a.txt"), make([]byte, 100), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), make([]byte, 100), 0600); err != nil {
 		t.Fatalf("write a: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sub, "b.txt"), make([]byte, 50), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(sub, "b.txt"), make([]byte, 50), 0600); err != nil {
 		t.Fatalf("write b: %v", err)
 	}
 
@@ -449,7 +449,7 @@ func TestQuickView_DotDot_ScansCurrentDir(t *testing.T) {
 	vtui.SetDefaultPalette()
 
 	tmp := t.TempDir()
-	if err := os.WriteFile(filepath.Join(tmp, "one.bin"), make([]byte, 200), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "one.bin"), make([]byte, 200), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -499,13 +499,13 @@ func TestQuickView_DirScan_CancelsOnSelectionChange(t *testing.T) {
 	tmp := t.TempDir()
 	dirA := filepath.Join(tmp, "A")
 	dirB := filepath.Join(tmp, "B")
-	if err := os.MkdirAll(dirA, 0755); err != nil {
+	if err := os.MkdirAll(dirA, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.MkdirAll(dirB, 0755); err != nil {
+	if err := os.MkdirAll(dirB, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dirA, "onlyA.bin"), make([]byte, 42), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(dirA, "onlyA.bin"), make([]byte, 42), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -615,7 +615,7 @@ func TestQuickView_ImageFilePreview(t *testing.T) {
 		0xff, 0xff, 0x00, 0x00, 0xff,
 	}
 
-	if err := os.WriteFile(filePath, qoiBytes, 0644); err != nil {
+	if err := os.WriteFile(filePath, qoiBytes, 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
 
@@ -693,7 +693,7 @@ func TestQuickView_ImageGraphicsNotSupported(t *testing.T) {
 		for x := q.X1; x <= q.X2; x++ {
 			ci := scr.GetCell(x, y)
 			if ci.Char != 0 {
-				line = append(line, rune(ci.Char))
+				line = append(line, testRune(ci.Char))
 			}
 		}
 		if strings.Contains(string(line), "not supported") {

--- a/cmd/f4/session_unix_test.go
+++ b/cmd/f4/session_unix_test.go
@@ -193,7 +193,7 @@ func TestWatchdog_DetectsClientDisconnect(t *testing.T) {
 	// POLLOUT must be requested: macOS reports nothing for Events: 0, so
 	// polling with an empty event mask never detects the closed read end
 	// (the watchdog bug this test guards against).
-	pfds := []unix.PollFd{{Fd: int32(writeEnd), Events: unix.POLLOUT}}
+	pfds := []unix.PollFd{{Fd: testInt32(writeEnd), Events: unix.POLLOUT}}
 	_, err := unix.Poll(pfds, 0)
 	if err != nil {
 		t.Fatalf("poll: %v", err)
@@ -208,7 +208,7 @@ func TestWatchdog_DetectsClientDisconnect(t *testing.T) {
 	}
 
 	// Now poll on writeEnd must report POLLERR, POLLHUP, or POLLNVAL
-	pfds = []unix.PollFd{{Fd: int32(writeEnd), Events: unix.POLLOUT}}
+	pfds = []unix.PollFd{{Fd: testInt32(writeEnd), Events: unix.POLLOUT}}
 	_, err = unix.Poll(pfds, 0)
 	if err != nil {
 		t.Fatalf("poll after close: %v", err)

--- a/cmd/f4/sheet_frame_test.go
+++ b/cmd/f4/sheet_frame_test.go
@@ -172,7 +172,7 @@ func TestSheetFrameRendersGrid(t *testing.T) {
 
 	var header strings.Builder
 	for x := 0; x < 40; x++ {
-		header.WriteRune(rune(scr.GetCell(x, sf.headerY()).Char))
+		header.WriteRune(testRune(scr.GetCell(x, sf.headerY()).Char))
 	}
 	if !strings.Contains(header.String(), "A") || !strings.Contains(header.String(), "B") {
 		t.Errorf("column header row = %q, want the column letters", header.String())
@@ -180,7 +180,7 @@ func TestSheetFrameRendersGrid(t *testing.T) {
 
 	var firstRow strings.Builder
 	for x := 0; x < 20; x++ {
-		firstRow.WriteRune(rune(scr.GetCell(x, sf.gridTopY()).Char))
+		firstRow.WriteRune(testRune(scr.GetCell(x, sf.gridTopY()).Char))
 	}
 	if !strings.Contains(firstRow.String(), "1") || !strings.Contains(firstRow.String(), "42") {
 		t.Errorf("first grid row = %q, want the row number and the value", firstRow.String())

--- a/cmd/f4/shell_integration_test.go
+++ b/cmd/f4/shell_integration_test.go
@@ -61,7 +61,7 @@ func TestPanelsFrame_CtrlEnterOnDirectoryInsertsWithoutEntering(t *testing.T) {
 	defer pf.Close()
 
 	tmp := t.TempDir()
-	if err := os.Mkdir(filepath.Join(tmp, "subdir"), 0755); err != nil {
+	if err := os.Mkdir(filepath.Join(tmp, "subdir"), 0700); err != nil {
 		t.Fatal(err)
 	}
 	fsp := pf.panels[0].(*FileSystemPanel)
@@ -106,7 +106,7 @@ func TestPanelsFrame_CD_QuotedParsing(t *testing.T) {
 	// Мокаем VFS, чтобы не ходить на реальный диск
 	tmp := t.TempDir()
 	targetDir := filepath.Join(tmp, "dir with space's")
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := fsp.vfs.SetPath(tmp); err != nil {
@@ -142,7 +142,7 @@ func TestPanelsFrame_PTY_SyncEscaping(t *testing.T) {
 	tmp := t.TempDir()
 	dirName := "space 'n' quotes"
 	targetDir := filepath.Join(tmp, dirName)
-	if err := os.MkdirAll(targetDir, 0755); err != nil {
+	if err := os.MkdirAll(targetDir, 0700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/sixel_terminal_test.go
+++ b/cmd/f4/sixel_terminal_test.go
@@ -51,7 +51,7 @@ func sixelBody(w, h int) string {
 func sixelLineText(tv *TerminalView, row int) string {
 	var sb strings.Builder
 	for _, c := range tv.Lines[row] {
-		sb.WriteRune(rune(c.Char))
+		sb.WriteRune(testRune(c.Char))
 	}
 	return sb.String()
 }

--- a/cmd/f4/style_overrides_test.go
+++ b/cmd/f4/style_overrides_test.go
@@ -12,7 +12,7 @@ func withOverrides(t *testing.T, body string) {
 	t.Helper()
 	dir := t.TempDir()
 	if body != "" {
-		if err := os.WriteFile(filepath.Join(dir, "farcolors.ini"), []byte(body), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, "farcolors.ini"), []byte(body), 0600); err != nil {
 			t.Fatalf("write overrides: %v", err)
 		}
 	}

--- a/cmd/f4/style_test.go
+++ b/cmd/f4/style_test.go
@@ -15,7 +15,7 @@ func TestAvailableColorStylesIncludesBuiltInsAndUserStyles(t *testing.T) {
 	defer func() { getUserStylesDir = oldDir }()
 
 	custom := []byte("[style]\nName = Solarized\n\n[farcolors]\nPanel.Text = foreground:#123456\n")
-	if err := os.WriteFile(filepath.Join(userDir, "solarized.ini"), custom, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(userDir, "solarized.ini"), custom, 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/terminal_selection_test.go
+++ b/cmd/f4/terminal_selection_test.go
@@ -16,7 +16,7 @@ func seedRow(tv *TerminalView, row int, text string) {
 		if i >= tv.Width {
 			return
 		}
-		tv.Lines[row][i] = vtui.CharInfo{Char: uint64(r), Attributes: attr}
+		tv.Lines[row][i] = vtui.CharInfo{Char: testUint64Rune(r), Attributes: attr}
 	}
 }
 

--- a/cmd/f4/terminal_view_test.go
+++ b/cmd/f4/terminal_view_test.go
@@ -423,7 +423,7 @@ func TestTerminalView_WideCharAlignment(t *testing.T) {
 	// Write 'A' after '世'
 	tv.PutChar('A', DefaultTermAttr)
 	if tv.Lines[0][2].Char != 'A' {
-		t.Errorf("Character after wide char misaligned: expected 'A' at index 2, got %c", rune(tv.Lines[0][2].Char))
+		t.Errorf("Character after wide char misaligned: expected 'A' at index 2, got %c", testRune(tv.Lines[0][2].Char))
 	}
 }
 func TestTerminalView_AutoWrap_Behavior(t *testing.T) {
@@ -461,7 +461,7 @@ func TestTerminalView_AutoWrap_Behavior(t *testing.T) {
 		t.Errorf("AutoWrap OFF: expected CursorX=10, got %d", tv.CursorX)
 	}
 	if tv.Lines[0][9].Char != 'B' {
-		t.Errorf("AutoWrap OFF: expected 'B' at (9,0), got '%c'", rune(tv.Lines[0][9].Char))
+		t.Errorf("AutoWrap OFF: expected 'B' at (9,0), got '%c'", testRune(tv.Lines[0][9].Char))
 	}
 }
 func TestTerminalView_VTEMirror_PromptOverwrite(t *testing.T) {
@@ -1062,7 +1062,7 @@ func TestIssue117_F4Host_ClipboardProtocolTypes(t *testing.T) {
 	stkSet := vtinput.Far2lStack{}
 	testData := []byte("secret")
 	stkSet.PushBytes(testData)
-	stkSet.PushU32(uint32(len(testData)))
+	stkSet.PushU32(testUint32(len(testData)))
 	stkSet.PushU32(1) // CF_TEXT
 	stkSet.PushU8('s')
 	stkSet.PushU8('c')

--- a/cmd/f4/top_bar_test.go
+++ b/cmd/f4/top_bar_test.go
@@ -34,8 +34,8 @@ func TestTopBar_Show(t *testing.T) {
 	expectedText := "My Test Status"
 	for i, r := range expectedText {
 		cell := scr.GetCell(i, 0)
-		if cell.Char != uint64(r) {
-			t.Errorf("Expected char %q at x=%d, got %q", r, i, rune(cell.Char))
+		if cell.Char != testUint64Rune(r) {
+			t.Errorf("Expected char %q at x=%d, got %q", r, i, testRune(cell.Char))
 		}
 	}
 }
@@ -108,8 +108,8 @@ func TestTopBar_LeftRightAlignment(t *testing.T) {
 	leftText := "LeftPart"
 	for i, r := range leftText {
 		cell := scr.GetCell(i, 0)
-		if cell.Char != uint64(r) {
-			t.Errorf("Expected char %q at x=%d, got %q", r, i, rune(cell.Char))
+		if cell.Char != testUint64Rune(r) {
+			t.Errorf("Expected char %q at x=%d, got %q", r, i, testRune(cell.Char))
 		}
 	}
 
@@ -118,8 +118,8 @@ func TestTopBar_LeftRightAlignment(t *testing.T) {
 	rightStart := 40 - len(rightText)
 	for i, r := range rightText {
 		cell := scr.GetCell(rightStart+i, 0)
-		if cell.Char != uint64(r) {
-			t.Errorf("Expected char %q at x=%d, got %q", r, rightStart+i, rune(cell.Char))
+		if cell.Char != testUint64Rune(r) {
+			t.Errorf("Expected char %q at x=%d, got %q", r, rightStart+i, testRune(cell.Char))
 		}
 	}
 }
@@ -146,8 +146,8 @@ func TestTopBar_Truncation(t *testing.T) {
 	expectedLeft := "VeryLongLeftP…"
 	for i, r := range expectedLeft {
 		cell := scr.GetCell(i, 0)
-		if cell.Char != uint64(r) {
-			t.Errorf("Expected truncated char %q at x=%d, got %q", r, i, rune(cell.Char))
+		if cell.Char != testUint64Rune(r) {
+			t.Errorf("Expected truncated char %q at x=%d, got %q", r, i, testRune(cell.Char))
 		}
 	}
 
@@ -155,8 +155,8 @@ func TestTopBar_Truncation(t *testing.T) {
 	rightStart := 20 - len(expectedRight)
 	for i, r := range expectedRight {
 		cell := scr.GetCell(rightStart+i, 0)
-		if cell.Char != uint64(r) {
-			t.Errorf("Expected right char %q at x=%d, got %q", r, rightStart+i, rune(cell.Char))
+		if cell.Char != testUint64Rune(r) {
+			t.Errorf("Expected right char %q at x=%d, got %q", r, rightStart+i, testRune(cell.Char))
 		}
 	}
 }

--- a/cmd/f4/updater_issue635_test.go
+++ b/cmd/f4/updater_issue635_test.go
@@ -18,7 +18,7 @@ func TestIssue635NetworkDropWhileProgressScreenIsBackground(t *testing.T) {
 	defer func() { updateDownloadIdleTimeout = oldTimeout }()
 	tmpDir := t.TempDir()
 	exePath := filepath.Join(tmpDir, "f4")
-	if err := os.WriteFile(exePath, []byte("old"), 0755); err != nil {
+	if err := os.WriteFile(exePath, []byte("old"), 0755); err != nil { // #nosec G306 -- the updater fixture represents an executable binary.
 		t.Fatal(err)
 	}
 	oldExe := osExecutable

--- a/cmd/f4/updater_repro_test.go
+++ b/cmd/f4/updater_repro_test.go
@@ -26,7 +26,7 @@ func TestUpdateFailureMessageRepro(t *testing.T) {
 		exeName = "f4.exe"
 	}
 	exePath := filepath.Join(tmpDir, exeName)
-	if err := os.WriteFile(exePath, []byte("original binary content"), 0755); err != nil {
+	if err := os.WriteFile(exePath, []byte("original binary content"), 0755); err != nil { // #nosec G306 -- the updater fixture represents an executable binary.
 		t.Fatal(err)
 	}
 
@@ -48,17 +48,17 @@ func TestUpdateFailureMessageRepro(t *testing.T) {
 		// We also make the file itself read-only, because if rename fails, writeFileSafe
 		// will fall back to truncating the existing file, which would otherwise succeed
 		// if the file itself is writable.
-		if err := os.Chmod(exePath, 0444); err != nil {
+		if err := os.Chmod(exePath, 0444); err != nil { // #nosec G302 -- the read-only executable is required to exercise update failure.
 			t.Fatal(err)
 		}
-		if err := os.Chmod(tmpDir, 0555); err != nil {
+		if err := os.Chmod(tmpDir, 0555); err != nil { // #nosec G302 -- the non-writable directory is required to exercise update failure.
 			t.Fatal(err)
 		}
 		t.Cleanup(func() {
-			if err := os.Chmod(tmpDir, 0755); err != nil {
+			if err := os.Chmod(tmpDir, 0755); err != nil { // #nosec G302 -- cleanup must restore access to the deliberately locked directory.
 				t.Errorf("restore temporary directory permissions: %v", err)
 			}
-			if err := os.Chmod(exePath, 0755); err != nil {
+			if err := os.Chmod(exePath, 0755); err != nil { // #nosec G302 -- cleanup restores the fixture's executable mode.
 				t.Errorf("restore executable permissions: %v", err)
 			}
 		})

--- a/cmd/f4/updater_test.go
+++ b/cmd/f4/updater_test.go
@@ -669,15 +669,15 @@ func TestUpdater_WriteFileSafe_FallbackOldName(t *testing.T) {
 	targetPath := filepath.Join(tmpDir, "binary.exe")
 	oldPath := targetPath + ".old"
 
-	if err := os.WriteFile(targetPath, []byte("v1"), 0755); err != nil {
+	if err := os.WriteFile(targetPath, []byte("v1"), 0755); err != nil { // #nosec G306 -- the updater fixture represents an executable binary.
 		t.Fatal(err)
 	}
 
 	// Make os.Remove(oldPath) fail by creating a non-empty directory
-	if err := os.Mkdir(oldPath, 0755); err != nil {
+	if err := os.Mkdir(oldPath, 0700); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(oldPath, "lock"), []byte("lock"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(oldPath, "lock"), []byte("lock"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -809,11 +809,11 @@ func TestUpdater_WriteFileSafe_SudoElevationFallback(t *testing.T) {
 
 	// Создаем директорию с ограниченными правами доступа (только чтение и выполнение)
 	protectedDir := filepath.Join(tmpDir, "protected_dir")
-	if err := os.Mkdir(protectedDir, 0555); err != nil {
+	if err := os.Mkdir(protectedDir, 0555); err != nil { // #nosec G301 -- the read-only directory is the behavior under test.
 		t.Fatalf("failed to create read-only dir: %v", err)
 	}
 	t.Cleanup(func() {
-		if err := os.Chmod(protectedDir, 0755); err != nil {
+		if err := os.Chmod(protectedDir, 0755); err != nil { // #nosec G302 -- cleanup must restore access to the deliberately locked directory.
 			t.Errorf("restore protected directory permissions: %v", err)
 		}
 	})

--- a/cmd/f4/uri_navigation_test.go
+++ b/cmd/f4/uri_navigation_test.go
@@ -231,7 +231,7 @@ func TestFolderHistoryBackUsesPendingVisualTargetInsteadOfSourceVFS(t *testing.T
 	sourcePath := filepath.Join(root, "source")
 	olderPath := filepath.Join(root, "older")
 	for _, path := range []string{sourcePath, olderPath} {
-		if err := os.Mkdir(path, 0o755); err != nil {
+		if err := os.Mkdir(path, 0o700); err != nil {
 			t.Fatal(err)
 		}
 	}

--- a/cmd/f4/url_links_test.go
+++ b/cmd/f4/url_links_test.go
@@ -86,7 +86,7 @@ func TestTerminalURLHoverUnderlinesVisibleLink(t *testing.T) {
 	tv.SetPosition(0, 0, 39, 2)
 	tv.SetVisible(true)
 	for i, r := range "https://example.org" {
-		tv.Lines[0][i] = vtui.CharInfo{Char: uint64(r), Attributes: DefaultTermAttr}
+		tv.Lines[0][i] = vtui.CharInfo{Char: testUint64Rune(r), Attributes: DefaultTermAttr}
 	}
 	if !tv.UpdateURLHover(4, 0) {
 		t.Fatal("hover state did not change")

--- a/cmd/f4/user_menu_ini_test.go
+++ b/cmd/f4/user_menu_ini_test.go
@@ -12,7 +12,7 @@ func writeTemp(t *testing.T, content string) string {
 	t.Helper()
 	dir := t.TempDir()
 	p := filepath.Join(dir, "main_menu.ini")
-	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(p, []byte(content), 0o600); err != nil {
 		t.Fatalf("write temp: %v", err)
 	}
 	return p

--- a/cmd/f4/user_menu_ui_test.go
+++ b/cmd/f4/user_menu_ui_test.go
@@ -128,11 +128,11 @@ func TestFormatMenuItemText_AmpersandInLabel(t *testing.T) {
 func TestFindLocalFarMenu_WalksUp(t *testing.T) {
 	root := t.TempDir()
 	deep := filepath.Join(root, "a", "b", "c")
-	if err := os.MkdirAll(deep, 0o755); err != nil {
+	if err := os.MkdirAll(deep, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	wanted := filepath.Join(root, "a", farMenuFileName)
-	if err := os.WriteFile(wanted, []byte("x:  X\r\n"), 0o644); err != nil {
+	if err := os.WriteFile(wanted, []byte("x:  X\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	got, found := findLocalFarMenu(deep)
@@ -160,15 +160,15 @@ func TestFindLocalFarMenu_PicksClosest(t *testing.T) {
 	root := t.TempDir()
 	mid := filepath.Join(root, "mid")
 	leaf := filepath.Join(mid, "leaf")
-	if err := os.MkdirAll(leaf, 0o755); err != nil {
+	if err := os.MkdirAll(leaf, 0o700); err != nil {
 		t.Fatal(err)
 	}
 	rootMenu := filepath.Join(root, farMenuFileName)
 	midMenu := filepath.Join(mid, farMenuFileName)
-	if err := os.WriteFile(rootMenu, []byte("r:  R\r\n"), 0o644); err != nil {
+	if err := os.WriteFile(rootMenu, []byte("r:  R\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(midMenu, []byte("m:  M\r\n"), 0o644); err != nil {
+	if err := os.WriteFile(midMenu, []byte("m:  M\r\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	got, _ := findLocalFarMenu(leaf)

--- a/cmd/f4/viewer_backend_test.go
+++ b/cmd/f4/viewer_backend_test.go
@@ -131,7 +131,7 @@ func TestViewerBackendLineStartFromEnd(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")
 	content := "line1\nline2\nline3\n"
-	if err := os.WriteFile(tmp, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -172,7 +172,7 @@ func TestViewerBackendLineStartFromEnd(t *testing.T) {
 func TestViewerBackendLineStartFromEndFallsBack(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(tmp, []byte("a\nb\n"), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte("a\nb\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -230,7 +230,7 @@ func (v *searchingVFS) Search(ctx context.Context, path, pattern string) (chan i
 func TestViewerBackendSearchFrom(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(tmp, []byte("needle here and needle there\n"), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte("needle here and needle there\n"), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -314,7 +314,7 @@ func TestViewerBackendLineStart(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")
 	content := "line1\nline2\nline3\n"
-	if err := os.WriteFile(tmp, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte(content), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -354,7 +354,7 @@ func TestViewerBackendLineStart(t *testing.T) {
 func TestViewerBackendLineStartWithoutTrailingNewline(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")
-	if err := os.WriteFile(tmp, []byte("alpha\nomega"), 0644); err != nil {
+	if err := os.WriteFile(tmp, []byte("alpha\nomega"), 0600); err != nil {
 		t.Fatal(err)
 	}
 	vb, err := NewViewerBackend(context.Background(), vfs.NewOSVFS(dir), tmp)

--- a/cmd/f4/viewer_view_test.go
+++ b/cmd/f4/viewer_view_test.go
@@ -643,14 +643,14 @@ func TestViewerView_TabRendering(t *testing.T) {
 	// "b" should be at col 4.
 	cell := scr.GetCell(4, 1) // Y=1 is content row
 	if cell.Char != 'b' {
-		t.Errorf("Tab expansion failed. Expected 'b' at column 4, got '%c' (U+%04X)", rune(cell.Char), cell.Char)
+		t.Errorf("Tab expansion failed. Expected 'b' at column 4, got '%c' (U+%04X)", testRune(cell.Char), cell.Char)
 	}
 
 	// Columns 1, 2, 3 should be empty spaces (' ')
 	for x := 1; x <= 3; x++ {
 		c := scr.GetCell(x, 1)
 		if c.Char != ' ' {
-			t.Errorf("Expected space at col %d, got '%c'", x, rune(c.Char))
+			t.Errorf("Expected space at col %d, got '%c'", x, testRune(c.Char))
 		}
 	}
 }

--- a/cmd/f4/wasm_plugin_test.go
+++ b/cmd/f4/wasm_plugin_test.go
@@ -15,7 +15,7 @@ var emptyWasmModule = []byte{0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00}
 func writeWasmModule(t *testing.T, name string, content []byte) string {
 	t.Helper()
 	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, content, 0o644); err != nil {
+	if err := os.WriteFile(path, content, 0o600); err != nil {
 		t.Fatalf("writing module: %v", err)
 	}
 	return path


### PR DESCRIPTION
Продолжение разбора gosec, на этот раз тесты `cmd/f4`. Ни строчки боевого кода.

**Права на файлы**

Заготовки пишутся с правами `0600`, каталоги под них — `0700`.

Не тронуты те случаи, где права и есть предмет проверки: три заготовки обновлятора остаются исполняемыми, один каталог остаётся недоступным на запись, и восемь мест, где права меняются, чтобы проверить поведение при отказе или вернуть их при уборке. У каждого написана причина. Ужимать их значило бы сломать смысл теста, а не починить его.

**Преобразования чисел**

Раньше значение, не влезающее в целевой тип, молча обрезалось — и тест проходил не по той причине, по которой был написан. Теперь преобразования идут через помощники с проверкой границ: не влезло — падение прямо в тесте.

**Проверено**

`go build`, `go vet`, полный набор тестов `cmd/f4`. В границах задачи находок не осталось.

**Что сюда сознательно не входит**

Непроверенные ошибки (G104) — их около 232 в боевом коде, они закрываются отдельной веткой, где errcheck доведён до нуля по всему дереву. Правила про открытие файла по имени, запуск программы из настроек и запрос по сохранённому адресу исключаются по всему проекту: для файлового менеджера это его прямое назначение.