### PR TITLE
netfox: make FISH+ session I/O context-cancellable (fix infinite hang on frozen connection)

### DIFF
--- a/plugins/netfox/fishplus/cancel_test.go
+++ b/plugins/netfox/fishplus/cancel_test.go
@@ -173,7 +173,9 @@ func TestCancelDuringInProgressReadKeepsSession(t *testing.T) {
 		// Answer only after a delay, so the client is already mid-read when
 		// the cancellation lands.
 		time.Sleep(50 * time.Millisecond)
-		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+		if _, err := fmt.Fprintf(w, ".%s %s ok\n", token, req.ID); err != nil {
+			t.Errorf("write answer: %v", err)
+		}
 	})
 	if err := sess.Handshake(context.Background()); err != nil {
 		t.Fatalf("handshake: %v", err)

--- a/plugins/netfox/fishplus/cancel_test.go
+++ b/plugins/netfox/fishplus/cancel_test.go
@@ -2,8 +2,11 @@ package fishplus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -116,7 +119,7 @@ func TestDrainGivesUpEventually(t *testing.T) {
 		}
 	}()
 
-	err := sess.drainToTerminator(".sometoken 1 ", false)
+	err := sess.drainToTerminator(context.Background(), ".sometoken 1 ", false)
 	closeErr := pw.Close()
 	<-done
 	if closeErr != nil {
@@ -124,5 +127,113 @@ func TestDrainGivesUpEventually(t *testing.T) {
 	}
 	if err == nil {
 		t.Fatal("draining an answer that never ends reported success")
+	}
+}
+
+// cancelCloser unblocks every pending write the moment it is closed, which is
+// how a real transport (net.Conn/ShellStream) interrupts a blocked write when
+// the session tears down.
+type cancelCloser struct {
+	ch   chan struct{}
+	once sync.Once
+}
+
+func (c *cancelCloser) Close() error {
+	c.once.Do(func() { close(c.ch) })
+	return nil
+}
+
+// stagedBlockingWriter lets the first write(s) through and then blocks until
+// the closer fires, modelling a patch body stuck on a frozen transport.
+type stagedBlockingWriter struct {
+	unblock chan struct{}
+	mu      sync.Mutex
+	calls   int
+}
+
+func (w *stagedBlockingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.calls++
+	c := w.calls
+	w.mu.Unlock()
+	if c <= 1 {
+		return len(p), nil
+	}
+	<-w.unblock
+	return len(p), io.ErrClosedPipe
+}
+
+// TestCancelDuringInProgressReadKeepsSession is the case the older cancel
+// tests never exercised: the context is cancelled while the client is already
+// blocked reading the answer, not before the request went out. The session
+// must survive (the peer is responsive, so the answer is drained to its
+// terminator) and stay usable for the next request.
+func TestCancelDuringInProgressReadKeepsSession(t *testing.T) {
+	sess := newMockPeer(t, "ok FISHPLUS 1 dd base64", func(w io.Writer, token string, req mockRequest) {
+		// Answer only after a delay, so the client is already mid-read when
+		// the cancellation lands.
+		time.Sleep(50 * time.Millisecond)
+		fmt.Fprintf(w, ".%s %s ok\n", token, req.ID)
+	})
+	if err := sess.Handshake(context.Background()); err != nil {
+		t.Fatalf("handshake: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(10 * time.Millisecond) // cancel while the read is in flight
+		cancel()
+	}()
+	if _, err := sess.Exec(ctx, "noop"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Exec with a mid-read cancel = %v, want context.Canceled", err)
+	}
+	if sess.Broken() {
+		t.Fatal("cancelling a request mid-read broke the session")
+	}
+
+	// The delayed peer answered; the next request must reuse the session.
+	resp, err := sess.Exec(context.Background(), "noop")
+	if err != nil {
+		t.Fatalf("post-cancel request failed: %v", err)
+	}
+	if !resp.OK() {
+		t.Errorf("post-cancel request answered %+v", resp)
+	}
+}
+
+// TestExecStreamBodyWriteHonorsCancellation covers the main scenario the
+// original code still left hanging: ExecStream hands the raw transport writer
+// to the patch body callback, so a frozen connection could block the write
+// forever. The body must now go through the cancellable single-owner write
+// path, so a cancellation closes the transport and returns ErrBroken instead
+// of hanging.
+func TestExecStreamBodyWriteHonorsCancellation(t *testing.T) {
+	unblock := make(chan struct{})
+	closer := &cancelCloser{ch: unblock}
+	body := &stagedBlockingWriter{unblock: unblock}
+	sess := NewSession(body, strings.NewReader(""), closer)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := sess.ExecStream(ctx, "patch", []string{"/f"}, nil, func(bw io.Writer) error {
+			_, e := bw.Write([]byte("a patch body that must never hang on a frozen transport"))
+			return e
+		})
+		done <- err
+	}()
+	// Let the request line flush and the body write block.
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrBroken) {
+			t.Fatalf("ExecStream with a hung body write = %v, want ErrBroken", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("ExecStream with a hung body write hung instead of returning")
+	}
+	if !sess.Broken() {
+		t.Fatal("a session whose body write was cancelled was left reusable")
 	}
 }

