### PR TITLE
feat(editor): show labeled cursor status

### DIFF
--- a/cmd/f4/editor_status.go
+++ b/cmd/f4/editor_status.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/unxed/f4/vfs"
+)
+
+// editorStatusPosition returns the user-facing logical position. CursorPos is
+// kept as a byte offset for editor internals, while the status bar reports a
+// one-based visual column so tabs, wide characters, and bidi text match the
+// caret the user sees.
+func (ev *EditorView) editorStatusPosition() (line, totalLines, column, lineWidth int) {
+	line = ev.CursorLine + 1
+	if line < 1 {
+		line = 1
+	}
+
+	totalLines = 1
+	if ev.li != nil {
+		totalLines = ev.li.LineCount()
+		if totalLines < 1 {
+			totalLines = 1
+		}
+	}
+	// During lazy indexing the cursor can already point beyond the prefix that
+	// the line index has seen. Keep the status internally consistent until the
+	// index catches up instead of rendering a denominator smaller than Ln.
+	if totalLines < line {
+		totalLines = line
+	}
+	lineWidth = len(strconv.Itoa(totalLines))
+
+	column = ev.CursorPos + 1
+	if column < 1 {
+		column = 1
+	}
+	if ev.HexMode || ev.DecodeMode || ev.engine == nil || ev.li == nil ||
+		ev.CursorLine < 0 || ev.CursorLine >= ev.li.LineCount() {
+		return line, totalLines, column, lineWidth
+	}
+
+	lineStart := ev.li.GetLineOffset(ev.CursorLine)
+	if lineStart < 0 {
+		return line, totalLines, column, lineWidth
+	}
+	pos := ev.CursorPos
+	lineLen := ev.getLineLength(ev.CursorLine)
+	if pos < 0 {
+		pos = 0
+	}
+	if pos > lineLen {
+		pos = lineLen
+	}
+	_, visualColumn := ev.engine.LogicalToVisual(lineStart + pos)
+	column = visualColumn + ev.CursorVirtualSpaces + 1
+	if column < 1 {
+		column = 1
+	}
+	return line, totalLines, column, lineWidth
+}
+
+func (ev *EditorView) editorStatusPositionText() string {
+	line, totalLines, column, lineWidth := ev.editorStatusPosition()
+	// The current line, total line count, and column share a width derived
+	// from the largest line number. This keeps the status fields stationary as
+	// the cursor moves through a file; wider columns expand only when needed.
+	columnWidth := lineWidth
+	if digits := len(strconv.Itoa(column)); digits > columnWidth {
+		columnWidth = digits
+	}
+	return fmt.Sprintf("Ln %*d/%*d Col %*d", lineWidth, line, lineWidth, totalLines, columnWidth, column)
+}
+
+func (ev *EditorView) editorStatusPrefix() string {
+	marker := " "
+	if ev.modified {
+		marker = "*"
+	}
+	return fmt.Sprintf("%s %s │ ", marker, vfs.DisplayCodepageName(ev.Codepage))
+}
+
+func (ev *EditorView) editorStatusText() string {
+	prefix := ev.editorStatusPrefix()
+	if ev.colorerIndexing {
+		percent := 0
+		if ev.colorerTotal > 0 {
+			percent = ev.colorerProgress * 100 / ev.colorerTotal
+			if percent > 100 {
+				percent = 100
+			}
+		}
+		return fmt.Sprintf("%sColorer %d%% (Esc) │ %s     ", prefix, percent, ev.editorStatusPositionText())
+	}
+	if st := ev.IndexState(); st.Phase == IndexScanning {
+		return fmt.Sprintf("%s%s %d%% (Esc) │ %s     ", prefix, Msg("Editor.Indexing"), st.Percent(), ev.editorStatusPositionText())
+	}
+
+	if ev.DecodeMode {
+		absPos := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
+		modeBits := ev.DisasmMode
+		if modeBits == 0 {
+			modeBits = 64
+		}
+		return fmt.Sprintf("%sDec:%d │ 0x%08X     ", prefix, modeBits, absPos)
+	}
+	if ev.HexMode {
+		absPos := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
+		return fmt.Sprintf("%sHex │ 0x%08X     ", prefix, absPos)
+	}
+	return fmt.Sprintf("%s%s     ", prefix, ev.editorStatusPositionText())
+}

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -501,40 +501,7 @@ func newEditorView(pt *piecetable.PieceTable, v vfs.VFS, path string, useEditorC
 			}
 			return " " + base
 		},
