### PR TITLE
Fix encrypted archive prompts and multi-volume RAR

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -1973,6 +1973,7 @@ type mockSlowVFS struct {
 	vfs.VFS
 	onOpen    func()
 	openDelay time.Duration
+	openBlock <-chan struct{}
 }
 
 func (m *mockSlowVFS) GetPath() string     { return "/mock" }
@@ -1991,6 +1992,13 @@ func (m *mockSlowVFS) Open(ctx context.Context, p string) (vfs.ReadAtCloser, err
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case <-timer.C:
+		}
+	}
+	if m.openBlock != nil {
+		select {
+		case <-m.openBlock:
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
 	return &vfs.MemoryReadAtCloser{Data: []byte("mock")}, nil
@@ -2083,6 +2091,82 @@ func TestActionOpenViewer_FastTaskDoesNotFlashProgressDialog(t *testing.T) {
 			return
 		default:
 			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func TestActionOpenViewer_PromptStaysAboveDelayedProgressDialog(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	modalShown := make(chan struct{})
+	releaseOpen := make(chan struct{})
+	var prompt *vtui.Window
+	mv := &mockSlowVFS{
+		openBlock: releaseOpen,
+		onOpen: func() {
+			vtui.FrameManager.PostTask(func() {
+				prompt = vtui.NewCenteredDialog(30, 5, "Archive.PasswordTitle")
+				vtui.FrameManager.Push(prompt)
+				close(modalShown)
+			})
+		},
+	}
+
+	actionOpenViewer(pf, mv, "/mock/file.txt")
+
+	deadline := time.After(openingProgressDelay + 300*time.Millisecond)
+	for prompt == nil {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-deadline:
+			t.Fatal("password prompt was not shown")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	select {
+	case <-modalShown:
+	case <-time.After(time.Second):
+		t.Fatal("password prompt was not published")
+	}
+
+	if top := vtui.FrameManager.GetTopFrame(); top != prompt {
+		title := "<nil>"
+		if top != nil {
+			title = top.GetTitle()
+		}
+		t.Fatalf("top frame = %T %q, want the password prompt", top, title)
+	}
+	for _, screen := range vtui.FrameManager.Screens {
+		for _, frame := range screen.Frames {
+			if strings.Contains(frame.GetTitle(), "Opening") {
+				t.Fatalf("delayed progress dialog covered the prompt")
+			}
+		}
+	}
+
+	vtui.FrameManager.Pop()
+	close(releaseOpen)
+	deadline = time.After(time.Second)
+	for {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-deadline:
+			t.Fatal("viewer open did not complete after dismissing the prompt")
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+		if top := vtui.FrameManager.GetTopFrame(); top != nil && strings.Contains(top.GetTitle(), "Opening") {
+			t.Fatal("progress dialog appeared after the prompt was dismissed")
+		}
+		if len(vtui.FrameManager.Screens) > 1 {
+			return
 		}
 	}
 }

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -3669,7 +3669,9 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 
 	done := make(chan struct{})
 	dialogShown := false // accessed only from UI tasks
-	showDialog := func() {
+	uiFrames := vtui.FrameManager
+	var showDialog func()
+	showDialog = func() {
 		if delay > 0 {
 			select {
 			case <-done:
@@ -3677,12 +3679,23 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 			default:
 			}
 		}
+		// A worker may ask for a modal dialog (for example, an archive
+		// password) before this delayed progress screen is due to appear.
+		// Do not put the progress screen on a new active screen while that
+		// prompt is waiting on the old one: it would hide the prompt and leave
+		// the worker blocked forever. Retry after the modal dialog is dismissed.
+		if top := uiFrames.GetTopFrame(); top != nil && top.IsModal() {
+			time.AfterFunc(50*time.Millisecond, func() {
+				uiFrames.PostTask(showDialog)
+			})
+			return
+		}
 		if forked && pf != nil {
 			clone := pf.Clone()
-			vtui.FrameManager.AddScreen(clone)
-			vtui.FrameManager.Push(dlg)
+			uiFrames.AddScreen(clone)
+			uiFrames.Push(dlg)
 		} else {
-			vtui.FrameManager.AddScreenHeadless(dlg)
+			uiFrames.AddScreenHeadless(dlg)
 		}
 		dialogShown = true
 	}
@@ -3692,14 +3705,13 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 		// Read on the goroutine that starts this work, not inside it: the
 		// work outlives the call, and reading the global from it races
 		// anything that reassigns vtui.FrameManager meanwhile.
-		uiFrames := vtui.FrameManager
 		showTimer = time.AfterFunc(delay, func() {
 			uiFrames.PostTask(showDialog)
 		})
 	} else {
 		// Preserve the existing immediate-dialog contract for callers that do
 		// not opt into a delay.
-		vtui.FrameManager.PostTask(showDialog)
+		uiFrames.PostTask(showDialog)
 	}
 
 	ctx := vtui.RunAsync(func(ctx *vtui.TaskContext) {
@@ -3741,6 +3753,8 @@ func (pf *PanelsFrame) runProgressTaskAfter(delay time.Duration, title, startMsg
 func (pf *PanelsFrame) RunAdvancedProgressTask(title string, forked bool, worker func(ctx context.Context, reporter vfs.TaskReporter) error, onComplete func(err error)) {
 	dlg := NewFileOpProgressDialog(title)
 	var taskCtx *vtui.TaskContext
+	done := make(chan struct{})
+	dialogShown := false // accessed only from UI tasks
 	dlg.btnCancel.OnClick = func() { dlg.SetExitCode(1) }
 	dlg.OnResult = func(code int) {
 		if taskCtx != nil {
@@ -3750,21 +3764,41 @@ func (pf *PanelsFrame) RunAdvancedProgressTask(title string, forked bool, worker
 
 	reporter := newDialogReporter(dlg)
 
-	vtui.FrameManager.PostTask(func() {
+	uiFrames := vtui.FrameManager
+	var showDialog func()
+	showDialog = func() {
+		select {
+		case <-done:
+			return
+		default:
+		}
+		// Keep a password or other modal prompt reachable if the worker posts
+		// it before this progress screen reaches the UI queue.
+		if top := uiFrames.GetTopFrame(); top != nil && top.IsModal() {
+			time.AfterFunc(50*time.Millisecond, func() {
+				uiFrames.PostTask(showDialog)
+			})
+			return
+		}
 		if forked && pf != nil {
 			clone := pf.Clone()
-			vtui.FrameManager.AddScreen(clone)
-			vtui.FrameManager.Push(dlg)
+			uiFrames.AddScreen(clone)
+			uiFrames.Push(dlg)
 		} else {
-			vtui.FrameManager.AddScreenHeadless(dlg)
+			uiFrames.AddScreenHeadless(dlg)
 		}
-	})
+		dialogShown = true
+	}
+	uiFrames.PostTask(showDialog)
 
 	taskCtx = vtui.RunAsync(func(ctx *vtui.TaskContext) {
 		err := worker(ctx.Context, reporter)
+		close(done)
 		ctx.RunOnUI(func() {
 			reporter.Stop()
-			dlg.Close()
+			if dialogShown {
+				dlg.Close()
+			}
 			if onComplete != nil {
 				onComplete(err)
 			}

--- a/docs/ISSUES/ISSUE_816_FOLLOWUP_SOLUTION_REVIEW.md
+++ b/docs/ISSUES/ISSUE_816_FOLLOWUP_SOLUTION_REVIEW.md
@@ -1,0 +1,58 @@
+# Issue 816 follow-up solution review
+
+## Reported failures
+
+The follow-up contains two separate regressions:
+
+1. F3/F4 on a member of an encrypted archive can leave the password dialog
+   underneath the delayed `Opening...` progress screen.
+2. RAR archives split into volumes fail while the archive VFS reads the
+   directory, because the generic fallback passes only one input stream to
+   `rardecode`.
+
+The second failure was reproduced on Windows 10 x64 with the two-volume RAR
+fixture shipped by `github.com/unxed/archives`: the current code returned
+`rardecode: multi-volume archive continues in next file`.
+
+## Three candidate approaches
+
+### 1. Fix the shared archive libraries
+
+Add a volume-aware `FileSystem` implementation to `unxed/archives` or change
+`unxed/zipper` so its fallback always supplies the first volume name and a
+filesystem rooted at the volume directory. This would put the behavior at the
+most reusable layer, but it would require a separate dependency change and
+would still leave `ArchiveFS.Open` needing a lifetime-safe member reader.
+
+### 2. Concatenate all volumes in f4
+
+Discover the volume files, concatenate them into a temporary stream, and keep
+using the existing generic fallback. This preserves the current f4 interfaces,
+but it requires extra disk space, loses the decoder's volume semantics, makes
+encrypted and solid archives more fragile, and cannot handle missing volumes
+with a useful error.
+
+### 3. Add an f4 RAR filesystem adapter and guard progress dialogs
+
+When the identified local format is RAR, configure `archives.Rar` with the
+first volume's basename and a directory `fs.FS`. Use the shared archive index
+for `ReadDir`/`Stat`, and materialize a requested member while the
+volume-aware decoder is still alive before returning an `fs.File`. Separately,
+make delayed progress screens wait while another modal prompt is active.
+
+## Comparison and decision
+
+Candidate 3 is selected. It is a small, local integration fix that exercises
+the API already provided by the pinned archive libraries, avoids a dependency
+fork, and gives F3/F4 a stable member lifetime across volume boundaries. The
+adapter is used only after format identification confirms RAR, so ZIP, 7z,
+tar, and ordinary fallback behavior remain unchanged. The progress change is
+generic and protects any modal prompt that races with a delayed operation
+screen, not only archive passwords.
+
+The implementation is covered by a Windows-capable two-volume RAR regression
+test and a UI regression test that keeps a password-style modal above the
+delayed viewer progress screen. Existing archive and viewer tests remain part
+of validation.
+
+— zoin-bot

--- a/plugins/archive/issue816_multivolume_test.go
+++ b/plugins/archive/issue816_multivolume_test.go
@@ -21,14 +21,14 @@ func TestArchiveVFS_MultiVolumeRar(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmp, "test.part01.rar"), part01, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "test.part01.rar"), part01, 0600); err != nil { // #nosec G703 -- tmp is the per-test directory created by testing.T.TempDir.
 		t.Fatal(err)
 	}
 	part02, err := os.ReadFile(filepath.Join(sourceDir, "test.part02.rar"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(tmp, "test.part02.rar"), part02, 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "test.part02.rar"), part02, 0600); err != nil { // #nosec G703 -- tmp is the per-test directory created by testing.T.TempDir.
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/issue816_multivolume_test.go
+++ b/plugins/archive/issue816_multivolume_test.go
@@ -2,7 +2,7 @@ package archive
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"io"
 	"os"
@@ -17,14 +17,19 @@ import (
 func TestArchiveVFS_MultiVolumeRar(t *testing.T) {
 	sourceDir := archivesRarFixtureDir(t)
 	tmp := t.TempDir()
-	for _, name := range []string{"test.part01.rar", "test.part02.rar"} {
-		data, err := os.ReadFile(filepath.Join(sourceDir, name))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tmp, name), data, 0600); err != nil {
-			t.Fatal(err)
-		}
+	part01, err := os.ReadFile(filepath.Join(sourceDir, "test.part01.rar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "test.part01.rar"), part01, 0600); err != nil {
+		t.Fatal(err)
+	}
+	part02, err := os.ReadFile(filepath.Join(sourceDir, "test.part02.rar"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "test.part02.rar"), part02, 0600); err != nil {
+		t.Fatal(err)
 	}
 
 	v, err := NewArchiveVFS(vfs.NewOSVFS(tmp), "test.part01.rar")
@@ -53,8 +58,8 @@ func TestArchiveVFS_MultiVolumeRar(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("Read: %v", readErr)
 	}
-	hash := sha1.Sum(data)
-	if got := hex.EncodeToString(hash[:]); got != "4da7f88f69b44a3fdb705667019a65f4c6e058a3" {
+	hash := sha256.Sum256(data)
+	if got := hex.EncodeToString(hash[:]); got != "b1040e9bde2125471abc00773c7c589c32ee879354dd188a919988f70b84ea19" {
 		t.Fatalf("RAR entry SHA-1 = %s, want the complete multi-volume payload", got)
 	}
 
@@ -69,7 +74,7 @@ func TestArchiveVFS_MultiVolumeRar(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if copyHash := sha1.Sum(copyData); hex.EncodeToString(copyHash[:]) != "4da7f88f69b44a3fdb705667019a65f4c6e058a3" {
+	if copyHash := sha256.Sum256(copyData); hex.EncodeToString(copyHash[:]) != "b1040e9bde2125471abc00773c7c589c32ee879354dd188a919988f70b84ea19" {
 		t.Fatalf("CopyBulk payload differs from the complete multi-volume entry")
 	}
 }

--- a/plugins/archive/issue816_multivolume_test.go
+++ b/plugins/archive/issue816_multivolume_test.go
@@ -1,0 +1,98 @@
+package archive
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestArchiveVFS_MultiVolumeRar(t *testing.T) {
+	sourceDir := archivesRarFixtureDir(t)
+	tmp := t.TempDir()
+	for _, name := range []string{"test.part01.rar", "test.part02.rar"} {
+		data, err := os.ReadFile(filepath.Join(sourceDir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(tmp, name), data, 0600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	v, err := NewArchiveVFS(vfs.NewOSVFS(tmp), "test.part01.rar")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = v.Close() })
+	var currentItems []vfs.VFSItem
+	if err := v.ReadDir(context.Background(), v.GetPath(), func(items []vfs.VFSItem) {
+		currentItems = append(currentItems, items...)
+	}); err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(currentItems) != 1 || currentItems[0].Name != "test.txt" {
+		t.Fatalf("entries = %#v", currentItems)
+	}
+	file, err := v.Open(context.Background(), v.Join(v.GetPath(), "test.txt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	data, readErr := io.ReadAll(ctxReader{r: file, ctx: context.Background()})
+	closeErr := file.Close()
+	if closeErr != nil {
+		t.Fatalf("Close: %v", closeErr)
+	}
+	if readErr != nil {
+		t.Fatalf("Read: %v", readErr)
+	}
+	hash := sha1.Sum(data)
+	if got := hex.EncodeToString(hash[:]); got != "4da7f88f69b44a3fdb705667019a65f4c6e058a3" {
+		t.Fatalf("RAR entry SHA-1 = %s, want the complete multi-volume payload", got)
+	}
+
+	dstDir := filepath.Join(tmp, "out")
+	if err := os.Mkdir(dstDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.CopyBulk(context.Background(), []string{"test.txt"}, vfs.NewOSVFS(dstDir), dstDir, &dummyReporter{}); err != nil {
+		t.Fatalf("CopyBulk: %v", err)
+	}
+	copyData, err := os.ReadFile(filepath.Join(dstDir, "test.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if copyHash := sha1.Sum(copyData); hex.EncodeToString(copyHash[:]) != "4da7f88f69b44a3fdb705667019a65f4c6e058a3" {
+		t.Fatalf("CopyBulk payload differs from the complete multi-volume entry")
+	}
+}
+
+func archivesRarFixtureDir(t *testing.T) string {
+	t.Helper()
+	cmd := exec.Command("go", "env", "GOMODCACHE")
+	output, err := cmd.Output()
+	if err != nil {
+		t.Skipf("cannot locate Go module cache: %v", err)
+	}
+	root := strings.TrimSpace(string(output))
+	matches, err := filepath.Glob(filepath.Join(root, "github.com", "unxed", "archives@*", "testdata"))
+	if err != nil {
+		t.Skipf("locating archives RAR fixture: %v", err)
+	}
+	for _, dir := range matches {
+		if _, err := os.Stat(filepath.Join(dir, "test.part01.rar")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "test.part02.rar")); err == nil {
+				return dir
+			}
+		}
+	}
+	t.Skip("archives RAR fixture is unavailable")
+	return ""
+}

--- a/plugins/archive/multivolume_rar.go
+++ b/plugins/archive/multivolume_rar.go
@@ -227,7 +227,7 @@ func identifyArchiveFormat(ctx context.Context, localPath, displayName string) (
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	if displayName == "" {
 		displayName = filepath.Base(localPath)
 	}

--- a/plugins/archive/multivolume_rar.go
+++ b/plugins/archive/multivolume_rar.go
@@ -1,0 +1,259 @@
+package archive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"sync"
+
+	"github.com/unxed/archives"
+	zipperarchive "github.com/unxed/zipper/archive"
+)
+
+// rarArchiveFileSystem keeps the volume-aware RAR reader on the filesystem
+// path. zipper's generic fallback receives only one input stream, while
+// rardecode needs the first volume name and its containing directory to find
+// the following volumes.
+type rarArchiveFileSystem struct {
+	root   *archives.ArchiveFS
+	format archives.Rar
+
+	mu     sync.RWMutex
+	closed bool
+}
+
+func newRARArchiveFileSystem(localPath, password string) (zipperarchive.FileSystem, error) {
+	if _, err := os.Stat(localPath); err != nil {
+		return nil, err
+	}
+
+	format := archives.Rar{
+		Name:     filepath.Base(localPath),
+		FS:       archives.DirFS(filepath.Dir(localPath)),
+		Password: password,
+	}
+	return &rarArchiveFileSystem{
+		root: &archives.ArchiveFS{
+			Path:    localPath,
+			Format:  format,
+			Context: context.Background(),
+		},
+		format: format,
+	}, nil
+}
+
+func (r *rarArchiveFileSystem) rootFS() (*archives.ArchiveFS, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.closed {
+		return nil, errors.New("RAR filesystem is closed")
+	}
+	return r.root, nil
+}
+
+func (r *rarArchiveFileSystem) Open(name string) (fs.File, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrInvalid}
+	}
+	root, err := r.rootFS()
+	if err != nil {
+		return nil, err
+	}
+
+	info, err := root.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	if info.IsDir() {
+		entries, err := root.ReadDir(name)
+		if err != nil {
+			return nil, err
+		}
+		return &rarDirectoryFile{info: info, entries: append([]fs.DirEntry(nil), entries...)}, nil
+	}
+
+	tmp, err := os.CreateTemp("", "f4arc-rar-member-*")
+	if err != nil {
+		return nil, err
+	}
+	tmpName := tmp.Name()
+	removeTemp := true
+	defer func() {
+		if removeTemp {
+			_ = tmp.Close()
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	target := path.Clean(name)
+	found := false
+	err = r.format.Extract(context.Background(), nil, func(_ context.Context, entry archives.FileInfo) error {
+		if path.Clean(entry.NameInArchive) != target {
+			return nil
+		}
+		if entry.IsDir() {
+			return fmt.Errorf("RAR entry %q is a directory", name)
+		}
+
+		member, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tmp, member)
+		closeErr := member.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		found = true
+		return fs.SkipAll
+	})
+	if err != nil {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fmt.Errorf("extract: %w", err)}
+	}
+	if !found {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+	if err := tmp.Close(); err != nil {
+		return nil, err
+	}
+	file, err := os.Open(tmpName)
+	if err != nil {
+		return nil, err
+	}
+	removeTemp = false
+	return &rarMemberFile{File: file, info: info, tempPath: tmpName}, nil
+}
+
+func (r *rarArchiveFileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "readdir", Path: name, Err: fs.ErrInvalid}
+	}
+	root, err := r.rootFS()
+	if err != nil {
+		return nil, err
+	}
+	return root.ReadDir(name)
+}
+
+func (r *rarArchiveFileSystem) Stat(name string) (fs.FileInfo, error) {
+	if !fs.ValidPath(name) {
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrInvalid}
+	}
+	root, err := r.rootFS()
+	if err != nil {
+		return nil, err
+	}
+	return root.Stat(name)
+}
+
+func (r *rarArchiveFileSystem) Close() error {
+	r.mu.Lock()
+	r.closed = true
+	r.mu.Unlock()
+	return nil
+}
+
+type rarMemberFile struct {
+	*os.File
+	info     fs.FileInfo
+	tempPath string
+	once     sync.Once
+	err      error
+}
+
+func (f *rarMemberFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+
+func (f *rarMemberFile) Close() error {
+	f.once.Do(func() {
+		closeErr := f.File.Close()
+		removeErr := os.Remove(f.tempPath)
+		f.err = errors.Join(closeErr, removeErr)
+	})
+	return f.err
+}
+
+type rarDirectoryFile struct {
+	info        fs.FileInfo
+	entries     []fs.DirEntry
+	entriesRead int
+}
+
+func (rarDirectoryFile) Read([]byte) (int, error) {
+	return 0, errors.New("cannot read a directory file")
+}
+
+func (f *rarDirectoryFile) Stat() (fs.FileInfo, error) { return f.info, nil }
+func (rarDirectoryFile) Close() error                  { return nil }
+
+func (f *rarDirectoryFile) ReadDir(n int) ([]fs.DirEntry, error) {
+	if n <= 0 {
+		entries := f.entries[f.entriesRead:]
+		f.entriesRead = len(f.entries)
+		return entries, nil
+	}
+	if f.entriesRead >= len(f.entries) {
+		return nil, io.EOF
+	}
+	end := f.entriesRead + n
+	if end > len(f.entries) {
+		end = len(f.entries)
+	}
+	entries := f.entries[f.entriesRead:end]
+	f.entriesRead = end
+	return entries, nil
+}
+
+func openArchiveFileSystem(ctx context.Context, localPath, displayName, password string) (zipperarchive.FileSystem, error) {
+	format, err := identifyArchiveFormat(ctx, localPath, displayName)
+	if err == nil {
+		switch format.(type) {
+		case archives.Rar, *archives.Rar:
+			return newRARArchiveFileSystem(localPath, password)
+		}
+	}
+	return zipperarchive.OpenFS(localPath, zipperarchive.Options{Password: password})
+}
+
+func identifyArchiveFormat(ctx context.Context, localPath, displayName string) (archives.Format, error) {
+	file, err := os.Open(localPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	if displayName == "" {
+		displayName = filepath.Base(localPath)
+	}
+	format, _, err := archives.Identify(ctx, displayName, file)
+	return format, err
+}
+
+func configureRARArchiveFormat(format archives.Format, localPath, password string) (archives.Format, bool) {
+	switch value := format.(type) {
+	case archives.Rar:
+		value.Name = filepath.Base(localPath)
+		value.FS = archives.DirFS(filepath.Dir(localPath))
+		value.Password = password
+		return value, true
+	case *archives.Rar:
+		if value == nil {
+			return format, false
+		}
+		copy := *value
+		copy.Name = filepath.Base(localPath)
+		copy.FS = archives.DirFS(filepath.Dir(localPath))
+		copy.Password = password
+		return &copy, true
+	default:
+		return format, false
+	}
+}
+
+var _ zipperarchive.FileSystem = (*rarArchiveFileSystem)(nil)

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -108,7 +108,7 @@ func (v *ArchiveVFS) ensureFSLocked() error {
 	if v.cleanupTimer == nil || v.activePath() == "" {
 		return fmt.Errorf("archive VFS is closed")
 	}
-	reopened, err := archive.OpenFS(v.activePath(), archive.Options{Password: v.password})
+	reopened, err := openArchiveFileSystem(context.Background(), v.activePath(), v.displayName, v.password)
 	if err != nil {
 		return err
 	}
@@ -189,7 +189,7 @@ type archiveFSOpenResult struct {
 func openArchiveFSWithContext(ctx context.Context, localPath, displayName string, backing io.Closer, password string) (archive.FileSystem, bool, error) {
 	result := make(chan archiveFSOpenResult, 1)
 	go func() {
-		fsys, err := archive.OpenFS(localPath, archive.Options{Password: password})
+		fsys, err := openArchiveFileSystem(ctx, localPath, displayName, password)
 		result <- archiveFSOpenResult{fsys: fsys, err: err}
 	}()
 
@@ -1781,7 +1781,7 @@ func (v *ArchiveVFS) Remove(ctx context.Context, path string) error {
 }
 
 func (v *ArchiveVFS) reloadFS() error {
-	newFS, err := archive.OpenFS(v.activePath(), archive.Options{Password: v.password})
+	newFS, err := openArchiveFileSystem(context.Background(), v.activePath(), v.displayName, v.password)
 	if err != nil {
 		return err
 	}
@@ -2524,7 +2524,9 @@ func (v *ArchiveVFS) openBulkExtractor(ctx context.Context, f vfs.ReadAtCloser, 
 		_ = localF.Close()
 		return nil, nil, err
 	}
-	if passwordFormat, ok := archivePasswordFormat(format, password); ok {
+	if configuredFormat, ok := configureRARArchiveFormat(format, localPath, password); ok {
+		format = configuredFormat
+	} else if passwordFormat, ok := archivePasswordFormat(format, password); ok {
 		format = passwordFormat
 	}
 


### PR DESCRIPTION
## Summary

- Keep delayed progress dialogs below password and other modal prompts, so archive credentials remain usable during F3/F4 operations.
- Add a volume-aware RAR filesystem adapter for multi-volume archives, including safe materialization for random-access member reads and bulk extraction.
- Cover the regressions with UI, password, and multi-volume RAR tests.

Fixes #816

## Verification

- `go test ./plugins/archive -count=1 -v` — passed; external 7z/zip command tests were skipped because those executables are not installed.
- Targeted `cmd/f4` progress-dialog tests — passed.
- Windows 10 x64 native `--gui=win32` validation from this commit:
  - encrypted 7z: password prompt, listing, and F3 viewer passed;
  - encrypted ZIP: password prompt and F3 viewer passed;
  - multi-volume RAR: first-volume listing and F3 viewer passed (`test.txt`, 8895 bytes).
- `git diff --check upstream/main..HEAD` — passed.

The full `cmd/f4` package run still has the pre-existing environment-sensitive `TestEditorView_PasteConvertsInternalClipboardCodepage` failure; race tests require a GCC/CGO toolchain that is not installed on this host.

— zoin-bot