### PR TITLE
netfox: enable TCP keep-alive on the SSH transport so a frozen peer is detected

### DIFF
--- a/plugins/netfox/ssh_dial.go
+++ b/plugins/netfox/ssh_dial.go
@@ -165,6 +165,26 @@ func sshHostKeyCallbackForHome(home string) (ssh.HostKeyCallback, error) {
 	return callback, nil
 }
 
+// setTransportKeepAlive makes the OS probe a long-lived SSH transport so a
+// silently dead peer (suspended VM, yanked cable, stale NAT) is noticed
+// instead of hanging every read/write on the channel forever. Without probes
+// the TCP connection stays ESTABLISHED with no traffic to trip a timeout, so
+// neither the FISH+ nor the SFTP backend can ever learn the link is gone. The
+// call is best-effort: some proxy wrappers hide the underlying socket and do
+// not expose SetKeepAlive, in which case the default behaviour is left intact.
+func setTransportKeepAlive(conn net.Conn) {
+	if ka, ok := conn.(interface {
+		SetKeepAlive(bool) error
+	}); ok {
+		_ = ka.SetKeepAlive(true)
+	}
+	if p, ok := conn.(interface {
+		SetKeepAlivePeriod(time.Duration) error
+	}); ok {
+		_ = p.SetKeepAlivePeriod(15 * time.Second)
+	}
+}
+
 // dialSSHVia opens the transport through px and speaks SSH over it.
 func dialSSHVia(px netproxy.Settings, addr string, config *ssh.ClientConfig) (*ssh.Client, error) {
 	ctx := context.Background()
@@ -177,6 +197,7 @@ func dialSSHVia(px netproxy.Settings, addr string, config *ssh.ClientConfig) (*s
 	if err != nil {
 		return nil, err
 	}
+	setTransportKeepAlive(conn)
 	if config.Timeout > 0 {
 		_ = conn.SetDeadline(time.Now().Add(config.Timeout))
 	}


### PR DESCRIPTION
## Проблема

Замороженное, но *установленное* SSH-соединение (приостановленная ВМ, оборванный кабель, «протухший» NAT) остаётся ESTABLISHED на уровне TCP — нет никакого трафика, который мог бы вызвать таймаут. В итоге любое чтение/запись по SSH-каналу блокируются бесконечно.

Это висение касается **обоих** SSH-бэкендов плагина NetFox:
- **FISH+**: ранее висело навсегда; в отдельном PR (`netfox: make FISH+ session I/O context-cancellable`) добавлен **жёстко захардкоженный бэкстоп 90с** (`sessionIOTimeout = 90 * time.Second`), который всё же разрывает зависший запрос.
- **SFTP**: никакого бэкстопа и вообще **никакого переподключения** в плагине нет, поэтому замороженный SFTP-сеанс повисает навсегда без возможности восстановления.

## Почему это бага (корень)

`DialSSH` → `dialSSHVia` (`plugins/netfox/ssh_dial.go`) создаёт SSH-транспорт, но на нижележащем `net.Conn` никогда не включает TCP keep-alive. `net.Dialer` в `netproxy` включает `KeepAlive` только для *прямого* TCP; для прокси-туннелей (`connectDialer`) его нет вовсе. А стандартный `KEEPCNT` ОС делает детект мёртвого пира при 30с периоде ~5 минутными — слишком медленным и не deterministic.

## Как исправлено

В `dialSSHVia` сразу после установки транспорта вызывается новый `setTransportKeepAlive(conn)`:
- `conn.SetKeepAlive(true)`;
- `conn.SetKeepAlivePeriod(15 * time.Second)` — агрессивнее дефолта, чтобы ОС сама начала зондировать пира и объявила его мёртвым за приемлемое время.

Вызов best-effort через type assertion: для прямого TCP и для прокси-туннеля (`bufferedConn` промоутирует `SetKeepAlive*` на вложенный `*net.TCPConn`) методы доступны, а для транспортов, скрывающих сокет, поведение оставляется без изменений.

Теперь сама ОС разрывает «мёртвый» сокет, что **одним выстрелом** разблокирует и FISH+, и SFTP — это общий транспортный уровень, а не повязка на каждом бэкенде.

## Заметка

Этот фикс **дополняет**, а не заменяет FISH+-PR: для FISH+ 90с бэкстоп остаётся страховкой на случай, если у вызывающего `ctx` нет дедлайна; для SFTP же это теперь **единственная** защита от зависания, и стоит рассмотреть добавление `sftp.WithContext` и `SessionReconnector` (как у FISH+), чтобы замороженный SFTP-сеанс не только падал по ошибке, но и предлагал переподключение.

---

## Problem

A frozen-but-established SSH connection (suspended VM, yanked cable, stale NAT) stays ESTABLISHED at the TCP layer — there is no traffic to trip a timeout, so every read/write on the SSH channel blocks forever.

This hang affects **both** SSH backends of the NetFox plugin:
- **FISH+**: used to hang forever; a separate PR (`netfox: make FISH+ session I/O context-cancellable`) added a **hardcoded 90s backstop** (`sessionIOTimeout = 90 * time.Second`) that still tears down a stuck request.
- **SFTP**: has no such backstop and, in fact, **no reconnect path at all** in the plugin, so a frozen SFTP session hangs indefinitely with no recovery.

## Why this is a bug (root cause)

`DialSSH` → `dialSSHVia` (`plugins/netfox/ssh_dial.go`) builds the SSH transport but never enables TCP keep-alive on the underlying `net.Conn`. The `net.Dialer` in `netproxy` enables `KeepAlive` only for *direct* TCP; proxy tunnels (`connectDialer`) have none. And the OS default `KEEPCNT` makes dead-peer detection ~5 minutes at a 30s period — far too slow and non-deterministic.

## How it is fixed

Right after the transport is established, `dialSSHVia` now calls a new `setTransportKeepAlive(conn)`:
- `conn.SetKeepAlive(true)`;
- `conn.SetKeepAlivePeriod(15 * time.Second)` — more aggressive than the default so the OS itself starts probing the peer and declares it dead within a reasonable time.

The call is best-effort via a type assertion: for direct TCP and for proxy tunnels (`bufferedConn` promotes `SetKeepAlive*` to the embedded `*net.TCPConn`) the methods are available; for transports that hide the socket, behaviour is left intact.

Now the OS itself breaks the dead socket, which unblocks **both** FISH+ and SFTP in one shot — this is the general transport-level fix rather than a per-backend band-aid.

## Note

This change **complements** rather than replaces the FISH+ PR: the 90s backstop remains a safety net for FISH+ requests whose caller `ctx` carries no deadline; for SFTP this is now the **only** protection against hangs, and it would be worth also adding `sftp.WithContext` plus a `SessionReconnector` (as FISH+ has) so a frozen SFTP session not only errors out but offers to reconnect.
