### PR TITLE
fix(gui): use Shift+click for screen text selection

### DIFF
--- a/cmd/f4/grabber.go
+++ b/cmd/f4/grabber.go
@@ -66,6 +66,44 @@ func OpenGrabber() {
 	vtui.FrameManager.Redraw()
 }
 
+// handleForcedMouseSelectionEvent turns Shift+left-click into a screen
+// grabber gesture. A plain left-click must keep its normal meaning (including
+// moving a window), while Ctrl/Alt combinations remain available to their
+// existing handlers.
+//
+// The first press is consumed by FrameManager.EventFilter before regular
+// frame dispatch, so the new grabber has to receive that same press after its
+// initial snapshot. Later motion/release events are routed through the normal
+// FrameManager mouse-capture path.
+func handleForcedMouseSelectionEvent(e *vtinput.InputEvent) bool {
+	if e == nil || e.Type != vtinput.MouseEventType || !e.KeyDown ||
+		e.MouseEventFlags&vtinput.MouseMoved != 0 ||
+		e.ButtonState != vtinput.FromLeft1stButtonPressed {
+		return false
+	}
+
+	const modifierMask = vtinput.LeftCtrlPressed | vtinput.RightCtrlPressed |
+		vtinput.LeftAltPressed | vtinput.RightAltPressed | vtinput.ShiftPressed
+	if e.ControlKeyState&modifierMask != vtinput.ShiftPressed {
+		return false
+	}
+	if vtui.FrameManager == nil || vtui.FrameManager.Screen() == nil {
+		return false
+	}
+	if _, alreadyOpen := vtui.FrameManager.GetTopFrame().(*GrabberFrame); alreadyOpen {
+		return false
+	}
+
+	grabber := NewGrabberFrame()
+	vtui.FrameManager.Push(grabber)
+	// Push only changes the frame stack. Snapshot and handle the press now so
+	// the first drag motion cannot arrive before the selection has an anchor.
+	grabber.Show(vtui.FrameManager.Screen())
+	grabber.ProcessMouse(e)
+	vtui.FrameManager.Redraw()
+	return true
+}
+
 // actionScreenGrab is the context-aware App.ScreenGrab handler. Invoking the
 // action again while the grabber owns the screen has the same toggle semantics
 // as its native Alt+Ins key instead of stacking a second snapshot frame.

