### PR TITLE
grabber: select screen area with the mouse

### DIFF
--- a/cmd/f4/grabber.go
+++ b/cmd/f4/grabber.go
@@ -37,6 +37,11 @@ type GrabberFrame struct {
 	shiftHeld bool
 	ctrlHeld  bool
 	altHeld   bool
+
+	// mouseSelecting is true while the left button is held after a
+	// press inside the grabber, so motion events extend the
+	// rectangular selection until the button is released.
+	mouseSelecting bool
 }
 
 // NewGrabberFrame constructs an empty grabber. The screen snapshot is
@@ -361,8 +366,55 @@ func (g *GrabberFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	return true
 }
 
+// ProcessMouse drives the grabber's rectangular selection with the
+// pointer. Pressing the left button anchors the selection, dragging
+// with the button held extends the rectangle, and releasing the left
+// button stops the selection, leaving the highlighted rectangle in
+// place so it can be copied with Enter / Ctrl+Ins like any
+// keyboard-driven selection.
 func (g *GrabberFrame) ProcessMouse(e *vtinput.InputEvent) bool {
-	// Consume everything — mouse-driven grabber selection is a follow-up.
+	if e.Type != vtinput.MouseEventType {
+		return true
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	// Wheel events are not used by the grabber.
+	if e.WheelDirection != 0 {
+		return true
+	}
+	if g.snapW == 0 || g.snapH == 0 {
+		return true
+	}
+
+	x, y := int(e.MouseX), int(e.MouseY)
+	leftDown := e.ButtonState&vtinput.FromLeft1stButtonPressed != 0
+
+	// While selecting, pointer motion extends the rectangle. Check
+	// this before the release test so a drag reported without the
+	// button bit (some backends) still extends instead of ending.
+	if g.mouseSelecting && e.MouseEventFlags&vtinput.MouseMoved != 0 {
+		g.jump(x, y, true)
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	// Releasing the left button — or any event without the button
+	// held — stops the selection, freezing the highlighted rectangle
+	// until the next press. This makes the area stay fixed through
+	// any later mouse movement.
+	if g.mouseSelecting && (!e.KeyDown || !leftDown) {
+		g.mouseSelecting = false
+		vtui.FrameManager.Redraw()
+		return true
+	}
+
+	// Button press: anchor the selection (or extend on re-press).
+	if leftDown {
+		g.jump(x, y, g.mouseSelecting)
+		g.mouseSelecting = true
+		vtui.FrameManager.Redraw()
+	}
 	return true
 }
 

--- a/cmd/f4/grabber_test.go
+++ b/cmd/f4/grabber_test.go
@@ -204,6 +204,64 @@ func TestGrabber_AltInsToggleCloses(t *testing.T) {
 	}
 }
 
+func mouseEvent(x, y int16, button uint32, moved, down bool) *vtinput.InputEvent {
+	e := &vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		MouseX:      x,
+		MouseY:      y,
+		ButtonState: button,
+		KeyDown:     down,
+	}
+	if moved {
+		e.MouseEventFlags |= vtinput.MouseMoved
+	}
+	return e
+}
+
+func TestGrabber_MouseDragSelectsArea(t *testing.T) {
+	scr := setupGrabberScreen(t)
+	g := NewGrabberFrame()
+	g.Show(scr)
+
+	// Press at (1,0) — anchors the selection.
+	g.ProcessMouse(mouseEvent(1, 0, vtinput.FromLeft1stButtonPressed, false, true))
+	if g.curX != 1 || g.curY != 0 || g.anchorX != 1 || g.anchorY != 0 {
+		t.Fatalf("after press: cur=(%d,%d) anchor=(%d,%d), want (1,0)/(1,0)",
+			g.curX, g.curY, g.anchorX, g.anchorY)
+	}
+
+	// Drag to (5,2) — extends the rectangle.
+	g.ProcessMouse(mouseEvent(5, 2, vtinput.FromLeft1stButtonPressed, true, true))
+	if g.curX != 5 || g.curY != 2 || g.anchorX != 1 || g.anchorY != 0 {
+		t.Fatalf("after drag: cur=(%d,%d) anchor=(%d,%d), want (5,2)/(1,0)",
+			g.curX, g.curY, g.anchorX, g.anchorY)
+	}
+
+	// Release stops the selection, keeping it highlighted.
+	g.ProcessMouse(mouseEvent(5, 2, 0, false, false))
+	if g.mouseSelecting {
+		t.Fatal("release should clear mouseSelecting")
+	}
+	if got := g.copyText(); got == "" {
+		t.Fatal("mouse drag should produce a non-empty selection")
+	}
+
+	// Subsequent pointer movement (button up) must NOT change the
+	// frozen rectangle.
+	g.ProcessMouse(mouseEvent(0, 5, 0, true, true))
+	if g.curX != 5 || g.curY != 2 || g.anchorX != 1 || g.anchorY != 0 {
+		t.Fatalf("after release hover: cur=(%d,%d) anchor=(%d,%d), want frozen (5,2)/(1,0)",
+			g.curX, g.curY, g.anchorX, g.anchorY)
+	}
+
+	// A new press starts a fresh selection again.
+	g.ProcessMouse(mouseEvent(2, 1, vtinput.FromLeft1stButtonPressed, false, true))
+	if g.anchorX != 2 || g.anchorY != 1 || g.curX != 2 || g.curY != 1 {
+		t.Fatalf("after re-press: cur=(%d,%d) anchor=(%d,%d), want (2,1)/(2,1)",
+			g.curX, g.curY, g.anchorX, g.anchorY)
+	}
+}
+
 func TestGrabber_JumpKeys(t *testing.T) {
 	scr := setupGrabberScreen(t)
 	g := NewGrabberFrame()


### PR DESCRIPTION
The feature is completely consistent with the behavior in FAR3

## Summary
Add mouse support to the Screen Grabber (Alt+Ins). The selection can now
be made with the pointer instead of keyboard-only navigation.

Behavior:
- Left button press anchors the selection.
- Dragging with the button held extends the rectangular area.
- Releasing the left button freezes the highlighted rectangle; it no
  longer changes on later pointer movement.
- A new left button press starts a fresh selection.
- Copying still happens via Enter / Ctrl+Ins, matching keyboard use.

## Implementation
- `GrabberFrame` gains a `mouseSelecting` flag and a reworked
  `ProcessMouse`: motion extends while the button is held, and any event
  without the left button (release or hover) stops the selection. The
  release test covers both `KeyDown==false` and `ButtonState==0` so it
  works across backends that report the release differently.
- Coordinates use absolute `MouseX/MouseY`, which map 1:1 to the full-
  screen snapshot.

## Notes
Platform coverage follows the existing mouse pipeline: works on Linux
(X11/Wayland), Windows GUI/gogpu, and ebiten. The legacy Windows console
backend does not deliver mouse events at all, so this (like every other
mouse feature in f4) is unavailable there.

## Test
`TestGrabber_MouseDragSelectsArea` verifies anchor/drag/release and that
