### PR TITLE
perf(editor): colour the whole viewport in one Colorer worker round trip

### DIFF
--- a/cmd/f4/colorer_async.go
+++ b/cmd/f4/colorer_async.go
@@ -15,7 +15,7 @@ type colorerJob struct {
 	id           uint64
 	generation   uint64
 	target       int
-	line         string
+	lines        []string
 	contextStart int
 	context      []string
 	reset        bool
@@ -24,12 +24,19 @@ type colorerJob struct {
 	total        int
 }
 
-type colorerResult struct {
-	job        colorerJob
+type colorerLineAttrs struct {
 	attrs      []uint64
 	background uint64
-	parsedIdx  int
-	err        error
+}
+
+type colorerResult struct {
+	job   colorerJob
+	lines []colorerLineAttrs
+	// partial marks a batch cut short by a parse error on a prefetched line:
+	// the attributes up to the bad line are good, but the session's position
+	// is unknown, so the next job must re-anchor.
+	partial bool
+	err     error
 }
 
 // startWorker transfers ownership of session calls to one goroutine. A
@@ -66,7 +73,7 @@ func (ch *ColorerHighlighter) runWorker(ctx context.Context, session *colorer.Se
 			return
 		case job := <-ch.workerJobs:
 			if err := ch.prepareWorkerSession(ctx, session, job, &parsedIdx, &forgottenUpTo); err != nil {
-				ch.postColorerResult(colorerResult{job: job, parsedIdx: parsedIdx, err: err})
+				ch.postColorerResult(colorerResult{job: job, err: err})
 				return
 			}
 
@@ -74,7 +81,7 @@ func (ch *ColorerHighlighter) runWorker(ctx context.Context, session *colorer.Se
 			if !baseKnown || baseAttr != job.baseAttr || schemeGen != generation {
 				activeScheme := currentColorerSchemeName()
 				if err := session.SetHRD("rgb", activeScheme); err != nil {
-					ch.postColorerResult(colorerResult{job: job, parsedIdx: parsedIdx, err: err})
+					ch.postColorerResult(colorerResult{job: job, err: err})
 					return
 				}
 				baseAttr = job.baseAttr
@@ -88,37 +95,56 @@ func (ch *ColorerHighlighter) runWorker(ctx context.Context, session *colorer.Se
 				}
 				if _, err := session.ParseLine(contextLine); err != nil {
 					vtui.DebugLog("COLORER: ParseLine failed in context at line %d: %v", job.contextStart+i, err)
-					ch.postColorerResult(colorerResult{job: job, parsedIdx: parsedIdx, err: err})
+					ch.postColorerResult(colorerResult{job: job, err: err})
 					return
 				}
 				parsedIdx++
 				if i == len(job.context)-1 || i%16 == 0 {
-					ch.postColorerProgress(job, i+1)
+					ch.postColorerProgress(job.id, job.total, i+1)
 				}
 			}
 
 			if parsedIdx != job.target {
 				err := colorerWorkerStateError{want: job.target, got: parsedIdx}
-				ch.postColorerResult(colorerResult{job: job, parsedIdx: parsedIdx, err: err})
+				ch.postColorerResult(colorerResult{job: job, err: err})
 				return
 			}
 
+			// No progress posts inside the batch: the attributes only land on
+			// screen with the final result, so a mid-batch redraw would paint
+			// nothing new — the per-line render cost the batch exists to avoid.
+			lineResults := make([]colorerLineAttrs, 0, len(job.lines))
+			partial := false
+			for i, lineText := range job.lines {
+				if ctx.Err() != nil {
+					return
+				}
+				regions, err := session.ParseLine(lineText)
+				if err != nil {
+					vtui.DebugLog("COLORER: ParseLine failed at line %d: %v", job.target+i, err)
+					if len(lineResults) == 0 {
+						// The line the viewport actually asked for cannot be
+						// parsed; nothing to salvage.
+						ch.postColorerResult(colorerResult{job: job, err: err})
+						return
+					}
+					// A prefetched line failed: keep the finished attributes
+					// instead of throwing the whole batch away. Whether the
+					// session consumed the bad line is unknown, so its
+					// position is unknown too — the next job must re-anchor.
+					partial = true
+					break
+				}
+				parsedIdx++
+				attrs, background := ch.attrsForSyntax(lineText, regions, job.baseAttr, job.syntax)
+				lineResults = append(lineResults, colorerLineAttrs{attrs: attrs, background: background})
+			}
 			if ctx.Err() != nil {
 				return
 			}
-			regions, err := session.ParseLine(job.line)
-			parsedIdx = job.target + 1
-			if err != nil {
-				vtui.DebugLog("COLORER: ParseLine failed at line %d: %v", job.target, err)
-				ch.postColorerResult(colorerResult{job: job, parsedIdx: parsedIdx, err: err})
-				return
-			}
-
-			attrs, background := ch.attrsForSyntax(job.line, regions, job.baseAttr, job.syntax)
-			if ctx.Err() != nil {
-				return
-			}
-			if !forgetDisabled {
+			if partial {
+				parsedIdx = -1 // never matches a contextStart: forces a reset
+			} else if !forgetDisabled {
 				if keepFrom, do := colorerForgetPlan(parsedIdx, forgottenUpTo); do {
 					if err := session.ForgetBefore(keepFrom); err != nil {
 						vtui.DebugLog("COLORER: ForgetBefore unsupported, disabling for this session: %v", err)
@@ -128,12 +154,10 @@ func (ch *ColorerHighlighter) runWorker(ctx context.Context, session *colorer.Se
 					}
 				}
 			}
-			ch.postColorerProgress(job, job.total)
 			ch.postColorerResult(colorerResult{
-				job:        job,
-				attrs:      attrs,
-				background: background,
-				parsedIdx:  parsedIdx,
+				job:     job,
+				lines:   lineResults,
+				partial: partial,
 			})
 		}
 	}
@@ -178,6 +202,10 @@ func (ch *ColorerHighlighter) prepareWorkerSession(ctx context.Context, session 
 // never calls into Colorer. A jump is re-anchored to at most
 // hlColorerContext lines, and ordinary scrolling snapshots only the missing
 // forward lines.
+//
+// One job covers the whole uncoloured run starting at idx, up to
+// hlColorerBatchLines: colouring a viewport in one round trip is what keeps
+// the screen from filling in visibly line by line, one redraw per line.
 func (ch *ColorerHighlighter) queueLine(idx int, line string, baseAttr uint64) {
 	if ch.pending || ch.workerJobs == nil || ch.lineAt == nil {
 		return
@@ -211,18 +239,37 @@ func (ch *ColorerHighlighter) queueLine(idx int, line string, baseAttr uint64) {
 		contextLines = append(contextLines, contextLine)
 	}
 
+	// The batch stops at the first line that is already coloured or whose
+	// text is not available yet — the next frame picks up from there — and
+	// at the byte budget, which keeps this snapshot loop from copying
+	// megabytes inside a frame when lines are huge.
+	batch := make([]string, 0, hlColorerBatchLines)
+	batch = append(batch, line)
+	batchBytes := len(line)
+	for lineIdx := idx + 1; len(batch) < hlColorerBatchLines && batchBytes < hlColorerBatchBytes; lineIdx++ {
+		if _, cached := ch.attrCache[lineIdx]; cached {
+			break
+		}
+		text, ok := ch.lineAt(lineIdx)
+		if !ok {
+			break
+		}
+		batch = append(batch, text)
+		batchBytes += len(text)
+	}
+
 	ch.workGeneration++
 	job := colorerJob{
 		id:           ch.workGeneration,
 		generation:   ch.workGeneration,
 		target:       idx,
-		line:         line,
+		lines:        batch,
 		contextStart: start,
 		context:      contextLines,
 		reset:        reset,
 		baseAttr:     baseAttr,
 		syntax:       AppConfig.EditorColorerSyntax,
-		total:        len(contextLines) + 1,
+		total:        len(contextLines) + len(batch),
 	}
 	ch.forceReset = false
 	ch.pending = true
@@ -235,7 +282,10 @@ func (ch *ColorerHighlighter) queueLine(idx int, line string, baseAttr uint64) {
 	}
 }
 
-func (ch *ColorerHighlighter) postColorerProgress(job colorerJob, done int) {
+// postColorerProgress takes the job's id and total, not the job: the queued
+// closure would otherwise keep the whole line snapshot — up to hundreds of
+// lines of text — alive until the UI thread gets around to it.
+func (ch *ColorerHighlighter) postColorerProgress(jobID uint64, total, done int) {
 	if ch.postTask == nil || ch.owner == nil {
 		return
 	}
@@ -243,11 +293,11 @@ func (ch *ColorerHighlighter) postColorerProgress(job colorerJob, done int) {
 	redraw := ch.redraw
 	owner := ch.owner
 	postTask(func() {
-		if ch.closed || owner.highlighter != vtui.Highlighter(ch) || owner.colorerWorkID != job.id {
+		if ch.closed || owner.highlighter != vtui.Highlighter(ch) || owner.colorerWorkID != jobID {
 			return
 		}
 		owner.colorerProgress = done
-		owner.colorerTotal = job.total
+		owner.colorerTotal = total
 		if redraw != nil {
 			redraw()
 		}
@@ -277,8 +327,16 @@ func (ch *ColorerHighlighter) postColorerResult(result colorerResult) {
 			ch.disabled = true
 			vtui.DebugLog("COLORER: background highlighting stopped: %v", result.err)
 		} else {
-			ch.parsedIdx = result.parsedIdx
-			ch.storeAttrs(result.job.target, result.attrs, result.background)
+			ch.parsedIdx = result.job.target + len(result.lines)
+			for i, lineAttrs := range result.lines {
+				ch.storeAttrs(result.job.target+i, lineAttrs.attrs, lineAttrs.background)
+			}
+			if result.partial {
+				// The worker lost the session's position on the failed line;
+				// forward-feeding from here would cold-start the parser with
+				// no context. The next job re-anchors instead.
+				ch.forceReset = true
+			}
 		}
 		owner.finishColorerWork(result.job.id)
 		if redraw != nil {

--- a/cmd/f4/colorer_plugin.go
+++ b/cmd/f4/colorer_plugin.go
@@ -50,6 +50,22 @@ const (
 	// makes; batching keeps the cost negligible while still bounding memory
 	// well under file size. See HIGHLIGHT.md, item 9 and item 4's log.
 	hlColorerForgetEvery = 1000
+
+	// How many uncoloured lines one worker job may take on, counting the
+	// line that missed the cache. One job per line meant one full UI round
+	// trip — worker, PostTask, whole-screen redraw — per line, and the
+	// viewport visibly filled with colour line by line. A batch colours a
+	// screen in a single round trip; the cap only has to exceed any
+	// realistic terminal height.
+	hlColorerBatchLines = 200
+
+	// How much line text one batch snapshot may copy on the UI render
+	// thread. Lines are cut at 64 KB each, so a line count alone bounds the
+	// snapshot at ~12.8 MB — fine as a parse budget, not as a synchronous
+	// copy inside a frame. Ordinary code is a few dozen bytes per line and
+	// never notices this; only files with enormous lines trade batch depth
+	// for a bounded frame.
+	hlColorerBatchBytes = 256 * 1024
 )
 
 // The style bits an hrd assign carries, as StyledRegion defines them.

--- a/cmd/f4/colorer_plugin_test.go
+++ b/cmd/f4/colorer_plugin_test.go
@@ -157,6 +157,118 @@ func TestColorerQueueLineBoundsDocumentSnapshot(t *testing.T) {
 	}
 }
 
+// One job covers the whole uncoloured run, so a viewport colours in a single
+// worker round trip instead of one redraw per line.
+func TestColorerQueueLineBatchesTheUncolouredRun(t *testing.T) {
+	ch := &ColorerHighlighter{
+		lineAt:     func(idx int) (string, bool) { return "text", idx < 50 },
+		workerJobs: make(chan colorerJob, 1),
+	}
+
+	ch.queueLine(10, "target", 0)
+	job := <-ch.workerJobs
+	if len(job.lines) != 40 {
+		t.Fatalf("batch holds %d lines, want the 40 remaining document lines", len(job.lines))
+	}
+	if job.lines[0] != "target" {
+		t.Errorf("the first batched line must be the caller's snapshot, got %q", job.lines[0])
+	}
+	if job.total != len(job.context)+len(job.lines) {
+		t.Errorf("total = %d, want context %d + batch %d", job.total, len(job.context), len(job.lines))
+	}
+}
+
+func TestColorerQueueLineBatchStopsAtCachedLines(t *testing.T) {
+	ch := &ColorerHighlighter{
+		attrCache:  map[int][]uint64{12: {0}},
+		lineAt:     func(idx int) (string, bool) { return "text", true },
+		workerJobs: make(chan colorerJob, 1),
+	}
+
+	ch.queueLine(10, "target", 0)
+	job := <-ch.workerJobs
+	if len(job.lines) != 2 {
+		t.Fatalf("batch holds %d lines, want 2: it must stop at the already-coloured line", len(job.lines))
+	}
+}
+
+func TestColorerQueueLineBatchIsBounded(t *testing.T) {
+	ch := &ColorerHighlighter{
+		lineAt:     func(idx int) (string, bool) { return "text", true },
+		workerJobs: make(chan colorerJob, 1),
+	}
+
+	ch.queueLine(0, "target", 0)
+	job := <-ch.workerJobs
+	if len(job.lines) != hlColorerBatchLines {
+		t.Fatalf("batch holds %d lines, want the hlColorerBatchLines cap of %d", len(job.lines), hlColorerBatchLines)
+	}
+}
+
+// Lines are cut at 64 KB each, so a line count alone would let one snapshot
+// copy ~12.8 MB inside a frame; the byte budget bounds the copy instead.
+func TestColorerQueueLineBatchRespectsTheByteBudget(t *testing.T) {
+	big := strings.Repeat("x", 64*1024)
+	ch := &ColorerHighlighter{
+		lineAt:     func(idx int) (string, bool) { return big, true },
+		workerJobs: make(chan colorerJob, 1),
+	}
+
+	ch.queueLine(0, big, 0)
+	job := <-ch.workerJobs
+	if want := hlColorerBatchBytes / len(big); len(job.lines) != want {
+		t.Fatalf("batch holds %d huge lines, want %d: the byte budget must cut it short", len(job.lines), want)
+	}
+}
+
+// A parse error on a prefetched line must not throw away the attributes the
+// batch already computed, and must not disable highlighting — only the line
+// the viewport actually asked for is allowed to be terminal. The session's
+// position after the failure is unknown, so the next job must re-anchor.
+func TestColorerPartialResultKeepsAttrsAndForcesReanchor(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	pt := piecetable.New([]byte("a\nb\nc\n"))
+	ev := NewEditorView(pt, nil, "test.txt")
+	defer ev.Close()
+
+	ch := &ColorerHighlighter{
+		owner:          ev,
+		postTask:       func(f func()) { f() },
+		redraw:         func() {},
+		pending:        true,
+		workGeneration: 1,
+	}
+	ev.highlighter = ch
+
+	job := colorerJob{id: 1, generation: 1, target: 10, lines: []string{"l0", "l1", "l2"}}
+	ch.postColorerResult(colorerResult{
+		job:     job,
+		lines:   []colorerLineAttrs{{attrs: []uint64{1}}, {attrs: []uint64{2}}},
+		partial: true,
+	})
+
+	if ch.disabled {
+		t.Error("a prefetch failure must not disable highlighting")
+	}
+	if ch.pending {
+		t.Error("the finished job must clear pending")
+	}
+	if !ch.forceReset {
+		t.Error("a partial result must force the next job to re-anchor")
+	}
+	if ch.parsedIdx != 12 {
+		t.Errorf("parsedIdx = %d, want target + the 2 salvaged lines = 12", ch.parsedIdx)
+	}
+	if _, ok := ch.attrCache[11]; !ok {
+		t.Error("salvaged attributes were not stored")
+	}
+	if _, ok := ch.attrCache[12]; ok {
+		t.Error("the unparsed line must not get attributes")
+	}
+}
+
 func TestColorerCancelInvalidatesWork(t *testing.T) {
 	ch := &ColorerHighlighter{pending: true, workGeneration: 7}
 	ch.Cancel()

--- a/docs/HIGHLIGHT.md
+++ b/docs/HIGHLIGHT.md
@@ -122,18 +122,29 @@ seconds after a held `PgDn`.
 ### 3.2 Colorer is addressed by line number, from an anchor
 
 `ColorerHighlighter.HighlightLine(idx, line, baseAttr)` is what the render loop
-calls. Internally:
+calls. A cache hit returns the stored attributes; a miss queues work and
+returns nil — the line stays plain until the result lands. Internally
+(`colorer_async.go`):
 
 - `colorerContextPlan(parsedIdx, idx)` — pure, and the whole decision. If the
   wanted line is ahead of the session and no further than `hlColorerForward`
   (2000) lines, feed the session forward. Otherwise reset and restart
   `hlColorerContext` (300) lines above the target.
-- `ensureContext` is called **only on an attribute-cache miss**, so a screen
-  that is already coloured costs nothing and does not move the session.
-- `resetSessionAt(start)` resets, re-selects the file type, and declares
-  `start` to be the session's first line.
-- `parseThrough(idx)` feeds lines up to but not including `idx`, reading them
-  through `ch.lineAt`.
+- `queueLine` runs on the UI thread but never calls into Colorer. It snapshots
+  the context lines and the whole uncoloured run starting at `idx` — bounded
+  by `hlColorerBatchLines` and `hlColorerBatchBytes`, stopping at the first
+  line already coloured or not yet loaded — into one immutable `colorerJob`.
+  One job per screen, not per line: the per-line version coloured the viewport
+  visibly line by line, one worker round trip and one full redraw each.
+- A single worker goroutine owns the session (`runWorker`). It replays the
+  context, parses the batch, and posts all the attributes back in one
+  `PostTask`, which stores them and triggers one redraw. `workGeneration`
+  invalidates results that were overtaken by an edit or a cancel.
+- A parse error on the first batch line — the one the viewport asked for —
+  disables highlighting for the file. An error on a *prefetched* line only
+  cuts the batch short: the finished attributes are posted (`partial`), and
+  both sides force a re-anchor, because the session's position after a failed
+  `ParseLine` is unknown.
 
 *Why an anchor.* A jump then costs the same at line 500 and at line 500 000,
 which is the only way a 600 000-line file can behave. Sequential scrolling
@@ -175,13 +186,19 @@ When the Colorer session cannot be created, or no schema matches the file,
 Otherwise a perfectly ordinary Chroma highlighter would be treated as Colorer
 by `usesStateChain` and lose both its chain and its walker.
 
-### 3.6 Everything runs on the UI thread
+### 3.6 Everything runs on the UI thread — except Colorer parsing
 
-The walker's slices, the render loop and every highlighter call happen there,
-through `PostTask`. Highlighters are not thread-safe, the Colorer session is a
-pooled external resource, and the wrap engine mutates its caches as a side
-effect of what look like reads. Responsiveness comes from bounding each slice
-in time, not from moving work to another thread.
+The walker's slices, the render loop and every Chroma-style highlighter call
+happen there, through `PostTask`. Highlighters are not thread-safe and the
+wrap engine mutates its caches as a side effect of what look like reads.
+Responsiveness comes from bounding each slice in time.
+
+Colorer's `ParseLine` can execute arbitrary grammar code and is the one thing
+that moved off-thread: a single worker goroutine owns the session, the UI only
+queues immutable line snapshots and consumes posted results
+(`colorer_async.go`). One worker, not a pool — the session is stateful and
+line order is its state, so concurrent calls are wrong by construction, and
+one owner gives cancellation a single well-defined home.
 
 ---
 
@@ -313,20 +330,18 @@ margin.
 *Acceptance.* `TestColorer_AttrCacheIsBounded` extended to push past the new
 limit and assert the map stays bounded.
 
-### Item 4 — bound the session on a long forward scroll
+### Item 4 — bound the session on a long forward scroll — superseded by item 9
 
 Re-anchoring resets the session, which is what releases the wasm line vector
 and the parse cache. One case never re-anchors: scrolling straight down, which
 feeds the session forward for as long as the user holds `PgDn`.
 
-*What to do.* Force a re-anchor after `hlColorerParsedMax` lines have been fed
-since the last reset — start with 20 000. `ensureContext` is the place;
-`colorerContextPlan` gains the counter as an argument so the decision stays
-pure and testable.
-
-*Measure first.* Hold `PgDn` from the top of the reference file to the bottom
-and watch RSS. If it does not grow meaningfully, skip this item: the reset
-costs the exactness of every construct opened before it.
+*Resolution.* The forced-re-anchor counter proposed here was never needed:
+item 9's upstream `colorer_forget_before` landed and is wired in as
+`session.ForgetBefore`, driven by `colorerForgetPlan` in the worker — every
+`hlColorerForgetEvery` (1000) lines fed, the session drops everything more
+than `hlColorerKeepBehind` (300) lines behind the parse position. A long
+forward scroll stays bounded without ever paying a reset's loss of context.
 
 ### Item 5 — cheaper editing in a large file
 
@@ -373,14 +388,18 @@ allocation per line for nothing. If a highlighter also offers something like
 and use it. Chroma-side support lives in vtui, so this may become an upstream
 change there.
 
-### Item 9 — colorer4go: trim the session window
+### Item 9 — colorer4go: trim the session window — done
 
 Upstream, in `github.com/unxed/colorer4go`. The wrapper only appends; a
 `colorer_forget_before(lno)` (or a ring buffer in `WasmLineSource`) would let
 the session drop lines the editor will never ask about again, which makes item
-4 unnecessary and removes the only reason a long scroll ever resets. Ask for
-this after items 1-4 have shown exactly which shape is needed. Do **not** ask
-for state snapshots — see section 4.
+4 unnecessary and removes the only reason a long scroll ever resets. Do
+**not** ask for state snapshots — see section 4.
+
+*Resolution.* Delivered as `Session.ForgetBefore`; the worker calls it every
+`hlColorerForgetEvery` lines through `colorerForgetPlan` (see item 4). A
+session that answers `ForgetBefore` with an error keeps the old
+grow-until-reset behaviour for that session only.
 
 ---
 
@@ -438,8 +457,12 @@ loader or the line index, and nothing in this document applies.
 |---|---|---|
 | `hlColorerForward` | 2000 | furthest the session is fed forward instead of re-anchored |
 | `hlColorerContext` | 300 | context lines parsed above a new anchor |
-| `maxCachedAttrLines` | 5 000 000 | attribute cache limit (item 3) |
-| `attrCacheKeepWindow` | 1 000 000 | eviction window (item 3) |
+| `hlColorerBatchLines` | 200 | longest uncoloured run one worker job takes on |
+| `hlColorerBatchBytes` | 256 KB | most line text one batch snapshot copies on the UI thread |
+| `hlColorerKeepBehind` | 300 | lines kept behind the parse position when the session is trimmed |
+| `hlColorerForgetEvery` | 1000 | lines fed between two `ForgetBefore` wasm calls |
+| `maxCachedAttrLines` | 20 000 | attribute cache limit (item 3, done) |
+| `attrCacheKeepWindow` | 5000 | eviction window (item 3, done) |
 
 None of these are settings. Do not add them to `AppConfig` before a
 measurement asks for it.
@@ -459,3 +482,9 @@ measurement asks for it.
   needed; fallback engine handed to the editor.
 - Reported: the tail of the reference file appears and colours immediately with
   both highlighters. Remaining: the blank window on open, item 1.
+- Colorer parsing moved to a worker goroutine owning the session; the UI
+  queues immutable snapshots and consumes posted results (`colorer_async.go`).
+- One worker job per line made the viewport colour visibly line by line: each
+  line cost a full worker→PostTask→redraw round trip, ~40 full render passes
+  per screen. Jobs now batch the whole uncoloured run (`hlColorerBatchLines`),
+  so a screen colours in one round trip and one redraw.


### PR DESCRIPTION
## Problem

Opening a file with the Colorer highlighter, the viewport visibly fills with colour line by line. The async worker processed exactly one line per job: each visible line cost a full worker → PostTask → whole-screen redraw round trip, so one screen took ~40 sequential cycles — ~40 full render passes and 80 cross-goroutine hops. The wasm parse itself was never the bottleneck.

## Change

`queueLine` now snapshots the whole uncoloured run starting at the missed line — stopping at the first already-coloured or not-yet-loaded line, bounded by `hlColorerBatchLines` (200) and `hlColorerBatchBytes` (256 KB) — into one `colorerJob`. The worker parses the batch in a single pass and posts all attributes in one task: one round trip and one redraw per screen. The existing invariants are untouched: the worker still owns the session alone, jobs still carry only immutable snapshots, and `workGeneration` still invalidates results overtaken by an edit.

Also in this change:

- **Error salvage.** A `ParseLine` failure on a *prefetched* line no longer disables highlighting for the file: the finished attributes are posted as a partial result, and both sides force a re-anchor, since the session's position after a failed parse is unknown. Only a failure on the line the viewport actually asked for stays terminal, as before.
- No progress posts inside the batch and no unconditional 100% post before the result — those redraws coloured nothing and partially reinstated the per-line cost.
- `postColorerProgress` takes `(id, total, done)` instead of capturing the whole job snapshot in the queued closure.
- `colorerResult.parsedIdx` removed; derived from `target + len(lines)` at its single use.
- `docs/HIGHLIGHT.md` brought up to date: §3.2/§3.6 now describe the worker-based design, items 4 and 9 are marked resolved via `ForgetBefore`, and the constants table matches the code.

## Testing

- New tests: the batch covers the uncoloured run, stops at cached lines, respects the line cap and the byte budget, and a partial result keeps salvaged attributes, forces a re-anchor, and does not disable highlighting.
- `go build ./...` and `go test -run 'Colorer|Highlight|State|Editor_|Queue' ./cmd/f4` pass on top of current main.
- Verified interactively on Windows: the viewport colours in one step instead of rippling line by line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PYfhcUp8H7X9BF2DsmPp1L