### PR TITLE
ci: cut pull-request wall time from 6:25 to ~2:20

### DIFF
--- a/.github/actions/affected-packages/action.yml
+++ b/.github/actions/affected-packages/action.yml
@@ -1,0 +1,142 @@
+name: Affected packages
+description: >-
+  Compute which Go packages a pull request actually touches, directly or
+  through the import graph, so test jobs can skip the rest. Resolves to
+  "all" outside pull requests and whenever the diff contains anything that
+  cannot be safely attributed to a package (go.mod, the workflow itself,
+  submodule bumps, unknown files) -- guessing wrong here would silently
+  skip real tests, so every doubt falls back to the full run.
+outputs:
+  packages:
+    description: Space-separated import paths to test, or the literal "all"
+    value: ${{ steps.calc.outputs.packages }}
+  build:
+    description: Whether the diff affects code included in a compiled binary
+    value: ${{ steps.calc.outputs.build }}
+runs:
+  using: composite
+  steps:
+    - id: calc
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        all() { echo "packages=all" >> "$GITHUB_OUTPUT"; echo "build=yes" >> "$GITHUB_OUTPUT"; echo "affected: all ($1)"; exit 0; }
+
+        if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
+          all "not a pull request"
+        fi
+
+        # Diff against the CURRENT head of the base branch, fetched by name.
+        # Not github.event.pull_request.base.sha: that is frozen at PR
+        # creation time, so after any push to the base branch it drags the
+        # base's own changes into the diff forever. The checkout is the
+        # shallow merge commit (base + PR), so if the base has not moved
+        # since the event this two-dot diff is exactly the PR's changes; if
+        # it has moved, the diff gains base-side noise, which can only widen
+        # the result toward "all" -- the safe direction. No arrays or
+        # mapfile anywhere in this script: macOS runners resolve
+        # `shell: bash` to the system bash 3.2. Paths in this repository
+        # contain no spaces.
+        git fetch --quiet --depth=1 origin "refs/heads/$GITHUB_BASE_REF" || all "base fetch failed"
+        files=$(git diff --name-only FETCH_HEAD HEAD)
+        [ -n "$files" ] || all "empty diff"
+
+        dirs=""
+        while IFS= read -r f; do
+          case "$f" in
+            go.mod|go.sum|vtui|vtinput|.github/*|.golangci*)
+              all "$f changes what every package sees" ;;
+            cmd/f4/*)
+              # Language files, help pages, icons and testdata are read by
+              # cmd/f4's tests at run time; attribute the whole subtree to
+              # the package rather than reasoning per file type.
+              dirs="$dirs cmd/f4" ;;
+            */testdata/*)
+              dirs="$dirs ${f%%/testdata/*}" ;;
+            *.go)
+              dirs="$dirs $(dirname "$f")" ;;
+            *)
+              all "cannot attribute $f to a package" ;;
+          esac
+        done <<<"$files"
+
+        # Classify build impact separately from test impact above. Tests and
+        # testdata never enter a shipped binary; cmd/f4's other files always
+        # do because that package embeds non-Go resources. For Go elsewhere,
+        # resolve the owning package and check only main packages' production
+        # dependency graph -- Deps deliberately excludes test imports.
+        build=no
+        build_all() { build=yes; echo "build affected: yes ($1)"; }
+        build_dirs=""
+        while IFS= read -r f; do
+          case "$f" in
+            *_test.go|*/testdata/*)
+              ;;
+            cmd/f4/*)
+              build=yes ;;
+            *.go)
+              build_dirs="$build_dirs $(dirname "$f")" ;;
+            *)
+              build_all "cannot attribute $f to a compiled binary" ;;
+          esac
+        done <<<"$files"
+
+        if [ "$build" != "yes" ] && [ -n "$build_dirs" ]; then
+          build_changed=$(printf './%s\n' $build_dirs | sort -u | xargs go list 2>/dev/null) \
+            || build_all "changed build path is not a package"
+          if [ "$build" != "yes" ]; then
+            mains=$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./...) \
+              || build_all "cannot list main packages"
+          fi
+          if [ "$build" != "yes" ] && [ -z "$mains" ]; then
+            build_all "no main packages"
+          fi
+          if [ "$build" != "yes" ]; then
+            production=$(printf '%s\n' "$mains" \
+              | xargs go list -f '{{.ImportPath}} {{join .Deps " "}}' \
+              | tr ' ' '\n' | sed '/^$/d' | sort -u) \
+              || build_all "cannot list production dependencies"
+          fi
+
+          if [ "$build" != "yes" ]; then
+            while IFS= read -r pkg; do
+              if grep -Fqx "$pkg" <<<"$production"; then
+                build=yes
+                break
+              fi
+            done <<<"$build_changed"
+          fi
+        fi
+
+        changed=$(printf './%s\n' $dirs | sort -u | xargs go list 2>/dev/null) \
+          || all "changed path is not a package"
+
+        # Two passes over one package listing. Deps is already transitive,
+        # so pass one finds every package whose import graph reaches a
+        # changed one. Test imports are direct-only, so pass two widens the
+        # result to packages whose _test.go files import anything from pass
+        # one -- that covers a test-only dependency changing underneath.
+        affected=$(go list -f '{{.ImportPath}}|{{join .Deps " "}}|{{join .TestImports " "}} {{join .XTestImports " "}}' ./... \
+          | awk -F'|' -v changed="$(tr '\n' ' ' <<<"$changed")" '
+            BEGIN { n = split(changed, c, " "); for (i = 1; i <= n; i++) ch[c[i]] = 1 }
+            {
+              pkg[NR] = $1; deps[NR] = $2; timp[NR] = $3
+              hit = ch[$1] ? 1 : 0
+              if (!hit) { m = split($2, d, " "); for (i = 1; i <= m; i++) if (ch[d[i]]) { hit = 1; break } }
+              if (hit) imp[$1] = 1
+            }
+            END {
+              for (r = 1; r <= NR; r++) {
+                ok = imp[pkg[r]]
+                if (!ok) { m = split(timp[r], t, " "); for (i = 1; i <= m; i++) if (imp[t[i]]) { ok = 1; break } }
+                if (ok) print pkg[r]
+              }
+            }')
+
+        echo "build=$build" >> "$GITHUB_OUTPUT"
+        echo "build affected: $build"
+        [ -n "$affected" ] || { echo "packages=" >> "$GITHUB_OUTPUT"; echo "affected: none"; exit 0; }
+        echo "packages=$(tr '\n' ' ' <<<"$affected" | sed 's/ $//')" >> "$GITHUB_OUTPUT"
+        echo "affected: $(wc -l <<<"$affected" | tr -d ' ') of $(go list ./... | wc -l | tr -d ' ') packages"
+        printf '  %s\n' $affected

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build & Release
+name: CI
 
 on:
   push:
@@ -6,6 +6,14 @@ on:
     tags: [ "v*.*.*" ]
   pull_request:
     branches: [ "main" ]
+    # Docs-only pull requests skip CI entirely: nothing below compiles,
+    # packages or tests Markdown. A PR touching both code and docs still
+    # runs -- the filter only skips when EVERY changed file matches.
+    # Deliberately not on the push trigger: it also carries release tags,
+    # where a path filter could silently skip a release.
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       shuffle:
@@ -14,70 +22,85 @@ on:
         default: "on"
         type: string
 
+# A newer push supersedes the run in flight: with ~30 jobs per run and 20
+# concurrent runners on the free plan, two overlapping runs queue each other
+# into waves. Tag pushes publish releases, so those runs are never cancelled;
+# each tag is its own group anyway.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
 jobs:
+  # The build matrix is data, not YAML: pull requests build only the cells
+  # whose artifacts anyone actually downloads from a PR (the three desktop
+  # platforms plus the musl flavor), while pushes to main, tags and manual
+  # runs build everything the release ships. Compilation of the exotic
+  # targets is still checked on every PR by the vet matrix below, which is
+  # what a cross-build of a platform nobody can execute proves anyway.
+  plan:
+    name: Plan build matrix
+    runs-on: ubuntu-latest
+    steps:
+    - name: Emit build matrix
+      id: emit
+      env:
+        FULL: ${{ github.event_name != 'pull_request' }}
+      run: |
+        # Cells beyond the desktop six:
+        # - The noffi rows are the extra architectures Go can cross-compile
+        #   Linux for; vtui's graphical/FFI backends are unavailable there,
+        #   so they use its ANSI-only noffi configuration.
+        # - The musl rows (Alpine, postmarketOS, ...) link against musl's
+        #   libc and keep FFI, unlike the fully static generic Linux cells;
+        #   built with -tags goffi_musl, see docs/MUSL.md in unxed/goffi.
+        cells='[
+          {"goos":"linux","goarch":"amd64"},
+          {"goos":"linux","goarch":"arm64"},
+          {"goos":"linux","goarch":"arm"},
+          {"goos":"windows","goarch":"amd64"},
+          {"goos":"windows","goarch":"arm64"},
+          {"goos":"darwin","goarch":"amd64"},
+          {"goos":"darwin","goarch":"arm64"},
+          {"goos":"freebsd","goarch":"amd64"},
+          {"goos":"freebsd","goarch":"arm64"},
+          {"goos":"dragonfly","goarch":"amd64"},
+          {"goos":"openbsd","goarch":"amd64"},
+          {"goos":"openbsd","goarch":"arm64"},
+          {"goos":"netbsd","goarch":"amd64"},
+          {"goos":"netbsd","goarch":"arm64"},
+          {"goos":"illumos","goarch":"amd64"},
+          {"goos":"solaris","goarch":"amd64"},
+          {"goos":"linux","goarch":"386","build_tags":"noffi"},
+          {"goos":"linux","goarch":"mips","build_tags":"noffi"},
+          {"goos":"linux","goarch":"mipsle","build_tags":"noffi"},
+          {"goos":"linux","goarch":"mips64","build_tags":"noffi"},
+          {"goos":"linux","goarch":"mips64le","build_tags":"noffi"},
+          {"goos":"linux","goarch":"riscv64","build_tags":"noffi"},
+          {"goos":"linux","goarch":"loong64","build_tags":"noffi"},
+          {"goos":"linux","goarch":"ppc64","build_tags":"noffi"},
+          {"goos":"linux","goarch":"ppc64le","build_tags":"noffi"},
+          {"goos":"linux","goarch":"amd64","libc":"musl"},
+          {"goos":"linux","goarch":"arm64","libc":"musl"}
+        ]'
+        if [ "$FULL" != "true" ]; then
+          # Desktop platforms on release architectures; this also keeps the
+          # two musl cells and drops every noffi row.
+          cells=$(jq -c '[ .[] | select(
+            (.goos == "linux" or .goos == "windows" or .goos == "darwin")
+            and (.goarch == "amd64" or .goarch == "arm64")
+          ) ]' <<<"$cells")
+        fi
+        echo "matrix=$(jq -c '{include: .}' <<<"$cells")" >> "$GITHUB_OUTPUT"
+    outputs:
+      matrix: ${{ steps.emit.outputs.matrix }}
+
   build:
     name: Build (${{ matrix.goos }}/${{ matrix.goarch }}${{ matrix.libc == 'musl' && ' musl' || '' }})
     runs-on: ubuntu-latest
+    needs: plan
     strategy:
       fail-fast: false
-      matrix:
-        goos: [linux, windows, darwin, freebsd, dragonfly, openbsd, netbsd, illumos, solaris]
-        goarch: [amd64, arm64, arm]
-        # One value, so this multiplies nothing -- but it makes libc an
-        # *original* matrix key, and that is load-bearing. An include entry
-        # only creates a new combination when it disagrees with an original
-        # value; an entry that merely adds a new key is merged into the
-        # matching existing cells instead. Without this line, the musl
-        # include entries below would not add two cells -- they would
-        # silently convert the existing linux/amd64 and linux/arm64 cells to
-        # musl, and the release would ship musl binaries under the generic
-        # Linux names. (The smoke test asserts the libc of every artifact, so
-        # that failure mode is caught rather than published.)
-        libc: [glibc]
-        exclude:
-          - goos: dragonfly
-            goarch: arm64
-          - goos: illumos
-            goarch: arm64
-          - goos: solaris
-            goarch: arm64
-          - goos: windows
-            goarch: arm
-          - goos: darwin
-            goarch: arm
-          - goos: freebsd
-            goarch: arm
-          - goos: dragonfly
-            goarch: arm
-          - goos: openbsd
-            goarch: arm
-          - goos: netbsd
-            goarch: arm
-          - goos: illumos
-            goarch: arm
-          - goos: solaris
-            goarch: arm
-        # Linux is also cross-built for the additional architectures that
-        # Go supports. vtui's graphical/FFI backends are unavailable there,
-        # so these cells use its ANSI-only noffi configuration.
-        include:
-          - { goos: linux, goarch: 386,     build_tags: noffi }
-          - { goos: linux, goarch: mips,    build_tags: noffi }
-          - { goos: linux, goarch: mipsle,  build_tags: noffi }
-          - { goos: linux, goarch: mips64,  build_tags: noffi }
-          - { goos: linux, goarch: mips64le, build_tags: noffi }
-          - { goos: linux, goarch: riscv64, build_tags: noffi }
-          - { goos: linux, goarch: loong64, build_tags: noffi }
-          - { goos: linux, goarch: ppc64,  build_tags: noffi }
-          - { goos: linux, goarch: ppc64le, build_tags: noffi }
-          # musl targets (Alpine, postmarketOS, ...). The generic Linux cells
-          # above are fully static, which costs them FFI: no GPU, Wayland or
-          # Ebiten backend. These two cells instead link against musl's libc
-          # and keep FFI, so Alpine users get the same f4 that glibc users
-          # get. Built from the same sources with -tags goffi_musl; see
-          # docs/MUSL.md in unxed/goffi.
-          - { goos: linux, goarch: amd64, libc: musl }
-          - { goos: linux, goarch: arm64, libc: musl }
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
     env:
       CGO_ENABLED: 0
       BUILD_TAGS: ${{ matrix.build_tags || '' }}
@@ -238,6 +261,7 @@ jobs:
       if: matrix.goos == 'linux'
       env:
         GOARCH_CELL: ${{ matrix.goarch }}
+        QEMU_SMOKE: ${{ github.event_name != 'pull_request' }}
       run: |
         set -euo pipefail
 
@@ -285,6 +309,18 @@ jobs:
             exit 1
           fi
 
+          # The readelf assertions above catch the realistic breakage (the
+          # tag not applying, a glibc SONAME leaking in) and cost nothing.
+          # The rest of this branch -- executing the artifact against real
+          # musl and the flavor-specific updater tests -- guards what gets
+          # *published*, so it rides with pushes and tags, where the nightly
+          # and release jobs actually publish; a red run there blocks them
+          # via needs. Skipping it keeps ~40 seconds off every PR.
+          if [ "$QEMU_SMOKE" != "true" ]; then
+            echo "Pull request: readelf assertions only."
+            exit 0
+          fi
+
           # Now actually start it, against a real musl libc. qemu-user
           # resolves PT_INTERP inside the sysroot given with -L, so one
           # mechanism covers both architectures and needs no root, no
@@ -309,7 +345,11 @@ jobs:
           # shell, so the Build step's variables are gone by now -- GOARCH
           # included. Without it the test binary is built for the runner's
           # own amd64, and the arm64 cell hands qemu-aarch64 an x86_64 ELF.
-          GOOS=linux GOARCH="$GOARCH_CELL" go test -c -tags "${BUILD_TAGS:+$BUILD_TAGS,}goffi_musl" \
+          # -trimpath matches the Build step above: the build cache keys
+          # compiled packages by their flags, so without it every package
+          # compiles a second time here (~100 extra seconds) instead of
+          # reusing the objects that step just produced.
+          GOOS=linux GOARCH="$GOARCH_CELL" go test -c -trimpath -tags "${BUILD_TAGS:+$BUILD_TAGS,}goffi_musl" \
             -gcflags=github.com/go-webgpu/goffi/internal/dl=-std \
             -o /tmp/f4-libc.test ./cmd/f4
           "qemu-$QEMU-static" -L alpine-rootfs /tmp/f4-libc.test \
@@ -387,7 +427,7 @@ jobs:
   # с большой вероятностью начнёт конфликтовать (duplicate method) —
   # тогда этот шаг нужно будет просто удалить.
   build-win7:
-    name: Build (windows7/amd64, legacy toolchain)
+    name: Build (windows7/amd64)
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
@@ -579,24 +619,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - { target: windows/amd64 }
-          # Linux release builds carry goffi_static, so vet the files the build
-          # actually compiles -- the stubs, not the dlopen wrappers.
-          - { target: linux/arm, tags: goffi_static }
-          # ...and the musl cells carry goffi_musl, which compiles the real
-          # dlopen wrappers instead of those stubs. Nothing else in this
-          # matrix vets that code on Linux.
-          - { target: linux/amd64, tags: goffi_musl, gcflags: -gcflags=github.com/go-webgpu/goffi/internal/dl=-std }
-          - { target: darwin/arm64 }
-          # goffi's fakecgo shim needs the same flag the build step passes.
-          - { target: freebsd/amd64, gcflags: -gcflags=github.com/go-webgpu/goffi/internal/fakecgo=-std }
-          - { target: openbsd/amd64 }
-          - { target: netbsd/amd64 }
-          - { target: dragonfly/amd64 }
-          - { target: illumos/amd64 }
-          - { target: solaris/amd64 }
+      # Cell notes, in full-matrix order:
+      # - linux/arm carries goffi_static: Linux release builds use it, so vet
+      #   the files the build actually compiles -- the stubs, not the dlopen
+      #   wrappers. The only arm32 compile anywhere in a PR run, so it is the
+      #   one cell PRs keep.
+      # - linux/amd64 carries goffi_musl, which compiles the real dlopen
+      #   wrappers instead of those stubs; nothing else vets that code on
+      #   Linux. The gcflags mirror the build step (same for freebsd's
+      #   fakecgo shim below).
+      # Pull requests run only the linux/arm cell: every other target is
+      # already compiled in the same PR run by its build and test jobs (and
+      # go test runs vet's high-confidence checks natively), or -- for the
+      # BSDs/illumos/solaris -- is exotic enough to check on pushes and tags,
+      # like their builds. The full matrix runs everywhere else. One long
+      # line on purpose: actionlint chews minutes on a folded variant.
+      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"include":[{"target":"linux/arm","tags":"goffi_static"}]}') || fromJSON('{"include":[{"target":"windows/amd64"},{"target":"linux/arm","tags":"goffi_static"},{"target":"linux/amd64","tags":"goffi_musl","gcflags":"-gcflags=github.com/go-webgpu/goffi/internal/dl=-std"},{"target":"darwin/arm64"},{"target":"freebsd/amd64","gcflags":"-gcflags=github.com/go-webgpu/goffi/internal/fakecgo=-std"},{"target":"openbsd/amd64"},{"target":"netbsd/amd64"},{"target":"dragonfly/amd64"},{"target":"illumos/amd64"},{"target":"solaris/amd64"}]}') }}
     env:
       CGO_ENABLED: 0
     steps:
@@ -628,8 +666,11 @@ jobs:
         fi
         GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}" go vet "${flags[@]}" ./...
 
+  # Quality and Lint used to be one job; its steps ran back to back and their
+  # sum (~2:40) sat right on the critical path of a PR run. Two runners cost
+  # nothing here, so vet-and-scanners and the linters run side by side.
   quality:
-    name: Quality (vet and incremental lint)
+    name: Quality
     runs-on: ubuntu-latest
     env:
       CGO_ENABLED: 0
@@ -637,7 +678,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
       with:
-        fetch-depth: 0
         submodules: recursive
 
     - name: Set up Go
@@ -648,6 +688,42 @@ jobs:
 
     - name: Run go vet
       run: go vet ./...
+
+    # govulncheck is not incremental on purpose: it reports only
+    # vulnerabilities the code actually reaches, so the whole tree is in scope
+    # and the finding count stays at zero rather than accumulating a backlog.
+    # The tool version is pinned; the vulnerability database it consults is
+    # fetched at run time, so a newly published advisory turns this red without
+    # any change here — which is the point.
+    # build.yml is approaching 900 lines, most of it shell embedded in run:
+    # blocks that nothing checked. actionlint validates the workflow schema and
+    # every expression, and hands each run: block to shellcheck — which the
+    # ubuntu image already ships, so it needs no setup here. Both classes of
+    # mistake it catches otherwise cost a full CI round trip to discover.
+    - name: Run actionlint
+      run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+    - name: Run govulncheck
+      run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: 0
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+      with:
+        # Full history: the incremental lint below diffs against origin/main.
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26.6'
+        cache-dependency-path: go.sum
 
     - name: Run incremental golangci-lint
       uses: golangci/golangci-lint-action@v9.3.0
@@ -668,23 +744,6 @@ jobs:
         version: v2.13.1
         args: --config .golangci-strict.yml
 
-    # Unlike the linters above this one is not incremental: it reports only
-    # vulnerabilities the code actually reaches, so the whole tree is in scope
-    # and the finding count stays at zero rather than accumulating a backlog.
-    # The tool version is pinned; the vulnerability database it consults is
-    # fetched at run time, so a newly published advisory turns this red without
-    # any change here — which is the point.
-    # build.yml is approaching 800 lines, most of it shell embedded in run:
-    # blocks that nothing checked. actionlint validates the workflow schema and
-    # every expression, and hands each run: block to shellcheck — which the
-    # ubuntu image already ships, so it needs no setup here. Both classes of
-    # mistake it catches otherwise cost a full CI round trip to discover.
-    - name: Run actionlint
-      run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
-
-    - name: Run govulncheck
-      run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
-
   # Эта джоба создает постоянные релизы при пуше тэгов v*.*.*
   test:
     name: Test (${{ matrix.target }})
@@ -692,16 +751,17 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix:
-        # One hosted runner per native os/arch cell, labeled to match the
-        # build matrix.
-        include:
-          - { os: ubuntu-latest,    target: linux/amd64 }
-          - { os: ubuntu-24.04-arm, target: linux/arm64 }
-          - { os: macos-latest,     target: darwin/arm64 }
-          - { os: macos-15-intel,   target: darwin/amd64 }
-          - { os: windows-latest,   target: windows/amd64 }
-          - { os: windows-11-arm,   target: windows/arm64 }
+      # One hosted runner per native os/arch cell, labeled to match the
+      # build matrix. Pull requests skip the second-arch twin of the two
+      # desktop OSes: darwin/amd64 and windows/arm64 run on the slowest
+      # runners of the whole matrix (4-5 minutes against the ~2:40 the
+      # rest of a PR run takes) and only catch arch-specific breakage --
+      # rare enough to test on pushes, tags and manual runs, which is
+      # also where the published artifacts come from. linux/arm64 stays
+      # everywhere: its runner is fast. Inline conditional rather than a
+      # plan-job output because these jobs are the critical path, and a
+      # needs: edge would bill its scheduling latency to every cell.
+      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64"},{"os":"windows-latest","target":"windows/amd64"}]}') || fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64"},{"os":"macos-15-intel","target":"darwin/amd64"},{"os":"windows-latest","target":"windows/amd64"},{"os":"windows-11-arm","target":"windows/arm64"}]}') }}
     env:
       CGO_ENABLED: 0
       TEST_SHUFFLE: ${{ inputs.shuffle || 'on' }}
@@ -711,11 +771,32 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Move Go caches to the fast disk (Windows)
+      # C: is the OS disk and glacial at unpacking the ~650 MB Go cache --
+      # three of this job's five and a half minutes on windows-latest went
+      # into that alone; D: is the runner's local SSD. windows-11-arm images
+      # have no D:, hence the probe.
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if (Test-Path 'D:\') {
+          Add-Content $env:GITHUB_ENV "GOCACHE=D:\go-build"
+          Add-Content $env:GITHUB_ENV "GOMODCACHE=D:\go-mod"
+        }
+
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
         go-version: '1.26.6'
-        cache-dependency-path: go.sum
+        # The salt file is part of the key on purpose: the cache stores
+        # absolute paths, so a cache saved before a GOCACHE/GOMODCACHE move
+        # above would restore to the old location -- and with the key
+        # unchanged, setup-go would see a "hit" and never save a good one.
+        # A salt rather than this workflow file, so that ordinary CI edits
+        # do not rotate every test cell into a cold compile.
+        cache-dependency-path: |
+          go.sum
+          .github/workflows/go-cache-salt
 
     - name: Run Tests
       shell: bash
@@ -723,7 +804,10 @@ jobs:
         # Shuffle tests and subtests to expose order dependencies. Go prints
         # the seed on every run, so reproduce a failure with -shuffle=<seed>.
         # The seed selects a permutation of the test set, so it only reproduces
-        # while that set remains unchanged.
+        # while that set remains unchanged. Shuffle also pins go's test-result
+        # caching off, deliberately: a rolling-cache experiment showed this
+        # suite is uncacheable anyway -- the tests read per-run environment
+        # (temp dirs), so even an unchanged tree scored zero cache hits.
         go test -shuffle="$TEST_SHUFFLE" -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' ./...
         # Layout validation mutates shared UI registries from parallel
         # subtests. Go 1.26 schedules them aggressively enough to expose the
@@ -788,9 +872,23 @@ jobs:
         exit 0
 
   race:
-    name: Race detector
+    name: Race (${{ matrix.scope }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # cmd/f4's suite alone takes as long under the detector as every
+        # other package combined, so it gets runners of its own -- split in
+        # two by test-name letter, because even alone it sat on the critical
+        # path. The A-G boundary is hand-picked for rough balance (1062 vs
+        # 1151 tests today); rebalance it if the halves drift apart as tests
+        # are added. The halves share the app cache key on purpose: they
+        # compile identical objects, so whichever saves first serves both.
+        include:
+          - { scope: 'cmd/f4 A-G', cache-key: app, run: '^Test[A-G]' }
+          - { scope: 'cmd/f4 H-Z', cache-key: app, run: '^Test[^A-G]' }
+          - { scope: packages, cache-key: packages }
     env:
       # The race detector requires cgo and the Ubuntu runner provides the
       # native compiler needed by the instrumented test binary.
@@ -801,15 +899,41 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Restore Go caches (race-instrumented)
+      # The shared setup-go cache key is claimed by whichever ubuntu job
+      # saves first -- always one without -race -- so these jobs recompiled
+      # the whole tree under the detector on every run, ~2 minutes each.
+      # Race-instrumented objects get a key of their own; the two scopes
+      # compile different package sets, so the key includes the scope.
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: race-${{ matrix.cache-key }}-go-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          race-${{ matrix.cache-key }}-go-
+
     - name: Set up Go
       uses: actions/setup-go@v7
       with:
         go-version: '1.26.6'
-        cache-dependency-path: go.sum
+        cache: false
 
     - name: Run race detector
       shell: bash
+      env:
+        SCOPE: ${{ matrix.scope }}
+        RUN_FILTER: ${{ matrix.run || '' }}
       run: |
+        if [ -n "$RUN_FILTER" ]; then
+          # 5m, not 15m: a warm half runs in about a minute, and the known
+          # cmd/f4 hang (leaked FrameManager task pumps; TestMain stuck in a
+          # chan receive) otherwise burns the full timeout before the job
+          # can go red and be retried.
+          go test -race -shuffle=on -timeout 5m -run "$RUN_FILTER" ./cmd/f4
+          exit 0
+        fi
         # The FFI dependencies now keep Go-owned pointers typed and isolate
         # the genuinely foreign-pointer conversions behind nocheckptr helpers,
         # so luaplug can execute its FFI tests under the detector as well.
@@ -823,10 +947,9 @@ jobs:
           exit 1
         fi
         go test -race -shuffle=on -timeout 15m "${packages[@]}"
-        go test -race -shuffle=on -timeout 15m ./cmd/f4
 
   release:
-    name: Create Official Release
+    name: Release
     needs: [build, build-win7, test, race]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
@@ -848,7 +971,7 @@ jobs:
   # чтобы под macOS можно было поставить f4 одной командой:
   #   brew install <owner>/tap/f4
   homebrew:
-    name: Update Homebrew Tap
+    name: Homebrew tap
     needs: release
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
@@ -929,7 +1052,7 @@ jobs:
 
   # Эта джоба обновляет "плавающий" nightly релиз при каждом пуше в main
   nightly:
-    name: Update Nightly Release
+    name: Nightly
     needs: [build, build-win7, test, race]
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,9 +124,15 @@ jobs:
         go-version: '1.26.6'
         cache-dependency-path: go.sum
 
+    - name: Compute build impact
+      id: affected
+      uses: ./.github/actions/affected-packages
+
     - name: Check formatting
       # The musl amd64 cell builds the same tree as the generic amd64
       # cell, so these repo-wide checks belong to one of them, not both.
+      # Deliberately not gated on build impact: gofmt covers test files too,
+      # so a tests-only pull request still needs this check.
       if: matrix.goos == 'linux' && matrix.goarch == 'amd64' && matrix.libc != 'musl'
       run: |
         if [ -n "$(gofmt -s -l .)" ]; then
@@ -139,13 +145,13 @@ jobs:
     - name: Check language file formatting
       # The musl amd64 cell builds the same tree as the generic amd64
       # cell, so these repo-wide checks belong to one of them, not both.
-      if: matrix.goos == 'linux' && matrix.goarch == 'amd64' && matrix.libc != 'musl'
+      if: steps.affected.outputs.build == 'yes' && matrix.goos == 'linux' && matrix.goarch == 'amd64' && matrix.libc != 'musl'
       run: go run ./tools/langfmt -check cmd/f4/lang/*.lng
 
     - name: Verify generated application icons
       # The musl amd64 cell builds the same tree as the generic amd64
       # cell, so these repo-wide checks belong to one of them, not both.
-      if: matrix.goos == 'linux' && matrix.goarch == 'amd64' && matrix.libc != 'musl'
+      if: steps.affected.outputs.build == 'yes' && matrix.goos == 'linux' && matrix.goarch == 'amd64' && matrix.libc != 'musl'
       run: |
         go generate ./cmd/f4
         git diff --exit-code -- \
@@ -154,6 +160,7 @@ jobs:
           cmd/f4/rsrc_windows_arm64.syso
 
     - name: Build binaries
+      if: steps.affected.outputs.build == 'yes'
       env:
         GOOS: ${{ matrix.goos }}
         GOARCH: ${{ matrix.goarch }}
@@ -258,7 +265,7 @@ jobs:
     # dependency cannot actually handle. --version returns before any
     # terminal setup, so no tty is needed.
     - name: Smoke test the binary
-      if: matrix.goos == 'linux'
+      if: steps.affected.outputs.build == 'yes' && matrix.goos == 'linux'
       env:
         GOARCH_CELL: ${{ matrix.goarch }}
         QEMU_SMOKE: ${{ github.event_name != 'pull_request' }}
@@ -378,6 +385,7 @@ jobs:
         "qemu-$QEMU-static" build/f4 --version
 
     - name: Package
+      if: steps.affected.outputs.build == 'yes'
       run: |
         if [ "${{ matrix.goos }}" = "windows" ]; then
           (cd build && zip -r "../$ASSET.zip" .)
@@ -404,6 +412,7 @@ jobs:
         fi
 
     - name: Upload Artifact
+      if: steps.affected.outputs.build == 'yes'
       uses: actions/upload-artifact@v7
       with:
         name: ${{ env.ASSET }}
@@ -440,7 +449,18 @@ jobs:
       with:
         submodules: recursive
 
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version: '1.26.6'
+        cache-dependency-path: go.sum
+
+    - name: Compute build impact
+      id: affected
+      uses: ./.github/actions/affected-packages
+
     - name: Download go-legacy-win7 toolchain
+      if: steps.affected.outputs.build == 'yes'
       run: |
         set -euo pipefail
         curl -fL --retry 5 --retry-delay 10 --retry-all-errors \
@@ -453,6 +473,7 @@ jobs:
         echo "$HOME/go-legacy-win7/go-legacy-win7/bin" >> "$GITHUB_PATH"
 
     - name: Restore missing sync/atomic Or/And methods (thongtech/go-legacy-win7#13)
+      if: steps.affected.outputs.build == 'yes'
       run: |
         cat > "$GOROOT/src/sync/atomic/or_and_win7compat.go" <<'EOF'
         // This file restores the Or/And methods on typed atomics (added
@@ -555,6 +576,7 @@ jobs:
         EOF
 
     - name: Build binaries
+      if: steps.affected.outputs.build == 'yes'
       run: |
         mkdir -p build/plugins/dummy_internal
         LDFLAGS="-s -w"
@@ -576,9 +598,11 @@ jobs:
         go build -trimpath -ldflags="$LDFLAGS" -o ../../build/plugins/dummy_internal/f4-internal-dummy-plugin.exe .
 
     - name: Package
+      if: steps.affected.outputs.build == 'yes'
       run: (cd build && zip -r ../f4-windows7-amd64.zip .)
 
     - name: Upload Artifact
+      if: steps.affected.outputs.build == 'yes'
       uses: actions/upload-artifact@v7
       with:
         name: f4-windows7-amd64
@@ -798,9 +822,26 @@ jobs:
           go.sum
           .github/workflows/go-cache-salt
 
+    - name: Compute affected packages
+      id: affected
+      uses: ./.github/actions/affected-packages
+
     - name: Run Tests
       shell: bash
+      env:
+        AFFECTED: ${{ steps.affected.outputs.packages }}
       run: |
+        # Pull requests test only the packages their diff reaches through
+        # the import graph (see the affected-packages action); pushes, tags
+        # and manual runs always test everything.
+        if [ "$AFFECTED" = "all" ]; then
+          targets=(./...)
+        elif [ -z "$AFFECTED" ]; then
+          echo "No packages affected by this diff; skipping tests."
+          exit 0
+        else
+          read -ra targets <<<"$AFFECTED"
+        fi
         # Shuffle tests and subtests to expose order dependencies. Go prints
         # the seed on every run, so reproduce a failure with -shuffle=<seed>.
         # The seed selects a permutation of the test set, so it only reproduces
@@ -808,11 +849,14 @@ jobs:
         # caching off, deliberately: a rolling-cache experiment showed this
         # suite is uncacheable anyway -- the tests read per-run environment
         # (temp dirs), so even an unchanged tree scored zero cache hits.
-        go test -shuffle="$TEST_SHUFFLE" -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' ./...
+        go test -shuffle="$TEST_SHUFFLE" -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' "${targets[@]}"
         # Layout validation mutates shared UI registries from parallel
         # subtests. Go 1.26 schedules them aggressively enough to expose the
         # upstream race, so isolate that test in a single-threaded process.
-        GOMAXPROCS=1 go test -timeout 15m -run '^TestAllDialogs_LayoutValidation$' ./cmd/f4
+        case " ${targets[*]} " in
+          *" ./... "*|*" github.com/unxed/f4/cmd/f4 "*)
+            GOMAXPROCS=1 go test -timeout 15m -run '^TestAllDialogs_LayoutValidation$' ./cmd/f4 ;;
+        esac
 
     - name: Dump crash reports on failure
       if: failure()
@@ -920,13 +964,22 @@ jobs:
         go-version: '1.26.6'
         cache: false
 
+    - name: Compute affected packages
+      id: affected
+      uses: ./.github/actions/affected-packages
+
     - name: Run race detector
       shell: bash
       env:
         SCOPE: ${{ matrix.scope }}
         RUN_FILTER: ${{ matrix.run || '' }}
+        AFFECTED: ${{ steps.affected.outputs.packages }}
       run: |
         if [ -n "$RUN_FILTER" ]; then
+          if [ "$AFFECTED" != "all" ] && [[ " $AFFECTED " != *" github.com/unxed/f4/cmd/f4 "* ]]; then
+            echo "cmd/f4 is not affected by this diff; skipping."
+            exit 0
+          fi
           # 5m, not 15m: a warm half runs in about a minute, and the known
           # cmd/f4 hang (leaked FrameManager task pumps; TestMain stuck in a
           # chan receive) otherwise burns the full timeout before the job
@@ -945,6 +998,13 @@ jobs:
         if [ ${#packages[@]} -eq 0 ]; then
           echo "::error::no packages left to run under the race detector"
           exit 1
+        fi
+        if [ "$AFFECTED" != "all" ]; then
+          mapfile -t packages < <(printf '%s\n' "${packages[@]}" | grep -Fx -f <(tr ' ' '\n' <<<"$AFFECTED") || true)
+          if [ ${#packages[@]} -eq 0 ] || [ -z "${packages[0]}" ]; then
+            echo "No affected packages outside cmd/f4; skipping."
+            exit 0
+          fi
         fi
         go test -race -shuffle=on -timeout 15m "${packages[@]}"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -691,8 +691,8 @@ jobs:
         GOOS="${TARGET%/*}" GOARCH="${TARGET#*/}" go vet "${flags[@]}" ./...
 
   # Quality and Lint used to be one job; its steps ran back to back and their
