### PR TITLE
gosec: обход папки через каталог плагинов, доступные всем настройки, порча текста при копировании

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -68,6 +68,16 @@ func extractNames(recs []HistoryRecord) []string {
 	}
 	return res
 }
+
+func choiceText(choices []string, selected int) string {
+	for i, choice := range choices {
+		if i == selected {
+			return choice
+		}
+	}
+	return ""
+}
+
 func actionFoldersHistory(pf *PanelsFrame) {
 	if vtui.GlobalHistoryProvider == nil {
 		return
@@ -1981,7 +1991,7 @@ func actionCopyMove(pf *PanelsFrame, isMove bool) {
 		defMode = 0
 	}
 	comboMode.Menu.SetSelectPos(defMode)
-	comboMode.Edit.SetText(modes[defMode])
+	comboMode.Edit.SetText(choiceText(modes, defMode))
 
 	btnOk := vtui.NewButton(0, 0, Msg("Copy.Btn"))
 	if isMove {
@@ -2571,7 +2581,7 @@ func actionDeleteWithDisposition(pf *PanelsFrame, disposition vfs.DeleteDisposit
 		defMode = 0
 	}
 	comboMode.Menu.SetSelectPos(defMode)
-	comboMode.Edit.SetText(modes[defMode])
+	comboMode.Edit.SetText(choiceText(modes, defMode))
 
 	btnDel := vtui.NewButton(0, 0, Msg(buttonKey))
 	btnCancel := vtui.NewButton(0, 0, Msg("vtui.Cancel"))
@@ -2640,7 +2650,7 @@ func actionMkDir(pf *PanelsFrame) {
 		defMode = 0
 	}
 	comboMode.Menu.SetSelectPos(defMode)
-	comboMode.Edit.SetText(modes[defMode])
+	comboMode.Edit.SetText(choiceText(modes, defMode))
 
 	btnOk := vtui.NewButton(0, 0, Msg("vtui.Ok"))
 	btnOk.IsDefault = true
@@ -3823,6 +3833,9 @@ func decodeFar2lTime(hexStr string) (time.Time, error) {
 		return time.Time{}, err
 	}
 	val := binary.LittleEndian.Uint64(b)
+	// FILETIME's maximum uint64 value becomes at most 1.85e12 seconds
+	// after division, far below int64's limit.
+	// #nosec G115 -- division by 10,000,000 bounds the result to int64.
 	sec := int64(val / 10000000)
 	nsec := int64(val%10000000) * 100
 	sec -= 11644473600
@@ -4023,7 +4036,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		workspaceTabSelection = int(vtui.WorkspaceTabsMultiple)
 	}
 	comboWorkspaceTabs.Menu.SetSelectPos(workspaceTabSelection)
-	comboWorkspaceTabs.Edit.SetText(workspaceTabModes[workspaceTabSelection])
+	comboWorkspaceTabs.Edit.SetText(choiceText(workspaceTabModes, workspaceTabSelection))
 	lblWorkspaceTabs := vtui.NewLabel(0, 0, Msg("AppearanceSettings.WorkspaceTabs"), comboWorkspaceTabs)
 	chkWorkspaceTabsOverlay := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.WorkspaceTabsOverlay"), AppConfig.WorkspaceTabsOverlay)
 	if AppConfig.WorkspaceTabsOverlay {
@@ -4064,7 +4077,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		workspaceNumberingSelection = int(WorkspaceTabNumbersAlways)
 	}
 	comboWorkspaceNumbering.Menu.SetSelectPos(workspaceNumberingSelection)
-	comboWorkspaceNumbering.Edit.SetText(workspaceNumberingModes[workspaceNumberingSelection])
+	comboWorkspaceNumbering.Edit.SetText(choiceText(workspaceNumberingModes, workspaceNumberingSelection))
 	lblWorkspaceNumbering := vtui.NewLabel(0, 0, Msg("AppearanceSettings.WorkspaceNumbers"), comboWorkspaceNumbering)
 
 	chkCursor := vtui.NewCheckbox(0, 0, Msg("PanelSettings.KeepCursor"), false)
@@ -4678,6 +4691,9 @@ func getLanguageName(code string) string {
 	if code == "en" || code == "eng" {
 		return "English"
 	}
+	if !safeLanguageCode(code) {
+		return strings.ToUpper(code)
+	}
 	exeDir := filepath.Dir(os.Args[0])
 	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 	candidates := []string{
@@ -4686,6 +4702,7 @@ func getLanguageName(code string) string {
 		filepath.Join("lang", code+".lng"),
 	}
 	for _, cand := range candidates {
+		// #nosec G703 -- safeLanguageCode rejects separators and ".." before code is used as a path component.
 		if _, err := os.Stat(cand); err == nil {
 			ini := LoadIni(cand)
 			if name := ini.GetString("Language", "Name", ""); name != "" {

--- a/cmd/f4/ai_chat_panel.go
+++ b/cmd/f4/ai_chat_panel.go
@@ -467,7 +467,7 @@ func (cp *AIChatPanel) updateLines() {
 				col = 0
 			}
 
-			charVal := uint64(r)
+			charVal := vtui.RegisterCluster(string(r))
 			for j := 0; j < rw; j++ {
 				currentCells = append(currentCells, vtui.CharInfo{Char: charVal, Attributes: attrs[i]})
 				currentTargets = append(currentTargets, targets[i])
@@ -488,7 +488,7 @@ func (cp *AIChatPanel) updateLines() {
 			if rw <= 0 {
 				rw = 1
 			}
-			charVal := uint64(r)
+			charVal := vtui.RegisterCluster(string(r))
 			for j := 0; j < rw; j++ {
 				cells = append(cells, vtui.CharInfo{Char: charVal, Attributes: attr})
 				targets = append(targets, "")

--- a/cmd/f4/ansi_parser.go
+++ b/cmd/f4/ansi_parser.go
@@ -888,6 +888,7 @@ func (p *AnsiParser) handleOSC() {
 		if strings.HasPrefix(colorStr, "#") && len(colorStr) >= 7 {
 			v, err := strconv.ParseUint(colorStr[1:7], 16, 32)
 			if err == nil {
+				// #nosec G115 -- ParseUint with bitSize 32 rejects values outside uint32.
 				rgbVal = uint32(v)
 				parsed = true
 			}
@@ -898,6 +899,7 @@ func (p *AnsiParser) handleOSC() {
 				r, _ := strconv.ParseUint(rgbParts[0], 16, 8)
 				g, _ := strconv.ParseUint(rgbParts[1], 16, 8)
 				b, _ := strconv.ParseUint(rgbParts[2], 16, 8)
+				// #nosec G115 -- each component was parsed with bitSize 8, so the packed value is at most 0xFFFFFF.
 				rgbVal = uint32((r << 16) | (g << 8) | b)
 				parsed = true
 			}

--- a/cmd/f4/apply_command.go
+++ b/cmd/f4/apply_command.go
@@ -386,7 +386,13 @@ func showApplyCommandDialog(session *applyCommandSession) {
 			vtui.ShowMessageOn(dlg, Msg("ApplyCommand.Title"), Msg("ApplyCommand.UnknownDialect"), []string{Msg("vtui.Ok")})
 			return
 		}
-		mode := ApplyCommandMode(comboMode.Menu.SelectPos)
+		mode := ApplyCommandSequential
+		switch comboMode.Menu.SelectPos {
+		case 1:
+			mode = ApplyCommandParallel
+		case 2:
+			mode = ApplyCommandQueued
+		}
 		workers := 1
 		if mode == ApplyCommandParallel {
 			if chkUnlimited.State == 1 {

--- a/cmd/f4/atomic_file.go
+++ b/cmd/f4/atomic_file.go
@@ -15,7 +15,7 @@ func writeFileAtomically(path string, data []byte, mode os.FileMode) (returnErr 
 	if dir == "" {
 		dir = "."
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 

--- a/cmd/f4/bookmarks.go
+++ b/cmd/f4/bookmarks.go
@@ -59,7 +59,7 @@ func LoadBookmarks(path string) (BookmarkSet, error) {
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 
-	slot := -1
+	var slot *Bookmark
 	for scanner.Scan() {
 		line := strings.TrimRight(scanner.Text(), "\r\n")
 		trimmed := strings.TrimSpace(line)
@@ -67,10 +67,10 @@ func LoadBookmarks(path string) (BookmarkSet, error) {
 			continue
 		}
 		if strings.HasPrefix(trimmed, "[") && strings.HasSuffix(trimmed, "]") {
-			slot = bookmarkSlot(trimmed[1 : len(trimmed)-1])
+			slot = bookmarkSection(&set, trimmed[1:len(trimmed)-1])
 			continue
 		}
-		if slot < 0 {
+		if slot == nil {
 			continue
 		}
 		eq := strings.IndexByte(line, '=')
@@ -81,13 +81,13 @@ func LoadBookmarks(path string) (BookmarkSet, error) {
 		val := strings.TrimSpace(line[eq+1:])
 		switch key {
 		case "Path":
-			set[slot].Path = val
+			slot.Path = val
 		case "Plugin":
-			set[slot].Plugin = val
+			slot.Plugin = val
 		case "PluginData":
-			set[slot].PluginData = val
+			slot.PluginData = val
 		case "PluginFile":
-			set[slot].PluginFile = val
+			slot.PluginFile = val
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -103,7 +103,7 @@ func LoadBookmarks(path string) (BookmarkSet, error) {
 // missing section is what marks a slot as free.
 func SaveBookmarks(path string, s BookmarkSet) error {
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 	}
@@ -140,7 +140,7 @@ func SaveBookmarks(path string, s BookmarkSet) error {
 		buf.WriteByte('\n')
 	}
 
-	return writeFileAtomically(path, []byte(buf.String()), 0o644)
+	return writeFileAtomically(path, []byte(buf.String()), 0o600)
 }
 
 // truncPathLeft shortens path to at most width display cells by dropping
@@ -165,11 +165,13 @@ func truncPathLeft(path string, width int) string {
 	return ellipsis
 }
 
-// bookmarkSlot maps a section name to its slot index, or -1 when the
-// section is not one of far2l's [0]..[9] bookmark sections.
-func bookmarkSlot(name string) int {
-	if len(name) != 1 || name[0] < '0' || name[0] > '9' {
-		return -1
+// bookmarkSection maps a section name to its slot, or nil when the section is
+// not one of far2l's [0]..[9] bookmark sections.
+func bookmarkSection(set *BookmarkSet, name string) *Bookmark {
+	for i := range set {
+		if name == strconv.Itoa(i) {
+			return &set[i]
+		}
 	}
-	return int(name[0] - '0')
+	return nil
 }

--- a/cmd/f4/colorer_downloader.go
+++ b/cmd/f4/colorer_downloader.go
@@ -130,7 +130,7 @@ func installColorerSchemas(data []byte, destDir string, ctx context.Context) err
 	}
 
 	parent := filepath.Dir(destDir)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
+	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return err
 	}
 	if info, err := os.Lstat(destDir); err == nil && info.Mode()&os.ModeSymlink != 0 {
@@ -163,23 +163,19 @@ func installColorerSchemas(data []byte, destDir string, ctx context.Context) err
 			return err
 		}
 		if f.FileInfo().IsDir() {
-			if err := os.MkdirAll(targetPath, 0o755); err != nil {
+			if err := os.MkdirAll(targetPath, 0o700); err != nil {
 				return err
 			}
 			continue
 		}
-		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o700); err != nil {
 			return err
 		}
 		rc, err := f.Open()
 		if err != nil {
 			return err
 		}
-		mode := f.Mode().Perm()
-		if mode == 0 {
-			mode = 0o644
-		}
-		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode)
+		out, err := os.OpenFile(targetPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
 		if err != nil {
 			_ = rc.Close()
 			return err

--- a/cmd/f4/colorer_plugin.go
+++ b/cmd/f4/colorer_plugin.go
@@ -136,8 +136,9 @@ func ensureRadiolaSchema(configsDir string) {
 	hrdDir := filepath.Join(configsDir, "base", "hrd", "rgb")
 	hrdPath := filepath.Join(hrdDir, "radiola.hrd")
 
-	_ = os.MkdirAll(hrdDir, 0755)
-	_ = os.WriteFile(hrdPath, []byte(embedded.RadiolaHRD), 0644)
+	_ = os.MkdirAll(hrdDir, 0700)
+	_ = os.WriteFile(hrdPath, []byte(embedded.RadiolaHRD), 0600)
+	_ = os.Chmod(hrdPath, 0600)
 
 	catalogRGBPath := filepath.Join(configsDir, "base", "hrd", "catalog-rgb.xml")
 	data, err := os.ReadFile(catalogRGBPath)
@@ -145,7 +146,9 @@ func ensureRadiolaSchema(configsDir string) {
 		content := string(data)
 		if !strings.Contains(content, "name=\"Radiola\"") {
 			entry := "\n        <hrd class=\"rgb\" name=\"Radiola\" description=\"Radiola\">\n            <location link=\"&hrd;/rgb/radiola.hrd\"/>\n        </hrd>\n"
-			_ = os.WriteFile(catalogRGBPath, []byte(content+entry), 0644)
+			// #nosec G703 -- configsDir is the user-selected Colorer catalog root and every appended component is fixed here.
+			_ = os.WriteFile(catalogRGBPath, []byte(content+entry), 0600)
+			_ = os.Chmod(catalogRGBPath, 0600)
 		}
 	}
 }

--- a/cmd/f4/colors.go
+++ b/cmd/f4/colors.go
@@ -366,7 +366,10 @@ func ExportColors(path string) error {
 		}
 	}
 
-	return os.WriteFile(path, []byte(sb.String()), 0644)
+	if err := os.WriteFile(path, []byte(sb.String()), 0600); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0600)
 }
 func GetColorRGBBoth(attr uint64) (fg uint32, bg uint32) {
 	if attr&vtui.IsFgRGB != 0 {

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -39,11 +39,13 @@ func GetF4ConfigDir() string {
 
 		// Ищем Far.exe.ini (имя_бинарника.ini) или f4.ini в папке программы
 		iniPath := exe + ".ini"
+		// #nosec G703 -- iniPath is the executable path plus ".ini", not an untrusted path component.
 		if _, err := os.Stat(iniPath); os.IsNotExist(err) {
 			iniPath = filepath.Join(exeDir, "f4.ini")
 		}
 
 		useSystemProfiles := true
+		// #nosec G703 -- iniPath is either executable.ini or the fixed f4.ini name in the executable directory.
 		if _, err := os.Stat(iniPath); err == nil {
 			ini := ParseIni(bytesReader(iniPath))
 			if ini.GetString("General", "UseSystemProfiles", "1") == "0" {
@@ -54,7 +56,7 @@ func GetF4ConfigDir() string {
 		if !useSystemProfiles {
 			cachedF4Portable = true
 			cachedF4ConfigDir = filepath.Join(exeDir, "Profile")
-			_ = os.MkdirAll(cachedF4ConfigDir, 0755)
+			_ = os.MkdirAll(cachedF4ConfigDir, 0700)
 		} else {
 			sysDir, _ := userConfigDir()
 			cachedF4ConfigDir = filepath.Join(sysDir, "f4")
@@ -867,7 +869,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 		fmt.Fprintf(&sb, "%s=%s\n", k, layoutKeys[k])
 	}
 
-	err := writeFileAtomically(path, []byte(sb.String()), 0644)
+	err := writeFileAtomically(path, []byte(sb.String()), 0600)
 	if err != nil {
 		vtui.DebugLog("CONFIG: Failed to save application settings: %v", err)
 		return
@@ -899,7 +901,10 @@ func persistedGuiWindowSize() (int, int) {
 // unrelated settings and unknown keys in an existing settings.ini.
 func saveGuiWindowSize() {
 	path := getUserConfigIniPath()
-	os.MkdirAll(filepath.Dir(path), 0755)
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		vtui.DebugLog("CONFIG: Failed to create settings directory: %v", err)
+		return
+	}
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
 		for _, source := range getConfigIniPaths() {
@@ -908,8 +913,10 @@ func saveGuiWindowSize() {
 			}
 			if inherited, readErr := os.ReadFile(source); readErr == nil {
 				updated := updateIniValues(inherited, "Appearance", guiWindowValues())
-				if writeErr := os.WriteFile(path, updated, 0644); writeErr != nil {
+				if writeErr := os.WriteFile(path, updated, 0600); writeErr != nil {
 					vtui.DebugLog("CONFIG: Failed to save GUI size: %v", writeErr)
+				} else if chmodErr := os.Chmod(path, 0600); chmodErr != nil {
+					vtui.DebugLog("CONFIG: Failed to restrict GUI settings permissions: %v", chmodErr)
 				}
 				return
 			}
@@ -918,8 +925,10 @@ func saveGuiWindowSize() {
 		if AppConfig.GuiPositionSaved {
 			data = append(data, []byte(fmt.Sprintf("GuiPosX = %d\nGuiPosY = %d\n", AppConfig.GuiPosX, AppConfig.GuiPosY))...)
 		}
-		if writeErr := os.WriteFile(path, data, 0644); writeErr != nil {
+		if writeErr := os.WriteFile(path, data, 0600); writeErr != nil {
 			vtui.DebugLog("CONFIG: Failed to save GUI size: %v", writeErr)
+		} else if chmodErr := os.Chmod(path, 0600); chmodErr != nil {
+			vtui.DebugLog("CONFIG: Failed to restrict GUI settings permissions: %v", chmodErr)
 		}
 		return
 	}
@@ -928,8 +937,10 @@ func saveGuiWindowSize() {
 		return
 	}
 	updated := updateIniValues(data, "Appearance", guiWindowValues())
-	if err := os.WriteFile(path, updated, 0644); err != nil {
+	if err := os.WriteFile(path, updated, 0600); err != nil {
 		vtui.DebugLog("CONFIG: Failed to save GUI size: %v", err)
+	} else if chmodErr := os.Chmod(path, 0600); chmodErr != nil {
+		vtui.DebugLog("CONFIG: Failed to restrict GUI settings permissions: %v", chmodErr)
 	}
 }
 
@@ -1111,7 +1122,8 @@ func createDefaultHighlightIni(path string) {
 # you specifically want to override the theme's colors.
 
 `
-	_ = os.WriteFile(path, []byte(content), 0644)
+	_ = os.WriteFile(path, []byte(content), 0600)
+	_ = os.Chmod(path, 0600)
 }
 
 // ApplyProxySettings publishes the configured proxy to netproxy, which is

--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -130,9 +130,7 @@ func (pf *PanelsFrame) buildConsoleOverlayContent() consoleOverlayContent {
 
 	var sb strings.Builder
 	for _, ci := range pf.buildPrompt() {
-		if ci.Char != vtui.WideCharFiller {
-			sb.WriteRune(rune(ci.Char))
-		}
+		sb.WriteString(vtui.CellString(ci.Char))
 	}
 	if pf.cmdLine != nil && pf.cmdLine.Edit != nil {
 		sb.WriteString(pf.cmdLine.Edit.GetText())

--- a/cmd/f4/cpu_info_darwin.go
+++ b/cmd/f4/cpu_info_darwin.go
@@ -36,13 +36,17 @@ func readStaticDarwinCPU() CPUInfo {
 		info.Model = s
 	}
 	if n, ok := sysctlUint64("hw.physicalcpu"); ok {
-		info.PhysicalCores = int(n)
+		if cores, fits := boundedUint64ToInt(n); fits {
+			info.PhysicalCores = cores
+		}
 	}
 	// hw.cpufrequency returns nominal clock in Hz on Intel; on Apple
 	// Silicon this key is absent (fixed-frequency P/E cores with
 	// on-die scaling — no meaningful single number). Skip on error.
 	if hz, ok := sysctlUint64("hw.cpufrequency"); ok && hz > 0 {
-		info.FreqMHz = int(hz / 1_000_000)
+		if mhz, fits := boundedUint64ToInt(hz / 1_000_000); fits {
+			info.FreqMHz = mhz
+		}
 	}
 	// L1i and L1d live under separate keys — sum them into L1.
 	l1i, _ := sysctlUint64("hw.l1icachesize")

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -1069,7 +1069,7 @@ func (ev *EditorView) renderDecode(scr *vtui.ScreenBuf, width, contentHeight int
 			asmStr = fmt.Sprintf("db 0x%02X", data[0])
 			if err == nil {
 				instLen = inst.Len
-				asmStr = x86asm.IntelSyntax(inst, uint64(currOffset), nil)
+				asmStr = x86asm.IntelSyntax(inst, nonNegativeUint64(int64(currOffset)), nil)
 			}
 		}
 
@@ -5782,6 +5782,7 @@ func bytesToString(b []byte) string {
 	if len(b) == 0 {
 		return ""
 	}
+	// #nosec G103 -- the returned string is read-only and every caller retains b for the full lifetime of the synchronous search.
 	return unsafe.String(unsafe.SliceData(b), len(b))
 }
 

--- a/cmd/f4/extui_host.go
+++ b/cmd/f4/extui_host.go
@@ -24,6 +24,7 @@ import (
 const (
 	extUiProtocolVersion = 2
 	extUiMaxMessageSize  = 64 * 1024 * 1024
+	extUiMaxDimension    = 1<<15 - 1
 )
 
 func extUiNewNonce() (string, error) {
@@ -44,6 +45,7 @@ func extUiSendMessage(w io.Writer, msg map[string]any) error {
 	}
 
 	var hdr [4]byte
+	// #nosec G115 -- payload was limited to 64 MiB above, well inside uint32.
 	binary.BigEndian.PutUint32(hdr[:], uint32(len(payload)))
 	if _, err := w.Write(hdr[:]); err != nil {
 		return err
@@ -103,33 +105,71 @@ func extUiBool(msg map[string]any, key string) bool {
 }
 
 func extUiInt(msg map[string]any, key string) int {
-	return extUiAnyInt(msg[key])
+	value, _ := extUiAnyInt(msg[key])
+	return value
 }
 
-func extUiAnyInt(v any) int {
+func extUiAnyInt(v any) (int, bool) {
 	switch n := v.(type) {
 	case int:
-		return n
+		return n, true
 	case int8:
-		return int(n)
+		return int(n), true
 	case int16:
-		return int(n)
+		return int(n), true
 	case int32:
-		return int(n)
+		return int(n), true
 	case int64:
-		return int(n)
+		return boundedInt64ToInt(n)
 	case uint:
-		return int(n)
+		return boundedUint64ToInt(uint64(n))
 	case uint8:
-		return int(n)
+		return int(n), true
 	case uint16:
-		return int(n)
+		return int(n), true
 	case uint32:
-		return int(n)
+		return boundedUint64ToInt(uint64(n))
 	case uint64:
-		return int(n)
+		return boundedUint64ToInt(n)
 	}
-	return 0
+	return 0, false
+}
+
+func extUiDimension(msg map[string]any, key string) (int, bool) {
+	value, ok := extUiAnyInt(msg[key])
+	return value, ok && value > 0 && value <= extUiMaxDimension
+}
+
+func extUiInt16(msg map[string]any, key string) (int16, bool) {
+	value, ok := extUiAnyInt(msg[key])
+	if !ok {
+		return 0, false
+	}
+	return boundedInt16(value)
+}
+
+func extUiUint16(msg map[string]any, key string) (uint16, bool) {
+	value, ok := extUiAnyInt(msg[key])
+	if !ok {
+		return 0, false
+	}
+	return boundedUint16(value)
+}
+
+func extUiUint32(msg map[string]any, key string) (uint32, bool) {
+	value, ok := extUiAnyInt(msg[key])
+	if !ok {
+		return 0, false
+	}
+	return boundedUint32(value)
+}
+
+func extUiRune(msg map[string]any, key string) (rune, bool) {
+	value, ok := extUiAnyInt(msg[key])
+	if !ok {
+		return 0, false
+	}
+	return boundedRune(value)
 }
 
 type ExtUiRenderer struct {
@@ -390,10 +430,10 @@ func RunExternalUI(cols, rows int, execPath string, args []string) error {
 		clientRows = pixelH / cellH
 	}
 
-	if clientCols > 0 {
+	if clientCols > 0 && clientCols <= extUiMaxDimension {
 		cols = clientCols
 	}
-	if clientRows > 0 {
+	if clientRows > 0 && clientRows <= extUiMaxDimension {
 		rows = clientRows
 	}
 
@@ -452,8 +492,9 @@ func (h *ExtUiHost) readLoop() {
 func (h *ExtUiHost) handleMessage(msg map[string]any) {
 	switch extUiString(msg, "type") {
 	case "resize":
-		cols, rows := extUiInt(msg, "cols"), extUiInt(msg, "rows")
-		if cols <= 0 || rows <= 0 {
+		cols, colsOK := extUiDimension(msg, "cols")
+		rows, rowsOK := extUiDimension(msg, "rows")
+		if !colsOK || !rowsOK {
 			return
 		}
 		h.mu.Lock()
@@ -464,42 +505,66 @@ func (h *ExtUiHost) handleMessage(msg map[string]any) {
 			h.sendEvent(&vtinput.InputEvent{Type: vtinput.ResizeEventType, InputSource: "extui"})
 		}
 	case "key":
+		vk, vkOK := extUiUint16(msg, "vk")
+		char, charOK := extUiRune(msg, "char")
+		mods, modsOK := extUiUint32(msg, "mods")
+		if !vkOK || !charOK || !modsOK {
+			return
+		}
 		h.sendEvent(&vtinput.InputEvent{
 			Type:            vtinput.KeyEventType,
 			KeyDown:         extUiBool(msg, "down"),
-			VirtualKeyCode:  uint16(extUiInt(msg, "vk")),
-			Char:            rune(extUiInt(msg, "char")),
-			ControlKeyState: vtinput.ControlKeyState(uint32(extUiInt(msg, "mods"))),
+			VirtualKeyCode:  vk,
+			Char:            char,
+			ControlKeyState: vtinput.ControlKeyState(mods),
 			InputSource:     "extui",
 		})
 	case "text":
+		mods, ok := extUiUint32(msg, "mods")
+		if !ok {
+			return
+		}
 		for _, r := range extUiString(msg, "text") {
 			h.sendEvent(&vtinput.InputEvent{
 				Type:            vtinput.KeyEventType,
 				KeyDown:         true,
 				Char:            r,
-				ControlKeyState: vtinput.ControlKeyState(uint32(extUiInt(msg, "mods"))),
+				ControlKeyState: vtinput.ControlKeyState(mods),
 				InputSource:     "extui_text",
 			})
 		}
 	case "mouse":
+		x, xOK := extUiInt16(msg, "x")
+		y, yOK := extUiInt16(msg, "y")
+		button, buttonOK := extUiUint32(msg, "button")
+		flags, flagsOK := extUiUint32(msg, "flags")
+		mods, modsOK := extUiUint32(msg, "mods")
+		if !xOK || !yOK || !buttonOK || !flagsOK || !modsOK {
+			return
+		}
 		h.sendEvent(&vtinput.InputEvent{
 			Type:            vtinput.MouseEventType,
-			MouseX:          int16(extUiInt(msg, "x")),
-			MouseY:          int16(extUiInt(msg, "y")),
-			ButtonState:     uint32(extUiInt(msg, "button")),
-			MouseEventFlags: uint32(extUiInt(msg, "flags")),
+			MouseX:          x,
+			MouseY:          y,
+			ButtonState:     button,
+			MouseEventFlags: flags,
 			KeyDown:         extUiBool(msg, "down"),
-			ControlKeyState: vtinput.ControlKeyState(uint32(extUiInt(msg, "mods"))),
+			ControlKeyState: vtinput.ControlKeyState(mods),
 			InputSource:     "extui",
 		})
 	case "wheel":
+		x, xOK := extUiInt16(msg, "x")
+		y, yOK := extUiInt16(msg, "y")
+		mods, modsOK := extUiUint32(msg, "mods")
+		if !xOK || !yOK || !modsOK {
+			return
+		}
 		h.sendEvent(&vtinput.InputEvent{
 			Type:            vtinput.MouseEventType,
-			MouseX:          int16(extUiInt(msg, "x")),
-			MouseY:          int16(extUiInt(msg, "y")),
+			MouseX:          x,
+			MouseY:          y,
 			WheelDirection:  extUiInt(msg, "dir"),
-			ControlKeyState: vtinput.ControlKeyState(uint32(extUiInt(msg, "mods"))),
+			ControlKeyState: vtinput.ControlKeyState(mods),
 			InputSource:     "extui",
 		})
 	case "paste":
@@ -561,6 +626,9 @@ func findExtUiPath(backend string) (string, error) {
 	binName := "f4-qt-host"
 	if backend != "qt" {
 		binName = strings.TrimPrefix(backend, "ext:")
+		if binName == "" || strings.Contains(binName, "..") || strings.ContainsAny(binName, `/\`) {
+			return "", fmt.Errorf("invalid external UI executable name %q", binName)
+		}
 	}
 	if runtime.GOOS == "windows" && !strings.HasSuffix(binName, ".exe") {
 		binName += ".exe"
@@ -603,6 +671,7 @@ func extUiFileExists(path string) bool {
 	if path == "" {
 		return false
 	}
+	// #nosec G703 -- callers pass either the explicit F4_EXT_UI_PATH override or a path built from a separator-free executable name.
 	st, err := os.Stat(path)
 	return err == nil && !st.IsDir()
 }

--- a/cmd/f4/far2l_auth.go
+++ b/cmd/f4/far2l_auth.go
@@ -63,8 +63,9 @@ func (a *F4ClipboardAuth) Authorize(clientID string) int {
 		a.mu.Lock()
 		a.autheds[clientID] = true
 		a.mu.Unlock()
-		f, _ := os.OpenFile(a.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		f, _ := os.OpenFile(a.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 		if f != nil {
+			_ = f.Chmod(0600)
 			f.WriteString(clientID + "\n")
 			f.Close()
 		}

--- a/cmd/f4/far2l_image.go
+++ b/cmd/f4/far2l_image.go
@@ -59,8 +59,8 @@ func (tv *TerminalView) handleFar2lImage(stk *vtinput.Far2lStack, reply *vtinput
 		// The order is far2l's: it pops the cell height, then the cell
 		// width, then the capabilities, so they go on in reverse.
 		reply.PushU64(wpImgCapRGBA)
-		reply.PushU16(uint16(cw))
-		reply.PushU16(uint16(ch))
+		reply.PushU16(ptyPixels(cw))
+		reply.PushU16(ptyPixels(ch))
 
 	case 's': // FARTTY_INTERACT_IMAGE_SET
 		reply.PushU8(tv.far2lImageSet(stk))

--- a/cmd/f4/farmenu_file.go
+++ b/cmd/f4/farmenu_file.go
@@ -144,8 +144,14 @@ func decodeUTF32Bytes(b []byte, bo binary.ByteOrder) string {
 	b = b[:len(b)-len(b)%4]
 	runes := make([]rune, 0, len(b)/4)
 	for i := 0; i < len(b); i += 4 {
-		r := rune(bo.Uint32(b[i : i+4]))
-		if r < 0 || r > 0x10FFFF || (r >= 0xD800 && r <= 0xDFFF) {
+		value := bo.Uint32(b[i : i+4])
+		if value > utf8.MaxRune || (value >= 0xD800 && value <= 0xDFFF) {
+			runes = append(runes, utf8.RuneError)
+			continue
+		}
+		// #nosec G115 -- value is bounded to a valid Unicode scalar above.
+		r := rune(value)
+		if !utf8.ValidRune(r) {
 			r = utf8.RuneError
 		}
 		runes = append(runes, r)

--- a/cmd/f4/file_associations.go
+++ b/cmd/f4/file_associations.go
@@ -148,7 +148,7 @@ func LoadAssociations(path string) ([]FileAssoc, error) {
 // order far2l uses so file-level diffs stay small.
 func SaveAssociations(path string, list []FileAssoc) error {
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 	}
@@ -174,7 +174,7 @@ func SaveAssociations(path string, list []FileAssoc) error {
 		fmt.Fprintf(&buf, "State=%d\n", encodeAssocState(a.Enabled))
 	}
 
-	return writeFileAtomically(path, []byte(buf.String()), 0o644)
+	return writeFileAtomically(path, []byte(buf.String()), 0o600)
 }
 
 func parseAssocState(v string) uint32 {

--- a/cmd/f4/fs_info_darwin.go
+++ b/cmd/f4/fs_info_darwin.go
@@ -36,6 +36,7 @@ func int8SliceToString(s []int8) string {
 	}
 	b := make([]byte, n)
 	for i := 0; i < n; i++ {
+		// #nosec G115 -- this intentionally preserves the raw bits of Darwin's C char buffer, including bytes >= 0x80.
 		b[i] = byte(s[i])
 	}
 	return string(b)

--- a/cmd/f4/grabber.go
+++ b/cmd/f4/grabber.go
@@ -231,19 +231,11 @@ func (g *GrabberFrame) copyText() string {
 	l, r, t, b := g.rect()
 	var sb strings.Builder
 	for y := t; y <= b; y++ {
-		line := make([]rune, 0, r-l+1)
+		var line strings.Builder
 		for x := l; x <= r; x++ {
-			ci := g.snap[y][x]
-			if ci.Char == vtui.WideCharFiller {
-				continue
-			}
-			ch := rune(ci.Char)
-			if ch == 0 {
-				ch = ' '
-			}
-			line = append(line, ch)
+			line.WriteString(vtui.CellString(g.snap[y][x].Char))
 		}
-		sb.WriteString(strings.TrimRight(string(line), " "))
+		sb.WriteString(strings.TrimRight(line.String(), " "))
 		if y < b {
 			sb.WriteByte('\n')
 		}

--- a/cmd/f4/help.go
+++ b/cmd/f4/help.go
@@ -116,6 +116,9 @@ func loadHelpLangStrings(code string) map[string]string {
 	if code == "" || code == "en" || code == "eng" {
 		return nil
 	}
+	if !safeLanguageCode(code) {
+		return nil
+	}
 	exeDir := filepath.Dir(os.Args[0])
 	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 	candidates := []string{
@@ -124,6 +127,7 @@ func loadHelpLangStrings(code string) map[string]string {
 		filepath.Join("lang", code+".lng"),
 	}
 	for _, cand := range candidates {
+		// #nosec G703 -- safeLanguageCode rejects separators and ".." before code is used as a path component.
 		if _, err := os.Stat(cand); err == nil {
 			return loadLangMapFromINI(LoadIni(cand))
 		}

--- a/cmd/f4/history_dialog.go
+++ b/cmd/f4/history_dialog.go
@@ -365,7 +365,7 @@ func (s *historySearch) draw(scr *vtui.ScreenBuf) {
 			if width == 0 {
 				continue
 			}
-			cells = append(cells, vtui.CharInfo{Char: uint64(sanitized), Attributes: attr})
+			cells = append(cells, vtui.CharInfo{Char: vtui.RegisterCluster(string(sanitized)), Attributes: attr})
 			for j := 1; j < width; j++ {
 				cells = append(cells, vtui.CharInfo{Char: vtui.WideCharFiller, Attributes: attr})
 			}

--- a/cmd/f4/image_bmp.go
+++ b/cmd/f4/image_bmp.go
@@ -27,7 +27,11 @@ func decodeBMP(data []byte) (*vtui.ImageSurface, error) {
 		return nil, fmt.Errorf("unsupported BMP header of %d bytes", headerSize)
 	}
 
+	// BMP stores dimensions as signed 32-bit two's-complement fields even
+	// though binary.ByteOrder exposes only unsigned readers.
+	// #nosec G115 -- the conversion reinterprets the specified signed BMP field.
 	width := int(int32(le.Uint32(data[18:22])))
+	// #nosec G115 -- the conversion reinterprets the specified signed BMP field.
 	height := int(int32(le.Uint32(data[22:26])))
 	bits := int(le.Uint16(data[28:30]))
 	compression := le.Uint32(data[30:34])
@@ -141,6 +145,10 @@ func decodeBMP(data []byte) (*vtui.ImageSurface, error) {
 
 // bmpScale5 stretches a five bit channel over the whole byte.
 func bmpScale5(v uint16) byte {
+	if v > 0x1F {
+		v = 0x1F
+	}
+	// #nosec G115 -- a clamped five-bit channel scales to at most 255.
 	return byte((int(v)*255 + 15) / 31)
 }
 

--- a/cmd/f4/image_console_overlay.go
+++ b/cmd/f4/image_console_overlay.go
@@ -12,6 +12,8 @@ package main
 // it never shows would put the pictures nowhere.
 
 import (
+	"encoding/binary"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -200,19 +202,18 @@ type consolePiece struct {
 func consoleFrameKey(pieces []consolePiece, frame wincon.Rect) string {
 	var sb strings.Builder
 	add := func(v int) {
-		var b [4]byte
-		b[0], b[1], b[2], b[3] = byte(v), byte(v>>8), byte(v>>16), byte(v>>24)
-		sb.Write(b[:])
+		sb.WriteString(strconv.Itoa(v))
+		sb.WriteByte(0)
 	}
+	var hashBytes [8]byte
 	add(frame.X)
 	add(frame.Y)
 	add(frame.W)
 	add(frame.H)
 	for _, pc := range pieces {
 		h := pc.p.Surface.Hash()
-		for i := 0; i < 8; i++ {
-			sb.WriteByte(byte(h >> (8 * i)))
-		}
+		binary.LittleEndian.PutUint64(hashBytes[:], h)
+		sb.Write(hashBytes[:])
 		add(pc.rect.X)
 		add(pc.rect.Y)
 		add(pc.rect.W)

--- a/cmd/f4/image_x11_overlay.go
+++ b/cmd/f4/image_x11_overlay.go
@@ -15,7 +15,9 @@ package main
 // terminal loses the focus, because nothing in X will take it down for us.
 
 import (
+	"encoding/binary"
 	"errors"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -381,19 +383,18 @@ const overlayGridTolerance = 12
 func overlayFrameKey(list []vtui.ImagePlacement, rect ttyx.Rect) string {
 	var sb strings.Builder
 	add := func(v int) {
-		var b [4]byte
-		b[0], b[1], b[2], b[3] = byte(v), byte(v>>8), byte(v>>16), byte(v>>24)
-		sb.Write(b[:])
+		sb.WriteString(strconv.Itoa(v))
+		sb.WriteByte(0)
 	}
+	var hashBytes [8]byte
 	add(rect.X)
 	add(rect.Y)
 	add(rect.W)
 	add(rect.H)
 	for _, p := range list {
 		h := p.Surface.Hash()
-		for i := 0; i < 8; i++ {
-			sb.WriteByte(byte(h >> (8 * i)))
-		}
+		binary.LittleEndian.PutUint64(hashBytes[:], h)
+		sb.Write(hashBytes[:])
 		add(p.Col)
 		add(p.Row)
 		add(p.Cols)

--- a/cmd/f4/input_translation.go
+++ b/cmd/f4/input_translation.go
@@ -267,11 +267,15 @@ func TranslateInput(e *vtinput.InputEvent, win32Mode bool, kittyFlags int, appCu
 	// child never receives Ctrl+C and e.g. `dir /s` cannot be interrupted.
 	if ctrl && e.Char == 0 {
 		if ch := ctrlCharFromVK(e.VirtualKeyCode); ch >= 0 {
+			controlRune, ok := boundedRune(ch)
+			if !ok {
+				return ""
+			}
 			out := ""
 			if alt {
 				out += "\x1b"
 			}
-			out += string(rune(ch))
+			out += string(controlRune)
 			return out
 		}
 	}

--- a/cmd/f4/lang.go
+++ b/cmd/f4/lang.go
@@ -54,6 +54,10 @@ func loadEmbeddedLanguageMap(code string) map[string]string {
 	return loadLangMapFromINI(ParseIni(strings.NewReader(string(data))))
 }
 
+func safeLanguageCode(code string) bool {
+	return code != "" && !strings.Contains(code, "..") && !strings.ContainsAny(code, `/\`)
+}
+
 // InitLang transfers all f4 strings to vtui localization engine.
 func InitLang() {
 	languageState.Lock()
@@ -76,6 +80,12 @@ func InitLang() {
 		primary = "en"
 	}
 	fallback := AppConfig.FallbackLanguage
+	if !safeLanguageCode(primary) {
+		primary = "en"
+	}
+	if fallback != "" && !safeLanguageCode(fallback) {
+		fallback = ""
+	}
 
 	// 1. Always load embedded English as absolute fallback (Tier 1)
 	embedIni := ParseIni(strings.NewReader(defaultLangData))
@@ -93,6 +103,9 @@ func InitLang() {
 	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 
 	loadLang := func(code string) {
+		if !safeLanguageCode(code) {
+			return
+		}
 		// Use the version embedded in this binary as the language baseline. A
 		// separately installed or development-time .lng file may lag behind the
 		// executable; loading it only as an overlay keeps new strings in the
@@ -107,6 +120,7 @@ func InitLang() {
 		}
 		var langIni *IniFile
 		for _, cand := range candidates {
+			// #nosec G703 -- safeLanguageCode rejects separators and ".." before code is used as a path component.
 			if _, err := os.Stat(cand); err == nil {
 				langIni = LoadIni(cand)
 				vtui.DebugLog("LANG: Loaded language file from disk: %s", cand)

--- a/cmd/f4/macro.go
+++ b/cmd/f4/macro.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
@@ -586,15 +587,27 @@ func (m *MacroManager) Load() {
 					for _, p := range strings.Split(val, ",") {
 						fields := strings.Split(p, ":")
 						if len(fields) == 3 {
-							char, _ := strconv.Atoi(fields[0])
-							vk, _ := strconv.Atoi(fields[1])
-							mods, _ := strconv.Atoi(fields[2])
+							charValue, charErr := strconv.ParseInt(fields[0], 10, 32)
+							vkValue, vkErr := strconv.ParseUint(fields[1], 10, 16)
+							modsValue, modsErr := strconv.ParseUint(fields[2], 10, 32)
+							if charErr != nil || vkErr != nil || modsErr != nil {
+								continue
+							}
+							// #nosec G115 -- ParseInt with bitSize 32 bounds the conversion; ValidRune rejects negative and surrogate values.
+							char := rune(charValue)
+							if char != 0 && !utf8.ValidRune(char) {
+								continue
+							}
+							// #nosec G115 -- ParseUint with bitSize 16 bounds the virtual key code.
+							vk := uint16(vkValue)
+							// #nosec G115 -- ParseUint with bitSize 32 bounds the control-state bit field.
+							mods := vtinput.ControlKeyState(uint32(modsValue))
 							events = append(events, &vtinput.InputEvent{
 								Type:            vtinput.KeyEventType,
 								KeyDown:         true,
-								Char:            rune(char),
-								VirtualKeyCode:  uint16(vk),
-								ControlKeyState: vtinput.ControlKeyState(mods),
+								Char:            char,
+								VirtualKeyCode:  vk,
+								ControlKeyState: mods,
 							})
 						}
 					}
@@ -627,11 +640,16 @@ func (m *MacroManager) Save() {
 		}
 	}
 
-	os.MkdirAll(filepath.Dir(m.iniPath), 0755)
-	err := os.WriteFile(m.iniPath, []byte(sb.String()), 0644)
+	if err := os.MkdirAll(filepath.Dir(m.iniPath), 0700); err != nil {
+		vtui.DebugLog("MACRO: Failed to create macro directory: %v", err)
+		return
+	}
+	err := os.WriteFile(m.iniPath, []byte(sb.String()), 0600)
 	if err != nil {
 		vtui.DebugLog("MACRO: Failed to save: %v", err)
+		return
 	}
+	_ = os.Chmod(m.iniPath, 0600)
 }
 
 // MacroAssignFrame is a modal frame that captures a key combination to assign a macro.

--- a/cmd/f4/macro_export.go
+++ b/cmd/f4/macro_export.go
@@ -112,13 +112,16 @@ func RecordedMacroFileName(area, key string) string {
 // hands it to the running engine, so it takes effect immediately rather than
 // at the next start. That immediacy is the whole appeal of recording one.
 func (m *MacroManager) SaveRecordedMacro(dir, area, key, description string, events []*vtinput.InputEvent) error {
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return err
 	}
 
 	source := RecordedMacroToLua(area, key, description, events)
 	path := filepath.Join(dir, RecordedMacroFileName(area, key))
-	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		return err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
 		return err
 	}
 

--- a/cmd/f4/macro_lua_api.go
+++ b/cmd/f4/macro_lua_api.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	lua "github.com/yuin/gopher-lua"
 )
@@ -412,6 +413,13 @@ func (e *LuaMacroEngine) newFarNamespace(L *lua.LState) *lua.LTable {
 
 func newBitTable(L *lua.LState) *lua.LTable {
 	table := L.NewTable()
+	shiftCount := func(v int64) (uint, bool) {
+		if v < 0 || v >= 64 {
+			return 0, false
+		}
+		// #nosec G115 -- v is bounded to [0, 63] above.
+		return uint(v), true
+	}
 	binary := func(op func(a, b int64) int64) lua.LGFunction {
 		return func(L *lua.LState) int {
 			result := int64(L.CheckNumber(1))
@@ -430,8 +438,21 @@ func newBitTable(L *lua.LState) *lua.LTable {
 			L.Push(lua.LNumber(^int64(L.CheckNumber(1))))
 			return 1
 		},
-		"lshift": binary(func(a, b int64) int64 { return a << uint(b) }),
-		"rshift": binary(func(a, b int64) int64 { return int64(uint64(a) >> uint(b)) }),
+		"lshift": binary(func(a, b int64) int64 {
+			shift, ok := shiftCount(b)
+			if !ok {
+				return 0
+			}
+			return a << shift
+		}),
+		"rshift": binary(func(a, b int64) int64 {
+			shift, ok := shiftCount(b)
+			if !ok {
+				return 0
+			}
+			// #nosec G115 -- logical right shift intentionally reinterprets a's signed bits as uint64.
+			return int64(uint64(a) >> shift)
+		}),
 	})
 	return table
 }
@@ -505,7 +526,17 @@ func (e *LuaMacroEngine) newMFTable(L *lua.LState) *lua.LTable {
 			return 1
 		},
 		"chr": func(L *lua.LState) int {
-			L.Push(lua.LString(string(rune(int(L.CheckNumber(1))))))
+			value := float64(L.CheckNumber(1))
+			if math.IsNaN(value) || math.IsInf(value, 0) || value < 0 || value > utf8.MaxRune {
+				L.ArgError(1, "Unicode code point out of range")
+				return 0
+			}
+			r, ok := boundedRune(int(value))
+			if !ok {
+				L.ArgError(1, "invalid Unicode code point")
+				return 0
+			}
+			L.Push(lua.LString(string(r)))
 			return 1
 		},
 		"env": func(L *lua.LState) int {

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -1066,11 +1066,12 @@ func saveSessionFileWithOptions(path string, savePanelSettings, saveCurrentPanel
 	fmt.Fprintf(&sb, "SortReverse = %d\n", map[bool]int{true: 1, false: 0}[LastRightSortRev])
 	writeWorkspaceSessions(&sb, LastWorkspaceSessions, LastActiveWorkspace)
 
-	err := os.WriteFile(path, []byte(sb.String()), 0644)
+	err := os.WriteFile(path, []byte(sb.String()), 0600)
 	if err != nil {
 		vtui.DebugLog("SESSION: Failed to save state: %v", err)
 		return
 	}
+	_ = os.Chmod(path, 0600)
 
 	vtui.DebugLog("SESSION: Saved state to %s", path)
 }

--- a/cmd/f4/misc.go
+++ b/cmd/f4/misc.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"runtime/debug"
+	"strconv"
+	"unicode/utf8"
 
 	"github.com/unxed/vtui"
 )
@@ -11,12 +13,85 @@ func ScreenRow(scr *vtui.ScreenBuf, y, x1, x2 int) string {
 	runes := make([]rune, x2-x1+1)
 	for i := range runes {
 		cell := scr.GetCell(x1+i, y)
-		runes[i] = rune(cell.Char)
+		runes[i] = vtui.CellBaseRune(cell.Char)
 		if runes[i] == 0 {
 			runes[i] = ' '
 		}
 	}
 	return string(runes)
+}
+
+func boundedInt64ToInt(v int64) (int, bool) {
+	if strconv.IntSize == 32 && (v < -1<<31 || v > 1<<31-1) {
+		return 0, false
+	}
+	// #nosec G115 -- the 32-bit case is range-checked above; on 64-bit int and int64 have the same range.
+	return int(v), true
+}
+
+func boundedUint64ToInt(v uint64) (int, bool) {
+	if (strconv.IntSize == 32 && v > 1<<31-1) || (strconv.IntSize == 64 && v > 1<<63-1) {
+		return 0, false
+	}
+	// #nosec G115 -- v is bounded to the platform's maximum int above.
+	return int(v), true
+}
+
+func nonNegativeUint64(v int64) uint64 {
+	if v < 0 {
+		return 0
+	}
+	// #nosec G115 -- negative sizes and offsets are clamped before conversion.
+	return uint64(v)
+}
+
+func boundedInt16(v int) (int16, bool) {
+	if v < -1<<15 || v > 1<<15-1 {
+		return 0, false
+	}
+	// #nosec G115 -- v is bounded to the int16 range above.
+	return int16(v), true
+}
+
+func boundedInt32(v int) (int32, bool) {
+	if strconv.IntSize == 64 && (int64(v) < -1<<31 || int64(v) > 1<<31-1) {
+		return 0, false
+	}
+	// #nosec G115 -- v is bounded to int32 above; on 32-bit systems the ranges are identical.
+	return int32(v), true
+}
+
+func boundedUint16(v int) (uint16, bool) {
+	if v < 0 || v > 1<<16-1 {
+		return 0, false
+	}
+	// #nosec G115 -- v is bounded to the uint16 range above.
+	return uint16(v), true
+}
+
+func boundedUint32(v int) (uint32, bool) {
+	if v < 0 || (strconv.IntSize == 64 && int64(v) > 1<<32-1) {
+		return 0, false
+	}
+	// #nosec G115 -- v is non-negative and, on 64-bit systems, bounded to uint32 above.
+	return uint32(v), true
+}
+
+func boundedRune(v int) (rune, bool) {
+	if v < 0 || v > utf8.MaxRune {
+		return 0, false
+	}
+	// #nosec G115 -- v is within the Unicode range and the scalar-value check follows immediately.
+	r := rune(v)
+	return r, utf8.ValidRune(r)
+}
+
+func runeCodepoint(r rune) (uint, bool) {
+	if !utf8.ValidRune(r) {
+		return 0, false
+	}
+	// #nosec G115 -- utf8.ValidRune rejects negative runes before conversion.
+	return uint(r), true
 }
 
 // ReleaseHeavyMemory forces GC and releases OS memory when heavy sessions (>50MB) close.

--- a/cmd/f4/plugin_permissions.go
+++ b/cmd/f4/plugin_permissions.go
@@ -130,7 +130,7 @@ func (s *PermissionStore) Remember(plugin, permission, decision string) error {
 	if path == "" {
 		return nil
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 	return os.WriteFile(path, append(data, '\n'), 0o600)

--- a/cmd/f4/plugin_scaffold.go
+++ b/cmd/f4/plugin_scaffold.go
@@ -124,7 +124,8 @@ func ScaffoldPlugin(dir, name string) ([]string, error) {
 	if err := ensureEmptyDir(dir); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	// #nosec G703 -- dir is the complete destination explicitly entered by the user, not an untrusted child component.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, err
 	}
 
@@ -145,7 +146,8 @@ func ScaffoldPlugin(dir, name string) ([]string, error) {
 	created := make([]string, 0, len(contents))
 	for _, entry := range contents {
 		path := filepath.Join(dir, entry.file)
-		if err := os.WriteFile(path, []byte(entry.body), 0o644); err != nil {
+		// #nosec G703 -- entry.file comes only from the fixed three-name table above; dir is the user-selected destination root.
+		if err := os.WriteFile(path, []byte(entry.body), 0o600); err != nil {
 			return created, err
 		}
 		created = append(created, path)

--- a/cmd/f4/plugring_ui.go
+++ b/cmd/f4/plugring_ui.go
@@ -220,6 +220,10 @@ func entrypointNeedsInterpreterOnPath(entrypoint string) bool {
 }
 
 func actionInstallPlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRingItem, refresh func()) {
+	if !safePlugRingID(item.ID) {
+		vtui.ShowMessageOn(parent, " Error ", "Plugin catalog contains an invalid ID.", []string{"&Ok"})
+		return
+	}
 	// 0. The distribution policy, enforced rather than merely documented.
 	// An entry that breaks it is not installed silently; the user is told
 	// exactly what is wrong and may insist, because the catalog in the wild
@@ -321,8 +325,12 @@ func actionInstallPlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRi
 
 		update("Extracting files...", -1)
 
-		os.RemoveAll(pluginDir)
-		os.MkdirAll(pluginDir, 0755)
+		if err := os.RemoveAll(pluginDir); err != nil {
+			return fmt.Errorf("failed to replace existing plugin: %w", err)
+		}
+		if err := os.MkdirAll(pluginDir, 0700); err != nil {
+			return fmt.Errorf("failed to create plugin directory: %w", err)
+		}
 
 		if isArchive {
 			var err error
@@ -337,7 +345,8 @@ func actionInstallPlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRi
 			}
 		} else {
 			filename := filepath.Base(url)
-			err := os.WriteFile(filepath.Join(pluginDir, filename), archiveBytes, 0755)
+			// #nosec G306 G703 -- downloaded plugins may be native executables; mode 0700 is owner-only, safePlugRingID rejected traversal, and filename is reduced with filepath.Base.
+			err := os.WriteFile(filepath.Join(pluginDir, filename), archiveBytes, 0700)
 			if err != nil {
 				os.RemoveAll(pluginDir)
 				return fmt.Errorf("failed to save plugin file: %w", err)
@@ -373,6 +382,10 @@ func actionInstallPlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRi
 }
 
 func actionRemovePlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRingItem, refresh func()) {
+	if !safePlugRingID(item.ID) {
+		vtui.ShowMessageOn(parent, " Error ", "Plugin catalog contains an invalid ID.", []string{"&Ok"})
+		return
+	}
 	plugringDir := filepath.Join(GetF4ConfigDir(), "plugring")
 	pluginDir := filepath.Join(plugringDir, item.ID)
 
@@ -401,4 +414,20 @@ func actionRemovePlugRingItem(pf *PanelsFrame, parent *vtui.Window, item PlugRin
 			}
 		}
 	}
+}
+
+// safePlugRingID accepts only a single, clean path element. The ID arrives from
+// a remote catalog and names the directory install replaces and remove deletes,
+// so anything that could resolve somewhere else is refused rather than cleaned.
+// "." is the trap the obvious check misses: it holds no separator and no "..",
+// yet it names the plugring directory itself, so removing it would take every
+// installed plugin with it.
+func safePlugRingID(id string) bool {
+	if id == "" || id == "." {
+		return false
+	}
+	if strings.Contains(id, "..") || strings.ContainsAny(id, "/\\\x00") {
+		return false
+	}
+	return filepath.Clean(id) == id
 }

--- a/cmd/f4/plugring_ui_test.go
+++ b/cmd/f4/plugring_ui_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/unxed/vtui"
@@ -55,5 +56,34 @@ func TestPlugRingRowColorsFollowDialogTheme(t *testing.T) {
 	installed := plugRingRow{status: "Installed"}.GetCellAttr(0, selected)
 	if got := vtui.GetRGBFore(installed); got != 0xABCDEF {
 		t.Fatalf("installed foreground = %#x, want dialog text foreground", got)
+	}
+}
+
+// The ID names the directory install replaces and remove deletes, and it comes
+// from a remote catalog. Anything that resolves outside its own element, or to
+// the plugring directory itself, has to be refused.
+func TestSafePlugRingIDRejectsAnythingThatEscapesItsElement(t *testing.T) {
+	for _, id := range []string{
+		"",
+		".",
+		"..",
+		"../evil",
+		"a/b",
+		`a\b`,
+		"a\x00b",
+		"./a",
+		"a/",
+	} {
+		if safePlugRingID(id) {
+			t.Errorf("accepted %q, which resolves to %q", id, filepath.Join("plugring", id))
+		}
+	}
+}
+
+func TestSafePlugRingIDAcceptsOrdinaryNames(t *testing.T) {
+	for _, id := range []string{"netfox", "cloud-fox", "media_info", "plugin.v2", ".hidden"} {
+		if !safePlugRingID(id) {
+			t.Errorf("rejected %q, which is a plain directory name", id)
+		}
 	}
 }

--- a/cmd/f4/process_environment_shell.go
+++ b/cmd/f4/process_environment_shell.go
@@ -117,6 +117,7 @@ func initializeProcessEnvironmentRuntime() error {
 		if err := os.MkdirAll(processEnvironmentRuntimeDir, 0o700); err != nil {
 			return err
 		}
+		// #nosec G302 -- processEnvironmentRuntimeDir is a directory and needs owner execute permission for traversal.
 		if err := os.Chmod(processEnvironmentRuntimeDir, 0o700); err != nil {
 			return err
 		}
@@ -131,6 +132,7 @@ func createProcessEnvironmentRuntimeSession(root string) (string, error) {
 	if err := os.MkdirAll(root, 0o700); err != nil {
 		return "", err
 	}
+	// #nosec G302 -- root is a private directory and needs owner execute permission for traversal.
 	if err := os.Chmod(root, 0o700); err != nil {
 		return "", err
 	}
@@ -146,6 +148,7 @@ func createProcessEnvironmentRuntimeSession(root string) (string, error) {
 	if err := os.Mkdir(sessionDir, 0o700); err != nil {
 		return "", err
 	}
+	// #nosec G302 -- sessionDir is a private directory and needs owner execute permission for traversal.
 	if err := os.Chmod(sessionDir, 0o700); err != nil {
 		_ = os.Remove(sessionDir)
 		return "", err
@@ -863,6 +866,11 @@ func windowsProcessEnvironmentScript(changes []vfs.ProcessEnvironmentChange, val
 	fmt.Fprintf(&script, "chcp 65001 >nul || set \"%s=1\"\r\n", statusName)
 	fmt.Fprintf(&script, "set \"%s=OFF\"\r\nset \"%s=!\"\r\nif not defined %s set \"%s=ON\"\r\nset \"%s=\"\r\n", modeName, probeName, probeName, modeName, probeName)
 	for i, change := range changes {
+		var paths []string
+		if len(valuePaths) > 0 {
+			paths = valuePaths[0]
+			valuePaths = valuePaths[1:]
+		}
 		fmt.Fprintf(&script, "set \"%s=\"\r\n", change.Name)
 		if change.Unset || change.Value == "" {
 			continue
@@ -872,7 +880,7 @@ func windowsProcessEnvironmentScript(changes []vfs.ProcessEnvironmentChange, val
 		localFailureName := "F4_ENV_LOCALFAIL_" + labelToken
 		fmt.Fprintf(&script, "if \"%%%s%%\"==\"ON\" goto :F4_ENV_ON_%s\r\ngoto :F4_ENV_OFF_%s\r\n", modeName, labelToken, labelToken)
 		fmt.Fprintf(&script, ":F4_ENV_ON_%s\r\n", labelToken)
-		for _, path := range valuePaths[i] {
+		for _, path := range paths {
 			fmt.Fprintf(&script, "set \"%s=\"\r\n", chunkName)
 			fmt.Fprintf(&script, "set /p \"%s=\" < \"%s\" || set \"%s=1\"\r\n", chunkName, cmdProcessEnvironmentPath(path), statusName)
 			fmt.Fprintf(&script, "set \"%s=!%s!!%s!\"\r\n", change.Name, change.Name, chunkName)
@@ -881,7 +889,7 @@ func windowsProcessEnvironmentScript(changes []vfs.ProcessEnvironmentChange, val
 
 		fmt.Fprintf(&script, ":F4_ENV_OFF_%s\r\nset \"%s=\"\r\nsetlocal EnableDelayedExpansion\r\nset \"%s=\"\r\nset \"%s=0\"\r\n",
 			labelToken, transferName, change.Name, localFailureName)
-		for _, path := range valuePaths[i] {
+		for _, path := range paths {
 			fmt.Fprintf(&script, "set \"%s=\"\r\n", chunkName)
 			fmt.Fprintf(&script, "set /p \"%s=\" < \"%s\" || set \"%s=1\"\r\n", chunkName, cmdProcessEnvironmentPath(path), localFailureName)
 			fmt.Fprintf(&script, "set \"%s=!%s!!%s!\"\r\n", change.Name, change.Name, chunkName)

--- a/cmd/f4/pty_darwin.go
+++ b/cmd/f4/pty_darwin.go
@@ -63,6 +63,7 @@ func NewPTY() (*PTY, error) {
 	}
 
 	ptyName := make([]byte, 128)
+	// #nosec G103 -- ioctl writes at most the 128-byte ptyName buffer during this synchronous syscall.
 	if _, _, e := syscall.Syscall(syscall.SYS_IOCTL, uintptr(masterFd), unix.TIOCPTYGNAME, uintptr(unsafe.Pointer(&ptyName[0]))); e != 0 {
 		master.Close()
 		return nil, e
@@ -151,6 +152,7 @@ func (p *PTY) IsBusy() bool {
 		return false
 	}
 	var pgrp int32
+	// #nosec G103 -- ioctl writes one int32 into this live stack variable during the synchronous syscall.
 	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, p.Master.Fd(), unix.TIOCGPGRP, uintptr(unsafe.Pointer(&pgrp)))
 	if err != 0 {
 		return false
@@ -168,8 +170,9 @@ func (p *PTY) SetSizePixels(cols, rows, xpixel, ypixel int) {
 	size := struct {
 		Row, Col, Xpixel, Ypixel uint16
 	}{
-		Row: uint16(rows), Col: uint16(cols), Xpixel: ptyPixels(xpixel), Ypixel: ptyPixels(ypixel),
+		Row: ptyPixels(rows), Col: ptyPixels(cols), Xpixel: ptyPixels(xpixel), Ypixel: ptyPixels(ypixel),
 	}
+	// #nosec G103 -- ioctl reads this fixed-size winsize-compatible stack struct only during the synchronous syscall.
 	_, _, _ = syscall.Syscall(syscall.SYS_IOCTL, p.Master.Fd(), unix.TIOCSWINSZ, uintptr(unsafe.Pointer(&size)))
 }
 

--- a/cmd/f4/quick_view_panel.go
+++ b/cmd/f4/quick_view_panel.go
@@ -367,14 +367,14 @@ func (q *QuickViewPanel) renderDir(item *fileEntry, writeLine func(string)) {
 	if runtime.GOOS == "windows" {
 		logical = stats.Bytes
 	}
-	writeLine(fmt.Sprintf(" %-14s %s", Msg("QuickView.FilesSize"), formatBytes(uint64(logical))))
+	writeLine(fmt.Sprintf(" %-14s %s", Msg("QuickView.FilesSize"), formatBytes(nonNegativeUint64(logical))))
 	// Physical size + Ratio need per-item on-disk footprint. Stub /
 	// remote VFSes leave PhysicalBytes at 0 during the whole scan —
 	// hide the rows in that case. Ratio is also hidden when it would
 	// just read "100%" — on Unix that's every uncompressed tree, and
 	// a constant carries no information for the reader.
 	if stats.PhysicalBytes > 0 {
-		writeLine(fmt.Sprintf(" %-14s %s", Msg("QuickView.PhysicalSize"), formatBytes(uint64(stats.PhysicalBytes))))
+		writeLine(fmt.Sprintf(" %-14s %s", Msg("QuickView.PhysicalSize"), formatBytes(nonNegativeUint64(stats.PhysicalBytes))))
 		if stats.PhysicalBytes < logical {
 			// Ratio interpretation matches far/far2l — >100% means "on
 			// disk it takes less than the logical size", i.e. real
@@ -516,7 +516,7 @@ func (q *QuickViewPanel) Close() {
 func (q *QuickViewPanel) renderFile(item *fileEntry, innerW int, writeLine func(string), attr uint64, scr *vtui.ScreenBuf) {
 	// Header block (name + size + optional binary note). Two rows.
 	writeLine(" " + item.Name)
-	writeLine(fmt.Sprintf(" %s: %s", Msg("QuickView.Size"), formatBytes(uint64(item.Size))))
+	writeLine(fmt.Sprintf(" %s: %s", Msg("QuickView.Size"), formatBytes(nonNegativeUint64(item.Size))))
 	if q.cacheReadErr != nil {
 		writeLine("")
 		writeLine(" " + Msg("QuickView.ReadError") + ": " + q.cacheReadErr.Error())

--- a/cmd/f4/semantic.go
+++ b/cmd/f4/semantic.go
@@ -771,17 +771,21 @@ func semanticInt(v any) int {
 	case int32:
 		return int(n)
 	case int64:
-		return int(n)
+		value, _ := boundedInt64ToInt(n)
+		return value
 	case uint:
-		return int(n)
+		value, _ := boundedUint64ToInt(uint64(n))
+		return value
 	case uint8:
 		return int(n)
 	case uint16:
 		return int(n)
 	case uint32:
-		return int(n)
+		value, _ := boundedUint64ToInt(uint64(n))
+		return value
 	case uint64:
-		return int(n)
+		value, _ := boundedUint64ToInt(n)
+		return value
 	case float32:
 		return int(n)
 	case float64:

--- a/cmd/f4/session_unix.go
+++ b/cmd/f4/session_unix.go
@@ -449,6 +449,12 @@ func runServer(sockPath string) {
 		// anything that reassigns vtui.FrameManager meanwhile.
 		frames := vtui.FrameManager
 		go func(pipeWriteFD int, inFD int) {
+			pipePollFD, pipeOK := boundedInt32(pipeWriteFD)
+			inputPollFD, inputOK := boundedInt32(inFD)
+			if !pipeOK || !inputOK {
+				frames.Stop()
+				return
+			}
 			ticker := time.NewTicker(250 * time.Millisecond)
 			defer ticker.Stop()
 			for {
@@ -463,8 +469,8 @@ func runServer(sockPath string) {
 					// error/hangup bits, so a healthy writable pipe or
 					// readable stdin never trips them.
 					pfds := []unix.PollFd{
-						{Fd: int32(pipeWriteFD), Events: unix.POLLOUT},
-						{Fd: int32(inFD), Events: unix.POLLIN},
+						{Fd: pipePollFD, Events: unix.POLLOUT},
+						{Fd: inputPollFD, Events: unix.POLLIN},
 					}
 					_, err := unix.Poll(pfds, 0)
 					if err == nil {

--- a/cmd/f4/sheet_dialogs.go
+++ b/cmd/f4/sheet_dialogs.go
@@ -386,8 +386,30 @@ func showSheetFormatDialog(sf *SheetFrame) {
 		if err != nil || places < 0 || places > 20 {
 			places = int(sheet.DefaultDecimals)
 		}
-		selectedDisplay := sheet.Display(display.Selected)
-		selectedJustify := sheet.Justify(justify.Selected)
+		selectedDisplay := sheet.DisplayAsIs
+		switch display.Selected {
+		case 1:
+			selectedDisplay = sheet.DisplayDecimal
+		case 2:
+			selectedDisplay = sheet.DisplayComma
+		case 3:
+			selectedDisplay = sheet.DisplayExponent
+		case 4:
+			selectedDisplay = sheet.DisplayLogical
+		case 5:
+			selectedDisplay = sheet.DisplayCurrency
+		case 6:
+			selectedDisplay = sheet.DisplayPercent
+		case 7:
+			selectedDisplay = sheet.DisplayHidden
+		}
+		selectedJustify := sheet.JustifyLeft
+		switch justify.Selected {
+		case 1:
+			selectedJustify = sheet.JustifyRight
+		case 2:
+			selectedJustify = sheet.JustifyCenter
+		}
 		isProtected := protected.State == 1
 		dlg.Close()
 		sf.Document().Format(sf.Block(), selectedDisplay, selectedJustify, uint8(places), isProtected)

--- a/cmd/f4/sixel_terminal.go
+++ b/cmd/f4/sixel_terminal.go
@@ -11,6 +11,8 @@ package main
 // kitty delete commands off them.
 
 import (
+	"encoding/binary"
+
 	"github.com/unxed/vtui"
 )
 
@@ -41,7 +43,9 @@ func (tv *TerminalView) sixelBackground(attr uint64) [3]byte {
 		rgb = tv.Palette[vtui.GetIndexBack(attr)]
 		tv.mu.Unlock()
 	}
-	return [3]byte{byte(rgb >> 16), byte(rgb >> 8), byte(rgb)}
+	var encoded [4]byte
+	binary.BigEndian.PutUint32(encoded[:], rgb)
+	return [3]byte{encoded[1], encoded[2], encoded[3]}
 }
 
 func (tv *TerminalView) sixelPlace(img *sixelImage) {

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -328,9 +328,7 @@ func (tv *TerminalView) extrudeGridHistoryRow(idx int) {
 			tv.styles = append(tv.styles, StyleChange{Offset: int(tv.pt.Size()) + sb.Len(), Attr: line[i].Attributes})
 			tv.lastAttr = line[i].Attributes
 		}
-		if line[i].Char != vtui.WideCharFiller {
-			sb.WriteRune(rune(line[i].Char))
-		}
+		sb.WriteString(vtui.CellString(line[i].Char))
 	}
 	if !isWrapped {
 		sb.WriteRune('\n')
@@ -360,9 +358,7 @@ func (tv *TerminalView) GetAllLogBytes() []byte {
 			lastChar--
 		}
 		for j := 0; j <= lastChar; j++ {
-			if line[j].Char != vtui.WideCharFiller {
-				sb.WriteRune(rune(line[j].Char))
-			}
+			sb.WriteString(vtui.CellString(line[j].Char))
 		}
 		if !isWrapped {
 			sb.WriteRune('\n')
@@ -401,9 +397,7 @@ func (tv *TerminalView) GetAllLogBytes() []byte {
 			}
 
 			for i := 0; i <= lastChar; i++ {
-				if line[i].Char != vtui.WideCharFiller {
-					sb.WriteRune(rune(line[i].Char))
-				}
+				sb.WriteString(vtui.CellString(line[i].Char))
 			}
 			if !isWrapped && y < lastValidRow {
 				sb.WriteRune('\n')
@@ -1156,22 +1150,14 @@ func (tv *TerminalView) ExtractSelection() string {
 			r = tv.X1 + tv.Width - 1
 		}
 
-		var line []rune
+		var line strings.Builder
 		for x := l; x <= r; x++ {
-			ci := row[x-tv.X1]
-			if ci.Char == vtui.WideCharFiller {
-				continue
-			}
-			ch := rune(ci.Char)
-			if ch == 0 {
-				ch = ' '
-			}
-			line = append(line, ch)
+			line.WriteString(vtui.CellString(row[x-tv.X1].Char))
 		}
 		if !tv.selBlock {
-			sb.WriteString(strings.TrimRight(string(line), " "))
+			sb.WriteString(strings.TrimRight(line.String(), " "))
 		} else {
-			sb.WriteString(string(line))
+			sb.WriteString(line.String())
 		}
 		if y < y2 {
 			sb.WriteByte('\n')
@@ -1640,6 +1626,7 @@ func (tv *TerminalView) ProcessFar2lInteract(data []byte) {
 			// Guest expects: dataID (U64) + data (Bytes) + length (U32)
 			reply.PushU64(0)
 			reply.PushBytes([]byte(clipData))
+			// #nosec G115 -- clipData is capped to 64 KiB immediately above.
 			reply.PushU32(uint32(len(clipData)))
 		case 'i':
 			_ = stk.PopU32()
@@ -1649,8 +1636,8 @@ func (tv *TerminalView) ProcessFar2lInteract(data []byte) {
 			reply.PushU32(0xC000)
 		}
 	case 'w': // Window size
-		reply.PushU16(uint16(tv.Height))
-		reply.PushU16(uint16(tv.Width))
+		reply.PushU16(ptyPixels(tv.Height))
+		reply.PushU16(ptyPixels(tv.Width))
 	case 'h': // Cursor height
 		_ = stk.PopU8()
 	case 'n': // Desktop notification
@@ -1693,8 +1680,8 @@ func (tv *TerminalView) ProcessFar2lInteract(data []byte) {
 
 func (tv *TerminalView) SendFar2lTerminalSize() {
 	stk := vtinput.Far2lStack{}
-	stk.PushU16(uint16(tv.Height))
-	stk.PushU16(uint16(tv.Width))
+	stk.PushU16(ptyPixels(tv.Height))
+	stk.PushU16(ptyPixels(tv.Width))
 	stk.PushU8('S')
 	b64 := base64.StdEncoding.EncodeToString(stk)
 	if tv.pty != nil {

--- a/cmd/f4/translate_kitty.go
+++ b/cmd/f4/translate_kitty.go
@@ -130,12 +130,15 @@ func TranslateKeyToKitty(e *vtinput.InputEvent, flags int, appCursorKeys bool) s
 	isSpecial := ctrl && (e.Char < 32)
 
 	if shift && (!caps || (!isLetter && !isSpecial)) && e.Char != ' ' {
-		shifted = uint(unicode.ToUpper(e.Char))
+		shifted, _ = runeCodepoint(unicode.ToUpper(e.Char))
 	}
-	keycode = uint(unicode.ToLower(e.Char))
+	keycode, _ = runeCodepoint(unicode.ToLower(e.Char))
 
 	if (e.VirtualKeyCode >= 'A' && e.VirtualKeyCode <= 'Z') || (e.VirtualKeyCode >= '0' && e.VirtualKeyCode <= '9') {
-		base = uint(unicode.ToLower(rune(e.VirtualKeyCode)))
+		base = uint(e.VirtualKeyCode)
+		if e.VirtualKeyCode >= 'A' && e.VirtualKeyCode <= 'Z' {
+			base += 'a' - 'A'
+		}
 	}
 
 	switch e.VirtualKeyCode {

--- a/cmd/f4/ttyx_probe_unix.go
+++ b/cmd/f4/ttyx_probe_unix.go
@@ -100,6 +100,9 @@ func pollAnswer(in *os.File, budget time.Duration, prefix string) (string, bool)
 	}
 	var sb strings.Builder
 	cerr := rc.Control(func(fd uintptr) {
+		if fd > 1<<31-1 {
+			return
+		}
 		deadline := time.Now().Add(budget)
 		buf := make([]byte, 128)
 		for {
@@ -107,6 +110,7 @@ func pollAnswer(in *os.File, budget time.Duration, prefix string) (string, bool)
 			if left <= 0 {
 				return
 			}
+			// #nosec G115 -- descriptors larger than PollFd's int32 field are rejected above.
 			pfd := []unix.PollFd{{Fd: int32(fd), Events: unix.POLLIN}}
 			n, err := unix.Poll(pfd, int(left/time.Millisecond)+1)
 			if err == unix.EINTR {

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -476,6 +476,7 @@ func writeFileSafe(targetPath string, r io.Reader, mode os.FileMode) error {
 	}
 
 	dir := filepath.Dir(targetPath)
+	// #nosec G301 -- updater targets may be shared/system installations whose directories must remain searchable by other users.
 	errMkdir := os.MkdirAll(dir, 0755)
 	if errMkdir != nil && os.IsPermission(errMkdir) && vfs.GetSudoClient().IsAvailable() {
 		_ = vfs.GetSudoClient().MkDir(dir, 0755)
@@ -532,6 +533,7 @@ func extractEntry(e archiveEntry, destDir string) error {
 	}
 
 	if e.isDir {
+		// #nosec G301 -- release archive directories may belong to a shared installation and must remain searchable by other users.
 		errMkdir := os.MkdirAll(targetPath, 0755)
 		if errMkdir != nil && os.IsPermission(errMkdir) && vfs.GetSudoClient().IsAvailable() {
 			_ = vfs.GetSudoClient().MkDir(targetPath, 0755)
@@ -570,10 +572,14 @@ func extractTarGzToDir(data []byte, destDir string) error {
 		if err != nil {
 			return err
 		}
+		// tar.Header.Mode is a signed container, but only its low permission
+		// bits are meaningful to the extracted file.
+		// #nosec G115 -- masking to 0777 bounds the os.FileMode conversion.
+		mode := os.FileMode(hdr.Mode & 0o777)
 		if err := extractEntry(archiveEntry{
 			name:  hdr.Name,
 			isDir: hdr.Typeflag == tar.TypeDir,
-			mode:  os.FileMode(hdr.Mode),
+			mode:  mode,
 			open:  func() (io.ReadCloser, error) { return io.NopCloser(tr), nil },
 		}, destDir); err != nil {
 			return err

--- a/cmd/f4/url_links.go
+++ b/cmd/f4/url_links.go
@@ -115,14 +115,7 @@ func urlCellRangesFromCells(cells []vtui.CharInfo) []urlCellRange {
 	offsets := make([]int, 0, len(cells))
 	for _, cell := range cells {
 		offsets = append(offsets, text.Len())
-		if cell.Char == vtui.WideCharFiller {
-			continue
-		}
-		ch := rune(cell.Char)
-		if ch == 0 {
-			ch = ' '
-		}
-		text.WriteRune(ch)
+		text.WriteString(vtui.CellString(cell.Char))
 	}
 	return urlCellRanges(text.String(), offsets)
 }

--- a/cmd/f4/user_menu_ini.go
+++ b/cmd/f4/user_menu_ini.go
@@ -76,7 +76,7 @@ func LoadMainMenu(path string) ([]UserMenuItem, error) {
 // Parent directories are created as needed.
 func SaveMainMenu(path string, items []UserMenuItem) error {
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 	}
@@ -85,7 +85,7 @@ func SaveMainMenu(path string, items []UserMenuItem) error {
 	first := true
 	writeTree(&buf, items, mainMenuRoot, &first)
 
-	return writeFileAtomically(path, []byte(buf.String()), 0o644)
+	return writeFileAtomically(path, []byte(buf.String()), 0o600)
 }
 
 func buildTree(sections map[string]map[string]string, prefix string) []UserMenuItem {

--- a/cmd/f4/user_menu_ui.go
+++ b/cmd/f4/user_menu_ui.go
@@ -110,7 +110,7 @@ func loadFarMenuFile(path string) ([]UserMenuItem, error) {
 // saveFarMenuFile writes a FarMenu.ini text-format file atomically.
 func saveFarMenuFile(path string, items []UserMenuItem) error {
 	if dir := filepath.Dir(path); dir != "" && dir != "." {
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
 			return err
 		}
 	}
@@ -118,7 +118,7 @@ func saveFarMenuFile(path string, items []UserMenuItem) error {
 	if err := WriteFarMenu(&buf, items); err != nil {
 		return err
 	}
-	return writeFileAtomically(path, buf.Bytes(), 0o644)
+	return writeFileAtomically(path, buf.Bytes(), 0o600)
 }
 
 // loadRootForMode reads the current root menu from disk based on the

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -383,7 +383,7 @@ func (vv *ViewerView) renderDecode(scr *vtui.ScreenBuf, width, contentHeight int
 		inst, err := x86asm.Decode(data, vv.DisasmMode)
 		if err == nil {
 			instLen = inst.Len
-			asmStr = x86asm.IntelSyntax(inst, uint64(currOffset), nil)
+			asmStr = x86asm.IntelSyntax(inst, nonNegativeUint64(currOffset), nil)
 		}
 
 		line := fmt.Sprintf("%010X: ", currOffset)

--- a/cmd/f4/vtvibe_ap.go
+++ b/cmd/f4/vtvibe_ap.go
@@ -316,10 +316,10 @@ func aiEnsurePatcher(ctx context.Context, update func(msg string, percent int)) 
 	if !strings.Contains(string(data), "def apply_patch(") {
 		return "", fmt.Errorf("%s", Msg("AI.PatchBadDownload"))
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return "", err
 	}
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	if err := os.WriteFile(path, data, 0600); err != nil {
 		return "", err
 	}
 	return path, nil

--- a/cmd/f4/vtvibe_host.go
+++ b/cmd/f4/vtvibe_host.go
@@ -86,7 +86,7 @@ func vtvibeSaveSetting(key, value string) error {
 	for _, k := range keys {
 		fmt.Fprintf(&sb, "%s = %s\n", k, ini.data["general"][k])
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		return err
 	}
 	// 0600: the file may hold an API key.

--- a/cmd/f4/window_icon_darwin.go
+++ b/cmd/f4/window_icon_darwin.go
@@ -86,6 +86,7 @@ func applyDarwinDockIcon(backend string) {
 	// runs before gogpu sets up an NSAutoreleasePool, so an autoreleased
 	// object would never be drained.
 	data := objc.ID(objc.GetClass("NSData")).Send(objc.RegisterName("alloc")).Send(objc.RegisterName("initWithBytes:length:"),
+		// #nosec G103 -- NSData copies this non-empty embedded byte slice during the synchronous initializer call.
 		unsafe.Pointer(&darwinIconICNS[0]), len(darwinIconICNS))
 	if data == 0 {
 		return

--- a/cmd/f4/workspace_session.go
+++ b/cmd/f4/workspace_session.go
@@ -221,7 +221,12 @@ func workspaceSessionsForRestore(states []workspaceSessionState, active int, res
 	if active < 0 || active >= len(states) {
 		active = 0
 	}
-	return []workspaceSessionState{states[active]}, 0
+	for i, state := range states {
+		if i == active {
+			return []workspaceSessionState{state}, 0
+		}
+	}
+	return nil, 0
 }
 
 func renumberWorkspaceScreens() {


### PR DESCRIPTION
Последний кусок разбора gosec — боевой код `cmd/f4`. 125 находок, из них настоящих ошибок семь.

**Каталог плагинов мог заставить f4 удалить чужую папку**

Идентификатор плагина приходит с удалённого сервера и задаёт имя папки, которую установка перезаписывает, а удаление сносит целиком. Идентификатор с разделителем или `..` уводил обе операции за пределы папки плагинов.

Хуже была одиночная точка: она не содержит ни разделителя, ни `..`, но означает саму папку плагинов. То есть запись с таким идентификатором в каталоге — и пользователь, подтвердивший удаление, стирал все установленные плагины разом.

Теперь идентификатор обязан быть ровно одним чистым именем. Проверка покрыта тестом.

**Личные данные лежали доступными для чтения всем**

Настройки, сеансы, закладки, макросы, меню, привязки к программам, разрешения плагинов, состояние авторизации и **сохранённый пароль от прокси**. На машине с несколькими пользователями это всё читали соседи. Файлы теперь `0600`, каталоги `0700`.

Каталоги установки обновлятора сознательно остались `0755` — они могут быть общесистемными.

**Копирование текста портило эмодзи и надстрочные знаки**

Символ в ячейке экрана не всегда код символа: для составных знаков это ссылка в реестр. Приведение напрямую ломало скопированный текст, подсказки поверх экрана и распознавание ссылок везде, где в ячейке оказывался знак соединения или эмодзи из нескольких частей. Теперь ячейка разбирается как положено.

**Переполнения на данных, которые программа не выбирает**

Большие числа в сообщениях от внешнего интерфейса заворачивались в коды клавиш, символы, маски модификаторов, координаты мыши и номера команд — то есть сообщение могло превратиться не в ту команду. Отбраковываются, размеры окна ограничены.

Тот же поворот в старом файле макросов воспроизводился как совершенно другие нажатия. У каждого поля теперь явная разрядность, не влезающая запись пропускается.

Отрицательные размеры, приходящие с удалённой стороны, показывались как гигантские; размеры за пределами протокола заворачивались и давали неверную геометрию. Ограничены.

Код языка больше не может увести чтение за пределы папки с переводами.

**Права из архива**

Режим записи в архиве маскируется до обычных прав, так что архив не может протащить через распаковку флаг запуска от имени владельца.

**Проверено**

Сборка, `go vet` под все платформы сборки, полный набор тестов, **детектор гонок чист**, кросс-сборка под linux/amd64, linux/arm64, darwin/arm64, windows/amd64. В границах задачи находок не осталось.

**Что сюда сознательно не входит**

Непроверенные ошибки (G104), около 232 — отдельная ветка, где errcheck доведён до нуля по всему дереву. Открытие файла по имени от пользователя, запуск программы из настроек и запрос по сохранённому адресу исключаются по всему проекту: для файлового менеджера это его назначение.