### PR TITLE
fix: keep debug logs in the f4 profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,12 +211,14 @@ go generate ./cmd/f4
 ```
 
 **5. Debug Mode**
-To enable detailed logging to `debug.log`, run with the `--debug` flag:
+To enable detailed logging to `Logs/debug.log` inside the active f4 profile,
+run with the `--debug` flag:
 ```bash
 ./f4 --debug
 ```
 
-You can also specify a custom log file using `--log`:
+You can also specify a custom log file using `--log`; an explicit path is
+kept unchanged:
 ```bash
 ./f4 --log /tmp/f4_trace.log
 ```

--- a/cmd/f4/debug_log.go
+++ b/cmd/f4/debug_log.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func f4DebugLogPath(configDir string) string {
+	return filepath.Join(configDir, "Logs", "debug.log")
+}
+
+// configureF4DebugLogPath keeps zoin-bot's default diagnostics inside the
+// active profile while preserving explicit VTUI_DEBUG file paths.
+func configureF4DebugLogPath(configDir string) {
+	switch os.Getenv("VTUI_DEBUG") {
+	case "1", "true":
+		path := f4DebugLogPath(configDir)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "f4: cannot create debug log directory %q: %v\n", filepath.Dir(path), err)
+			return
+		}
+		_ = os.Setenv("VTUI_DEBUG", path)
+	}
+}

--- a/cmd/f4/debug_log_test.go
+++ b/cmd/f4/debug_log_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestF4DebugLogPath(t *testing.T) {
+	configDir := filepath.Join("tmp", "f4", "Profile")
+	want := filepath.Join(configDir, "Logs", "debug.log")
+	if got := f4DebugLogPath(configDir); got != want {
+		t.Fatalf("debug log path = %q, want %q", got, want)
+	}
+}
+
+func TestConfigureF4DebugLogPath_DefaultsToProfile(t *testing.T) {
+	for _, value := range []string{"1", "true"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("VTUI_DEBUG", value)
+			configDir := filepath.Join(t.TempDir(), "Profile")
+			configureF4DebugLogPath(configDir)
+
+			want := f4DebugLogPath(configDir)
+			if got := os.Getenv("VTUI_DEBUG"); got != want {
+				t.Fatalf("VTUI_DEBUG = %q, want %q", got, want)
+			}
+			if info, err := os.Stat(filepath.Dir(want)); err != nil || !info.IsDir() {
+				t.Fatalf("debug log directory was not created: info=%v err=%v", info, err)
+			}
+		})
+	}
+}
+
+func TestConfigureF4DebugLogPath_PreservesExplicitValue(t *testing.T) {
+	for _, value := range []string{"", "stderr", "test", filepath.Join(t.TempDir(), "custom.log")} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("VTUI_DEBUG", value)
+			configDir := filepath.Join(t.TempDir(), "Profile")
+			configureF4DebugLogPath(configDir)
+
+			if got := os.Getenv("VTUI_DEBUG"); got != value {
+				t.Fatalf("VTUI_DEBUG = %q, want explicit value %q", got, value)
+			}
+			if _, err := os.Stat(filepath.Join(configDir, "Logs")); !os.IsNotExist(err) {
+				t.Fatalf("preserving explicit VTUI_DEBUG created profile Logs directory: %v", err)
+			}
+		})
+	}
+}

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -84,6 +84,7 @@ func sudoStartupMode(args []string, askpassParent bool) (dispatcher string, askp
 
 func main() {
 	vtui.AppName = "f4"
+	configureF4DebugLogPath(GetF4ConfigDir())
 	if archivePath, archiveKind, found, err := parseUpdateHelperArgs(os.Args[1:]); found {
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
@@ -266,6 +267,7 @@ func main() {
 			}
 			os.Exit(RunNewPlugin(pluginName, os.Stdout, os.Stderr))
 		case "-test-plugins":
+			configureF4DebugLogPath(GetF4ConfigDir())
 			vtui.ConfigDiskLogging(true)
 			vtui.DebugLog("--- PLUGIN TEST MODE ---")
 			pm := NewPluginManager()
@@ -326,6 +328,7 @@ func main() {
 			}
 		}
 	}
+	configureF4DebugLogPath(GetF4ConfigDir())
 
 	if version {
 		fmt.Println(getFormattedVersionInfo())
@@ -341,7 +344,7 @@ The following switches may be used in the command line:
  --attached             Force run in Attached-mode
  --client [clientPath]
  --cpuprofile [cpuprofile]
- --debug                Log to "debug.log" (equivalent to --log=1)
+ --debug                Log to profile Logs/debug.log (equivalent to --log=1)
  --dump-screen-after N  Auto-run Debug.ScreenDump N seconds after startup
                          (bypasses hotkeys entirely -- useful under Wine
                          tty mode, where complex combos like CtrlAltP can
@@ -357,7 +360,8 @@ The following switches may be used in the command line:
                          "auto" ignores the configured default for this run
  --input [InputMode]    Defines the preferred vtinput parser method;
                          [InputMode] values: "", "ansi", "ConPTY"
- --log [logfile]        If =1 or =true uses "debug.log", otherwise logfile
+ --log [logfile]        If =1 or =true uses profile Logs/debug.log,
+                         otherwise logfile
  --new-plugin [pluginName]
  --server [serverPath]
  -test-plugins          Plugin test mode

--- a/cmd/f4/ttyx_session.go
+++ b/cmd/f4/ttyx_session.go
@@ -13,7 +13,7 @@ package main
 // none of it can be seen from outside and all of it can fail for reasons that
 // depend on the window manager, the terminal and how f4 was started:
 //
-//	VTUI_DEBUG=1 f4 2>/dev/null; grep TTYX ~/.config/f4/debug.log
+//	VTUI_DEBUG=1 f4 2>/dev/null; grep TTYX ~/.config/f4/Logs/debug.log
 
 import (
 	"sync"

--- a/docs/DRAGDROP.md
+++ b/docs/DRAGDROP.md
@@ -56,7 +56,7 @@ target and the pointer says no. That is upstream, not here.
 
 ## When nothing happens
 
-Run with `VTUI_DEBUG=1` and read debug.log. f4 logs why a drag out was not
+Run with `VTUI_DEBUG=1` and read `Logs/debug.log` inside the active f4 profile. f4 logs why a drag out was not
 started and what a drop at a cell would do; vtui logs the protocol side, and
 the diagnosing section of its DRAGDROP.md lists every line and what a
 missing one means.

--- a/docs/TTYX.md
+++ b/docs/TTYX.md
@@ -342,7 +342,7 @@ decision is therefore written to the debug log under one prefix:
 
 ```sh
 VTUI_DEBUG=1 f4