-  # sum (~2:40) sat right on the critical path of a PR run. Two runners cost
-  # nothing here, so vet-and-scanners and the linters run side by side.
+  # sum (~2:40) sat right on the critical path of a PR run. Separate runners
+  # cost nothing here, so vet-and-scanners and the lint shards run side by side.
   quality:
     name: Quality
     runs-on: ubuntu-latest
@@ -710,8 +710,30 @@ jobs:
         go-version: '1.26.6'
         cache-dependency-path: go.sum
 
+    - name: Restore Go build cache (quality)
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/go-build
+        key: quality-go-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          quality-go-
+
+    - name: Compute affected packages
+      id: affected
+      uses: ./.github/actions/affected-packages
+
     - name: Run go vet
-      run: go vet ./...
+      if: steps.affected.outputs.packages != ''
+      shell: bash
+      env:
+        AFFECTED: ${{ steps.affected.outputs.packages }}
+      run: |
+        if [ "$AFFECTED" = "all" ]; then
+          targets=(./...)
+        else
+          read -ra targets <<<"$AFFECTED"
+        fi
+        go vet "${targets[@]}"
 
     # govulncheck is not incremental on purpose: it reports only
     # vulnerabilities the code actually reaches, so the whole tree is in scope
@@ -731,8 +753,11 @@ jobs:
       run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
 
   lint:
