### PR TITLE
fix: release stale mouse capture after Host console

### DIFF
--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
 
@@ -380,6 +381,22 @@ func (pf *PanelsFrame) leaveHostConsole() {
 	pf.hostConsoleActive = false
 	pf.hostConsoleMu.Unlock()
 	pf.syncAutoCompleteSuppression()
+
+	// A host-console application can receive a mouse-down record without a
+	// matching release reaching f4 (notably through native Windows console
+	// input). FrameManager keeps routing all later mouse events to the frame
+	// that handled that down event until it sees a release. Queue a neutral
+	// release while returning control to the panels so a stale capture cannot
+	// block the menu bar or modal dialogs.
+	if vtui.FrameManager != nil {
+		vtui.FrameManager.PostEvent(vtinput.InputEvent{
+			Type:        vtinput.MouseEventType,
+			MouseX:      -1,
+			MouseY:      -1,
+			KeyDown:     false,
+			ButtonState: 0,
+		})
+	}
 
 	// Protective reset sequence to clean up any terminal modes left by child applications
 	var resetSeq strings.Builder

--- a/cmd/f4/issue856_mouse_capture_test.go
+++ b/cmd/f4/issue856_mouse_capture_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestHostConsole_LeaveReleasesStaleMouseCapture_Issue856(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	oldNavigationMode := AppConfig.NavigationMode
+	AppConfig.NavigationMode = NavigationClassic
+	t.Cleanup(func() { AppConfig.NavigationMode = oldNavigationMode })
+
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(80, 25)
+	vtui.FrameManager.Init(scr)
+
+	pf := setupMockPanelsFrame(t)
+	t.Cleanup(pf.Close)
+	pf.shellMode = ShellModeHost
+	pf.showPanels = false
+	pf.ResizeConsole(80, 25)
+	pf.termView.MouseTrackingMode = 1003
+	pf.hostConsoleActive = true
+	vtui.FrameManager.Push(pf)
+
+	// A console application with mouse tracking can leave f4 with a button
+	// down but no release. The frame manager then captures the hidden panels
+	// frame and routes subsequent UI clicks back to it.
+	vtui.FrameManager.InjectEvents([]*vtinput.InputEvent{{
+		Type:        vtinput.MouseEventType,
+		MouseX:      10,
+		MouseY:      10,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+		KeyDown:     true,
+	}})
+	if !vtui.FrameManager.Step(0) {
+		t.Fatal("mouse-down event stopped the frame manager")
+	}
+	vtui.FrameManager.SyncCurrentScreen()
+	if got := vtui.FrameManager.Screens[0].CapturedFrame; got != pf {
+		t.Fatalf("mouse-down did not capture PanelsFrame: got %T", got)
+	}
+
+	// endExecution makes the panels visible before leaving the host console.
+	pf.showPanels = true
+	pf.leaveHostConsole()
+
+	// The queued neutral release must be processed before the next real click.
+	if !vtui.FrameManager.Step(0) {
+		t.Fatal("queued mouse release stopped the frame manager")
+	}
+	vtui.FrameManager.SyncCurrentScreen()
+	if got := vtui.FrameManager.Screens[0].CapturedFrame; got != nil {
+		t.Fatalf("stale mouse capture survived host-console return: %T", got)
+	}
+}


### PR DESCRIPTION
Fixes #856.

When a Host console application leaves a mouse-down event without a matching release, vtui FrameManager keeps routing subsequent mouse events to the hidden PanelsFrame. After returning to f4, this prevents the menu bar and modal dialogs from receiving mouse input.

This queues a neutral mouse-release event when leaving Host console, clearing stale FrameManager capture before the panels become interactive again. A regression test covers the missing-release sequence.

Validation:
- focused functional tests passed
- focused race tests passed
- go vet ./... passed
- ARM64 build passed on Linux aarch64
- real ANSI/Xwayland test passed: Host console command, mouse-down without release, return, F9 and menu click

— zoin-bot