### PR TITLE
fix(colors): make exported farcolors.ini a Custom scheme

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -4281,6 +4281,20 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		if err != nil {
 			vtui.ShowMessageOn(dlg, " Error ", fmt.Sprintf("Failed to export colors:\n%v", err), []string{"&Ok"})
 		} else {
+			customIdx := -1
+			for i, item := range comboStyle.Menu.Items {
+				if strings.EqualFold(item.Text, customColorStyleName) {
+					customIdx = i
+					break
+				}
+			}
+			if customIdx < 0 {
+				names = append(names, customColorStyleName)
+				comboStyle.Menu.AddItem(vtui.MenuItem{Text: customColorStyleName})
+				customIdx = len(names) - 1
+			}
+			comboStyle.Menu.SetSelectPos(customIdx)
+			comboStyle.Menu.OnAction(customIdx)
 			vtui.ShowMessageOn(dlg, " Info ", "Current colors successfully exported to:\n"+colorsPath+"\n\nYou can edit this file to customize your palette.", []string{"&Ok"})
 		}
 	}

--- a/cmd/f4/colors.go
+++ b/cmd/f4/colors.go
@@ -347,7 +347,11 @@ func FormatFarColor(attr uint64) string {
 // ExportColors writes the current palette to a farcolors.ini file.
 func ExportColors(path string) error {
 	var sb strings.Builder
-	sb.WriteString("[farcolors]\n")
+	sb.WriteString("[style]\nName = Custom\n")
+	if base := strings.TrimSpace(AppConfig.ColorStyle); base != "" && !strings.EqualFold(base, customColorStyleName) {
+		fmt.Fprintf(&sb, "Base = %s\n", base)
+	}
+	sb.WriteString("\n[farcolors]\n")
 
 	for _, group := range ColorGroups {
 		fmt.Fprintf(&sb, "\n# %s\n", group)

--- a/cmd/f4/style.go
+++ b/cmd/f4/style.go
@@ -16,9 +16,13 @@ import (
 var builtInStyles embed.FS
 
 type ColorStyle struct {
-	Name string
-	ini  *IniFile
+	Name     string
+	ini      *IniFile
+	custom   bool
+	baseName string
 }
+
+const customColorStyleName = "Custom"
 
 var getUserStylesDir = func() string {
 	return filepath.Join(GetF4ConfigDir(), "styles")
@@ -30,6 +34,22 @@ func styleFromIni(fallbackName string, ini *IniFile) ColorStyle {
 		name = fallbackName
 	}
 	return ColorStyle{Name: name, ini: ini}
+}
+
+func customStyleFromIni(ini *IniFile) ColorStyle {
+	baseName := strings.TrimSpace(ini.GetString("style", "Base", ""))
+	if baseName == "" || strings.EqualFold(baseName, customColorStyleName) {
+		baseName = strings.TrimSpace(AppConfig.ColorStyle)
+	}
+	if baseName == "" || strings.EqualFold(baseName, customColorStyleName) {
+		baseName = "Modern"
+	}
+	return ColorStyle{
+		Name:     customColorStyleName,
+		ini:      ini,
+		custom:   true,
+		baseName: baseName,
+	}
 }
 
 func loadStylesFromFS(source fs.FS, pattern string) []ColorStyle {
@@ -67,6 +87,15 @@ func AvailableColorStyles() []ColorStyle {
 		}
 	}
 
+	// An exported farcolors.ini is a complete user scheme. Keep it in the
+	// selector as Custom instead of applying it to every named style: a full
+	// file would otherwise overwrite every colour as soon as a built-in style
+	// is selected, making the selector appear broken. Partial files retain the
+	// historical overlay behavior below in ApplyColorStyle.
+	if path := userColorOverridesPath(); fileExists(path) {
+		byName[strings.ToLower(customColorStyleName)] = customStyleFromIni(LoadIni(path))
+	}
+
 	styles := make([]ColorStyle, 0, len(byName))
 	for _, style := range byName {
 		styles = append(styles, style)
@@ -91,34 +120,102 @@ func AvailableColorStyles() []ColorStyle {
 	return styles
 }
 
-// userColorOverridesPath points at the personal farcolors.ini that sits on top
-// of whichever style is active. It is a variable for the same reason
-// getUserStylesDir is: tests need to point it somewhere harmless.
+func findColorStyle(styles []ColorStyle, name string) (ColorStyle, bool) {
+	for _, style := range styles {
+		if strings.EqualFold(style.Name, name) {
+			return style, true
+		}
+	}
+	return ColorStyle{}, false
+}
+
+func colorIniDefinesSlot(ini *IniFile, slot ColorSlot) bool {
+	if ini == nil {
+		return false
+	}
+	section, ok := ini.data["farcolors"]
+	if !ok {
+		return false
+	}
+	if _, ok := section[slot.Canonical]; ok {
+		return true
+	}
+	for _, alias := range slot.Aliases {
+		if _, ok := section[alias]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func isCompleteColorIni(ini *IniFile) bool {
+	for _, slot := range ColorSlots {
+		if !colorIniDefinesSlot(ini, slot) {
+			return false
+		}
+	}
+	return true
+}
+
+func isStandaloneCustomColorIni(ini *IniFile) bool {
+	if ini != nil {
+		if section, ok := ini.data["style"]; ok && strings.EqualFold(strings.TrimSpace(section["Name"]), customColorStyleName) {
+			return true
+		}
+	}
+	// Recognize files exported by older f4 versions, before the explicit
+	// [style] marker was added.
+	return isCompleteColorIni(ini)
+}
+
+// userColorOverridesPath points at the personal farcolors.ini. A partial file
+// sits on top of whichever style is active; a complete exported file is also
+// available as the standalone Custom style. It is a variable for the same
+// reason getUserStylesDir is: tests need to point it somewhere harmless.
 var userColorOverridesPath = func() string {
 	return filepath.Join(GetF4ConfigDir(), "farcolors.ini")
 }
 
 // ApplyColorStyle rebuilds the palette from scratch: built-in defaults, then
-// the named style, then the user's own farcolors.ini. Every caller goes
-// through here, so switching styles at runtime lands on exactly the palette a
-// restart would produce — previously the overrides were applied only during
-// startup and silently disappeared until the next launch.
+// the named style, and finally any partial farcolors.ini overrides. A complete
+// farcolors.ini is applied only when Custom is selected, so a saved scheme
+// cannot mask every built-in style in the selector.
 func ApplyColorStyle(name string) error {
-	for _, style := range AvailableColorStyles() {
-		if strings.EqualFold(style.Name, name) {
-			vtui.SetDefaultPalette()
-			SetDefaultF4Palette()
-			ApplyColorIni(style.ini)
-			if path := userColorOverridesPath(); fileExists(path) {
-				ApplyColorIni(LoadIni(path))
+	styles := AvailableColorStyles()
+	style, ok := findColorStyle(styles, name)
+	if !ok {
+		return fmt.Errorf("color style %q not found", name)
+	}
+
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	themeStyle := style
+	if style.custom {
+		// Custom files normally contain every exported slot. When a user edits
+		// or creates a partial file, use the recorded base theme (or the
+		// currently configured theme) for newly-added slots.
+		base, found := findColorStyle(styles, style.baseName)
+		if !found || base.custom {
+			base, found = findColorStyle(styles, "Modern")
+		}
+		if found {
+			ApplyColorIni(base.ini)
+			themeStyle = base
+		}
+		ApplyColorIni(style.ini)
+	} else {
+		ApplyColorIni(style.ini)
+		if path := userColorOverridesPath(); fileExists(path) {
+			userIni := LoadIni(path)
+			if !isStandaloneCustomColorIni(userIni) {
+				ApplyColorIni(userIni)
 			}
-			FinishColors()
-			GlobalFileHighlighter.LoadThemeRules(style.ini)
-			configureWorkspaceTabColors()
-			return nil
 		}
 	}
-	return fmt.Errorf("color style %q not found", name)
+	FinishColors()
+	GlobalFileHighlighter.LoadThemeRules(themeStyle.ini)
+	configureWorkspaceTabColors()
+	return nil
 }
 
 func fileExists(path string) bool {

--- a/cmd/f4/style_completeness_test.go
+++ b/cmd/f4/style_completeness_test.go
@@ -21,7 +21,7 @@ import (
 func TestBuiltInThemesCoverPanelGroup(t *testing.T) {
 	styles := AvailableColorStyles()
 	for _, style := range styles {
-		if strings.EqualFold(style.Name, "Classic") {
+		if style.custom || strings.EqualFold(style.Name, "Classic") {
 			continue
 		}
 		var missing []string
@@ -49,7 +49,7 @@ func TestBuiltInThemesCoverPanelGroup(t *testing.T) {
 // Classic deliberately remains a sparse inheritance style.
 func TestBuiltInThemesCoverAllColorSlots(t *testing.T) {
 	for _, style := range AvailableColorStyles() {
-		if strings.EqualFold(style.Name, "Classic") {
+		if style.custom || strings.EqualFold(style.Name, "Classic") {
 			continue
 		}
 		for _, slot := range ColorSlots {

--- a/cmd/f4/style_custom_test.go
+++ b/cmd/f4/style_custom_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestApplyColorStyle_ExportedSchemeIsCustom(t *testing.T) {
+	dir := t.TempDir()
+	oldOverrides := userColorOverridesPath
+	userColorOverridesPath = func() string { return filepath.Join(dir, "farcolors.ini") }
+	t.Cleanup(func() { userColorOverridesPath = oldOverrides })
+
+	oldStyles := getUserStylesDir
+	getUserStylesDir = func() string { return filepath.Join(dir, "styles") }
+	t.Cleanup(func() { getUserStylesDir = oldStyles })
+
+	oldCfg := AppConfig
+	AppConfig.EnforceColorCorrection = false
+	AppConfig.ColorStyle = "Modern"
+	t.Cleanup(func() { AppConfig = oldCfg })
+
+	if err := ApplyColorStyle("Modern"); err != nil {
+		t.Fatalf("ApplyColorStyle(Modern): %v", err)
+	}
+	wantCustom := vtui.SetRGBBoth(0, 0x123456, 0x654321)
+	vtui.Palette[ColPanelText] = wantCustom
+	if err := ExportColors(userColorOverridesPath()); err != nil {
+		t.Fatalf("ExportColors: %v", err)
+	}
+
+	styles := AvailableColorStyles()
+	custom, found := findColorStyle(styles, customColorStyleName)
+	if !found || !custom.custom {
+		t.Fatalf("AvailableColorStyles() = %v, want a Custom style", styleNames(styles))
+	}
+	if base := custom.ini.GetString("style", "Base", ""); base != "Modern" {
+		t.Fatalf("Custom base style = %q, want Modern", base)
+	}
+
+	if err := ApplyColorStyle("Classic"); err != nil {
+		t.Fatalf("ApplyColorStyle(Classic): %v", err)
+	}
+	if got := vtui.Palette[ColPanelText]; got == wantCustom {
+		t.Fatalf("Classic was masked by exported farcolors.ini: got %#x", got)
+	}
+	if got := vtui.GetRGBBack(vtui.Palette[ColPanelText]); got != 0x0000A0 {
+		t.Fatalf("Classic panel background = %06X, want 0000A0", got)
+	}
+
+	if err := ApplyColorStyle(customColorStyleName); err != nil {
+		t.Fatalf("ApplyColorStyle(Custom): %v", err)
+	}
+	if got := vtui.Palette[ColPanelText]; got != wantCustom {
+		t.Fatalf("Custom panel text = %#x, want %#x", got, wantCustom)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #845.

`Export Scheme` writes a complete palette to `farcolors.ini`. Previously that file was reapplied over every built-in style, so changing Application style could not change the visible theme. The exported file is now offered as `Custom`; complete exported files are applied only for `Custom`, while partial hand-written files retain the existing overlay behavior. The export also records its base style for missing future entries and refreshes the open selector immediately.

## Validation

- `go test -p=2 -timeout 20m ./cmd/f4`
- `go test -race -p=2 ./cmd/f4 -run TestApplyColorStyle -count=1`
- `go vet ./...`
- Native ARM64 build and `--version`
- Live Linux aarch64 ANSI TTY run: exported `Custom`, then switched to `Modern` and `Classic` with `farcolors.ini` present; both changed the rendered palette.

— zoin-bot