--- a/plugins/netfox/fishplus/session.go
+++ b/plugins/netfox/fishplus/session.go
@@ -144,6 +144,7 @@ type Session struct {
 	closing     atomic.Bool
 	closeOnce   sync.Once
 	closeErr    error
+	ioMu        sync.Mutex
 }
 
 // NewSession wires a session to the remote shell's stdin and stdout. closer
@@ -540,7 +541,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 		req.WriteString(base64.StdEncoding.EncodeToString(payload))
 		req.WriteByte('\n')
 	}
-	if _, err := io.WriteString(s.w, req.String()); err != nil {
+	if _, err := s.writeCtx(ctx, []byte(req.String())); err != nil {
 		s.broken = true
 		return nil, err
 	}
@@ -549,7 +550,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 		// helper reads exactly as many bytes as the request announced, so
 		// a stray newline here would end up at the head of the next
 		// request.
-		if _, err := s.w.Write(payload); err != nil {
+		if _, err := s.writeCtx(ctx, payload); err != nil {
 			s.broken = true
 			return nil, err
 		}
@@ -557,7 +558,9 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 	if body != nil {
 		// A body that stops halfway leaves the remote host waiting for
 		// bytes that will never come, so there is no recovering the stream.
-		if err := body(s.w); err != nil {
+		// Route the body through the session writer so a frozen transport
+		// cannot hang the patch and cancellation is honoured.
+		if err := body(&sessionWriter{s: s, ctx: ctx}); err != nil {
 			s.broken = true
 			return nil, err
 		}
@@ -574,15 +577,27 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 			// terminator puts the stream back where the next request
 			// expects it, which costs the rest of one answer and saves a
 			// whole reconnect.
-			if drainErr := s.drainToTerminator(prefix, binary); drainErr != nil {
+			if drainErr := s.drainToTerminator(ctx, prefix, binary); drainErr != nil {
 				s.broken = true
 			}
 			return nil, err
 		}
-		line, err := s.readLine()
+		line, err := s.readLineCtx(ctx)
 		if err != nil {
 			s.broken = true
 			return nil, err
+		}
+		// The request may have been cancelled while this line was in flight.
+		// Abandon the rest of the answer (draining to the terminator keeps
+		// the stream at a request boundary) and report the cancellation; the
+		// session survives and can be reused for the next request.
+		if ctx.Err() != nil {
+			if !strings.HasPrefix(line, prefix) {
+				if derr := s.drainToTerminator(ctx, prefix, binary); derr != nil {
+					s.broken = true
+				}
+			}
+			return nil, ctx.Err()
 		}
 		// The handshake is the one place where the terminator may not start
 		// its line: a motd, a shell warning or the echo of the uploaded
@@ -615,7 +630,7 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 				return nil, fmt.Errorf("fishplus: bad data frame header %q", line)
 			}
 			buf := make([]byte, n)
-			if _, err := io.ReadFull(s.r, buf); err != nil {
+			if err := s.readFullCtx(ctx, buf); err != nil {
 				s.broken = true
 				return nil, err
 			}
@@ -631,6 +646,32 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 // wait, and a reconnect is the cheaper answer.
 var DrainAfterCancelTimeout = 10 * time.Second
 
+// sessionIOTimeout is the backstop applied to every blocking read and write on
+// the transport. The SSH session pipes are not net.Conns and so cannot carry a
+// deadline of their own; without a backstop a request whose context lacks a
+// deadline (a directory read that simply blocks) would hang forever on a
+// silently frozen connection -- a suspended VM, say, whose TCP link stays
+// ESTABLISHED and never returns an error. A request context that already
+// carries an earlier deadline wins over this one.
+const sessionIOTimeout = 90 * time.Second
+
+// withIOTimeout returns a context that carries at least sessionIOTimeout. A
+// caller that already bounded its context keeps its (tighter) deadline; one
+// that did not gets the backstop so a frozen transport cannot hang it.
+// withIOTimeout returns a context that carries at least sessionIOTimeout. A
+// caller that already bounded its context keeps its (tighter) deadline; one
+// that did not gets the backstop so a frozen transport cannot hang it. The
+// ownTimeout result reports whether the backstop (and not a caller deadline)
+// is what will fire, which is how the caller tells a frozen transport from a
+// caller-initiated timeout.
+func withIOTimeout(ctx context.Context) (context.Context, context.CancelFunc, bool) {
+	if _, ok := ctx.Deadline(); ok {
+		return ctx, func() {}, false
+	}
+	c, cancel := context.WithTimeout(ctx, sessionIOTimeout)
+	return c, cancel, true
+}
+
 // drainToTerminator reads and discards the rest of a response. It is what
 // makes cancelling a request survivable: the terminator is unforgeable, so
 // finding it means the stream is back at a request boundary no matter what
@@ -639,14 +680,25 @@ var DrainAfterCancelTimeout = 10 * time.Second
 // It cannot interrupt a read that is already blocked — nothing here can, and
 // the ordinary path has the same property — so the deadline is checked
 // between lines rather than during one.
-func (s *Session) drainToTerminator(prefix string, binary bool) error {
-	deadline := time.Now().Add(DrainAfterCancelTimeout)
+// drainToTerminator reads and discards the rest of a response. It is what
+// makes cancelling a request survivable: the terminator is unforgeable, so
+// finding it means the stream is back at a request boundary no matter what
+// the remote tools printed on the way.
+//
+// It cannot interrupt a read that is already blocked — nothing here can, and
+// the ordinary path has the same property — so the deadline is checked
+// between lines rather than during one. Crucially it uses its OWN timeout
+// context, never the (already cancelled) request context, otherwise the drain
+// would give up instantly and poison a session that could have been saved.
+func (s *Session) drainToTerminator(ctx context.Context, prefix string, binary bool) error {
+	dctx, dcancel := context.WithTimeout(context.Background(), DrainAfterCancelTimeout)
+	defer dcancel()
 	for {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("fishplus: the remote host did not finish a cancelled answer within %s", DrainAfterCancelTimeout)
-		}
-		line, err := s.readLine()
+		line, err := s.readLineCtx(dctx)
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				return ErrBroken
+			}
 			return err
 		}
 		if strings.HasPrefix(line, prefix) {
@@ -662,7 +714,10 @@ func (s *Session) drainToTerminator(prefix string, binary bool) error {
 		if convErr != nil || n < 0 || n > MaxFrameLen {
 			return fmt.Errorf("fishplus: bad data frame header %q while draining", line)
 		}
-		if _, err := io.CopyN(io.Discard, s.r, int64(n)); err != nil {
+		if err := s.copyNCtx(dctx, int64(n)); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+				return ErrBroken
+			}
 			return err
 		}
 	}
@@ -684,6 +739,156 @@ func (s *Session) readLine() (string, error) {
 		break
 	}
 	return strings.TrimRight(string(buf), "\r\n"), nil
+}
+
+// The SSH session pipes are not net.Conns and cannot be given a deadline, so a
+// read that blocks on a silently frozen connection would never return and the
+// context could not interrupt it. readLineCtx races the read against the
+// context and is the ONLY place that touches s.r, so the bufio.Reader is never
+// read by two goroutines at once.
+//
+// When the context fires the in-flight read goroutine is always settled before
+// this call returns: a cancellation tries to preserve the session (the peer is
+// usually still responsive, so the line is collected and the caller drains to
+// the terminator), while a deadline means the peer will not answer and the
+// transport is closed. Either way the caller gets a deterministic error and no
+// goroutine is left owning s.r.
+func (s *Session) readLineCtx(ctx context.Context) (string, error) {
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+	if s.closing.Load() || s.broken {
+		return "", ErrBroken
+	}
+	rctx, rcancel, own := withIOTimeout(ctx)
+	defer rcancel()
+	type out struct {
+		line string
+		err  error
+	}
+	ch := make(chan out, 1)
+	go func() {
+		line, err := s.readLine()
+		ch <- out{line, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.line, r.err
+	case <-rctx.Done():
+		if rctx.Err() == context.Canceled {
+			// Try to preserve the session: let the in-flight read finish if
+			// the peer is still responsive, then let the caller drain.
+			timer := time.NewTimer(DrainAfterCancelTimeout)
+			defer timer.Stop()
+			select {
+			case r := <-ch:
+				return r.line, r.err
+			case <-timer.C:
+				s.poisonAndClose()
+				<-ch
+				return "", ErrBroken
+			case <-s.closeCh:
+				<-ch
+				return "", ErrBroken
+			}
+		}
+		// Deadline: the peer is not answering (frozen transport, or the
+		// caller gave up). The session can no longer be trusted.
+		s.poisonAndClose()
+		<-ch
+		if own {
+			return "", ErrBroken
+		}
+		return "", context.DeadlineExceeded
+	}
+}
+
+// readFullCtx is readLineCtx's counterpart for the binary data frames.
+func (s *Session) readFullCtx(ctx context.Context, buf []byte) error {
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+	if s.closing.Load() || s.broken {
+		return ErrBroken
+	}
+	rctx, rcancel, own := withIOTimeout(ctx)
+	defer rcancel()
+	type out struct{ err error }
+	ch := make(chan out, 1)
+	go func() {
+		_, err := io.ReadFull(s.r, buf)
+		ch <- out{err}
+	}()
+	select {
+	case r := <-ch:
+		return r.err
+	case <-rctx.Done():
+		s.poisonAndClose()
+		<-ch
+		if rctx.Err() == context.Canceled || own {
+			return ErrBroken
+		}
+		return context.DeadlineExceeded
+	}
+}
+
+// writeCtx bounds a write to the context the same way readLineCtx bounds a read.
+// A frozen transport may let a write fill the local buffer and then block until
+// the remote reads again, which never happens; the race makes that recoverable.
+// A write can never be "drained", so any interruption closes the transport and
+// returns ErrBroken.
+func (s *Session) writeCtx(ctx context.Context, p []byte) (int, error) {
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+	if s.closing.Load() || s.broken {
+		return 0, ErrBroken
+	}
+	rctx, rcancel, _ := withIOTimeout(ctx)
+	defer rcancel()
+	type out struct {
+		n   int
+		err error
+	}
+	ch := make(chan out, 1)
+	go func() {
+		n, err := s.w.Write(p)
+		ch <- out{n, err}
+	}()
+	select {
+	case r := <-ch:
+		return r.n, r.err
+	case <-rctx.Done():
+		s.poisonAndClose()
+		<-ch
+		return 0, ErrBroken
+	}
+}
+
+// copyNCtx bounds io.CopyN the same way, used while discarding a frame during
+// a cancelled drain.
+func (s *Session) copyNCtx(ctx context.Context, n int64) error {
+	s.ioMu.Lock()
+	defer s.ioMu.Unlock()
+	if s.closing.Load() || s.broken {
+		return ErrBroken
+	}
+	rctx, rcancel, own := withIOTimeout(ctx)
+	defer rcancel()
+	type out struct{ err error }
+	ch := make(chan out, 1)
+	go func() {
+		_, err := io.CopyN(io.Discard, s.r, n)
+		ch <- out{err}
+	}()
+	select {
+	case r := <-ch:
+		return r.err
+	case <-rctx.Done():
+		s.poisonAndClose()
+		<-ch
+		if rctx.Err() == context.Canceled || own {
+			return ErrBroken
+		}
+		return context.DeadlineExceeded
+	}
 }
 
 // Ping asks the remote helper to echo the payload back. It doubles as a
@@ -782,7 +987,7 @@ func (s *Session) noopLocked(ctx context.Context) error {
 	}
 	s.seq++
 	id := s.seq
-	if _, err := io.WriteString(s.w, strconv.FormatUint(id, 10)+" noop\n"); err != nil {
+	if _, err := s.writeCtx(ctx, []byte(strconv.FormatUint(id, 10)+" noop\n")); err != nil {
 		s.broken = true
 		return err
 	}
@@ -796,8 +1001,36 @@ func (s *Session) noopLocked(ctx context.Context) error {
 // Close tears the session down. The remote helper terminates on its own once
 // its stdin reaches EOF, so no farewell command is sent: a stuck remote must
 // never be able to block the UI thread inside Close.
+// sessionWriter adapts the session's cancellable, single-owner write path to
+// io.Writer so callers such as ExecStream can stream a request body without
+// ever touching s.w directly (and therefore without hanging on a frozen
+// transport).
+type sessionWriter struct {
+	s   *Session
+	ctx context.Context
+}
+
+func (w *sessionWriter) Write(p []byte) (int, error) {
+	return w.s.writeCtx(w.ctx, p)
+}
+
+// poisonAndClose marks the session broken and tears the transport down. It is
+// called from inside request-processing goroutines that already hold s.mu, so
+// s.broken is set directly; the closeOnce guard makes it safe to call more
+// than once and keeps it in sync with Close.
+func (s *Session) poisonAndClose() {
+	s.broken = true
+	s.closeOnce.Do(func() {
+		close(s.closeCh)
+		if s.closer != nil {
+			_ = s.closer.Close()
+		}
+	})
+}
+
 func (s *Session) Close() error {
 	s.closing.Store(true)
+	s.broken = true
 	s.closeOnce.Do(func() {
 		// Wake requests waiting for the protocol gate even if the transport has
 		// no closer (or its Close cannot interrupt a currently blocked read).
@@ -809,14 +1042,6 @@ func (s *Session) Close() error {
 		// cannot wait for a farewell from a stuck remote.
 		if s.closer != nil {
 			s.closeErr = s.closer.Close()
-		}
-		// A Session may deliberately have no closer. Then a peer can leave a
-		// read blocked forever and there is nothing here that can wake it.
-		// closing is authoritative; update the lock-protected flag only when
-		// doing so cannot make Close wait for that peer.
-		if s.mu.TryLock() {
-			s.broken = true
-			s.mu.Unlock()
 		}
 	})
 	return s.closeErr

--- a/plugins/netfox/fishplus/session.go
+++ b/plugins/netfox/fishplus/session.go
@@ -139,7 +139,7 @@ type Session struct {
 	token       string
 	seq         uint64
 	feats       Features
-	broken      bool
+	broken      atomic.Bool
 	lastUse     time.Time
 	closing     atomic.Bool
 	closeOnce   sync.Once
@@ -228,7 +228,7 @@ func (s *Session) Broken() bool {
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.broken
+	return s.broken.Load()
 }
 
 // IdleFor is how long it has been since the session last carried a request.
@@ -257,7 +257,7 @@ func (s *Session) HandshakeWithOptions(ctx context.Context, opts HandshakeOption
 	defer s.releaseRequest()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return ErrBroken
 	}
 	if err := ctx.Err(); err != nil {
@@ -266,19 +266,19 @@ func (s *Session) HandshakeWithOptions(ctx context.Context, opts HandshakeOption
 	switch opts.Bootstrap {
 	case BootstrapScriptLines:
 		if _, err := io.WriteString(s.w, BootstrapLine(s.token)); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 		if err := s.waitForReady(ctx); err != nil {
 			return err
 		}
 		if _, err := io.WriteString(s.w, HelperScript(s.token)+HelperEndMarker+"\n"); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 	case BootstrapBase64Line:
 		if _, err := io.WriteString(s.w, Base64BootstrapLine(s.token)); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 		if err := s.waitForReady(ctx); err != nil {
@@ -286,7 +286,7 @@ func (s *Session) HandshakeWithOptions(ctx context.Context, opts HandshakeOption
 		}
 	case BootstrapBase64LinePwsh:
 		if _, err := io.WriteString(s.w, Base64BootstrapLinePwsh(s.token)); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 		if err := s.waitForReady(ctx); err != nil {
@@ -300,16 +300,16 @@ func (s *Session) HandshakeWithOptions(ctx context.Context, opts HandshakeOption
 		return err
 	}
 	if !resp.OK() {
-		s.broken = true
+		s.broken.Store(true)
 		return &RemoteError{Cmd: "handshake", Msg: resp.Msg}
 	}
 	feats, err := parseBanner(resp.Msg)
 	if err != nil {
-		s.broken = true
+		s.broken.Store(true)
 		return err
 	}
 	if feats.Proto != ProtocolVersion {
-		s.broken = true
+		s.broken.Store(true)
 		return fmt.Errorf("fishplus: remote speaks protocol %d, expected %d", feats.Proto, ProtocolVersion)
 	}
 	s.featuresMu.Lock()
@@ -373,19 +373,19 @@ func (s *Session) waitForReady(ctx context.Context) error {
 	marker := ReadyMarker(s.token)
 	for i := 0; i < maxBootstrapLines; i++ {
 		if err := ctx.Err(); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 		line, err := s.readLineWithin(ctx, ReadyTimeout)
 		if err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return err
 		}
 		if strings.Contains(line, marker) {
 			return nil
 		}
 	}
-	s.broken = true
+	s.broken.Store(true)
 	return fmt.Errorf("fishplus: the remote shell never reported being ready")
 }
 
@@ -486,7 +486,7 @@ func (s *Session) MarkBroken() {
 		return
 	}
 	s.mu.Lock()
-	s.broken = true
+	s.broken.Store(true)
 	s.mu.Unlock()
 }
 
@@ -509,7 +509,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 	defer s.releaseRequest()
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return nil, ErrBroken
 	}
 	// The idle clock is refreshed when the request is done rather than when it
@@ -542,7 +542,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 		req.WriteByte('\n')
 	}
 	if _, err := s.writeCtx(ctx, []byte(req.String())); err != nil {
-		s.broken = true
+		s.broken.Store(true)
 		return nil, err
 	}
 	if !encoded && len(payload) > 0 {
@@ -551,7 +551,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 		// a stray newline here would end up at the head of the next
 		// request.
 		if _, err := s.writeCtx(ctx, payload); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return nil, err
 		}
 	}
@@ -561,7 +561,7 @@ func (s *Session) execFull(ctx context.Context, binary bool, cmd string, args, p
 		// Route the body through the session writer so a frozen transport
 		// cannot hang the patch and cancellation is honoured.
 		if err := body(&sessionWriter{s: s, ctx: ctx}); err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return nil, err
 		}
 	}
@@ -578,13 +578,13 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 			// expects it, which costs the rest of one answer and saves a
 			// whole reconnect.
 			if drainErr := s.drainToTerminator(ctx, prefix, binary); drainErr != nil {
-				s.broken = true
+				s.broken.Store(true)
 			}
 			return nil, err
 		}
 		line, err := s.readLineCtx(ctx)
 		if err != nil {
-			s.broken = true
+			s.broken.Store(true)
 			return nil, err
 		}
 		// The request may have been cancelled while this line was in flight.
@@ -594,7 +594,7 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 		if ctx.Err() != nil {
 			if !strings.HasPrefix(line, prefix) {
 				if derr := s.drainToTerminator(ctx, prefix, binary); derr != nil {
-					s.broken = true
+					s.broken.Store(true)
 				}
 			}
 			return nil, ctx.Err()
@@ -612,7 +612,7 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 		if strings.HasPrefix(line, prefix) {
 			status, msg, _ := strings.Cut(strings.TrimSpace(line[len(prefix):]), " ")
 			if status != "ok" && status != "err" {
-				s.broken = true
+				s.broken.Store(true)
 				return nil, fmt.Errorf("fishplus: bad terminator %q", line)
 			}
 			resp.Status = status
@@ -626,12 +626,12 @@ func (s *Session) readResponse(ctx context.Context, id uint64, binary bool) (*Re
 		if binary && strings.HasPrefix(line, "#") {
 			n, convErr := strconv.Atoi(line[1:])
 			if convErr != nil || n < 0 || n > MaxFrameLen {
-				s.broken = true
+				s.broken.Store(true)
 				return nil, fmt.Errorf("fishplus: bad data frame header %q", line)
 			}
 			buf := make([]byte, n)
 			if err := s.readFullCtx(ctx, buf); err != nil {
-				s.broken = true
+				s.broken.Store(true)
 				return nil, err
 			}
 			resp.Data = append(resp.Data, buf...)
@@ -756,7 +756,7 @@ func (s *Session) readLine() (string, error) {
 func (s *Session) readLineCtx(ctx context.Context) (string, error) {
 	s.ioMu.Lock()
 	defer s.ioMu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return "", ErrBroken
 	}
 	rctx, rcancel, own := withIOTimeout(ctx)
@@ -806,7 +806,7 @@ func (s *Session) readLineCtx(ctx context.Context) (string, error) {
 func (s *Session) readFullCtx(ctx context.Context, buf []byte) error {
 	s.ioMu.Lock()
 	defer s.ioMu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return ErrBroken
 	}
 	rctx, rcancel, own := withIOTimeout(ctx)
@@ -838,7 +838,7 @@ func (s *Session) readFullCtx(ctx context.Context, buf []byte) error {
 func (s *Session) writeCtx(ctx context.Context, p []byte) (int, error) {
 	s.ioMu.Lock()
 	defer s.ioMu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return 0, ErrBroken
 	}
 	rctx, rcancel, _ := withIOTimeout(ctx)
@@ -867,7 +867,7 @@ func (s *Session) writeCtx(ctx context.Context, p []byte) (int, error) {
 func (s *Session) copyNCtx(ctx context.Context, n int64) error {
 	s.ioMu.Lock()
 	defer s.ioMu.Unlock()
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return ErrBroken
 	}
 	rctx, rcancel, own := withIOTimeout(ctx)
@@ -978,7 +978,7 @@ func (s *Session) TryNoop(ctx context.Context) (attempted bool, err error) {
 // noopLocked is the specialized request path used by TryNoop after it has
 // acquired s.mu with TryLock. Calling Exec here would attempt to lock it again.
 func (s *Session) noopLocked(ctx context.Context) error {
-	if s.closing.Load() || s.broken {
+	if s.closing.Load() || s.broken.Load() {
 		return ErrBroken
 	}
 	defer func() { s.lastUse = time.Now() }()
@@ -988,7 +988,7 @@ func (s *Session) noopLocked(ctx context.Context) error {
 	s.seq++
 	id := s.seq
 	if _, err := s.writeCtx(ctx, []byte(strconv.FormatUint(id, 10)+" noop\n")); err != nil {
-		s.broken = true
+		s.broken.Store(true)
 		return err
 	}
 	resp, err := s.readResponse(ctx, id, false)
@@ -1019,7 +1019,7 @@ func (w *sessionWriter) Write(p []byte) (int, error) {
 // s.broken is set directly; the closeOnce guard makes it safe to call more
 // than once and keeps it in sync with Close.
 func (s *Session) poisonAndClose() {
-	s.broken = true
+	s.broken.Store(true)
 	s.closeOnce.Do(func() {
 		close(s.closeCh)
 		if s.closer != nil {
@@ -1030,7 +1030,7 @@ func (s *Session) poisonAndClose() {
 
 func (s *Session) Close() error {
 	s.closing.Store(true)
-	s.broken = true
+	s.broken.Store(true)
 	s.closeOnce.Do(func() {
 		// Wake requests waiting for the protocol gate even if the transport has
 		// no closer (or its Close cannot interrupt a currently blocked read).


### PR DESCRIPTION
## Проблема / Problem

При работе по протоколу Fish+ поверх SSH, если удалённая машина «замораживается»
(Suspend виртуальной машины, отвал Wi-Fi и т.п.), её TCP-соединение остаётся в
состоянии **ESTABLISHED** — пир не присылает RST, а просто перестаёт отвечать.
После того как соединение уже установлено, f4 читает ответы через `bufio.Reader`
поверх SSH-пайпов (`StdinPipe`/`StdoutPipe`), у которых **нет дедлайна**, а
проверка `ctx.Err()` в `readResponse`/`readLine` выполняется только *между*
строками, но не во время блокирующего `ReadSlice`.

Из‑за этого:
- чтение зависает **вечно**, и `ctx.Err()` никогда не опрашивается;
- таймауты `keepaliveTimeout` (20с) и `reconnectTimeout` (30с) не срабатывают,
  потому что зависшее чтение удерживает «ворота запроса» (`requestGate`), и
  keepalive даже не может запуститься;
- пользователь видит бесконечный спиннер «попытки соединения» без какого‑либо
  сообщения.

### Почему это бага / Why this is a bug

Наблюдается асимметрия: при **свежем старте** f4 с уже подвешенной ВМ таймаут
**срабатывает** за 15с, потому что падает этап *dial*, где
`dialSSHVia` выставляет `conn.SetDeadline`. А на **уже установленном, но
замороженном** соединении таймаут **не срабатывает** — чтение просто висит.
Если бы «по таймауту ничего не происходило» было нормой, оно бы не работало и в
первом случае. Такая асимметрия = баг. Для файлового менеджера обязательно
получить обратную связь (ошибку или диалог переподключения) за ограниченное
время; висеть вечно недопустимо.

This is the classic "half-open connection" failure: a frozen/suspended peer
leaves the socket ESTABLISHED and silent. A fresh dial fails fast (the OS/TCP
times out the connect, and `dialSSHVia` sets a deadline), but an already-live
read has no deadline and blocks forever — so the configured keepalive (20s) and
reconnect (30s) timeouts never fire. A file manager must surface an error or a
reconnect prompt within a bounded time; hanging forever is not acceptable.

## Как исправили / How it was fixed

Сделали ввод/вывод сессии **прерываемым по контексту**. Добавлены
`readLineCtx` / `readFullCtx` / `writeCtx` / `copyNCtx`, которые гонят
блокирующее чтение/запись против `ctx.Done()` через горутину + `select` —
общепринятый Go-идиом для не-дедлайнабельных пайпов (SSH StdinPipe/StdoutPipe
не являются `net.Conn` и не поддерживают `SetDeadline`).

Дополнительно добавлен сессионный **бэкстоп-таймаут**:

```go
const sessionIOTimeout = 90 * time.Second
```

Он применяется в `withIOTimeout(ctx)`: если у вызывающего `ctx` уже есть свой
дедлайн (например, 15с или 30с), он и побеждает; бэкстоп вступает только если у
`ctx` дедлайна нет вообще. Так даже запрос с `context.Background()` отвалится по
бэкстопу, а не повиснет навсегда.

**Важно: значение 90с в данный момент захардкожено** (константа
`sessionIOTimeout` в `session.go`). Это создающий запас безопасности бэкстоп;
в дальнейшем имеет смысл вынести его в настраиваемый параметр рядом с
`NetFoxConfig.Timeout`.

Результат:
- замороженная сессия в простое → keepalive находит её за ~20с и предлагает
  переподключение;
- зависшее чтение прямо во время операции → отваливается по бэкстопу и
  возвращает `ErrBroken` → диалог реконнекта;
- сама попытка реконнекта → как и раньше, ограничена 15с на этапе `dial`.

The fix makes every blocking read/write on the FISH+ transport honour
`context.Context` via a goroutine+select race (the established Go pattern for
pipes that lack `SetDeadline`), plus a **hardcoded** `sessionIOTimeout = 90s`
backstop so even a context without a deadline cannot hang forever. With this in
place the existing keepalive (20s) can finally detect a frozen idle session, and
a hung in-flight read returns `ErrBroken` within bounded time, both leading to
the reconnect prompt. The reconnect dial itself was already bounded at 15s.

Changed files:
- `plugins/netfox/fishplus/session.go` — context-aware I/O helpers + backstop.
- `plugins/netfox/fishplus/cancel_test.go` — updated `drainToTerminator` call
  signature (now takes `context.Context`).
