### PR TITLE
fix(editor): keep key-bar actions working in Hex Mode

### DIFF
--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -1833,7 +1833,13 @@ func (ev *EditorView) processKeyInner(e *vtinput.InputEvent) bool {
 			e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed) != 0:
 			return false // Let the framework handle Ctrl+W
 		case e.VirtualKeyCode >= vtinput.VK_F1 && e.VirtualKeyCode <= vtinput.VK_F12:
-			return false // Let global hotkeys handle it
+			// KeyBar clicks inject F-key events after the frame-manager filter
+			// has already been bypassed. zoin-bot routes those events through
+			// the configured editor action before yielding to framework fallbacks.
+			if MacroMgr.LookupHotkey(e) {
+				return true
+			}
+			return false // Let framework fallbacks handle unbound F-keys
 		}
 		if MacroMgr.LookupHotkey(e) {
 			return true

--- a/cmd/f4/editor_view_test.go
+++ b/cmd/f4/editor_view_test.go
@@ -803,6 +803,47 @@ func TestEditorView_HexModeToggleAndTyping(t *testing.T) {
 	}
 }
 
+// TestEditorView_HexMode_KeyBarClickDispatchesConfiguredAction guards the
+// injected-event path used by vtui.KeyBar.ProcessMouse. Real key presses pass
+// through MacroMgr.Filter, but a key-bar click calls EditorView.ProcessKey
+// directly; Hex mode must still honor a user binding such as F9 -> Hex Mode.
+func TestEditorView_HexMode_KeyBarClickDispatchesConfiguredAction(t *testing.T) {
+	oldHotkeys := GlobalHotkeysMgr
+	oldMacro := MacroMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	MacroMgr = &MacroManager{}
+	t.Cleanup(func() {
+		GlobalHotkeysMgr = oldHotkeys
+		MacroMgr = oldMacro
+	})
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	ev := NewEditorView(piecetable.New([]byte("abc")), nil, "")
+	defer ev.Close()
+	ev.SetPosition(0, 0, 80, 24)
+	vtui.FrameManager.Push(ev)
+
+	if !RunAction("Editor.HexMode") {
+		t.Fatal("failed to enter Hex mode")
+	}
+	GlobalHotkeysMgr.Bind("Editor", "F9", "Editor.HexMode")
+	if labels := ev.GetKeyLabels(); labels.Normal[8] != "Hex Mode" {
+		t.Fatalf("F9 key-bar label = %q, want Hex Mode", labels.Normal[8])
+	}
+
+	// This is the exact key event synthesized for an F9 key-bar click.
+	if !ev.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_F9,
+	}) {
+		t.Fatal("injected F9 key-bar event was not handled")
+	}
+	if ev.HexMode || !ev.DecodeMode {
+		t.Fatalf("injected F9 did not run Editor.HexMode: hex=%v decode=%v", ev.HexMode, ev.DecodeMode)
+	}
+}
+
 func TestEditorView_WideCharBackspace(t *testing.T) {
 	// "A世" -> 'A' (1), '世' (3 bytes)
 	pt := piecetable.New([]byte("A世"))


### PR DESCRIPTION
## Summary

Fixes #827.

- Dispatch injected key-bar F1-F12 events through the configured editor action while Hex/Decode Mode is active.
- Preserve framework handling for unbound F-keys.
- Add a regression test for a custom F9 -> Editor.HexMode binding.

## Validation

- Native Linux aarch64 ANSI session: F4 entered Hex Mode, an actual SGR click on F9 switched to Decode Mode without opening the editor menu.
- `go test -p=2 -timeout 20m ./cmd/f4`
- `go test -race -shuffle=on -timeout 20m ./cmd/f4 -count=1`
- `go vet ./...`
- `go run ./tools/langfmt -check cmd/f4/lang/*.lng`
- Native aarch64 build and `--version`

— zoin-bot