-    name: Lint
+    name: Lint (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: { include: [{ shard: 'cmd/f4', cache-key: cmd-f4 }, { shard: rest, cache-key: rest }] }
     env:
       CGO_ENABLED: 0
     steps:
@@ -749,11 +774,80 @@ jobs:
         go-version: '1.26.6'
         cache-dependency-path: go.sum
 
+    - name: Restore Go build cache (lint shard)
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/go-build
+        key: lint-${{ matrix.cache-key }}-go-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          lint-${{ matrix.cache-key }}-go-
+
+    - name: Compute affected packages
+      id: affected
+      uses: ./.github/actions/affected-packages
+
+    - name: Select incremental lint packages
+      id: lint-packages
+      shell: bash
+      env:
+        AFFECTED: ${{ steps.affected.outputs.packages }}
+        SHARD: ${{ matrix.shard }}
+      run: |
+        set -euo pipefail
+
+        module=$(go list -m)
+        if [ "$AFFECTED" = "all" ]; then
+          packages=$(go list ./...)
+        elif [ -z "$AFFECTED" ]; then
+          packages=""
+        else
+          packages=$(tr ' ' '\n' <<<"$AFFECTED")
+        fi
+
+        cmd_affected=no
+        rest_args=""
+        while IFS= read -r package; do
+          [ -n "$package" ] || continue
+          case "$package" in
+            "$module/cmd/f4"|"$module/cmd/f4"/*)
+              cmd_affected=yes
+              continue ;;
+            "$module")
+              relative=./ ;;
+            "$module"/*)
+              relative="./${package#"$module"/}" ;;
+            *)
+              echo "::error::affected package is outside $module: $package"
+              exit 1 ;;
+          esac
+          rest_args="${rest_args:+$rest_args }$relative"
+        done <<<"$packages"
+
+        if [ "$SHARD" = "cmd/f4" ]; then
+          if [ "$cmd_affected" != "yes" ]; then
+            echo "cmd/f4 is not affected by this diff; skipping incremental lint."
+            echo "run=no" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "args=./cmd/f4/..." >> "$GITHUB_OUTPUT"
+          echo "run=yes" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [ -z "$rest_args" ]; then
+          echo "No affected packages outside cmd/f4; skipping incremental lint."
+          echo "run=no" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        echo "args=$rest_args" >> "$GITHUB_OUTPUT"
+        echo "run=yes" >> "$GITHUB_OUTPUT"
+
     - name: Run incremental golangci-lint
+      if: steps.lint-packages.outputs.run == 'yes'
       uses: golangci/golangci-lint-action@v9.3.0
       with:
         version: v2.13.1
-        args: --new-from-rev=origin/main
+        args: --new-from-rev=origin/main ${{ steps.lint-packages.outputs.args }}
 
     # The step above only reports findings on lines a pull request touched, so
     # everything the linters have to say about existing code stays invisible —
@@ -763,6 +857,7 @@ jobs:
     # Adding a linter to this list means clearing its debt first, in the same
     # change.
     - name: Run whole-tree golangci-lint for the linters with no backlog
+      if: matrix.shard == 'rest'
       uses: golangci/golangci-lint-action@v9.3.0
       with:
         version: v2.13.1
@@ -770,13 +865,14 @@ jobs:
 
   # Эта джоба создает постоянные релизы при пуше тэгов v*.*.*
   test:
-    name: Test (${{ matrix.target }})
+    name: Test (${{ matrix.target }}${{ matrix.shard && format(' {0}', matrix.shard) || '' }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      # One hosted runner per native os/arch cell, labeled to match the
-      # build matrix. Pull requests skip the second-arch twin of the two
+      # One hosted runner per native os/arch cell, except that the slow
+      # darwin/arm64 and windows/amd64 cells split their tests by name.
+      # Pull requests skip the second-arch twin of the two
       # desktop OSes: darwin/amd64 and windows/arm64 run on the slowest
       # runners of the whole matrix (4-5 minutes against the ~2:40 the
       # rest of a PR run takes) and only catch arch-specific breakage --
@@ -785,7 +881,11 @@ jobs:
       # everywhere: its runner is fast. Inline conditional rather than a
       # plan-job output because these jobs are the critical path, and a
       # needs: edge would bill its scheduling latency to every cell.
-      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64"},{"os":"windows-latest","target":"windows/amd64"}]}') || fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64"},{"os":"macos-15-intel","target":"darwin/amd64"},{"os":"windows-latest","target":"windows/amd64"},{"os":"windows-11-arm","target":"windows/arm64"}]}') }}
+      # A-D/rest is the closest timing split after charging the A shard for
+      # the isolated TestAllDialogs_LayoutValidation pass a second time.
+      # The first regex also covers an exact "Test" name; the negated class
+      # puts every other non-standard Test* suffix in the second shard.
+      matrix: ${{ github.event_name == 'pull_request' && fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64","shard":"A-D","run":"^Test([A-D]|$)"},{"os":"macos-latest","target":"darwin/arm64","shard":"rest","run":"^Test[^A-D]"},{"os":"windows-latest","target":"windows/amd64","shard":"A-D","run":"^Test([A-D]|$)"},{"os":"windows-latest","target":"windows/amd64","shard":"rest","run":"^Test[^A-D]"}]}') || fromJSON('{"include":[{"os":"ubuntu-latest","target":"linux/amd64"},{"os":"ubuntu-24.04-arm","target":"linux/arm64"},{"os":"macos-latest","target":"darwin/arm64","shard":"A-D","run":"^Test([A-D]|$)"},{"os":"macos-latest","target":"darwin/arm64","shard":"rest","run":"^Test[^A-D]"},{"os":"macos-15-intel","target":"darwin/amd64"},{"os":"windows-latest","target":"windows/amd64","shard":"A-D","run":"^Test([A-D]|$)"},{"os":"windows-latest","target":"windows/amd64","shard":"rest","run":"^Test[^A-D]"},{"os":"windows-11-arm","target":"windows/arm64"}]}') }}
     env:
       CGO_ENABLED: 0
       TEST_SHUFFLE: ${{ inputs.shuffle || 'on' }}
@@ -830,6 +930,7 @@ jobs:
       shell: bash
       env:
         AFFECTED: ${{ steps.affected.outputs.packages }}
+        RUN_FILTER: ${{ matrix.run || '' }}
       run: |
         # Pull requests test only the packages their diff reaches through
         # the import graph (see the affected-packages action); pushes, tags
@@ -849,14 +950,20 @@ jobs:
         # caching off, deliberately: a rolling-cache experiment showed this
         # suite is uncacheable anyway -- the tests read per-run environment
         # (temp dirs), so even an unchanged tree scored zero cache hits.
-        go test -shuffle="$TEST_SHUFFLE" -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' "${targets[@]}"
+        run_args=()
+        if [ -n "$RUN_FILTER" ]; then
+          run_args=(-run "$RUN_FILTER")
+        fi
+        go test -shuffle="$TEST_SHUFFLE" -timeout 15m -skip '^TestAllDialogs_LayoutValidation$' "${run_args[@]}" "${targets[@]}"
         # Layout validation mutates shared UI registries from parallel
         # subtests. Go 1.26 schedules them aggressively enough to expose the
         # upstream race, so isolate that test in a single-threaded process.
-        case " ${targets[*]} " in
-          *" ./... "*|*" github.com/unxed/f4/cmd/f4 "*)
-            GOMAXPROCS=1 go test -timeout 15m -run '^TestAllDialogs_LayoutValidation$' ./cmd/f4 ;;
-        esac
+        if [ -z "$RUN_FILTER" ] || [[ "TestAllDialogs_LayoutValidation" =~ $RUN_FILTER ]]; then
+          case " ${targets[*]} " in
+            *" ./... "*|*" github.com/unxed/f4/cmd/f4 "*)
+              GOMAXPROCS=1 go test -timeout 15m -run '^TestAllDialogs_LayoutValidation$' ./cmd/f4 ;;
+          esac
+        fi
 
     - name: Dump crash reports on failure
       if: failure()
@@ -924,14 +1031,16 @@ jobs:
       matrix:
         # cmd/f4's suite alone takes as long under the detector as every
         # other package combined, so it gets runners of its own -- split in
-        # two by test-name letter, because even alone it sat on the critical
-        # path. The A-G boundary is hand-picked for rough balance (1062 vs
-        # 1151 tests today); rebalance it if the halves drift apart as tests
-        # are added. The halves share the app cache key on purpose: they
-        # compile identical objects, so whichever saves first serves both.
+        # three by test-name letter, because even alone it sat on the critical
+        # path. TestAllDialogs_LayoutValidation dominates the A range under
+        # the detector, so A cannot be split any further by first letter;
+        # B-L/rest is the closest split of the remaining measured time. The
+        # three app shards share a cache key on purpose: they compile identical
+        # objects, so whichever saves first serves all three.
         include:
-          - { scope: 'cmd/f4 A-G', cache-key: app, run: '^Test[A-G]' }
-          - { scope: 'cmd/f4 H-Z', cache-key: app, run: '^Test[^A-G]' }
+          - { scope: 'cmd/f4 A', cache-key: app, run: '^TestA' }
+          - { scope: 'cmd/f4 B-L', cache-key: app, run: '^Test[B-L]' }
+          - { scope: 'cmd/f4 rest', cache-key: app, run: '^Test([^A-L]|$)' }
           - { scope: packages, cache-key: packages }
     env:
       # The race detector requires cgo and the Ubuntu runner provides the
@@ -947,8 +1056,8 @@ jobs:
       # The shared setup-go cache key is claimed by whichever ubuntu job
       # saves first -- always one without -race -- so these jobs recompiled
       # the whole tree under the detector on every run, ~2 minutes each.
-      # Race-instrumented objects get a key of their own; the two scopes
-      # compile different package sets, so the key includes the scope.
+      # Race-instrumented objects get a key of their own; the app shards and
+      # package scope compile different package sets, so the key includes it.
       uses: actions/cache@v4
       with:
         path: |
@@ -980,7 +1089,7 @@ jobs:
             echo "cmd/f4 is not affected by this diff; skipping."
             exit 0
           fi
-          # 5m, not 15m: a warm half runs in about a minute, and the known
+          # 5m, not 15m: a warm shard runs in about a minute, and the known
           # cmd/f4 hang (leaked FrameManager task pumps; TestMain stuck in a
           # chan receive) otherwise burns the full timeout before the job
           # can go red and be retried.

--- a/.github/workflows/go-cache-salt
+++ b/.github/workflows/go-cache-salt
@@ -1,0 +1,7 @@
+# This file is part of the test job's Go cache key (see build.yml).
+# Bump the number when the cache *location* changes -- e.g. the move of
+# GOCACHE/GOMODCACHE to D: on Windows -- so stale caches with the old
+# absolute paths rotate out. Do not bump it for ordinary CI edits: a
+# rotation costs every test cell a cold compile, ~9 minutes on the
+# darwin/amd64 runner alone.
+1

--- a/cmd/f4/action_menu_test.go
+++ b/cmd/f4/action_menu_test.go
@@ -204,14 +204,7 @@ func TestBuildMenuBarItems_OnClickRunsAction(t *testing.T) {
 }
 
 func TestBuildMenuBarItems_IncludesPluginPanelCommandsInDeclaredMenu(t *testing.T) {
-	oldScreens := vtui.FrameManager.Screens
-	oldActive := vtui.FrameManager.ActiveIdx
-	t.Cleanup(func() {
-		vtui.FrameManager.Screens = oldScreens
-		vtui.FrameManager.ActiveIdx = oldActive
-	})
-	vtui.FrameManager.Screens = []*vtui.AppScreen{{Frames: []vtui.Frame{&PanelsFrame{}}}}
-	vtui.FrameManager.ActiveIdx = 0
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{{Frames: []vtui.Frame{&PanelsFrame{}}}}, 0))
 
 	api := &coreAPI{}
 	run := 0
@@ -259,14 +252,7 @@ func TestBuildMenuBarItems_IncludesPluginPanelCommandsInDeclaredMenu(t *testing.
 }
 
 func TestBuildMenuBarItemsSkipsPluginVisibilityBeforePanelsFrameRegistration(t *testing.T) {
-	oldScreens := vtui.FrameManager.Screens
-	oldActive := vtui.FrameManager.ActiveIdx
-	t.Cleanup(func() {
-		vtui.FrameManager.Screens = oldScreens
-		vtui.FrameManager.ActiveIdx = oldActive
-	})
-	vtui.FrameManager.Screens = nil
-	vtui.FrameManager.ActiveIdx = 0
+	t.Cleanup(setFrameManagerScreensForTest(t, nil, 0))
 
 	api := &coreAPI{}
 	registration, err := api.RegisterPluginCommand(vfs.PluginCommand{

--- a/cmd/f4/action_registry.go
+++ b/cmd/f4/action_registry.go
@@ -1446,7 +1446,7 @@ func init() {
 				// Captured mode has no separate console view to switch to;
 				// output already went to a dialog, so panels stay visible.
 				pf.showPanels = true
-				vtui.ShowToast(Msg("Terminal.NotAvailableInEnv"), 3*time.Second)
+				showToast(Msg("Terminal.NotAvailableInEnv"), 3*time.Second)
 			default:
 				vtui.FrameManager.HardRefresh()
 			}
@@ -2282,7 +2282,7 @@ func init() {
 			AppConfig.EditorDefaultCodePage = next
 			SaveConfig()
 			ev.ReloadWithCodepage(next)
-			vtui.ShowToast(fmt.Sprintf("Codepage: %s", vfs.DisplayCodepageName(next)), time.Second)
+			showToast(fmt.Sprintf("Codepage: %s", vfs.DisplayCodepageName(next)), time.Second)
 		}),
 	})
 	RegisterAction(Action{
@@ -2472,7 +2472,7 @@ func init() {
 			AppConfig.ViewerDefaultCodePage = next
 			SaveConfig()
 			vv.ReloadWithCodepage(next)
-			vtui.ShowToast(fmt.Sprintf("Codepage: %s", vfs.DisplayCodepageName(next)), time.Second)
+			showToast(fmt.Sprintf("Codepage: %s", vfs.DisplayCodepageName(next)), time.Second)
 		}),
 	})
 	RegisterAction(Action{

--- a/cmd/f4/action_registry_test.go
+++ b/cmd/f4/action_registry_test.go
@@ -142,11 +142,10 @@ func TestActionPanelToggleTargetsActiveWorkspace(t *testing.T) {
 
 	first := &PanelsFrame{showPanels: true, showLeftPanel: true, showRightPanel: true}
 	active := &PanelsFrame{showPanels: true, showLeftPanel: true, showRightPanel: true}
-	vtui.FrameManager.Screens = []*vtui.AppScreen{
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{
 		{Number: 1, Frames: []vtui.Frame{first}},
 		{Number: 2, Frames: []vtui.Frame{active}},
-	}
-	vtui.FrameManager.ActiveIdx = 1
+	}, 1))
 
 	if !RunAction("Panel.Toggle") {
 		t.Fatal("Panel.Toggle did not run")

--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3115,7 +3115,7 @@ func actionSaveSettings(pf *PanelsFrame) {
 	btnSave.OnClick = func() {
 		saveSettingsGroups(chkGeneral.State == 1, chkPanel.State == 1, chkWindow.State == 1)
 		dlg.Close()
-		vtui.ShowToast(Msg("SaveSettings.Done"), 2*time.Second)
+		showToast(Msg("SaveSettings.Done"), 2*time.Second)
 	}
 
 	vtui.FrameManager.PushToFrameScreen(pf, dlg)
@@ -4049,7 +4049,7 @@ func actionImportFar2lHistory(pf *PanelsFrame) {
 				h := extractNames(merged)
 				pf.cmdLine.Edit.History = h
 
-				vtui.ShowToast(fmt.Sprintf("Imported %d new commands from far2l.", len(merged)-len(current)), 3*time.Second)
+				showToast(fmt.Sprintf("Imported %d new commands from far2l.", len(merged)-len(current)), 3*time.Second)
 			})
 		})
 	}

--- a/cmd/f4/ai_chat_panel.go
+++ b/cmd/f4/ai_chat_panel.go
@@ -176,7 +176,7 @@ func (cp *AIChatPanel) ProcessKey(e *vtinput.InputEvent) bool {
 		for i := len(turns) - 1; i >= 0; i-- {
 			if turns[i].Role != "user" && turns[i].Text != "RCtrl+A to hide" {
 				setClipboardAsync(turns[i].Text)
-				vtui.ShowToast("Copied last response to clipboard", 2*time.Second)
+				showToast("Copied last response to clipboard", 2*time.Second)
 				break
 			}
 		}
@@ -879,7 +879,7 @@ func (cp *AIChatPanel) copyLinkTarget(target string) {
 				vtui.ShowMessage(" Error ", "Copy failed:\n"+err.Error(), []string{"&Ok"})
 			} else {
 				dstFSP.ReadDirectory()
-				vtui.ShowToast("Copied "+fileName+" to "+dstDir, 2*time.Second)
+				showToast("Copied "+fileName+" to "+dstDir, 2*time.Second)
 			}
 		})
 }

--- a/cmd/f4/apply_command.go
+++ b/cmd/f4/apply_command.go
@@ -823,10 +823,10 @@ func (s *applyCommandSession) enqueue(request applyBatchRequest, model *applyBat
 			model.Finish(fallback)
 		}
 		s.refreshCapturedPanels()
-		vtui.ShowToast(Msg("ApplyCommand.StatusFinishedToast"), 3*time.Second)
+		showToast(Msg("ApplyCommand.StatusFinishedToast"), 3*time.Second)
 	}
 	GlobalQueueManager.Enqueue(task)
-	vtui.ShowToast(Msg("ApplyCommand.QueuedToast"), 3*time.Second)
+	showToast(Msg("ApplyCommand.QueuedToast"), 3*time.Second)
 }
 
 func (s *applyCommandSession) queuePreconditions() []OpPrecondition {

--- a/cmd/f4/command_palette_coverage_test.go
+++ b/cmd/f4/command_palette_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -382,6 +383,16 @@ func commandPaletteParseProductionGo(t *testing.T) []commandPaletteParsedGo {
 			return walkErr
 		}
 		if entry.IsDir() {
+			if path != root {
+				// Nested repositories and worktrees are not module production
+				// sources. Skipping their .git marker keeps local worktree copies
+				// (commonly under _work/) from duplicating this inventory.
+				if _, markerErr := os.Lstat(filepath.Join(path, ".git")); markerErr == nil {
+					return fs.SkipDir
+				} else if !os.IsNotExist(markerErr) {
+					return markerErr
+				}
+			}
 			switch entry.Name() {
 			case ".git", "testdata", "vendor":
 				if path != root {

--- a/cmd/f4/command_palette_dynamic_test.go
+++ b/cmd/f4/command_palette_dynamic_test.go
@@ -20,8 +20,7 @@ func setCommandPaletteActivePanelsForTest(t *testing.T, pf *PanelsFrame) {
 	screen := vtui.NewSilentScreenBuf()
 	screen.AllocBuf(100, 30)
 	vtui.FrameManager.Init(screen)
-	vtui.FrameManager.Screens = []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}
-	vtui.FrameManager.ActiveIdx = 0
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}, 0))
 }
 
 func TestCommandPaletteIncludesRecordedAndLuaMacros(t *testing.T) {
@@ -193,8 +192,7 @@ func TestCommandPalettePrefixAndDriveRejectPreviousWorkspace(t *testing.T) {
 	}
 
 	current := &PanelsFrame{cmdLine: NewCommandLine(""), panels: [2]Panel{&FileSystemPanel{}, &FileSystemPanel{}}}
-	vtui.FrameManager.Screens = append(vtui.FrameManager.Screens, &vtui.AppScreen{Number: 2, Frames: []vtui.Frame{current}})
-	vtui.FrameManager.ActiveIdx = 1
+	t.Cleanup(appendFrameManagerScreenForTest(t, &vtui.AppScreen{Number: 2, Frames: []vtui.Frame{current}}, 1))
 	if executeCommandPaletteEntry(prefixEntry) || pf.cmdLine.Edit.GetText() != "" {
 		t.Fatal("stale prefix entry mutated the previous workspace")
 	}

--- a/cmd/f4/command_palette_test.go
+++ b/cmd/f4/command_palette_test.go
@@ -163,12 +163,9 @@ func TestCommandPaletteIncludesBothPluginLocationsAndReResolves(t *testing.T) {
 		// Install the deliberately minimal PanelsFrame in an isolated manager so
 		// workspace validation stays meaningful without borrowing another test's
 		// active screen.
-		oldFrameManager := vtui.FrameManager
-		manager := vtui.NewFrameManager()
-		manager.Screens = []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}
-		manager.ActiveIdx = 0
-		vtui.FrameManager = manager
-		defer func() { vtui.FrameManager = oldFrameManager }()
+		restoreFrameManager := swapFrameManager(t)
+		defer restoreFrameManager()
+		defer setFrameManagerScreensForTest(t, []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}, 0)()
 
 		if !executeCommandPaletteEntry(panel) || runs != 1 {
 			t.Fatalf("live plugin command ran %d times", runs)

--- a/cmd/f4/config_test.go
+++ b/cmd/f4/config_test.go
@@ -164,19 +164,17 @@ func TestSaveSettingsGroupsKeepUnselectedValues(t *testing.T) {
 	oldUserPath := getUserConfigIniPath
 	oldConfigPaths := getConfigIniPaths
 	oldSessionPath := getSessionIniPath
-	oldFrameManager := vtui.FrameManager
+	t.Cleanup(swapFrameManager(t))
 	defer func() {
 		AppConfig = oldConfig
 		getUserConfigIniPath = oldUserPath
 		getConfigIniPaths = oldConfigPaths
 		getSessionIniPath = oldSessionPath
-		vtui.FrameManager = oldFrameManager
 	}()
 
 	getUserConfigIniPath = func() string { return settingsPath }
 	getConfigIniPaths = func() []string { return []string{settingsPath} }
 	getSessionIniPath = func() string { return sessionPath }
-	vtui.FrameManager = vtui.NewFrameManager()
 
 	AppConfig.ColorStyle = "Persisted"
 	AppConfig.GuiCols = 80
@@ -913,6 +911,11 @@ func TestRequestSaveConfigPostsToTheFrameManagerItWasArmedWith(t *testing.T) {
 	// What the next test does while the timer is still counting down.
 	replacement := vtui.NewFrameManager()
 	vtui.FrameManager = replacement
+	t.Cleanup(func() {
+		closeFrameManagerFrames(replacement)
+		replacement.Shutdown()
+		vtui.FrameManager = arming
+	})
 
 	deadline := time.NewTimer(5 * time.Second)
 	defer deadline.Stop()

--- a/cmd/f4/dialog_layouts_test.go
+++ b/cmd/f4/dialog_layouts_test.go
@@ -156,6 +156,9 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 	}
 	t.Cleanup(func() { runPanelMountTask = oldMountTaskRunner })
 
+	rig := newDialogLayoutRig(t, tmpDir)
+	defer rig.close(t)
+
 	// Complex-script widths are handled by vtui's grapheme-cell shaping.
 	for _, act := range GetActions() {
 		name := act.Name
@@ -176,68 +179,22 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 					vtui.AddStrings(pack.Strings)
 				}
 
-				errs := func() []error {
-					// Re-init FrameManager and Screen for each language pass.
-					scr := vtui.NewSilentScreenBuf()
-					scr.AllocBuf(120, 60)
-					manager := vtui.FrameManager
-					manager.Init(scr)
+				var errs []error
+				if dialogLayoutActionNeedsFreshRig(name) {
+					errs = func() []error {
+						rig.detach(t)
+						defer rig.attach()
 
-					// Create and push a dummy PanelsFrame so context-aware actions find it.
-					localVFS := vfs.NewOSVFS(tmpDir)
-					_ = localVFS.SetPath(tmpDir)
-					pf := NewPanelsFrame()
-					left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
-					right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
-					waitForLoad(t, left)
-					waitForLoad(t, right)
-					pf.panels[0] = left
-					pf.panels[1] = right
-					pf.ResizeConsole(120, 60)
-					waitForLoad(t, pf.panels[0].(*FileSystemPanel))
-					waitForLoad(t, pf.panels[1].(*FileSystemPanel))
-					manager.Push(pf)
-					defer func() {
-						waitForDirectoryLoads(t)
-						// This includes the PanelsFrame and every dialog added by the action.
-						closeFrameManagerFrames(manager)
+						fresh := newDialogLayoutRig(t, tmpDir)
+						defer fresh.close(t)
+						return fresh.validateAction(t, act, name, srcFile, rules)
 					}()
-
-					// Setup editor/viewer context if testing editor/viewer actions.
-					if strings.HasPrefix(name, "Editor.") {
-						showEditor(pf, localVFS, srcFile, &vfs.MemoryReadAtCloser{Data: []byte("dummy")})
-					} else if strings.HasPrefix(name, "Viewer.") {
-						vv, err := NewViewerView(context.Background(), localVFS, srcFile)
-						if err == nil {
-							showViewer(pf, vv, srcFile)
-						}
-					}
-
-					initialCount := len(manager.Screens[manager.ActiveIdx].Frames)
-
-					// Trigger the action handler.
-					act.Handler()
-					waitForLoad(t, pf.panels[0].(*FileSystemPanel))
-					waitForLoad(t, pf.panels[1].(*FileSystemPanel))
-					if manager.GetActiveToast() != "" {
-						waitForToastExpiry(t, 6*time.Second)
-					}
-
-					frames := manager.Screens[manager.ActiveIdx].Frames
-					if len(frames) <= initialCount {
-						// Many actions are silent and do not open a dialog (e.g. Editor.Save).
-						// This is completely expected, so skip validation for this pass.
-						return nil
-					}
-
-					// Check if the top-most frame is a container. If not (e.g. raw drawing view), skip it safely.
-					topFrame := frames[len(frames)-1]
-					container, ok := topFrame.(vtui.Container)
-					if !ok {
-						return nil
-					}
-					return vtui.ValidateLayoutWithRules(container, rules)
-				}()
+				} else {
+					errs = func() []error {
+						defer rig.reset(t)
+						return rig.validateAction(t, act, name, srcFile, rules)
+					}()
+				}
 
 				packName := pack.Name
 				if packName == "" {
@@ -252,5 +209,177 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 				t.Errorf("Layout validation failed for Action %s:\n%s", name, strings.Join(msgs, "\n"))
 			}
 		})
+	}
+}
+
+type dialogLayoutRig struct {
+	manager    *vtui.FrameManagerType
+	screen     *vtui.ScreenBuf
+	baseScreen *vtui.AppScreen
+	panels     *PanelsFrame
+	localVFS   vfs.VFS
+}
+
+func newDialogLayoutRig(t *testing.T, dir string) *dialogLayoutRig {
+	t.Helper()
+	screen := vtui.NewSilentScreenBuf()
+	screen.AllocBuf(120, 60)
+	manager := vtui.FrameManager
+	manager.Init(screen)
+
+	localVFS := vfs.NewOSVFS(dir)
+	if err := localVFS.SetPath(dir); err != nil {
+		t.Fatal(err)
+	}
+	panels := NewPanelsFrame()
+	left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
+	right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+	waitForLoad(t, left)
+	waitForLoad(t, right)
+	panels.panels[0] = left
+	panels.panels[1] = right
+	panels.ResizeConsole(120, 60)
+	waitForLoad(t, panels.panels[0].(*FileSystemPanel))
+	waitForLoad(t, panels.panels[1].(*FileSystemPanel))
+	manager.Push(panels)
+
+	return &dialogLayoutRig{
+		manager:    manager,
+		screen:     screen,
+		baseScreen: manager.Screens[manager.ActiveIdx],
+		panels:     panels,
+		localVFS:   localVFS,
+	}
+}
+
+func (rig *dialogLayoutRig) validateAction(t *testing.T, act Action, name, srcFile string, rules vtui.LayoutRules) []error {
+	t.Helper()
+	if strings.HasPrefix(name, "Editor.") {
+		showEditor(rig.panels, rig.localVFS, srcFile, &vfs.MemoryReadAtCloser{Data: []byte("dummy")})
+	} else if strings.HasPrefix(name, "Viewer.") {
+		viewer, err := NewViewerView(context.Background(), rig.localVFS, srcFile)
+		if err == nil {
+			showViewer(rig.panels, viewer, srcFile)
+		}
+	}
+
+	initialCount := len(rig.manager.Screens[rig.manager.ActiveIdx].Frames)
+	act.Handler()
+	waitForLoad(t, rig.panels.panels[0].(*FileSystemPanel))
+	waitForLoad(t, rig.panels.panels[1].(*FileSystemPanel))
+	if rig.manager.GetActiveToast() != "" {
+		waitForToastExpiry(t, 6*time.Second)
+	}
+
+	frames := rig.manager.Screens[rig.manager.ActiveIdx].Frames
+	if len(frames) <= initialCount {
+		// Many actions are silent and do not open a dialog (e.g. Editor.Save).
+		// This is completely expected, so skip validation for this pass.
+		return nil
+	}
+
+	// Check if the top-most frame is a container. If not (e.g. raw drawing view), skip it safely.
+	topFrame := frames[len(frames)-1]
+	container, ok := topFrame.(vtui.Container)
+	if !ok {
+		return nil
+	}
+	return vtui.ValidateLayoutWithRules(container, rules)
+}
+
+func (rig *dialogLayoutRig) reset(t *testing.T) {
+	t.Helper()
+	waitForDirectoryLoads(t)
+
+	baseIdx := -1
+	for i, screen := range rig.manager.Screens {
+		if screen == rig.baseScreen {
+			baseIdx = i
+			continue
+		}
+		closeFrameManagerScreens([]*vtui.AppScreen{screen})
+	}
+	if baseIdx < 0 {
+		t.Fatal("layout validation action removed the shared panels workspace")
+	}
+
+	// Drop any editor/viewer or action-created workspaces without rebuilding
+	// the shared panel fixture. Their frames have already been closed above.
+	for i := len(rig.manager.Screens) - 1; i >= 0; i-- {
+		if rig.manager.Screens[i] == rig.baseScreen {
+			continue
+		}
+		before := len(rig.manager.Screens)
+		rig.manager.CloseScreen(i)
+		if len(rig.manager.Screens) != before-1 {
+			t.Fatal("layout validation action left an extra workspace that could not be closed")
+		}
+	}
+
+	for i, screen := range rig.manager.Screens {
+		if screen == rig.baseScreen {
+			baseIdx = i
+			break
+		}
+	}
+	rig.manager.SwitchScreen(baseIdx)
+	frames := append([]vtui.Frame(nil), rig.baseScreen.Frames...)
+	foundPanels := false
+	for i := len(frames) - 1; i >= 0; i-- {
+		frame := frames[i]
+		if frame == rig.panels {
+			foundPanels = true
+			continue
+		}
+		frame.Close()
+		rig.manager.RemoveFrame(frame)
+	}
+	if !foundPanels || rig.panels.IsDone() {
+		t.Fatal("layout validation action mutated the shared panels frame")
+	}
+}
+
+func (rig *dialogLayoutRig) detach(t *testing.T) {
+	t.Helper()
+	// The next rig reinitializes the global manager. Clipboard workers read
+	// that global asynchronously, so join them at this lifecycle boundary.
+	waitForAsyncClipboard()
+	rig.reset(t)
+}
+
+func (rig *dialogLayoutRig) attach() {
+	rig.manager.Init(rig.screen)
+	rig.manager.Push(rig.panels)
+	rig.baseScreen = rig.manager.Screens[rig.manager.ActiveIdx]
+}
+
+func (rig *dialogLayoutRig) close(t *testing.T) {
+	t.Helper()
+	waitForAsyncClipboard()
+	waitForDirectoryLoads(t)
+	closeFrameManagerFrames(rig.manager)
+}
+
+// These handlers change the reusable PanelsFrame itself (or stop/close its
+// manager). Keeping their old per-combination freshness avoids making a later
+// action or translation depend on that mutation; ordinary actions share the
+// expensive VFS and panels fixture above.
+func dialogLayoutActionNeedsFreshRig(name string) bool {
+	name = strings.ToLower(name)
+	if strings.HasPrefix(name, "panel.left.") || strings.HasPrefix(name, "panel.right.") {
+		return true
+	}
+	switch name {
+	case "ai.togglepanel",
+		"app.background",
+		"panel.goparent",
+		"panel.goroot",
+		"panel.insertpath",
+		"panel.selectnavigation",
+		"panel.togglecommandlinefocus",
+		"workspace.close":
+		return true
+	default:
+		return false
 	}
 }

--- a/cmd/f4/dialog_layouts_test.go
+++ b/cmd/f4/dialog_layouts_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/unxed/f4/fusefs"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtui"
 )
@@ -141,6 +143,19 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 
 	// Load all language packs so the validator can assert layout against all translations dynamically
 	packs := LoadAllLanguagePacks()
+	if len(packs) == 0 {
+		packs = []vtui.LanguagePack{{Name: "current"}}
+	}
+
+	oldMountTaskRunner := runPanelMountTask
+	runPanelMountTask = func(pf *PanelsFrame, label string, readOnly bool, _ func(context.Context) (*fusefs.Mount, error)) {
+		reportMount(pf, label, &fusefs.Mount{
+			MountPoint: filepath.Join(tmpDir, "layout-validation-mount"),
+			ReadOnly:   readOnly,
+		}, nil, readOnly)
+	}
+	t.Cleanup(func() { runPanelMountTask = oldMountTaskRunner })
+
 	// Complex-script widths are handled by vtui's grapheme-cell shaping.
 	for _, act := range GetActions() {
 		name := act.Name
@@ -151,76 +166,89 @@ func TestAllDialogs_LayoutValidation(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			rules := vtui.DefaultLayoutRules
 			rules.MaxWidth = 120 // Allow configurator/large dialogs to exceed default 78 columns
+			baseStrings := vtui.SnapshotStrings()
+			defer vtui.ReplaceStrings(baseStrings)
 
-			errs := vtui.ValidateLayoutInLanguagesWithRules(packs, rules, func() vtui.Container {
-				// Re-init FrameManager and Screen for each test pass
-				scr := vtui.NewSilentScreenBuf()
-				scr.AllocBuf(120, 60)
-				vtui.FrameManager.Init(scr)
+			var msgs []string
+			for _, pack := range packs {
+				vtui.ReplaceStrings(baseStrings)
+				if len(pack.Strings) > 0 {
+					vtui.AddStrings(pack.Strings)
+				}
 
-				// Create and push a dummy PanelsFrame so context-aware actions find it
-				localVFS := vfs.NewOSVFS(tmpDir)
-				_ = localVFS.SetPath(tmpDir)
-				pf := NewPanelsFrame()
-				left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
-				right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
-				waitForLoad(t, left)
-				waitForLoad(t, right)
-				pf.panels[0] = left
-				pf.panels[1] = right
-				pf.ResizeConsole(120, 60)
-				waitForLoad(t, pf.panels[0].(*FileSystemPanel))
-				waitForLoad(t, pf.panels[1].(*FileSystemPanel))
-				vtui.FrameManager.Push(pf)
+				errs := func() []error {
+					// Re-init FrameManager and Screen for each language pass.
+					scr := vtui.NewSilentScreenBuf()
+					scr.AllocBuf(120, 60)
+					manager := vtui.FrameManager
+					manager.Init(scr)
 
-				// Setup editor/viewer context if testing editor/viewer actions
-				if strings.HasPrefix(name, "Editor.") {
-					showEditor(pf, localVFS, srcFile, &vfs.MemoryReadAtCloser{Data: []byte("dummy")})
-				} else if strings.HasPrefix(name, "Viewer.") {
-					vv, err := NewViewerView(context.Background(), localVFS, srcFile)
-					if err == nil {
-						showViewer(pf, vv, srcFile)
+					// Create and push a dummy PanelsFrame so context-aware actions find it.
+					localVFS := vfs.NewOSVFS(tmpDir)
+					_ = localVFS.SetPath(tmpDir)
+					pf := NewPanelsFrame()
+					left := NewFileSystemPanel(0, 0, 40, 20, localVFS)
+					right := NewFileSystemPanel(40, 0, 40, 20, localVFS.Clone())
+					waitForLoad(t, left)
+					waitForLoad(t, right)
+					pf.panels[0] = left
+					pf.panels[1] = right
+					pf.ResizeConsole(120, 60)
+					waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+					waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+					manager.Push(pf)
+					defer func() {
+						waitForDirectoryLoads(t)
+						// This includes the PanelsFrame and every dialog added by the action.
+						closeFrameManagerFrames(manager)
+					}()
+
+					// Setup editor/viewer context if testing editor/viewer actions.
+					if strings.HasPrefix(name, "Editor.") {
+						showEditor(pf, localVFS, srcFile, &vfs.MemoryReadAtCloser{Data: []byte("dummy")})
+					} else if strings.HasPrefix(name, "Viewer.") {
+						vv, err := NewViewerView(context.Background(), localVFS, srcFile)
+						if err == nil {
+							showViewer(pf, vv, srcFile)
+						}
 					}
+
+					initialCount := len(manager.Screens[manager.ActiveIdx].Frames)
+
+					// Trigger the action handler.
+					act.Handler()
+					waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+					waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+					if manager.GetActiveToast() != "" {
+						waitForToastExpiry(t, 6*time.Second)
+					}
+
+					frames := manager.Screens[manager.ActiveIdx].Frames
+					if len(frames) <= initialCount {
+						// Many actions are silent and do not open a dialog (e.g. Editor.Save).
+						// This is completely expected, so skip validation for this pass.
+						return nil
+					}
+
+					// Check if the top-most frame is a container. If not (e.g. raw drawing view), skip it safely.
+					topFrame := frames[len(frames)-1]
+					container, ok := topFrame.(vtui.Container)
+					if !ok {
+						return nil
+					}
+					return vtui.ValidateLayoutWithRules(container, rules)
+				}()
+
+				packName := pack.Name
+				if packName == "" {
+					packName = "?"
 				}
-
-				initialCount := len(vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx].Frames)
-
-				// Trigger the action handler!
-				act.Handler()
-				waitForLoad(t, pf.panels[0].(*FileSystemPanel))
-				waitForLoad(t, pf.panels[1].(*FileSystemPanel))
-				if vtui.FrameManager.GetActiveToast() != "" {
-					waitForToastExpiry(t, 6*time.Second)
-				}
-
-				frames := vtui.FrameManager.Screens[vtui.FrameManager.ActiveIdx].Frames
-				if len(frames) <= initialCount {
-					// Many actions are silent and do not open a dialog (e.g. Editor.Save).
-					// This is completely expected, so we safely return nil and skip validation.
-					return nil
-				}
-
-				// Check if the top-most frame is a container. If not (e.g. raw drawing view), skip it safely.
-				topFrame := frames[len(frames)-1]
-				container, ok := topFrame.(vtui.Container)
-				if !ok {
-					return nil
-				}
-				return container
-			})
-
-			// Clean up and close all frames to release file descriptors and prevent resource leaks.
-			for _, s := range vtui.FrameManager.Screens {
-				for _, f := range s.Frames {
-					f.Close()
+				for _, err := range errs {
+					msgs = append(msgs, fmt.Sprintf("[lang:%s] %s", packName, err))
 				}
 			}
 
-			if len(errs) > 0 {
-				var msgs []string
-				for _, e := range errs {
-					msgs = append(msgs, e.Error())
-				}
+			if len(msgs) > 0 {
 				t.Errorf("Layout validation failed for Action %s:\n%s", name, strings.Join(msgs, "\n"))
 			}
 		})

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -4580,7 +4580,7 @@ func (ev *EditorView) showConvertCodepageDialog() {
 				ev.codepageRaw = nil
 				ev.Codepage = cpID
 				ev.modified = true
-				vtui.ShowToast(fmt.Sprintf("Will be saved as: %s", vfs.DisplayCodepageName(cpID)), 2*time.Second)
+				showToast(fmt.Sprintf("Will be saved as: %s", vfs.DisplayCodepageName(cpID)), 2*time.Second)
 				ev.updateDesiredVisualCol()
 				ev.ensureCursorVisible()
 				vtui.FrameManager.Redraw()

--- a/cmd/f4/frame_manager_test_helpers_test.go
+++ b/cmd/f4/frame_manager_test_helpers_test.go
@@ -1,12 +1,76 @@
 package main
 
 import (
+	"bytes"
+	"runtime/pprof"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/unxed/vtui"
 	"github.com/unxed/vtui/vreactive"
 )
+
+func closeFrameManagerScreens(screens []*vtui.AppScreen) {
+	for _, screen := range screens {
+		if screen == nil {
+			continue
+		}
+		for _, frame := range screen.Frames {
+			if frame != nil {
+				frame.Close()
+			}
+		}
+	}
+}
+
+func closeFrameManagerFrames(manager *vtui.FrameManagerType) {
+	if manager != nil {
+		closeFrameManagerScreens(manager.Screens)
+	}
+}
+
+// setFrameManagerScreensForTest installs a screen fixture for the current
+// manager. Its cleanup closes exactly the frames supplied by the fixture and
+// then restores the manager's previous screen state.
+func setFrameManagerScreensForTest(t *testing.T, screens []*vtui.AppScreen, activeIdx int) func() {
+	t.Helper()
+	manager := vtui.FrameManager
+	oldScreens := manager.Screens
+	oldActiveIdx := manager.ActiveIdx
+	manager.Screens = screens
+	manager.ActiveIdx = activeIdx
+	return func() {
+		closeFrameManagerScreens(screens)
+		manager.Screens = oldScreens
+		manager.ActiveIdx = oldActiveIdx
+	}
+}
+
+// appendFrameManagerScreenForTest adds one owned screen fixture and removes it
+// during cleanup after closing its frames.
+func appendFrameManagerScreenForTest(t *testing.T, screen *vtui.AppScreen, activeIdx int) func() {
+	t.Helper()
+	manager := vtui.FrameManager
+	oldScreens := manager.Screens
+	oldActiveIdx := manager.ActiveIdx
+	manager.Screens = append(manager.Screens, screen)
+	manager.ActiveIdx = activeIdx
+	return func() {
+		closeFrameManagerScreens([]*vtui.AppScreen{screen})
+		manager.Screens = oldScreens
+		manager.ActiveIdx = oldActiveIdx
+	}
+}
+
+func taskPumpGoroutineProfile() (int, string, error) {
+	var stacks bytes.Buffer
+	if err := pprof.Lookup("goroutine").WriteTo(&stacks, 2); err != nil {
+		return 0, "", err
+	}
+	profile := stacks.String()
+	return strings.Count(profile, ".startTaskPump.func"), profile, nil
+}
 
 // waitForDirectoryLoads blocks until no directory-load worker is running
 // anywhere in the process.
@@ -76,13 +140,93 @@ func swapFrameManager(t *testing.T) func() {
 	old := vtui.FrameManager
 	oldUpdateQueue := vreactive.GlobalUpdateQueue
 	oldAnimationManager := vreactive.GlobalAnimationManager
-	vtui.FrameManager = vtui.NewFrameManager()
+	fresh := vtui.NewFrameManager()
+	vtui.FrameManager = fresh
 
 	return func() {
 		waitForAsyncClipboard()
 		waitForDirectoryLoads(t)
+		closeFrameManagerFrames(fresh)
+		fresh.Shutdown()
 		vtui.FrameManager = old
 		vreactive.GlobalUpdateQueue = oldUpdateQueue
 		vreactive.GlobalAnimationManager = oldAnimationManager
+	}
+}
+
+func TestFrameManagerShutdownStopsTaskPumpAndUnblocksPostTask(t *testing.T) {
+	before, _, err := taskPumpGoroutineProfile()
+	if err != nil {
+		t.Fatalf("capture initial goroutine profile: %v", err)
+	}
+
+	manager := vtui.NewFrameManager()
+	manager.Init(vtui.NewSilentScreenBuf())
+	t.Cleanup(manager.Shutdown)
+	taskChan := manager.TaskChan
+	if taskChan == nil {
+		t.Fatal("Init did not create TaskChan")
+	}
+	started, profile, err := taskPumpGoroutineProfile()
+	if err != nil {
+		t.Fatalf("capture running goroutine profile: %v", err)
+	}
+	if started <= before {
+		t.Fatalf("Init did not start a visible task-pump goroutine: before=%d after=%d\n%s", before, started, profile)
+	}
+
+	manager.PostTask(func() {})
+
+	start := make(chan struct{})
+	postReturned := make(chan struct{})
+	shutdownReturned := make(chan struct{})
+	go func() {
+		<-start
+		manager.PostTask(func() {})
+		close(postReturned)
+	}()
+	go func() {
+		<-start
+		manager.Shutdown()
+		close(shutdownReturned)
+	}()
+	close(start)
+
+	for _, operation := range []struct {
+		name string
+		done <-chan struct{}
+	}{
+		{name: "PostTask", done: postReturned},
+		{name: "Shutdown", done: shutdownReturned},
+	} {
+		select {
+		case <-operation.done:
+		case <-time.After(time.Second):
+			t.Fatalf("concurrent %s did not return after manager shutdown", operation.name)
+		}
+	}
+
+	if manager.TaskChan != nil {
+		t.Fatal("Shutdown left TaskChan attached to the manager")
+	}
+	select {
+	case <-taskChan:
+		t.Fatal("the stopped task pump delivered a queued task")
+	default:
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		after, profile, profileErr := taskPumpGoroutineProfile()
+		if profileErr != nil {
+			t.Fatalf("capture final goroutine profile: %v", profileErr)
+		}
+		if after <= before {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("FrameManager task pump did not exit: before=%d after=%d\n%s", before, after, profile)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/cmd/f4/fuse_mount_action.go
+++ b/cmd/f4/fuse_mount_action.go
@@ -9,6 +9,34 @@ import (
 	"github.com/unxed/vtui"
 )
 
+type panelMountTaskRunner func(
+	pf *PanelsFrame,
+	label string,
+	readOnly bool,
+	run func(context.Context) (*fusefs.Mount, error),
+)
+
+var runPanelMountTask panelMountTaskRunner
+
+func runPanelMountProgressTask(
+	pf *PanelsFrame,
+	label string,
+	readOnly bool,
+	run func(context.Context) (*fusefs.Mount, error),
+) {
+	var mount *fusefs.Mount
+	pf.RunProgressTask(" Mount ", "Mounting "+label+"...", false,
+		func(ctx context.Context, _ func(msg string, percent int)) error {
+			mounted, err := run(ctx)
+			if err != nil {
+				return err
+			}
+			mount = mounted
+			return nil
+		},
+		func(err error) { reportMount(pf, label, mount, err, readOnly) })
+}
+
 // The panel-side entry point for FUSE mounts (FUSE.md, iteration 2).
 //
 // This is the first, deliberately small step of that iteration: one command
@@ -87,18 +115,13 @@ func mountActivePanel(pf *PanelsFrame, readOnly bool) {
 	// extracted before it can be listed, a remote host may have to answer.
 	// Only the plan above touches the panel's own VFS, and it runs here on
 	// the UI thread; everything the task does afterwards belongs to the
-	// mount alone.
-	var m *fusefs.Mount
-	pf.RunProgressTask(" Mount ", "Mounting "+label+"...", false,
-		func(ctx context.Context, _ func(msg string, percent int)) error {
-			mounted, err := run(ctx)
-			if err != nil {
-				return err
-			}
-			m = mounted
-			return nil
-		},
-		func(err error) { reportMount(pf, label, m, err, readOnly) })
+	// mount alone. Tests can replace the runner while retaining the same
+	// action planning and result-dialog path without mounting through FUSE.
+	runner := runPanelMountTask
+	if runner == nil {
+		runner = runPanelMountProgressTask
+	}
+	runner(pf, label, readOnly, run)
 }
 
 // mountPlan decides what the active panel would have mounted, and returns a

--- a/cmd/f4/gui_font_catalog_test.go
+++ b/cmd/f4/gui_font_catalog_test.go
@@ -78,9 +78,8 @@ func TestFilterGuiFontDisplayChoicesMatchesSubstring(t *testing.T) {
 }
 
 func TestConfigureGuiFontComboFiltersWhileKeepingManualInput(t *testing.T) {
-	previousFrameManager := vtui.FrameManager
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager = nil
-	t.Cleanup(func() { vtui.FrameManager = previousFrameManager })
 
 	choices := []string{"JetBrainsMono-Regular", "NotoSansCJK", "Liberation Mono"}
 	combo := vtui.NewComboBox(0, 0, 30, choices)

--- a/cmd/f4/info_panel.go
+++ b/cmd/f4/info_panel.go
@@ -526,7 +526,7 @@ func (ip *InfoPanel) copyCurrent() {
 			return
 		}
 		vtui.SetClipboard(r.value)
-		vtui.ShowToast(fmt.Sprintf("%s: %s", Msg("InfoPanel.Copied"), r.value), 2*time.Second)
+		showToast(fmt.Sprintf("%s: %s", Msg("InfoPanel.Copied"), r.value), 2*time.Second)
 		return
 	}
 	var lines []string
@@ -535,7 +535,7 @@ func (ip *InfoPanel) copyCurrent() {
 	}
 	joined := strings.Join(lines, "\n")
 	vtui.SetClipboard(joined)
-	vtui.ShowToast(fmt.Sprintf("%s: %d", Msg("InfoPanel.CopiedRows"), len(selRows)), 2*time.Second)
+	showToast(fmt.Sprintf("%s: %d", Msg("InfoPanel.CopiedRows"), len(selRows)), 2*time.Second)
 }
 
 func (ip *InfoPanel) Show(scr *vtui.ScreenBuf) {

--- a/cmd/f4/macro_host.go
+++ b/cmd/f4/macro_host.go
@@ -238,9 +238,9 @@ func actionReloadLuaMacros() bool {
 	count, err := MacroMgr.ReloadLuaMacros(dir)
 	if err != nil {
 		vtui.DebugLog("MACRO: reload: %v", err)
-		vtui.ShowToast(fmt.Sprintf("%s (%d loaded)", Msg("Macro.ReloadFailed"), count), 3*time.Second)
+		showToast(fmt.Sprintf("%s (%d loaded)", Msg("Macro.ReloadFailed"), count), 3*time.Second)
 		return true
 	}
-	vtui.ShowToast(fmt.Sprintf(Msg("Macro.Reloaded"), count), 3*time.Second)
+	showToast(fmt.Sprintf(Msg("Macro.Reloaded"), count), 3*time.Second)
 	return true
 }

--- a/cmd/f4/panel_plugins.go
+++ b/cmd/f4/panel_plugins.go
@@ -101,7 +101,7 @@ func openRegisteredPanelProvider(app vfs.App, providerID string) {
 	controller, err := provider.Open(ctx)
 	if err != nil {
 		vtui.DebugLog("PANEL [%s]: open failed: %v", provider.ID, err)
-		vtui.ShowToast(fmt.Sprintf("Panel %s: %v", provider.Title, err), 3e9)
+		showToast(fmt.Sprintf("Panel %s: %v", provider.Title, err), 3e9)
 		return
 	}
 	if controller == nil {

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1171,7 +1171,7 @@ func (pf *PanelsFrame) reportLocalPTYFailure() {
 		return
 	}
 	vtui.FrameManager.PostTask(func() {
-		vtui.ShowToast(Msg("Terminal.PTYAllocFailed"), 5*time.Second)
+		showToast(Msg("Terminal.PTYAllocFailed"), 5*time.Second)
 	})
 }
 
@@ -3766,7 +3766,7 @@ func (pf *PanelsFrame) ExecuteDummyOp(mode int) {
 			Desc: desc,
 			Run:  runFunc,
 			OnComplete: func() {
-				vtui.ShowToast("Dummy operation finished successfully", 3*time.Second)
+				showToast("Dummy operation finished successfully", 3*time.Second)
 			},
 		})
 	} else {
@@ -4291,7 +4291,7 @@ func executeCapturedCommand(pf *PanelsFrame, action string, cmdStr string) {
 					return
 				}
 				vtui.SetClipboard(string(out))
-				vtui.ShowToast("Command output copied to clipboard", 3*time.Second)
+				showToast("Command output copied to clipboard", 3*time.Second)
 				pf.RefreshAll()
 			})
 		})

--- a/cmd/f4/plugring.go
+++ b/cmd/f4/plugring.go
@@ -144,7 +144,7 @@ func CheckForPluginUpdates() {
 
 		if updateCount > 0 {
 			frames.PostTask(func() {
-				vtui.ShowToast(fmt.Sprintf("PlugRing: %d plugin update(s) available!", updateCount), 5*time.Second)
+				showToast(fmt.Sprintf("PlugRing: %d plugin update(s) available!", updateCount), 5*time.Second)
 			})
 		}
 	}()

--- a/cmd/f4/process_environment_shell.go
+++ b/cmd/f4/process_environment_shell.go
@@ -486,11 +486,11 @@ func (pf *PanelsFrame) reportProcessEnvironmentShellFailure() {
 		}
 		// The localized title is intentionally value-free: neither environment
 		// names nor values may be copied to terminal or diagnostic output.
-		vtui.ShowToast(Msg("EnvMan.ShellSyncError"), processEnvironmentFailureToastDuration)
+		toastDuration := showToast(Msg("EnvMan.ShellSyncError"), processEnvironmentFailureToastDuration)
 		// ShowToast posts its setup. Queue our timer behind that setup so the
 		// coalescing window cannot end before vtui's own expiry timer.
 		manager.PostTask(func() {
-			time.AfterFunc(processEnvironmentFailureToastDuration, func() {
+			time.AfterFunc(toastDuration, func() {
 				finishProcessEnvironmentFailureToast(done)
 			})
 		})

--- a/cmd/f4/process_environment_test.go
+++ b/cmd/f4/process_environment_test.go
@@ -474,12 +474,10 @@ func TestProcessEnvironmentBroadcastReachesEveryLocalWorkspace(t *testing.T) {
 	secondPTY := &processEnvironmentPTY{}
 	first := &PanelsFrame{pty: firstPTY, termView: NewTerminalView(80, 24)}
 	second := &PanelsFrame{pty: secondPTY, termView: NewTerminalView(80, 24)}
-	defer first.closeProcessEnvironmentShell()
-	defer second.closeProcessEnvironmentShell()
-	vtui.FrameManager.Screens = []*vtui.AppScreen{
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{
 		{Number: 1, Frames: []vtui.Frame{first}},
 		{Number: 2, Frames: []vtui.Frame{second}},
-	}
+	}, 0))
 
 	broadcastProcessEnvironmentGenerations([]processEnvironmentGeneration{{
 		generation: 12,

--- a/cmd/f4/queue_manager.go
+++ b/cmd/f4/queue_manager.go
@@ -305,7 +305,9 @@ type OpQueueManager struct {
 }
 
 var GlobalQueueManager *OpQueueManager
-var queueShowToast = vtui.ShowToast
+var queueShowToast = func(message string, duration time.Duration) {
+	showToast(message, duration)
+}
 
 func init() {
 	GlobalQueueManager = &OpQueueManager{

--- a/cmd/f4/queue_manager_test.go
+++ b/cmd/f4/queue_manager_test.go
@@ -907,6 +907,11 @@ func TestQueueCancelFinalizesOnTheFrameManagerItStartedWith(t *testing.T) {
 	// What the next test does while the finalizer is still in flight.
 	replacement := vtui.NewFrameManager()
 	vtui.FrameManager = replacement
+	t.Cleanup(func() {
+		closeFrameManagerFrames(replacement)
+		replacement.Shutdown()
+		vtui.FrameManager = starting
+	})
 
 	deadline := time.NewTimer(5 * time.Second)
 	defer deadline.Stop()

--- a/cmd/f4/static_direct_actions_test.go
+++ b/cmd/f4/static_direct_actions_test.go
@@ -121,20 +121,12 @@ func TestArkanoidActionKeepsPhysicalShortcutFrameworkOwned(t *testing.T) {
 }
 
 func TestFixedSideActionsUseTheAddressedPanelState(t *testing.T) {
-	oldScreens := vtui.FrameManager.Screens
-	oldActive := vtui.FrameManager.ActiveIdx
-	defer func() {
-		vtui.FrameManager.Screens = oldScreens
-		vtui.FrameManager.ActiveIdx = oldActive
-	}()
-
 	left := &FileSystemPanel{viewMode: ViewModeBrief, sortMode: SortTime}
 	right := &FileSystemPanel{
 		vfs: &staticDirectActionsAITestVFS{VFS: vfs.NewNullVFS(0)},
 	}
 	pf := &PanelsFrame{panels: [2]Panel{left, right}}
-	vtui.FrameManager.Screens = []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}
-	vtui.FrameManager.ActiveIdx = 0
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}, 0))
 
 	leftBrief, _ := GetAction("Panel.Left.ViewBrief")
 	leftWide, _ := GetAction("Panel.Left.ViewWide")
@@ -231,19 +223,14 @@ func TestFixedSideMenuKeepsActivePanelShortcutHints(t *testing.T) {
 }
 
 func TestFixedSidePaletteEntriesUseLocalizedSideCategories(t *testing.T) {
-	oldScreens := vtui.FrameManager.Screens
-	oldActive := vtui.FrameManager.ActiveIdx
 	oldHotkeys := GlobalHotkeysMgr
 	defer func() {
-		vtui.FrameManager.Screens = oldScreens
-		vtui.FrameManager.ActiveIdx = oldActive
 		GlobalHotkeysMgr = oldHotkeys
 	}()
 	GlobalHotkeysMgr = NewHotkeyManager("")
 
 	pf := &PanelsFrame{cmdLine: NewCommandLine(""), panels: [2]Panel{&FileSystemPanel{}, &FileSystemPanel{}}}
-	vtui.FrameManager.Screens = []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}
-	vtui.FrameManager.ActiveIdx = 0
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{{Number: 1, Frames: []vtui.Frame{pf}}}, 0))
 
 	want := map[string]string{
 		"Panel.Left.ViewBrief":   plainLabel(Msg("Menu.Left")),

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -2021,7 +2021,7 @@ func (tv *TerminalView) ProcessFar2lInteract(data []byte) {
 		text := stk.PopString()
 		title := stk.PopString()
 		vtui.FrameManager.PostTask(func() {
-			vtui.ShowToast(title+": "+text, 3*time.Second)
+			showToast(title+": "+text, 3*time.Second)
 		})
 	case 'f': // FKey titles
 		for i := 0; i < 12; i++ {

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"fmt"
-	"github.com/unxed/f4/vfs"
-	"github.com/unxed/vtinput"
-	"github.com/unxed/vtui"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/unxed/f4/fusefs"
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
 )
 
 // pressKey dispatches a key through the production input path: the
@@ -60,7 +62,8 @@ func preserveActionRegistry(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	baseFrameManager := vtui.FrameManager
+	baseFrameManager.Init(vtui.NewSilentScreenBuf())
 	vfs.InitSudoClient("/usr/bin/f4", "")
 
 	// Unit tests must never hand control to the user's desktop. Individual
@@ -102,6 +105,34 @@ func TestMain(m *testing.M) {
 	}
 
 	result := m.Run()
+
+	for _, unmountErr := range fusefs.UnmountAll() {
+		_, _ = fmt.Fprintf(os.Stderr, "unmount test FUSE filesystem: %v\n", unmountErr)
+		result = 1
+	}
+
+	globalFrameManager := vtui.FrameManager
+	if globalFrameManager != nil {
+		closeFrameManagerFrames(globalFrameManager)
+		globalFrameManager.Shutdown()
+	}
+	if baseFrameManager != globalFrameManager {
+		_, _ = fmt.Fprintln(os.Stderr, "vtui.FrameManager was not restored to the TestMain manager")
+		closeFrameManagerFrames(baseFrameManager)
+		baseFrameManager.Shutdown()
+		result = 1
+	}
+
+	taskPumps, goroutineProfile, profileErr := taskPumpGoroutineProfile()
+	if profileErr != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "capture goroutine profile after vtui shutdown: %v\n", profileErr)
+		result = 1
+	} else if taskPumps > 0 {
+		_, _ = fmt.Fprintf(os.Stderr,
+			"vtui task-pump goroutine leak: %d startTaskPump goroutine(s) remain after test teardown; want 0\n%s",
+			taskPumps, goroutineProfile)
+		result = 1
+	}
 
 	if err == nil {
 		if removeErr := os.RemoveAll(tmpDir); removeErr != nil {

--- a/cmd/f4/test_main_test.go
+++ b/cmd/f4/test_main_test.go
@@ -75,6 +75,11 @@ func TestMain(m *testing.M) {
 	// tests that exercise the PTY path construct one explicitly.
 	spawnLocalShellPTY = false
 
+	// Toast behavior is still exercised through vtui's real asynchronous
+	// setup and expiry paths, but unit tests do not need production-length
+	// display times.
+	toastDurationOverride = func(time.Duration) time.Duration { return time.Millisecond }
+
 	// The machine's clipboard is global, slow to reach (pbcopy/xclip) and
 	// shared with whatever else the CI runner is doing; tests keep clipboard
 	// traffic in vtui's process-local buffer instead, and skip the OSC 52

--- a/cmd/f4/toast.go
+++ b/cmd/f4/toast.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"time"
+
+	"github.com/unxed/vtui"
+)
+
+// toastDurationOverride lets tests shorten f4-owned toast lifetimes without
+// changing vtui's timer. Production leaves it nil and uses each caller's
+// requested duration unchanged.
+var toastDurationOverride func(time.Duration) time.Duration
+
+func showToast(message string, duration time.Duration) time.Duration {
+	if toastDurationOverride != nil {
+		duration = toastDurationOverride(duration)
+	}
+	vtui.ShowToast(message, duration)
+	return duration
+}

--- a/cmd/f4/url_links.go
+++ b/cmd/f4/url_links.go
@@ -175,7 +175,7 @@ func launchExternalURLDefault(raw string) error {
 func openExternalURLAsync(raw string) {
 	go func() {
 		if err := openExternalURL(raw); err != nil {
-			vtui.ShowToast(fmt.Sprintf("Cannot open URL: %v", err), 3*time.Second)
+			showToast(fmt.Sprintf("Cannot open URL: %v", err), 3*time.Second)
 		}
 	}()
 }

--- a/cmd/f4/vtvibe_ap.go
+++ b/cmd/f4/vtvibe_ap.go
@@ -245,7 +245,7 @@ func aiAttachFailureReport(reportPath string) {
 		aiShowError(err)
 		return
 	}
-	vtui.ShowToast(Msg("AI.PatchReportAttached"), 3*time.Second)
+	showToast(Msg("AI.PatchReportAttached"), 3*time.Second)
 	if pf := findPanelsFrameAnyScreen(); pf != nil {
 		pf.RefreshAll()
 	}

--- a/cmd/f4/workspace_session_test.go
+++ b/cmd/f4/workspace_session_test.go
@@ -51,11 +51,10 @@ func TestCaptureWorkspaceSessionsUsesTabOrderAndActiveIndex(t *testing.T) {
 	}
 	first := newPanels(t.TempDir(), t.TempDir())
 	second := newPanels(t.TempDir(), t.TempDir())
-	vtui.FrameManager.Screens = []*vtui.AppScreen{
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{
 		{Number: 8, Frames: []vtui.Frame{first}},
 		{Number: 3, Frames: []vtui.Frame{second}},
-	}
-	vtui.FrameManager.ActiveIdx = 1
+	}, 1))
 
 	states, active := captureWorkspaceSessions()
 	if active != 1 {
@@ -152,11 +151,11 @@ func TestWorkspaceSessionsForRestore(t *testing.T) {
 func TestRenumberWorkspaceScreensFollowsCurrentOrder(t *testing.T) {
 	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
-	vtui.FrameManager.Screens = []*vtui.AppScreen{
+	t.Cleanup(setFrameManagerScreensForTest(t, []*vtui.AppScreen{
 		{Number: 7},
 		{Number: 2},
 		{Number: 11},
-	}
+	}, 0))
 
 	renumberWorkspaceScreens()
 


### PR DESCRIPTION
Follow-up to our chat about CI times. Five self-contained commits; every change keeps the full matrix on pushes and tags — only pull requests get selective.

1. **tests: deterministic vtui manager teardown** — fixes the `-race -shuffle` hang (~40% of runs): swapped frame managers are now shut down, TestMain unmounts FUSE, restores the base manager and fails the run on leaked `startTaskPump` goroutines. 12 consecutive green race+shuffle runs after the fix; the local race suite drops 128s → 67s.
2. **tests: cut the cmd/f4 suite wall time** — toast timers become a test-tunable knob (tests no longer wait out real 2-3s toasts) and TestAllDialogs shares one frame stand across the action×language matrix. Suite 44s → 26s locally, the isolated TestAllDialogs pass 20s → 4s.
3. **ci: restructure the pipeline** — build matrix as data from a plan job (PRs build the 8 desktop cells, pushes all 27), cancel-in-progress, docs-only PRs skip CI, second-arch test twins / exotic vet cells / qemu smoke move to pushes, Quality splits from the linters, the race suite runs in parallel shards with a 5-minute timeout, and caches stop cold-starting on every workflow edit (salt file) or being hijacked by the wrong job (dedicated race keys, D: drive on Windows).
4. **ci: run only what a pull request affects** — a composite action maps the PR diff to packages through the import graph (transitive Deps + test imports), with a hard fallback to "test everything" for anything unattributable; the same action gates build jobs: tests-only PRs turn nine ~2-minute builds into ~25-second no-ops.
5. **ci: shard the long jobs by measured time** — lint splits in two with affected-package selection (strict whole-tree pass unchanged), race cmd/f4 into three shards by measured elapsed time, darwin/windows test cells at A-D/rest, and lint/Quality get dedicated go-build caches.

Measured on a fork stand (~15 verification runs of the series):

| scenario | before | after |
|---|---|---|
| tests-only cmd/f4 PR | 6:25 | **2:24** |
| leaf-package PR | 6:25 | ~1:30 |
| docs-only PR | 6:25 | 0 |
| push / tag | unchanged | unchanged (full matrix) |

Final full run of this exact series on top of the live main: all green. Locally on the merged state: plain suite, isolated TestAllDialogs and `-race -shuffle` all green.

Two things worth knowing when merging:
- job names changed — if branch protection pins required checks, they need re-pointing;
- shard boundaries (`A-D`, `A`/`B-L` etc.) are picked from measured timings; the workflow comments explain how to rebalance them as the suite drifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)