### PR TITLE
Fix bookmarks and associations saving outside Profile in portable mode

### DIFF
--- a/cmd/f4/bookmarks.go
+++ b/cmd/f4/bookmarks.go
@@ -36,6 +36,13 @@ type BookmarkSet [10]Bookmark
 // ~/.config/far2l/settings/bookmarks.ini and the f4 directory without
 // renaming.
 func BookmarksFilePath() string {
+	// In portable mode (UseSystemProfiles=0) write under <exeDir>/Profile;
+	// otherwise use the system %AppData%/f4/settings path as before. Read
+	// userConfigDir live in non-portable mode so tests overriding the seam
+	// keep working.
+	if IsPortableProfile() {
+		return filepath.Join(GetF4ConfigDir(), "settings", "bookmarks.ini")
+	}
 	configDir, _ := userConfigDir()
 	return filepath.Join(configDir, "f4", "settings", "bookmarks.ini")
 }

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -429,6 +429,13 @@ var getUserConfigIniPath = func() string {
 
 var getConfigIniPaths = func() []string {
 	userPath := getUserConfigIniPath()
+	if IsPortableProfile() {
+		// In portable mode (UseSystemProfiles=0) all config lives under
+		// <exeDir>/Profile, so skip the machine-wide paths: otherwise system
+		// settings from ProgramData (Windows) or /etc/f4 (Unix) would leak into
+		// the isolated portable profile.
+		return []string{userPath}
+	}
 	if runtime.GOOS == "windows" {
 		progData := os.Getenv("ProgramData")
 		if progData != "" {

--- a/cmd/f4/file_associations.go
+++ b/cmd/f4/file_associations.go
@@ -63,6 +63,13 @@ var associationsFilePathFn = defaultAssociationsFilePath
 func AssociationsFilePath() string { return associationsFilePathFn() }
 
 func defaultAssociationsFilePath() string {
+	// In portable mode (UseSystemProfiles=0) write under <exeDir>/Profile;
+	// otherwise use the system %AppData%/f4/settings path as before. Read
+	// userConfigDir live in non-portable mode so tests overriding the seam
+	// keep working.
+	if IsPortableProfile() {
+		return filepath.Join(GetF4ConfigDir(), "settings", "associations.ini")
+	}
 	configDir, _ := userConfigDir()
 	return filepath.Join(configDir, "f4", "settings", "associations.ini")
 }

--- a/cmd/f4/portable_paths_test.go
+++ b/cmd/f4/portable_paths_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// iniResolvers lists per-INI path functions and the fragment they append to
+// the f4 config dir in both portable and non-portable modes. Portable resolves
+// under <exeDir>/Profile, non-portable under <userConfigDir>/f4, so the same
+// fragment works for both bases.
+var iniResolvers = []struct {
+	name string
+	fn   func() string
+	rel  string
+}{
+	{"BookmarksFilePath", BookmarksFilePath, "settings/bookmarks.ini"},
+	{"AssociationsFilePath", AssociationsFilePath, "settings/associations.ini"},
+	{"MainMenuFilePath", MainMenuFilePath, "settings/user_menu.ini"},
+	{"getSessionIniPath", getSessionIniPath, "session.ini"},
+	{"vtvibeIniPath", vtvibeIniPath, "vtvibe.ini"},
+	{"userColorOverridesPath", userColorOverridesPath, "farcolors.ini"},
+}
+
+// setupPortableIni points osExecutable at a mock f4 binary accompanied by an
+// f4.ini that selects the given UseSystemProfiles value, then drops the cached
+// config directory so GetF4ConfigDir/IsPortableProfile re-detect from scratch.
+// It returns the directory holding the mock executable.
+func setupPortableIni(t *testing.T, useSystemProfiles string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	mockExe := filepath.Join(tmpDir, "f4.exe")
+	if err := os.WriteFile(mockExe, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+	ini := "[General]\nUseSystemProfiles = " + useSystemProfiles + "\n"
+	if err := os.WriteFile(mockExe+".ini", []byte(ini), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	origExe := osExecutable
+	osExecutable = func() (string, error) { return mockExe, nil }
+	t.Cleanup(func() {
+		osExecutable = origExe
+		resetConfigDirForTest()
+		cachedF4Portable = false
+		cachedF4ConfigDir = ""
+	})
+	resetConfigDirForTest()
+	return tmpDir
+}
+
+func TestIniPaths_PortableProfile(t *testing.T) {
+	tmpDir := setupPortableIni(t, "0")
+	for _, tc := range iniResolvers {
+		want := filepath.Join(tmpDir, "Profile", tc.rel)
+		if got := tc.fn(); got != want {
+			t.Errorf("%s() portable = %q, want %q", tc.name, got, want)
+		}
+	}
+}
+
+func TestIniPaths_NonPortableProfile(t *testing.T) {
+	// Redirect the user config dir seam so the system path resolves inside a
+	// temp dir instead of the developer's real profile.
+	cfgDir := t.TempDir()
+	orig := userConfigDir
+	userConfigDir = func() (string, error) { return cfgDir, nil }
+	t.Cleanup(func() { userConfigDir = orig })
+
+	setupPortableIni(t, "1")
+	for _, tc := range iniResolvers {
+		want := filepath.Join(cfgDir, "f4", tc.rel)
+		if got := tc.fn(); got != want {
+			t.Errorf("%s() non-portable = %q, want %q", tc.name, got, want)
+		}
+	}
+}
+
+func TestConfigIniPaths_PortableProfile(t *testing.T) {
+	tmpDir := setupPortableIni(t, "0")
+	paths := getConfigIniPaths()
+	want := []string{filepath.Join(tmpDir, "Profile", "settings.ini")}
+	if len(paths) != len(want) || paths[0] != want[0] {
+		t.Errorf("getConfigIniPaths() portable = %v, want exactly %v (machine-wide paths must not leak)", paths, want)
+	}
+}
+
+func TestConfigIniPaths_NonPortableProfile(t *testing.T) {
+	cfgDir := t.TempDir()
+	orig := userConfigDir
+	userConfigDir = func() (string, error) { return cfgDir, nil }
+	t.Cleanup(func() { userConfigDir = orig })
+
+	setupPortableIni(t, "1")
+	paths := getConfigIniPaths()
+	userPath := filepath.Join(cfgDir, "f4", "settings.ini")
+	found := false
+	for _, p := range paths {
+		if p == userPath {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("getConfigIniPaths() non-portable = %v, want it to contain user path %q", paths, userPath)
+	}
+	if len(paths) < 2 {
+		t.Errorf("getConfigIniPaths() non-portable = %v, want at least system + user paths", paths)
+	}
+}

--- a/cmd/f4/user_menu_ui.go
+++ b/cmd/f4/user_menu_ui.go
@@ -64,8 +64,10 @@ func (u *userMenuFrame) Show(scr *vtui.ScreenBuf) {
 // between ~/.config/far2l/settings/user_menu.ini and the f4 directory
 // without renaming.
 func MainMenuFilePath() string {
-	configDir, _ := userConfigDir()
-	return filepath.Join(configDir, "f4", "settings", "user_menu.ini")
+	// In portable mode (UseSystemProfiles=0) write under <exeDir>/Profile;
+	// otherwise use the system %AppData%/f4/settings path as before, matching
+	// the other config INIs that resolve through GetF4ConfigDir.
+	return filepath.Join(GetF4ConfigDir(), "settings", "user_menu.ini")
 }
 
 // findLocalFarMenu walks startDir upward looking for FarMenu.ini.


### PR DESCRIPTION
Summary
In portable mode (UseSystemProfiles=0) f4 keeps all config under <exeDir>/Profile, but BookmarksFilePath() and defaultAssociationsFilePath() built their paths directly from os.UserConfigDir(), bypassing the portable profile. As a result bookmarks.ini and associations.ini were read/written to the system %AppData%/f4/settings even in portable mode.

Changes
cmd/f4/bookmarks.go: route BookmarksFilePath() through portable-aware resolution (<exeDir>/Profile/settings when portable, legacy %AppData%/f4/settings otherwise).
cmd/f4/file_associations.go: same fix for defaultAssociationsFilePath().
cmd/f4/config.go: getConfigIniPaths() no longer reads machine-wide ProgramData\f4\settings.ini / /etc/f4/settings.ini in portable mode, so system settings can't leak into the isolated portable profile.
Non-portable behavior and paths are unchanged (backward compatible); tests pass.