-		func() string {
-			// While a scan is running the line number on the right is the one
-			// the index knows about, and the file may well have more. Say so
-			// rather than let it read as the whole truth.
-			if ev.colorerIndexing {
-				percent := 0
-				if ev.colorerTotal > 0 {
-					percent = ev.colorerProgress * 100 / ev.colorerTotal
-					if percent > 100 {
-						percent = 100
-					}
-				}
-				return fmt.Sprintf(" %s │ Colorer %d%% (Esc) │ %d,%d     ",
-					vfs.DisplayCodepageName(ev.Codepage), percent, ev.CursorLine+1, ev.CursorPos)
-			}
-			if st := ev.IndexState(); st.Phase == IndexScanning {
-				return fmt.Sprintf(" %s │ %s %d%% (Esc) │ %d,%d     ",
-					vfs.DisplayCodepageName(ev.Codepage), Msg("Editor.Indexing"),
-					st.Percent(), ev.CursorLine+1, ev.CursorPos)
-			}
-			cpName := vfs.DisplayCodepageName(ev.Codepage)
-			if ev.DecodeMode {
-				absPos := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
-				modeBits := ev.DisasmMode
-				if modeBits == 0 {
-					modeBits = 64
-				}
-				return fmt.Sprintf(" %s │ Dec:%d │ 0x%08X     ", cpName, modeBits, absPos)
-			} else if ev.HexMode {
-				absPos := ev.li.GetLineOffset(ev.CursorLine) + ev.CursorPos
-				return fmt.Sprintf(" %s │ Hex │ 0x%08X     ", cpName, absPos)
-			}
-			return fmt.Sprintf(" %s │ %d,%d     ", cpName, ev.CursorLine+1, ev.CursorPos)
-		},
+		func() string { return ev.editorStatusText() },
 	)
 	ev.topBar.ColorIdx = ColEditorStatus
 	ev.topBar.SetVisible(true)

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -1335,32 +1335,44 @@ func TestEditorView_WordNavigation(t *testing.T) {
 func TestEditorBar_Content(t *testing.T) {
 	vtui.SetDefaultPalette()
 	SetDefaultF4Palette()
-	pt := piecetable.New([]byte("abc"))
+	pt := piecetable.New([]byte("abc\ndef"))
 	ev := NewEditorView(pt, nil, "test.go")
 	defer ev.Close()
 	ev.SetPosition(0, 0, 40, 10)
-	ev.CursorLine = 5
-	ev.CursorPos = 12
+	ev.CursorLine = 1
+	ev.CursorPos = 2
+	ev.modified = true
 
 	scr := vtui.NewSilentScreenBuf()
 	scr.AllocBuf(41, 11)
 
 	ev.GetTopBar().Show(scr)
 
-	// В статус-баре должно быть "6,12" (Line+1, Pos)
-	foundLine := false
-	foundPos := false
-	for x := 0; x < 40; x++ {
-		if scr.GetCell(x, 0).Char == '6' {
-			foundLine = true
-		}
-		if scr.GetCell(x, 0).Char == '1' && scr.GetCell(x+1, 0).Char == '2' {
-			foundPos = true
-		}
+	got := ev.GetTopBar().GetRight()
+	want := "* UTF-8 │ Ln 2/2 Col 3     "
+	if got != want {
+		t.Errorf("EditorBar status = %q, want %q", got, want)
 	}
+}
 
-	if !foundLine || !foundPos {
-		t.Errorf("EditorBar did not display correct cursor info (6,12). Found Line:%v, Pos:%v", foundLine, foundPos)
+func TestEditorBar_PositionFieldKeepsItsWidth(t *testing.T) {
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	ev := NewEditorView(piecetable.New([]byte("a\nb\nc\nd\ne\nf\ng\nh\ni\nj\n")), nil, "test.go")
+	defer ev.Close()
+
+	ev.CursorLine = 0
+	first := ev.GetTopBar().GetRight()
+	ev.CursorLine = 9
+	last := ev.GetTopBar().GetRight()
+	if len(first) != len(last) {
+		t.Fatalf("position field moved: first=%q (%d), last=%q (%d)", first, len(first), last, len(last))
+	}
+	if first == last {
+		t.Fatal("position field test did not move the cursor")
+	}
+	if !strings.Contains(first, "Ln  1/11") || !strings.Contains(last, "Ln 10/11") {
+		t.Errorf("status line numbers are not fixed-width: first=%q last=%q", first, last)
 	}
 }
 func TestEditorView_HandleClose(t *testing.T) {


### PR DESCRIPTION
Fixes #835.

The Editor status bar now shows an explicit modification marker and labeled cursor position, for example `* UTF-8 │ Ln  2/114 Col  3`. The current line and total line count use a fixed width derived from the file line count, so the fields do not jump as the cursor moves. Text mode reports the visible visual column, including tabs and wide characters; indexing and Colorer progress keep the same position format.

Added regression coverage for the dirty marker, labeled position, total line count, and fixed-width movement. Verified with the full cmd/f4 regular suite, targeted race tests, go vet, a native ARM64 build, and an actual ANSI TTY session on Linux aarch64 Fedora Asahi Remix 44 with KDE Plasma Wayland.

A full race run reached an unrelated existing order-dependent config-path test failure in TestMainMenuFilePath_HasExpectedSuffix.

— zoin-bot