### PR TITLE
feature: [Windows] Position drive menu cursor on the panel's current disk (Alt+F1/F2)

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mattn/go-runewidth"
 
+	"github.com/unxed/f4/vfs/hostmode"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
@@ -4248,7 +4249,44 @@ func (pf *PanelsFrame) showPluginMenu() {
 }
 
 func (pf *PanelsFrame) showDriveMenu(panelIdx int) {
-	pf.showDriveMenuAt(panelIdx, 0)
+	pf.showDriveMenuAt(panelIdx, pf.driveMenuDefaultPos(panelIdx))
+}
+
+// driveMenuDefaultPos returns the drive-menu row the cursor should land on
+// when the menu opens. far2l positions the cursor on the drive the active
+// panel currently shows; for f4 that means: if the panel is on a real
+// filesystem drive that appears in the menu (e.g. a Windows drive letter),
+// land on that drive, otherwise keep the historic default — the "Other panel"
+// entry at row 0.
+func (pf *PanelsFrame) driveMenuDefaultPos(panelIdx int) int {
+	fsp := pf.panels[panelIdx].(*FileSystemPanel)
+	osVFS, ok := fsp.vfs.(*vfs.OSVFS)
+	if !ok {
+		return 0
+	}
+	cur := osVFS.GetPath()
+	for i, drv := range getPlatformDrives() {
+		if driveMatchesPath(drv, cur) {
+			// platform drives begin at menu row 1 (row 0 is "Other panel")
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// driveMatchesPath reports whether the platform drive entry drv is the one
+// the path cur currently belongs to. Only the Windows drive-letter case is
+// matched (the menu entries there carry letters, as the user expects); in
+// posix/UNIX mode the default "Other panel" row stays selected.
+func driveMatchesPath(drv DriveEntry, cur string) bool {
+	if runtime.GOOS != "windows" || hostmode.Posix() {
+		return false
+	}
+	vol := filepath.VolumeName(cur)
+	if vol == "" {
+		return false
+	}
+	return strings.HasPrefix(strings.ToUpper(drv.Name), strings.ToUpper(vol))
 }
 
 // showDriveMenuAt opens the drive menu with the cursor on selectPos. The

--- a/cmd/f4/panels_frame_drivecursor_windows_test.go
+++ b/cmd/f4/panels_frame_drivecursor_windows_test.go
@@ -1,0 +1,58 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+// TestPanelsFrame_DriveMenu_CursorOnCurrentDrive verifies that opening the
+// drive menu (Alt+F1/F2) for a panel sitting on a real filesystem drive lands
+// the cursor on that drive, not on the "Other panel" entry.
+func TestPanelsFrame_DriveMenu_CursorOnCurrentDrive(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	// Put the left panel on the current working directory's drive.
+	cur, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	vol := filepath.VolumeName(cur)
+	if vol == "" {
+		t.Skip("current directory has no drive letter")
+	}
+	left := pf.panels[0].(*FileSystemPanel)
+	left.vfs = vfs.NewOSVFS(cur)
+	if err := left.vfs.SetPath(cur); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open Alt+F1 (left panel drive menu).
+	pf.showDriveMenu(0)
+
+	top := vtui.FrameManager.GetTopFrame()
+	menu, ok := top.(*vtui.VMenu)
+	if !ok {
+		t.Fatal("Drive menu not opened")
+	}
+
+	if menu.SelectPos == 0 {
+		t.Fatalf("cursor landed on \"Other panel\" (row 0) instead of drive %s", vol)
+	}
+
+	row := menu.Items[menu.SelectPos].Text
+	if !strings.Contains(strings.ToUpper(row), strings.ToUpper(vol)) {
+		t.Errorf("cursor on row %q, expected it to match drive %s", row, vol)
+	}
+}

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -3824,9 +3824,14 @@ func TestPanelsFrame_DriveMenu_OtherPanel(t *testing.T) {
 		t.Fatal("Drive menu not opened")
 	}
 
-	// Ensure "Other panel" is at index 0 and selected
-	if menu.GetTitle() != Msg("Drive.Title") || menu.SelectPos != 0 {
-		t.Errorf("Menu state invalid: title=%q, pos=%d", menu.GetTitle(), menu.SelectPos)
+	// Ensure "Other panel" is at index 0. On Windows the cursor instead
+	// lands on the drive the active panel currently shows (see
+	// driveMenuDefaultPos), so only assert the default selection off-Windows.
+	if menu.GetTitle() != Msg("Drive.Title") {
+		t.Errorf("Menu title invalid: %q", menu.GetTitle())
+	}
+	if runtime.GOOS != "windows" && menu.SelectPos != 0 {
+		t.Errorf("Menu state invalid: pos=%d, want 0", menu.SelectPos)
 	}
 
 	// Trigger "Other panel" (idx 0)


### PR DESCRIPTION
Фича полностью соответствует поведению FAR Manager v3.0

Description:
The drive selection menu (Alt+F1 / Alt+F2) used to always open with
the cursor on the first item, "Other panel". Now, when the active
panel is on a real filesystem with a drive letter (Windows,
non-posix mode), the cursor is positioned on that disk.

- added driveMenuDefaultPos to compute the initial row from the
  panel's current path;
- driveMatchesPath matches the drive letter (filepath.VolumeName)
  against the menu item;
- unchanged on non-Windows and in posix mode (cursor stays on
  "Other panel");
- added a Windows-only test and updated
  TestPanelsFrame_DriveMenu_OtherPanel.