--- a/cmd/f4/grabber_mouse_test.go
+++ b/cmd/f4/grabber_mouse_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestForcedMouseSelectionStartsAtShiftClick(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	scr := setupGrabberScreen(t)
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	press := mouseEvent(1, 0, vtinput.FromLeft1stButtonPressed, false, true)
+	press.ControlKeyState = vtinput.ShiftPressed
+	if !handleForcedMouseSelectionEvent(press) {
+		t.Fatal("Shift+left-click should start screen selection")
+	}
+
+	grabber, ok := vtui.FrameManager.GetTopFrame().(*GrabberFrame)
+	if !ok {
+		t.Fatalf("top frame = %T, want *GrabberFrame", vtui.FrameManager.GetTopFrame())
+	}
+	if !grabber.hasSnap || grabber.snapW != scr.Width() || grabber.snapH != scr.Height() {
+		t.Fatalf("grabber snapshot = %v %dx%d, want initialized %dx%d",
+			grabber.hasSnap, grabber.snapW, grabber.snapH, scr.Width(), scr.Height())
+	}
+	if grabber.anchorX != 1 || grabber.anchorY != 0 || grabber.curX != 1 || grabber.curY != 0 {
+		t.Fatalf("selection anchor/current = (%d,%d)/(%d,%d), want (1,0)/(1,0)",
+			grabber.anchorX, grabber.anchorY, grabber.curX, grabber.curY)
+	}
+	if !grabber.mouseSelecting {
+		t.Fatal("initial Shift+left-click should keep mouse selection active")
+	}
+
+	grabber.ProcessMouse(mouseEvent(5, 2, vtinput.FromLeft1stButtonPressed, true, true))
+	grabber.ProcessMouse(mouseEvent(5, 2, 0, false, false))
+	if grabber.mouseSelecting {
+		t.Fatal("mouse release should end selection")
+	}
+	if got := grabber.copyText(); got == "" {
+		t.Fatal("Shift+mouse drag should select non-empty screen text")
+	}
+}
+
+func TestForcedMouseSelectionLeavesOtherMouseGesturesAlone(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	setupGrabberScreen(t)
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	tests := []struct {
+		name  string
+		mods  vtinput.ControlKeyState
+		moved bool
+		btn   uint32
+		down  bool
+	}{
+		{name: "plain click", btn: vtinput.FromLeft1stButtonPressed, down: true},
+		{name: "ctrl shift", mods: vtinput.LeftCtrlPressed | vtinput.ShiftPressed, btn: vtinput.FromLeft1stButtonPressed, down: true},
+		{name: "alt shift", mods: vtinput.LeftAltPressed | vtinput.ShiftPressed, btn: vtinput.FromLeft1stButtonPressed, down: true},
+		{name: "middle button", mods: vtinput.ShiftPressed, btn: vtinput.FromLeft2ndButtonPressed, down: true},
+		{name: "motion", mods: vtinput.ShiftPressed, moved: true, btn: vtinput.FromLeft1stButtonPressed, down: true},
+		{name: "release", mods: vtinput.ShiftPressed, btn: 0, down: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := mouseEvent(1, 0, tt.btn, tt.moved, tt.down)
+			e.ControlKeyState = tt.mods
+			if handleForcedMouseSelectionEvent(e) {
+				t.Fatal("event should remain available to normal mouse dispatch")
+			}
+			if _, ok := vtui.FrameManager.GetTopFrame().(*GrabberFrame); ok {
+				t.Fatal("unexpected grabber opened")
+			}
+		})
+	}
+}
+
+func TestForcedMouseSelectionDoesNotNestGrabbers(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	setupGrabberScreen(t)
+	vtui.FrameManager.Push(vtui.NewDesktop())
+
+	first := mouseEvent(1, 0, vtinput.FromLeft1stButtonPressed, false, true)
+	first.ControlKeyState = vtinput.ShiftPressed
+	if !handleForcedMouseSelectionEvent(first) {
+		t.Fatal("first Shift+left-click should start selection")
+	}
+	grabber := vtui.FrameManager.GetTopFrame()
+	second := mouseEvent(2, 0, vtinput.FromLeft1stButtonPressed, false, true)
+	second.ControlKeyState = vtinput.ShiftPressed
+	if handleForcedMouseSelectionEvent(second) {
+		t.Fatal("a Shift+left-click must not open a nested grabber")
+	}
+	if vtui.FrameManager.GetTopFrame() != grabber {
+		t.Fatal("existing grabber was replaced")
+	}
+}

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -746,6 +746,9 @@ func SetupUI() {
 		if previousEventFilter != nil && previousEventFilter(e) {
 			return true
 		}
+		if handleForcedMouseSelectionEvent(e) {
+			return true
+		}
 		if handleMenuHistoryEvent(e) {
 			return true
 		}


### PR DESCRIPTION
## Summary
- make an initial Shift+left-click start f4's existing screen grabber at the clicked cell
- preserve plain window dragging and Ctrl/Alt mouse gestures
- keep the first press anchored so motion/release selection works across all movable frames

## Validation
- `go test ./cmd/f4 -count=1`
- ARM64 binary build
- live X11/XWayland test on Fedora Asahi Remix 44 / KDE Plasma Wayland: Shift+mouse drag selected screen text, Ctrl+Ins copied it, and window geometry stayed unchanged
- `go test ./... -count=1`: all packages passed except the pre-existing `internal/ttyx` X11 BadMatch/active-window geometry tests in this environment