### PR TITLE
vfs: resolve arbitrary reparse points in SetPath and ReadDir

### DIFF
--- a/vfs/os_vfs.go
+++ b/vfs/os_vfs.go
@@ -52,55 +52,26 @@ func (v *OSVFS) SetPath(path string) error {
 		return err
 	}
 
-	// Сначала пробуем проверить оригинальный путь напрямую.
-	// Если он существует, доступен и является директорией (симлинком на нее),
-	// мы сохраняем оригинальный визуальный путь в панели без принудительного разыменования!
+	// First try to verify the original path directly. If it exists, is
+	// accessible and is a directory (or a symlink to one), we keep the
+	// original visual path in the panel without forcing a dereference.
 	if st, errStat := hostfs.Stat(prepareOSPath(abs)); errStat == nil && st.IsDir() {
 		goto verify
 	}
 
-	// Если мы получили ошибку (например, Permission Denied на системном джанкшене Windows
-	// "Documents and Settings"), то только тогда пытаемся принудительно разыменовать симлинк.
-	if resolved, errEval := hostpath.EvalSymlinks(prepareOSPath(abs)); errEval == nil {
-		resolved = stripExtendedPrefix(resolved)
-		if runtime.GOOS == "windows" {
-			origVol := hostpath.VolumeName(abs)
-			resVol := hostpath.VolumeName(resolved)
-			// Prevent resolving mapped drives (e.g. T:\) into UNC paths (\\server\share)
-			if len(origVol) == 2 && origVol[1] == ':' && len(resVol) > 2 && strings.HasPrefix(resVol, `\\`) {
-				abs = origVol + strings.TrimPrefix(resolved, resVol)
-			} else {
-				abs = resolved
-			}
-		} else {
-			abs = resolved
-		}
-		goto verify
-	}
-
-	// Windows fallbacks when EvalSymlinks fails (e.g. protected junctions)
+	// If direct access failed (e.g. Permission Denied on the Windows system
+	// junction "Documents and Settings" or on a nested per-user profile
+	// junction like "Application Data"), force-resolve the reparse points.
+	// Resolution runs on the PLAIN path (no \\?\ prefix): the prefix disables
+	// Win32's transparent reparse redirection, so "Documents and Settings"
+	// is opened directly and yields Access Denied.
 	if runtime.GOOS == "windows" {
-		// 1. wellKnownJunction (string comparison, no syscall)
-		if link, ok := wellKnownJunction(abs); ok {
-			vtui.DebugLog("VFS: SetPath: resolved via wellKnownJunction: %q -> %q", abs, link)
-			abs = link
-			goto verify
-		}
-		// 2. os.Readlink
-		if link, errRead := hostfs.Readlink(abs); errRead == nil {
-			vtui.DebugLog("VFS: SetPath: resolved via Readlink: %q -> %q", abs, link)
-			if hostpath.IsAbs(link) {
-				abs = link
-			} else {
-				abs = hostpath.Join(hostpath.Dir(abs), link)
+		for _, candidate := range resolveReparseCandidates(abs) {
+			vtui.DebugLog("VFS: SetPath: trying reparse candidate %q -> %q", abs, candidate)
+			if st, errStat := hostfs.Stat(prepareOSPath(candidate)); errStat == nil && st.IsDir() {
+				abs = candidate
+				goto verify
 			}
-			goto verify
-		}
-		// 3. Direct syscall (CreateFile + DeviceIoControl)
-		if link, errJunc := resolveWindowsJunction(abs); errJunc == nil {
-			vtui.DebugLog("VFS: SetPath: resolved via resolveWindowsJunction: %q -> %q", abs, link)
-			abs = link
-			goto verify
 		}
 	}
 
@@ -136,11 +107,16 @@ func (v *OSVFS) ReadDir(ctx context.Context, path string, onChunk func([]VFSItem
 	dirPath := path
 	entries, err := hostfs.ReadDir(prepareOSPath(dirPath))
 	if err != nil && os.IsPermission(err) && runtime.GOOS == "windows" {
-		// Try to resolve protected junctions (e.g. "Documents and Settings")
-		if resolved, ok := wellKnownJunction(dirPath); ok {
-			vtui.DebugLog("VFS: ReadDir: resolved junction %q -> %q", dirPath, resolved)
-			dirPath = resolved
-			entries, err = hostfs.ReadDir(prepareOSPath(dirPath))
+		// Resolve protected/per-user junctions (e.g. "Documents and
+		// Settings", "<user>\Application Data") the same way SetPath does.
+		for _, candidate := range resolveReparseCandidates(dirPath) {
+			vtui.DebugLog("VFS: ReadDir: trying reparse candidate %q -> %q", dirPath, candidate)
+			if e, eErr := hostfs.ReadDir(prepareOSPath(candidate)); eErr == nil {
+				vtui.DebugLog("VFS: ReadDir: resolved junction %q -> %q", dirPath, candidate)
+				dirPath = candidate
+				entries, err = e, nil
+				break
+			}
 		}
 	}
 	if err != nil {
@@ -642,6 +618,54 @@ func wellKnownJunction(path string) (string, bool) {
 	}
 
 	return "", false
+}
+
+// resolveReparseCandidates returns candidate paths to retry a failed
+// operation on when the original Windows path could not be opened directly
+// because of a reparse point (junction or symlink) in its components. This
+// covers the compatibility shim "C:\Documents and Settings" (junction to
+// "C:\Users") and the per-user profile junctions such as "Application Data"
+// (-> "AppData\Roaming"), "Local Settings", "My Documents", etc.
+//
+// The first candidate is a full EvalSymlinks resolution of the PLAIN path:
+// the "\\?\" long-path prefix disables Win32's transparent reparse
+// redirection, so resolution must run on the unprefixed path. The remaining
+// candidates handle cases where EvalSymlinks itself is blocked (protected
+// reparse points): the hard-coded well-known junctions, Readlink on the
+// final component, and a raw DeviceIoControl reparse read.
+func resolveReparseCandidates(abs string) []string {
+	if runtime.GOOS != "windows" {
+		return nil
+	}
+	var out []string
+	if resolved, errEval := hostpath.EvalSymlinks(abs); errEval == nil {
+		resolved = stripExtendedPrefix(resolved)
+		// Prevent resolving mapped drives (e.g. T:\) into UNC paths (\\server\share).
+		origVol := hostpath.VolumeName(abs)
+		resVol := hostpath.VolumeName(resolved)
+		if len(origVol) == 2 && origVol[1] == ':' && len(resVol) > 2 && strings.HasPrefix(resVol, `\\`) {
+			resolved = origVol + strings.TrimPrefix(resolved, resVol)
+		}
+		out = append(out, resolved)
+	}
+	if link, ok := wellKnownJunction(abs); ok {
+		out = append(out, link)
+	}
+	if link, errRead := hostfs.Readlink(abs); errRead == nil {
+		if hostpath.IsAbs(link) {
+			out = append(out, link)
+		} else {
+			out = append(out, hostpath.Join(hostpath.Dir(abs), link))
+		}
+	}
+	if link, errJunc := resolveWindowsJunction(abs); errJunc == nil {
+		if hostpath.IsAbs(link) {
+			out = append(out, link)
+		} else {
+			out = append(out, hostpath.Join(hostpath.Dir(abs), link))
+		}
+	}
+	return out
 }
 
 // prepareOSPath adds the \\?\ prefix on Windows to prevent the Win32 API

--- a/vfs/os_vfs_junction_test.go
+++ b/vfs/os_vfs_junction_test.go
@@ -1,0 +1,101 @@
+package vfs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestResolveReparseCandidates verifies that an arbitrary reparse point
+// (junction/symlink) anywhere in the path is resolved to its target, not
+// just the few hard-coded well-known names. This is the core of the fix for
+// entering "C:\Documents and Settings\<user>\Application Data" which used to
+// fail with "Access Denied" because ReadDir only knew "documents and
+// settings", "all users" and "default user".
+func TestResolveReparseCandidates(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("reparse-point resolution is Windows-specific")
+	}
+
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	if err := os.MkdirAll(real, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// "Application Data" is deliberately NOT one of the hard-coded
+	// well-known junction names -- it is a per-user profile junction like
+	// the one that broke navigation.
+	link := filepath.Join(root, "Application Data")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink creation unavailable (need elevated privileges): %v", err)
+	}
+
+	candidates := resolveReparseCandidates(link)
+	if len(candidates) == 0 {
+		t.Fatalf("resolveReparseCandidates(%q) returned no candidates", link)
+	}
+
+	resolved := filepath.Clean(candidates[0])
+	want := filepath.Clean(real)
+	// EvalSymlinks normalizes path casing on Windows (e.g. "TEMP" -> "temp"),
+	// so compare case-insensitively.
+	if !strings.EqualFold(resolved, want) {
+		t.Errorf("resolveReparseCandidates(%q)[0] = %q, want %q", link, resolved, want)
+	}
+}
+
+// TestOSVFS_ReadDirFollowsNestedReparse exercises the full ReadDir path with a
+// reparse point nested inside another reparse point (outer "link" -> real,
+// inner "Application Data" -> real2). ReadDir must transparently resolve the
+// chain and list the payload that lives only in the final target.
+func TestOSVFS_ReadDirFollowsNestedReparse(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("reparse-point traversal is Windows-specific")
+	}
+
+	root := t.TempDir()
+	real := filepath.Join(root, "real")
+	real2 := filepath.Join(root, "real2")
+	if err := os.MkdirAll(real, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(real2, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(real2, "payload.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink creation unavailable (need elevated privileges): %v", err)
+	}
+	// Inner reparse living inside the target of the outer one, named like a
+	// real per-user profile junction.
+	inner := filepath.Join(real, "Application Data")
+	if err := os.Symlink(real2, inner); err != nil {
+		t.Skipf("symlink creation unavailable (need elevated privileges): %v", err)
+	}
+
+	v := NewOSVFS(link)
+	nested := filepath.Join(link, "Application Data")
+
+	var found bool
+	err := v.ReadDir(context.Background(), nested, func(items []VFSItem) {
+		for _, it := range items {
+			if it.Name == "payload.txt" {
+				found = true
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("ReadDir(%q) failed: %v", nested, err)
+	}
+	if !found {
+		t.Errorf("ReadDir(%q) did not follow the nested reparse and list payload.txt", nested)
+	}
+}


### PR DESCRIPTION
Windows compatibility junctions such as "C:\Documents and Settings" and the per-user profile junctions ("Application Data", "Local Settings", ...) could not be opened because:
- prepareOSPath adds the \\?\ prefix, which disables Win32's transparent reparse redirection, so "Documents and Settings" is opened directly and returns Access Denied;
- ReadDir only fell back to the three hard-coded well-known junction names, missing every per-user junction.

Introduce resolveReparseCandidates, which resolves the plain (non-\\?\) path via EvalSymlinks first (so redirection works), then wellKnownJunction, Readlink and resolveWindowsJunction as fallbacks. Use it in both SetPath and ReadDir so any reparse point anywhere in the path is followed.

Add white-box tests for the helper and for nested reparse traversal via ReadDir; they skip when symlink creation needs elevation.