### PR TITLE
feat(title): optionally show full file paths

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -4056,7 +4056,7 @@ func actionImportFar2lHistory(pf *PanelsFrame) {
 }
 
 func actionAppearanceSettings(pf *PanelsFrame) {
-	const width, height = 64, 29
+	const width, height = 64, 30
 	dlg := vtui.NewCenteredDialog(width, height, Msg("AppearanceSettings.Title"))
 	dlg.ShowClose = true
 	// Snapshot the whole palette (not just the style name) so a
@@ -4117,6 +4117,10 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 
 	editTitle := vtui.NewEdit(0, 0, 30, AppConfig.ConsoleTitleTemplate)
 	lblTitle := vtui.NewLabel(0, 0, Msg("AppearanceSettings.TitleTemplate"), editTitle)
+	chkFullPathTitle := vtui.NewCheckbox(0, 0, Msg("AppearanceSettings.DisplayFullPathInTitle"), false)
+	if AppConfig.DisplayFullPathInTitle {
+		chkFullPathTitle.State = 1
+	}
 
 	workspaceTabModes := []string{
 		Msg("AppearanceSettings.WorkspaceTabsAlways"),
@@ -4201,6 +4205,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 	dlg.AddItem(editSize)
 	dlg.AddItem(lblTitle)
 	dlg.AddItem(editTitle)
+	dlg.AddItem(chkFullPathTitle)
 	dlg.AddItem(lblWorkspaceTabs)
 	dlg.AddItem(comboWorkspaceTabs)
 	dlg.AddItem(chkWorkspaceTabsOverlay)
@@ -4233,6 +4238,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 
 	vbox.Add(lblTitle, vtui.Margins{Top: 1}, vtui.AlignLeft)
 	vbox.Add(editTitle, vtui.Margins{}, vtui.AlignFill)
+	vbox.Add(chkFullPathTitle, vtui.Margins{}, vtui.AlignLeft)
 
 	rowWorkspaceTabs := vtui.NewHBoxLayout(0, 0, width-4, 1)
 	rowWorkspaceTabs.Add(lblWorkspaceTabs, vtui.Margins{Right: 1}, vtui.AlignLeft)
@@ -4284,6 +4290,7 @@ func actionAppearanceSettings(pf *PanelsFrame) {
 		fontChanged := AppConfig.GuiUseSystemMonospace != useSystemMonospace || AppConfig.GuiFont != fontValue || fmt.Sprintf("%d", AppConfig.GuiFontSize) != editSize.GetText()
 
 		AppConfig.ConsoleTitleTemplate = editTitle.GetText()
+		AppConfig.DisplayFullPathInTitle = chkFullPathTitle.State == 1
 		AppConfig.GuiUseSystemMonospace = useSystemMonospace
 		AppConfig.GuiFont = fontValue
 		fmt.Sscanf(editSize.GetText(), "%d", &AppConfig.GuiFontSize)

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -2252,6 +2252,48 @@ func TestActionAppearanceSettingsSavesSystemMonospace(t *testing.T) {
 	}
 }
 
+func TestActionAppearanceSettingsSavesFullPathInTitle(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldConfig := AppConfig
+	oldPath := getUserConfigIniPath
+	getUserConfigIniPath = func() string { return filepath.Join(t.TempDir(), "settings.ini") }
+	defer func() {
+		AppConfig = oldConfig
+		getUserConfigIniPath = oldPath
+	}()
+	AppConfig.DisplayFullPathInTitle = false
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.panels[1].(*FileSystemPanel))
+	actionAppearanceSettings(pf)
+	top := vtui.FrameManager.GetTopFrame().(vtui.Container)
+
+	var fullPath *vtui.Checkbox
+	for _, child := range top.GetChildren() {
+		checkbox, ok := child.(*vtui.Checkbox)
+		if ok && checkbox.GetText() == Msg("AppearanceSettings.DisplayFullPathInTitle") {
+			fullPath = checkbox
+			break
+		}
+	}
+	if fullPath == nil {
+		t.Fatal("full path in title checkbox not found in Appearance Settings")
+	}
+	if fullPath.State != 0 {
+		t.Fatal("full path in title checkbox must be disabled by default")
+	}
+	fullPath.Toggle()
+	clickDialogButton(t, top, "Ok")
+	if !AppConfig.DisplayFullPathInTitle {
+		t.Fatal("full path in title setting was not saved")
+	}
+}
+
 func TestActionAppearanceSettingsSavesWorkspaceTabRestoration(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -281,6 +281,7 @@ type F4Config struct {
 	GuiBackend             string
 	TTYBackend             string
 	ConsoleTitleTemplate   string
+	DisplayFullPathInTitle bool
 	UpdateChannel          int // 0 = Stable, 1 = Nightly
 	UpdateInterval         int // 0 = Never, 1 = Every start, 2 = Daily, 3 = Weekly
 	EnforceColorCorrection bool
@@ -417,6 +418,7 @@ var AppConfig = F4Config{
 	GuiBackend:               "",
 	TTYBackend:               "",
 	ConsoleTitleTemplate:     "f4 %Ver %Platform %Admin - %State",
+	DisplayFullPathInTitle:   false,
 	UpdateChannel:            0,
 	ProxyMode:                netproxy.ModeSystem,
 	UpdateInterval:           3, // Default to Weekly
@@ -484,6 +486,7 @@ func LoadConfig() {
 	AppConfig.FallbackLanguage = ini.GetString("Interface", "FallbackLanguage", "")
 	AppConfig.HelpLanguage = ini.GetString("Interface", "HelpLanguage", "en")
 	AppConfig.ConsoleTitleTemplate = ini.GetString("Interface", "ConsoleTitleTemplate", "f4 %Ver %Platform %Admin - %State")
+	AppConfig.DisplayFullPathInTitle = ini.GetString("Interface", "DisplayFullPathInTitle", "0") == "1"
 	AppConfig.AlwaysShowMenuBar = ini.GetString("Interface", "AlwaysShowMenuBar", "0") == "1"
 	AppConfig.WindowsReflow = ini.GetString("Terminal", "WindowsReflow", "auto")
 	switch strings.ToLower(ini.GetString("Interface", "WorkspaceTabMode", "always")) {
@@ -749,6 +752,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 	fmt.Fprintf(&sb, "FallbackLanguage = %s\n", AppConfig.FallbackLanguage)
 	fmt.Fprintf(&sb, "HelpLanguage = %s\n", AppConfig.HelpLanguage)
 	fmt.Fprintf(&sb, "ConsoleTitleTemplate = %s\n", AppConfig.ConsoleTitleTemplate)
+	fmt.Fprintf(&sb, "DisplayFullPathInTitle = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.DisplayFullPathInTitle])
 	fmt.Fprintf(&sb, "AlwaysShowMenuBar = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.AlwaysShowMenuBar])
 	workspaceTabMode := "multiple"
 	if AppConfig.WorkspaceTabMode == int(vtui.WorkspaceTabsAlways) {

--- a/cmd/f4/config_test.go
+++ b/cmd/f4/config_test.go
@@ -53,6 +53,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersOrder
 	AppConfig.ApplyCommandParallelism = 0
 	AppConfig.AutoSaveSettings = false
+	AppConfig.DisplayFullPathInTitle = true
 
 	// 2. Save
 	SaveConfig()
@@ -79,6 +80,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.WorkspaceTabNumbering = WorkspaceTabNumbersAlways
 	AppConfig.ApplyCommandParallelism = 1
 	AppConfig.AutoSaveSettings = true
+	AppConfig.DisplayFullPathInTitle = false
 
 	// 4. Load
 	LoadConfig()
@@ -116,6 +118,9 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if AppConfig.AutoSaveSettings {
 		t.Error("LoadConfig failed to restore disabled AutoSaveSettings")
+	}
+	if !AppConfig.DisplayFullPathInTitle {
+		t.Error("LoadConfig failed to restore DisplayFullPathInTitle")
 	}
 	if !AppConfig.EditorCrosshair {
 		t.Error("LoadConfig failed to restore EditorCrosshair")

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -494,10 +494,8 @@ func newEditorView(pt *piecetable.PieceTable, v vfs.VFS, path string, useEditorC
 			base := ""
 			if ev.DisplayTitle != "" {
 				base = ev.DisplayTitle
-			} else if ev.vfs != nil {
-				base = ev.vfs.Base(ev.filePath)
 			} else {
-				base = filepath.Base(ev.filePath)
+				base = displayFileTitle(ev.vfs, ev.filePath)
 			}
 			return " " + base
 		},

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -1363,6 +1363,31 @@ func TestEditorBar_Content(t *testing.T) {
 		t.Errorf("EditorBar did not display correct cursor info (6,12). Found Line:%v, Pos:%v", foundLine, foundPos)
 	}
 }
+
+func TestEditorTitle_FullPathSettingKeepsWorkspaceTabCompact(t *testing.T) {
+	old := AppConfig.DisplayFullPathInTitle
+	t.Cleanup(func() { AppConfig.DisplayFullPathInTitle = old })
+
+	path := filepath.Join(t.TempDir(), "nested", "editor.txt")
+	ev := NewEditorView(piecetable.New([]byte("text")), nil, path)
+	defer ev.Close()
+
+	AppConfig.DisplayFullPathInTitle = false
+	if got, want := ev.GetTopBar().GetLeft(), " editor.txt"; got != want {
+		t.Fatalf("short editor title = %q, want %q", got, want)
+	}
+	if got, want := ev.GetWorkspaceTabTitle(), "editor.txt"; got != want {
+		t.Fatalf("workspace tab title = %q, want %q", got, want)
+	}
+
+	AppConfig.DisplayFullPathInTitle = true
+	if got, want := ev.GetTopBar().GetLeft(), " "+path; got != want {
+		t.Fatalf("full editor title = %q, want %q", got, want)
+	}
+	if got, want := ev.GetWorkspaceTabTitle(), "editor.txt"; got != want {
+		t.Fatalf("full-path workspace tab title = %q, want %q", got, want)
+	}
+}
 func TestEditorView_HandleClose(t *testing.T) {
 	pt := piecetable.New([]byte("test"))
 	ev := NewEditorView(pt, nil, "file.txt")

--- a/cmd/f4/file_title.go
+++ b/cmd/f4/file_title.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"path/filepath"
+
+	"github.com/unxed/f4/vfs"
+)
+
+// displayFileTitle returns the file identity used by the Editor and Viewer
+// title bars. VFS paths are kept opaque: a remote or virtual filesystem owns
+// the separator and any scheme prefix in its path, so the full-path setting
+// must not run the value through the host filepath package.
+func displayFileTitle(filesystem vfs.VFS, filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+	if AppConfig.DisplayFullPathInTitle {
+		return filePath
+	}
+	if filesystem != nil {
+		return filesystem.Base(filePath)
+	}
+	return filepath.Base(filePath)
+}

--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -756,6 +756,7 @@ AppearanceSettings.UseSystemMonospace=Use &system monospace font
 AppearanceSettings.Font=GUI F&ont (Path/Name):
 AppearanceSettings.FontSize=GUI Font Si&ze:
 AppearanceSettings.TitleTemplate=Window &Title Template:
+AppearanceSettings.DisplayFullPathInTitle=Display full path in editor and viewer title
 AppearanceSettings.WorkspaceTabs=Workspace &tabs:
 AppearanceSettings.WorkspaceTabsAlways=Always reserve top row
 AppearanceSettings.WorkspaceTabsMultiple=Show when multiple

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -746,6 +746,7 @@ AppearanceSettings.UseSystemMonospace=Использовать системны�
 AppearanceSettings.Font=Шрифт &GUI (Путь/Имя):
 AppearanceSettings.FontSize=Размер шрифта &GUI:
 AppearanceSettings.TitleTemplate=Шаблон &заголовка окна:
+AppearanceSettings.DisplayFullPathInTitle=Показывать полный путь в заголовке редактора и вьювера
 AppearanceSettings.WorkspaceTabs=&Вкладки пространств:
 AppearanceSettings.WorkspaceTabsAlways=Всегда резервировать верхнюю строку
 AppearanceSettings.WorkspaceTabsMultiple=Показывать, если больше одного

--- a/cmd/f4/top_bar.go
+++ b/cmd/f4/top_bar.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"strings"
+
 	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 	"github.com/unxed/vtui"
 )
 
@@ -51,7 +54,7 @@ func (tb *TopBar) Show(scr *vtui.ScreenBuf) {
 
 	if leftW+rightW > width {
 		if width > rightW+1 {
-			leftStr = runewidth.Truncate(leftStr, width-rightW-1, "…")
+			leftStr = truncateTopBarMiddle(leftStr, width-rightW-1)
 		} else {
 			leftStr = ""
 			rightStr = runewidth.Truncate(rightStr, width, "…")
@@ -64,4 +67,55 @@ func (tb *TopBar) Show(scr *vtui.ScreenBuf) {
 	if rightStr != "" {
 		scr.Write(tb.X2-runewidth.StringWidth(rightStr)+1, tb.Y1, vtui.StringToCharInfo(rightStr, attr))
 	}
+}
+
+// truncateTopBarMiddle keeps both ends of a title when the right-hand status
+// fields leave too little room for it. In particular, a full path keeps its
+// filename instead of losing the useful part to a right-side ellipsis.
+// runewidth's grapheme-aware helpers keep wide and combining characters from
+// splitting across terminal cells.
+func truncateTopBarMiddle(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= maxWidth {
+		return s
+	}
+	const marker = "..."
+	markerWidth := runewidth.StringWidth(marker)
+	if maxWidth <= markerWidth {
+		return runewidth.Truncate(s, maxWidth, "")
+	}
+
+	remaining := maxWidth - markerWidth
+	leftWidth := remaining / 2
+	rightWidth := remaining - leftWidth
+	return runewidth.Truncate(s, leftWidth, "") + marker + truncateTopBarSuffix(s, rightWidth)
+}
+
+func truncateTopBarSuffix(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if runewidth.StringWidth(s) <= maxWidth {
+		return s
+	}
+
+	clusters := make([]string, 0, len([]rune(s)))
+	graphemes := uniseg.NewGraphemes(s)
+	for graphemes.Next() {
+		clusters = append(clusters, graphemes.Str())
+	}
+
+	width := 0
+	start := len(clusters)
+	for start > 0 {
+		clusterWidth := runewidth.StringWidth(clusters[start-1])
+		if width+clusterWidth > maxWidth {
+			break
+		}
+		start--
+		width += clusterWidth
+	}
+	return strings.Join(clusters[start:], "")
 }

--- a/cmd/f4/top_bar_test.go
+++ b/cmd/f4/top_bar_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/mattn/go-runewidth"
 	"github.com/unxed/vtui"
 	"testing"
 )
@@ -141,9 +142,9 @@ func TestTopBar_Truncation(t *testing.T) {
 	tb.Show(scr)
 
 	// Combined length (20 + 5 = 25) exceeds width (20).
-	// Right part ("Right" - 5 chars) should be preserved, and Left part should be truncated with "…".
-	// Left part should become: runewidth.Truncate("VeryLongLeftPartName", 20 - 5 - 1 = 14, "…") -> "VeryLongLeftP…"
-	expectedLeft := "VeryLongLeftP…"
+	// Right part ("Right" - 5 chars) should be preserved, and the left part
+	// should retain both its beginning and its useful suffix.
+	expectedLeft := "VeryL...rtName"
 	for i, r := range expectedLeft {
 		cell := scr.GetCell(i, 0)
 		if cell.Char != testUint64Rune(r) {
@@ -158,5 +159,14 @@ func TestTopBar_Truncation(t *testing.T) {
 		if cell.Char != testUint64Rune(r) {
 			t.Errorf("Expected right char %q at x=%d, got %q", r, rightStart+i, testRune(cell.Char))
 		}
+	}
+}
+
+func TestTopBar_MiddleTruncationHandlesWideText(t *testing.T) {
+	if got, want := truncateTopBarMiddle("/tmp/путь/文件.txt", 12), "/tmp....txt"; got != want {
+		t.Fatalf("truncateTopBarMiddle() = %q, want %q", got, want)
+	}
+	if got, want := runewidth.StringWidth(truncateTopBarMiddle("/tmp/путь/文件.txt", 12)), 11; got != want {
+		t.Fatalf("truncated title width = %d, want %d (without splitting a wide character)", got, want)
 	}
 }

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -123,12 +123,7 @@ func NewViewerView(ctx context.Context, v vfs.VFS, path string) (*ViewerView, er
 	vv.menuBar = vtui.NewMenuBar(nil)
 	vv.topBar = NewTopBar(
 		func() string {
-			base := ""
-			if vv.vfs != nil {
-				base = vv.vfs.Base(vv.path)
-			} else {
-				base = filepath.Base(vv.path)
-			}
+			base := displayFileTitle(vv.vfs, vv.path)
 			return " " + base
 		},
 		func() string {

--- a/cmd/f4/viewer_view_test.go
+++ b/cmd/f4/viewer_view_test.go
@@ -540,6 +540,39 @@ func TestViewerView_GetTitle(t *testing.T) {
 	}
 
 }
+
+func TestViewerTitle_FullPathSetting(t *testing.T) {
+	old := AppConfig.DisplayFullPathInTitle
+	t.Cleanup(func() { AppConfig.DisplayFullPathInTitle = old })
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "nested", "doc.txt")
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("text"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	vv, err := NewViewerView(context.Background(), vfs.NewOSVFS(tmpDir), path)
+	if err != nil {
+		t.Fatalf("Failed to create NewViewerView: %v", err)
+	}
+	defer vv.Close()
+
+	AppConfig.DisplayFullPathInTitle = false
+	if got, want := vv.topBar.GetLeft(), " doc.txt"; got != want {
+		t.Fatalf("short viewer title = %q, want %q", got, want)
+	}
+
+	AppConfig.DisplayFullPathInTitle = true
+	if got, want := vv.topBar.GetLeft(), " "+path; got != want {
+		t.Fatalf("full viewer title = %q, want %q", got, want)
+	}
+	if got, want := vv.GetWorkspaceTabTitle(), "doc.txt"; got != want {
+		t.Fatalf("full-path viewer workspace tab title = %q, want %q", got, want)
+	}
+}
 func TestLayout_ViewerSearchDialog_Validity(t *testing.T) {
 	vtui.SetDefaultPalette()
 	tmp := filepath.Join(t.TempDir(), "search_layout.txt")

--- a/docs/ISSUES/ISSUE_834_SOLUTION_REVIEW.md
+++ b/docs/ISSUES/ISSUE_834_SOLUTION_REVIEW.md
@@ -1,0 +1,64 @@
+# Issue #834 — solution review
+
+## Problem model
+
+Editor and Viewer title bars currently reduce a file to its final name. That
+is ambiguous when several files with the same name are open, while simply
+printing a full path can collide with the codepage, mode, percentage, and
+cursor fields on the right. The feature therefore needs a persistent opt-in,
+must work with local and virtual VFS paths, and must keep the filename visible
+when the title bar is narrow.
+
+## Three candidate fixes
+
+### A — Always show the full path
+
+Replace the basename in both title bars with the path. This removes ambiguity,
+but changes the default layout and still lets a long path overwrite or obscure
+the status fields.
+
+### B — Add one shared opt-in and title-bar truncation (selected)
+
+Add `Interface.DisplayFullPathInTitle`, expose it in Appearance settings, and
+use a shared VFS-aware helper for Editor and Viewer. Keep workspace-tab labels
+compact, and make the common TopBar middle-truncate its left title when the
+right-side status fields need room. This preserves the default behavior while
+making the opt-in useful on both local and remote filesystems.
+
+### C — Add separate per-view settings or reserve a fixed path width
+
+Give Editor and Viewer independent controls, or reserve a fixed number of
+columns for the path. Separate controls duplicate a preference, while a fixed
+width wastes space for short paths and still does not adapt to terminal size.
+
+## Three-pass review
+
+### Pass 1: correctness
+
+The selected setting defaults to off, so existing title and workspace-tab
+behavior remains unchanged. When enabled, the title bar and the descriptive
+Editor/Viewer frame title use the complete VFS path. The TopBar computes the
+available left width after the right status string and keeps both path ends,
+including the filename, using display-cell-aware grapheme truncation.
+
+### Pass 2: VFS and lifecycle edge cases
+
+The full-path branch returns the opaque VFS path directly instead of applying
+the host `filepath` rules to an SFTP, archive, or other virtual path. Basename
+display still delegates to `VFS.Base` when available. Internal frame and
+workspace identities intentionally remain compact, and generated Editor
+titles continue to take precedence. Missing config keys default to the old
+basename behavior.
+
+### Pass 3: regression and scope
+
+Tests cover config round-tripping, the Appearance checkbox, local Editor and
+Viewer title bars, compact workspace tabs, and narrow/wide-character TopBar
+truncation. The implementation is shared by the two requested views; the
+unrelated image and video title identities are not changed.
+
+## Decision
+
+Use B. It provides the requested opt-in without consuming title-bar space by
+default, preserves the status fields, and generalizes cleanly across the VFS
+implementations already supported by f4.

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/nwaples/rardecode/v2 v2.2.3 // indirect
 	github.com/pierrec/lz4/v4 v4.1.27 // indirect
 	github.com/quic-go/quic-go v0.59.1 // indirect
-	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rivo/uniseg v0.2.0
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8 // indirect
 	github.com/sorairolake/lzip-go v0.3.8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect


### PR DESCRIPTION
Fixes #834.

Adds Interface.DisplayFullPathInTitle, exposed in Appearance settings, for the Editor and Viewer title bars. The default remains basename-only. When enabled, VFS paths are shown without applying host filepath rules, and the shared TopBar keeps the right-hand status fields clear by middle-truncating long titles while preserving the filename.

Workspace-tab titles and unrelated image/video title identities remain compact. Added config, UI, title rendering, Unicode truncation, and regression coverage.

Verified with the full cmd/f4 test suite, full race suite, go vet ./..., language formatter and language tests, a native ARM64 build, and an actual Linux aarch64 ANSI TTY session at 80x25 with the option enabled and a long path.

— zoin-bot