### PR TITLE
fix(terminal): honor DECTCEM cursor visibility

### DIFF
--- a/cmd/f4/ansi_parser.go
+++ b/cmd/f4/ansi_parser.go
@@ -576,6 +576,7 @@ func (p *AnsiParser) handleCSI(cmd byte) {
 				// DECTCEM. ConPTY brackets every repaint frame in ?25l ... ?25h
 				// (docs/TERMINAL_LEDGER.md P7); the reflow oracle keys on the
 				// closing one to know a frame has ended.
+				p.term.SetCursorVisible(isSet)
 				if isSet && p.term.OnCursorShown != nil {
 					p.term.OnCursorShown()
 				}

--- a/cmd/f4/ansi_parser_test.go
+++ b/cmd/f4/ansi_parser_test.go
@@ -961,6 +961,35 @@ func TestAnsiParser_DECSET_Modes(t *testing.T) {
 	}
 }
 
+func TestAnsiParser_DECTCEMControlsTerminalCursor(t *testing.T) {
+	tv := NewTerminalView(80, 24)
+	defer tv.Close()
+	p := NewAnsiParser(tv, nil)
+
+	if !tv.CursorVisible {
+		t.Fatal("new terminal must start with a visible cursor")
+	}
+	p.Process([]byte("\x1b[?25l"))
+	if tv.CursorVisible {
+		t.Fatal("CSI ? 25 l did not hide the terminal cursor")
+	}
+	p.Process([]byte("\x1b[?25h"))
+	if !tv.CursorVisible {
+		t.Fatal("CSI ? 25 h did not show the terminal cursor")
+	}
+
+	// The parser accepts the non-private spelling as well; it is useful for
+	// applications that emit the mode without the DEC private marker.
+	p.Process([]byte("\x1b[25l"))
+	if tv.CursorVisible {
+		t.Fatal("CSI 25 l did not hide the terminal cursor")
+	}
+	p.Process([]byte("\x1bc"))
+	if !tv.CursorVisible {
+		t.Fatal("RIS did not restore the terminal cursor visibility")
+	}
+}
+
 // recordingPty collects everything written back to it.
 type recordingPty struct {
 	mockPty

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -40,6 +40,10 @@ type TerminalView struct {
 	Height  int
 	CursorX int
 	CursorY int
+	// CursorVisible is the terminal application's DECTCEM state. The host
+	// screen cursor is reset by the frame manager before every paint, so the
+	// terminal view must apply this state whenever it is focused.
+	CursorVisible bool
 
 	// Состояние терминала (сохранение координат)
 	savedX, savedY       int
@@ -213,6 +217,7 @@ func (tv *TerminalView) CloneStateFrom(other *TerminalView) {
 	tv.ReflowOnResize = other.ReflowOnResize
 	tv.Palette = other.Palette
 	tv.CursorX, tv.CursorY = other.CursorX, other.CursorY
+	tv.CursorVisible = other.CursorVisible
 	tv.UseAltScreen = other.UseAltScreen
 	tv.ScrollTop, tv.ScrollBottom = other.ScrollTop, other.ScrollBottom
 	tv.KittyFlags = other.KittyFlags
@@ -274,6 +279,7 @@ func (tv *TerminalView) ResetBuffer(w, h int) {
 	tv.ScrollBottom = h - 1
 	tv.CursorX = 0
 	tv.CursorY = h - 1 // Восстановлено выравнивание по нижнему краю для правильного визуала (прилипание к низу)
+	tv.CursorVisible = true
 	tv.lastCharWasCR = true
 	vtui.DebugLog("TERM_VIEW: ResetBuffer to %dx%d. VTE Mirror initialized at bottom (%d)", w, h, tv.CursorY)
 
@@ -710,6 +716,15 @@ func (tv *TerminalView) SetCursor(x, y int) {
 	}
 }
 
+// SetCursorVisible applies DECTCEM (CSI ? 25 h/l) to the terminal state.
+// It is separate from the host ScreenBuf cursor: the latter is reset before
+// every frame and is only updated while this terminal view owns focus.
+func (tv *TerminalView) SetCursorVisible(visible bool) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	tv.CursorVisible = visible
+}
+
 func (tv *TerminalView) SaveCursor() {
 	tv.mu.Lock()
 	defer tv.mu.Unlock()
@@ -965,7 +980,7 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 		tv.paintSelectionHighlight(scr)
 	}
 
-	if tv.IsVisible() && tv.IsFocused() {
+	if tv.IsVisible() && tv.IsFocused() && tv.CursorVisible {
 		cursorDrawY := tv.Y1 + tv.CursorY + offset
 		if tv.UseAltScreen {
 			cursorDrawY = tv.Y1 + tv.CursorY
@@ -974,6 +989,8 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 			scr.SetCursorPos(tv.X1+tv.CursorX, cursorDrawY)
 			scr.SetCursorVisible(true)
 		}
+	} else if tv.IsVisible() && tv.IsFocused() {
+		scr.SetCursorVisible(false)
 	}
 }
 

--- a/cmd/f4/terminal_view_test.go
+++ b/cmd/f4/terminal_view_test.go
@@ -904,6 +904,25 @@ func TestTerminalView_WindowsConPTY_VisualGravity(t *testing.T) {
 	}
 }
 
+func TestTerminalView_HiddenCursorStaysHiddenWhenFocused(t *testing.T) {
+	tv := NewTerminalView(80, 10)
+	defer tv.Close()
+	tv.SetFocus(true)
+	tv.SetVisible(true)
+	tv.SetCursorVisible(false)
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 10)
+	scr.SetCursorVisible(true)
+	tv.SetPosition(0, 0, 79, 9)
+	tv.Show(scr)
+
+	_, _, visible, _ := scr.GetCursorStateForTesting()
+	if visible {
+		t.Fatal("focused terminal view made a DECTCEM-hidden cursor visible")
+	}
+}
+
 func TestTerminalView_WindowsConPTY_LogIntegrity(t *testing.T) {
 	// Проверяем, что абсолютные прыжки курсора ConPTY не создают
 	// "дырок" или дублей в текстовом логе GetAllLogBytes()


### PR DESCRIPTION
Fixes #839.

The terminal parser now stores CSI 25 h/l as terminal cursor visibility state. TerminalView applies that state during focused rendering, so the frame manager cannot make a DECTCEM-hidden application cursor visible again. Terminal reset and cloned terminal state preserve the expected visibility defaults.

Added parser and rendering regression tests. Verified with focused tests, full cmd/f4 regular tests, full cmd/f4 race tests, go vet, a native ARM64 build, and an actual ANSI TTY session on Linux aarch64 Fedora Asahi Remix 44 with KDE Plasma Wayland.

The broader ./... suite is affected by existing X11 focus/geometry failures under the current Wayland environment.

— zoin-bot