### PR TITLE
fix(delete): use neutral palette for Recycle Bin confirmations

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -2659,9 +2659,9 @@ func actionDeleteWithDisposition(pf *PanelsFrame, disposition vfs.DeleteDisposit
 	lines := vtui.WrapText(msg, 46)
 
 	dlg := vtui.NewCenteredDialog(50, 8+len(lines), title)
-	// Delete is destructive — render on the red WarnDialog palette
-	// so the confirmation reads as an alarm, not a neutral question.
-	dlg.IsWarning = true
+	// Moving an item to the Recycle Bin is recoverable, so keep that prompt on
+	// the neutral dialog palette. Only an irreversible deletion is an alarm.
+	dlg.IsWarning = disposition == vfs.DeletePermanently
 	vbox := vtui.NewVBoxLayout(dlg.X1+2, dlg.Y1+2, 50-4, (8+len(lines))-4)
 
 	for _, l := range lines {

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -1157,13 +1157,15 @@ func TestDelete_FocusCustomization(t *testing.T) {
 	fm.Pop()
 }
 
-// TestActionDelete_UsesWarnPalette_Issue379 pins the fix for #379:
-// delete is destructive, so the confirmation dialog must render on the
-// red WarnDialog palette instead of the neutral one.
+// TestActionDelete_UsesWarnPalette_Issue379 pins the fix for #379 and the
+// recoverable-trash distinction from #828: only permanent deletion uses the
+// red WarnDialog palette.
 func TestActionDelete_UsesWarnPalette_Issue379(t *testing.T) {
 	fm := vtui.FrameManager
 	fm.Init(vtui.NewSilentScreenBuf())
 	SetDefaultF4Palette()
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
 
 	pf := NewPanelsFrame()
 	defer pf.Close()
@@ -1172,6 +1174,8 @@ func TestActionDelete_UsesWarnPalette_Issue379(t *testing.T) {
 	fsp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "goner.txt"}, Selected: true}}
 	pf.activeIdx = 0
 
+	AppConfig.ConfirmDelete = true
+	AppConfig.UseTrash = true
 	actionDelete(pf)
 
 	top := fm.GetTopFrame()
@@ -1182,8 +1186,32 @@ func TestActionDelete_UsesWarnPalette_Issue379(t *testing.T) {
 	if !ok {
 		t.Fatalf("Top frame is not a *vtui.Window, got %T", top)
 	}
+	if dlg.IsWarning {
+		t.Error("Recycle Bin confirmation must render on the neutral dialog palette (see #828)")
+	}
+	fm.Pop()
+
+	AppConfig.UseTrash = false
+	actionDelete(pf)
+	top = fm.GetTopFrame()
+	dlg, ok = top.(*vtui.Window)
+	if !ok {
+		t.Fatalf("Top frame is not a *vtui.Window for permanent delete, got %T", top)
+	}
 	if !dlg.IsWarning {
-		t.Error("Delete confirmation must render on the WarnDialog palette (see #379)")
+		t.Error("Permanent delete confirmation must render on the WarnDialog palette (see #379)")
+	}
+	fm.Pop()
+
+	AppConfig.UseTrash = true
+	actionDeletePermanent(pf)
+	top = fm.GetTopFrame()
+	dlg, ok = top.(*vtui.Window)
+	if !ok {
+		t.Fatalf("Top frame is not a *vtui.Window for explicit permanent delete, got %T", top)
+	}
+	if !dlg.IsWarning {
+		t.Error("Explicit permanent delete confirmation must render on the WarnDialog palette")
 	}
 	fm.Pop()
 }


### PR DESCRIPTION
## Summary

Fixes #828.

- Keep the confirmation dialog neutral when deletion moves items to the Recycle Bin.
- Keep the warning palette for irreversible deletion, including explicit permanent deletion.
- Extend the existing palette regression test to cover both dispositions.

## Verification

- go test -p=2 -timeout 20m ./cmd/f4
- go test -race -shuffle=on -timeout 20m ./cmd/f4 -count=1
- go vet ./...
- go run ./tools/langfmt -check cmd/f4/lang/*.lng
- Native Linux aarch64 build and ANSI TTY run: the Recycle Bin dialog rendered with the neutral palette and the fixture remained intact.