-grep TTYX ~/.config/f4/debug.log
+grep TTYX ~/.config/f4/Logs/debug.log
 ```
 
 What to look for, in the order it happens:

--- a/test_plugins.sh
+++ b/test_plugins.sh
@@ -9,10 +9,14 @@ cd plugins/dummy_rpc
 go build -o f4-rpc-dummy-plugin
 cd ../..
 
-echo "3. Running f4 in test mode (Output will go to debug.log)..."
-rm -f debug.log
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export XDG_CONFIG_HOME="$TEST_ROOT/config"
+LOG_PATH="$XDG_CONFIG_HOME/f4/Logs/debug.log"
+
+echo "3. Running f4 in test mode (Output will go to $LOG_PATH)..."
 VTUI_DEBUG=1 go run ./cmd/f4 -test-plugins
 
 echo ""
-echo "=== debug.log Output ==="
-cat debug.log
+echo "=== $LOG_PATH Output ==="
+cat "$LOG_PATH"


### PR DESCRIPTION
## Summary

Fixes #824.

- Route default `VTUI_DEBUG=1/true` diagnostics to `<profile>/Logs/debug.log`, including rotated `debug.N.log` files.
- Preserve explicit `VTUI_DEBUG` and `--log` file paths.
- Configure the path before the package-level reflow parser logs, so pre-main diagnostics are covered too.
- Update documentation and the plugin test script, and add regression coverage.

## Validation

- Native Linux aarch64 portable build with `UseSystemProfiles=0`: two real `--version` runs created only `Profile/Logs/debug.log` and `Profile/Logs/debug.1.log`; no `run/debug.log` was created.
- Explicit `/tmp/.../custom.log` override was preserved.
- `go test -p=2 -timeout 20m ./cmd/f4`
- `go test -race -shuffle=on -timeout 20m ./cmd/f4 -count=1`
- `go vet ./...`
- `go run ./tools/langfmt -check cmd/f4/lang/*.lng`
- `gofmt -s -l .`, `git diff --check`, and `bash -n test_plugins.sh`
- Native aarch64 build confirmed by `file`.

— zoin-bot