### PR TITLE
fix: preserve selected command in history dialog

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -294,18 +294,21 @@ func actionCommandHistory(pf *PanelsFrame) {
 	}
 
 	// Shared "paste selected command" path used by Enter and mouse click.
-	pasteCurrent := func() {
-		_, rec, ok := search.selected()
-		if !ok {
-			return
-		}
+	// The record is passed in because VMenu.Close restores its initial
+	// selection, which would otherwise make Enter paste a different row.
+	pasteRecord := func(rec HistoryRecord) {
 		search.cleanup()
 		pf.cmdLine.Edit.SetText(rec.Name)
 		pf.cmdLine.Edit.HistoryPos = -1
 	}
 	// VMenu.ProcessMouse calls SetExitCode after OnAction, so click closes
-	// the menu automatically — pasteCurrent only does the side effect.
-	menu.OnAction = func(int) { pasteCurrent() }
+	// the menu automatically — pasteRecord only does the side effect.
+	menu.OnAction = func(int) {
+		_, rec, ok := search.selected()
+		if ok {
+			pasteRecord(rec)
+		}
+	}
 
 	// Setup shortcuts
 	menu.OnKeyDown = func(e *vtinput.InputEvent) bool {
@@ -336,7 +339,7 @@ func actionCommandHistory(pf *PanelsFrame) {
 				return true
 			}
 			menu.Close()
-			pasteCurrent()
+			pasteRecord(rec)
 			return true
 		}
 

--- a/cmd/f4/folder_history_navigation_test.go
+++ b/cmd/f4/folder_history_navigation_test.go
@@ -142,8 +142,12 @@ func TestFolderHistoryNavigationAndMenuDoNotReorderHistory(t *testing.T) {
 	if menu.SelectPos < 0 || menu.SelectPos >= len(menu.Items) {
 		t.Fatalf("initial menu selection = %d, item count %d", menu.SelectPos, len(menu.Items))
 	}
-	if selected := menu.Items[menu.SelectPos].Text; !sameFolderHistoryPath(selected, middle) {
-		t.Fatalf("initial menu selection = %q, want current folder %q", selected, middle)
+	if activeHistorySearch == nil {
+		t.Fatal("folder history did not install a history search")
+	}
+	_, selected, ok := activeHistorySearch.selected()
+	if !ok || !sameFolderHistoryPath(selected.Name, middle) {
+		t.Fatalf("initial menu selection = %q, want current folder %q", selected.Name, middle)
 	}
 	// Display order is oldest -> newest. Select the missing entry; activation
 	// must skip it and continue downwards to the newer, accessible entry.

--- a/cmd/f4/history_dialog.go
+++ b/cmd/f4/history_dialog.go
@@ -86,10 +86,36 @@ func (s *historySearch) applyFilter() {
 	s.menu.ItemCount = len(items)
 	s.menu.TopPos = 0
 	s.resize()
+	// VMenu's default renderer draws MenuItem.Text after the leading margin,
+	// without knowing about the frame's right border. Keep its copy bounded so
+	// a long command cannot paint into the terminal outside the dialog. The
+	// custom renderer below still obtains the complete text from s.all, so
+	// filtering and command insertion retain the original value.
+	for i := range s.menu.Items {
+		entry, ok := s.menu.Items[i].UserData.(historySearchEntry)
+		if !ok || entry.index < 0 || entry.index >= len(s.all) {
+			continue
+		}
+		s.menu.Items[i].Text = s.defaultMenuText(s.displayText(s.all[entry.index]))
+	}
 	// Open at the most recent visible entry. SetSelectPos also scrolls it into
 	// view, which places a long history at the bottom of the viewport.
 	s.menu.SetSelectPos(len(items) - 1)
 	vtui.FrameManager.Redraw()
+}
+
+func (s *historySearch) defaultMenuText(text string) string {
+	// VMenu reserves one cell for its leading space and one for the right
+	// border. There are no shortcuts in history menus, so this is the maximum
+	// number of cells its default renderer may draw for the item text.
+	maxWidth := s.menu.X2 - s.menu.X1 - 2
+	if maxWidth <= 0 {
+		// Unit tests and callers that have not allocated a screen yet leave the
+		// menu at its zero geometry. In that state there is no drawable border
+		// to clip against; preserve the logical item text until layout occurs.
+		return text
+	}
+	return runewidth.Truncate(text, maxWidth, "…")
 }
 
 func (s *historySearch) displayText(record HistoryRecord) string {
@@ -420,6 +446,9 @@ func (s *historySearch) draw(scr *vtui.ScreenBuf) {
 		}
 		item := s.menu.Items[itemIdx]
 		text := item.Text
+		if entry, ok := item.UserData.(historySearchEntry); ok && entry.index >= 0 && entry.index < len(s.all) {
+			text = s.displayText(s.all[entry.index])
+		}
 		_, highlights := historySearchMatch(text, s.query, s.prefixOnly)
 
 		baseAttr := vtui.Palette[s.menu.ColorTextIdx]

--- a/cmd/f4/issue821_test.go
+++ b/cmd/f4/issue821_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestIssue821CommandHistoryEnterPastesSelectedEntry(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	previousHistory := vtui.GlobalHistoryProvider
+	vtui.GlobalHistoryProvider = stubHistoryProvider{}
+	t.Cleanup(func() { vtui.GlobalHistoryProvider = previousHistory })
+
+	pf := setupMockPanelsFrame(t)
+	t.Cleanup(pf.Close)
+	pf.ResizeConsole(80, 25)
+	pf.cmdLine.Edit.History = []string{"pbrush.exe", "selected-command", "older-command"}
+
+	actionCommandHistory(pf)
+	menu, ok := vtui.FrameManager.GetTopFrame().(*vtui.VMenu)
+	if !ok {
+		t.Fatalf("top frame = %T, want *vtui.VMenu", vtui.FrameManager.GetTopFrame())
+	}
+
+	// The dialog displays the oldest record first, so select the middle row.
+	menu.SetSelectPos(1)
+	menu.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_RETURN,
+	})
+
+	if got := pf.cmdLine.Edit.GetText(); got != "selected-command" {
+		t.Fatalf("selected history entry pasted %q, want %q", got, "selected-command")
+	}
+}
+
+func TestIssue821CommandHistoryKeepsLongEntryInsideDialog(t *testing.T) {
+	const (
+		screenWidth  = 100
+		screenHeight = 20
+	)
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(screenWidth, screenHeight)
+	vtui.FrameManager.Init(scr)
+	SetDefaultF4Palette()
+
+	menu := vtui.NewVMenu("History")
+	search := newHistorySearch(menu, []HistoryRecord{{Name: strings.Repeat("x", 200)}}, "")
+	t.Cleanup(search.cleanup)
+	const sentinel = '~'
+	scr.FillRect(0, 0, screenWidth-1, screenHeight-1, sentinel, 0)
+	menu.Show(scr)
+	search.draw(scr)
+
+	for x := 0; x < screenWidth; x++ {
+		if x >= menu.X1 && x <= menu.X2 {
+			continue
+		}
+		if got := testRune(scr.GetCell(x, menu.Y1+1).Char); got != sentinel {
+			t.Fatalf("long history entry escaped dialog at column %d as %q", x, got)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #821

The command history dialog had two independent issues:

- long entries could be painted past the dialog border by the default VMenu renderer;
- pressing Enter closed the menu before reading the selected record, so the menu restored its initial selection and pasted the wrong command.

This change bounds the menu's display copy while keeping the full history record for filtering and insertion, and captures the selected record before closing. It also adds regression coverage for both cases and updates the folder-history assertion to check the full selected record.

Validation on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland):

- focused and full cmd/f4 tests passed;
- cmd/f4 race tests passed;
- go vet ./... passed;
- ARM64 build passed;
- real ANSI live test passed: long history entry stayed inside the dialog and selecting the middle entry with Up + Enter inserted the selected command.
