### PR TITLE
netfox: treat missing fish+ target as os.ErrNotExist

### DIFF
--- a/plugins/netfox/fishplus/fs.go
+++ b/plugins/netfox/fishplus/fs.go
@@ -2,7 +2,9 @@ package fishplus
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -346,6 +348,13 @@ func (c *Client) info(ctx context.Context, cmd, p string) (Entry, error) {
 		return Entry{}, err
 	}
 	if err := resp.Err(cmd + " " + p); err != nil {
+		// A missing path is not a failure: an upload target is not there
+		// yet, a move may have removed it. The helper reports it with a
+		// fixed marker so it maps to os.ErrNotExist, the answer the VFS
+		// contract expects and the caller uses to decide to create it.
+		if isRemoteNotFound(err) {
+			return Entry{}, os.ErrNotExist
+		}
 		return Entry{}, err
 	}
 	_, entries, err := ParseListing(resp.Lines)
@@ -360,6 +369,18 @@ func (c *Client) info(ctx context.Context, cmd, p string) (Entry, error) {
 	// name, so the name is taken from the request instead.
 	e.Name = path.Base(p)
 	return e, nil
+}
+
+// isRemoteNotFound reports whether a remote error means the requested path is
+// absent rather than the host being broken. The helper emits a fixed marker
+// for the missing-path case, but older helpers let find's own words through,
+// so both spellings are recognised.
+func isRemoteNotFound(err error) bool {
+	var re *RemoteError
+	if !errors.As(err, &re) {
+		return false
+	}
+	return strings.Contains(strings.ToLower(re.Msg), "no such file or directory")
 }
 
 // ReadLink returns the target of a symlink exactly as stored on the host.

--- a/plugins/netfox/fishplus/helper.sh
+++ b/plugins/netfox/fishplus/helper.sh
@@ -569,6 +569,15 @@ f4_cmd_info() {
   f4_end err "no supported stat tool on remote host"
   return
  fi
+ # A path that is neither a real entry nor a symlink simply does not exist.
+ # That is an expected answer -- an upload target is not there yet, a move
+ # may have already removed it -- not a tool failure, so report it
+ # distinctly instead of letting find's stderr leak through as a generic
+ # error the client cannot tell apart from a broken remote host.
+ if [ ! -e "$F4PATH" ] && [ ! -L "$F4PATH" ]; then
+  f4_end err "no such file or directory"
+  return
+ fi
  F4RV=
  case $F4MODE in
   find ) F4OUT=`find $1 "$F4PATH" -mindepth 0 -maxdepth 0 -printf "$F4FMT_FIND" 2>&1`; F4RV=$? ;;


### PR DESCRIPTION
## Problem
Uploading a file via NetFox over a Fish+ connection to a remote host (e.g. Ubuntu) failed with:
fishplus: linfo /home/zeroes/text.out: find: '/home/zeroes/text.out': No such file or directory

The copy path stats the destination before writing. A fresh upload target does not exist yet, but f4_cmd_info in the remote helper let find print 'No such file or directory' and reported it as a fatal error. The Go client surfaced that as a hard failure, aborting the upload even though the file only needed to be created.

## Fix
- plugins/netfox/fishplus/helper.sh (f4_cmd_info): detect a path that is neither a real entry nor a symlink and return the fixed marker no such file or directory instead of leaking find's stderr as a generic error.
- plugins/netfox/fishplus/fs.go (c.info): map the remote "no such file" marker (and the legacy find wording) to os.ErrNotExist via the new isRemoteNotFound helper.

This restores the standard VFS contract: a missing path yields os.ErrNotExist, which the caller interprets as "create it", so the upload proceeds through Create -> Truncate (which already creates the file with : > path).

## Test plan
- Build the netfox plugin.
- Connect to a remote host over Fish+.
- Upload a previously non-existent file (e.g. C:\9002\text.out -> /home/zeroes/text.out).
- Connect to a remote host over Fish+.
- Upload a previously non-existent file (e.g. C:\9002\text.out -> /home/zeroes/text.out).
- Verify the file is created on the remote host and the error no longer appears.