### PR TITLE
fix(console): complete Tab in host overlay

### DIFF
--- a/ISSUE_95_FOLLOWUP_SOLUTION_REVIEW.md
+++ b/ISSUE_95_FOLLOWUP_SOLUTION_REVIEW.md
@@ -1,0 +1,64 @@
+# Issue #95 follow-up solution review
+
+## Reproduction
+
+The first fix covered the normal f4 terminal path, but it did not cover the
+host/Far console path. In that mode `PanelsFrame.ProcessKey` sends a TAB to the
+PTY after the f4 command line declines it, while the command being completed is
+still only in f4's overlay. On an ANSI host console the regular autocomplete
+popup is intentionally suppressed because vtui cannot repaint the host screen
+safely, so the reporter sees no change.
+
+## Candidate solutions
+
+1. Handle a plain TAB in the host-console command line with the existing
+   `vtui.AutoCompleteMenu` and VFS path-hint provider. On a WinAPI overlay,
+   push the menu so the existing native popup renderer can display it. On an
+   ANSI overlay, accept the menu's first selectable match directly and redraw
+   the command line; this keeps the host screen safe while still completing the
+   command. **Chosen.**
+2. Remove `AutoCompleteSuppressed` for ANSI host consoles and let vtui draw its
+   normal menu. Rejected: the normal frame renderer targets f4's screen buffer,
+   not the live host console, and would repaint or erase host-console history.
+3. Forward TAB to the shell or implement a second filesystem scanner in the
+   host-console code. Rejected: the command is held by f4 until Enter, and a
+   second scanner would bypass remote/plugin VFSes, existing ranking, quoting,
+   colors, and replacement-span handling.
+
+## Three-pass review of the chosen solution
+
+### Pass 1 — behavior
+
+- A plain TAB with a non-empty command line asks the same autocomplete pipeline
+  used by panel mode for history and VFS path matches.
+- Host WinAPI consoles retain the popup and its keyboard navigation.
+- Host ANSI consoles complete the selected first item immediately and repaint
+  the overlay, so the command is visibly changed and TAB never reaches the
+  shell behind it.
+
+### Pass 2 — compatibility and scope
+
+- Ctrl/Alt/Shift-modified TAB, an empty line, disabled autocomplete, no-match
+  input, and overlays disabled continue through the existing shell path.
+- The fix is platform-neutral at the dispatch boundary; only the already
+  existing `consoleOverlayUsesWinAPI` capability decides whether to push or
+  accept the menu.
+- Path completion continues to use the active/passive panel VFS selection,
+  timeout, fuzzy matching, quote preservation, and replacement spans from
+  `path_hints.go`.
+
+### Pass 3 — regression and failure modes
+
+- A regression test models the reported host-console state with a real temporary
+  directory and verifies `cd sub` becomes `cd subdir/` without any PTY write.
+- Existing command-line, path-hint, host-console, and full f4 tests remain the
+  validation gate; the ARM64 binary is also rebuilt and exercised live.
+- If no completion candidate exists, the helper declines the event rather than
+  changing the line or swallowing unrelated shell input.
+
+## Conclusion
+
+The host console must complete f4-owned input before raw PTY forwarding. Reusing
+the existing menu keeps behavior consistent, while the ANSI direct-accept path
+honors the renderer's safety constraint instead of drawing a popup into an
+unreadable host buffer.

--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
 
@@ -338,6 +339,47 @@ func (pf *PanelsFrame) syncAutoCompleteSuppression() {
 		return
 	}
 	pf.cmdLine.AutoCompleteSuppressed = pf.consoleViewActive() && !consoleOverlayUsesWinAPI()
+}
+
+// handleHostConsoleTab completes a TAB in the f4-owned command line before it
+// can be forwarded to the shell behind a host-console overlay. The normal
+// autocomplete menu is safe on the WinAPI overlay because it has a native
+// renderer. ANSI host consoles cannot repaint a popup over the shell's screen
+// without a readable backing buffer, so they accept the first selectable item
+// directly and redraw only the overlay.
+func (pf *PanelsFrame) handleHostConsoleTab(e *vtinput.InputEvent) bool {
+	if e == nil || e.Type != vtinput.KeyEventType || !e.KeyDown || e.VirtualKeyCode != vtinput.VK_TAB {
+		return false
+	}
+	if e.ControlKeyState&(vtinput.LeftCtrlPressed|vtinput.RightCtrlPressed|vtinput.LeftAltPressed|vtinput.RightAltPressed|vtinput.ShiftPressed) != 0 {
+		return false
+	}
+	if pf.cmdLine == nil || pf.cmdLine.IsEmpty() || !AppConfig.CommandLineAutoComplete || vtui.FrameManager == nil {
+		return false
+	}
+
+	if ac, ok := vtui.FrameManager.GetTopFrame().(*vtui.AutoCompleteMenu); ok && ac != nil {
+		if ac.Edit != pf.cmdLine.Edit || !ac.HasMatches() {
+			return false
+		}
+		ac.ProcessKey(e)
+		pf.drawHostConsoleOverlay()
+		return true
+	}
+
+	ac := vtui.NewAutoCompleteMenu(pf.cmdLine.Edit)
+	if !ac.HasMatches() {
+		return false
+	}
+	if consoleOverlayUsesWinAPI() {
+		vtui.FrameManager.Push(ac)
+	} else {
+		// There is no safe ANSI readback for restoring the shell output under a
+		// popup. Complete the same selected item without painting the popup.
+		ac.ProcessKey(e)
+	}
+	pf.drawHostConsoleOverlay()
+	return true
 }
 
 // enterHostConsole switches the physical terminal to the primary screen and activates

--- a/cmd/f4/issue95_followup_test.go
+++ b/cmd/f4/issue95_followup_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
+)
+
+func TestIssue95_HostConsoleTabCompletesBareDirectory(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	oldConfig := AppConfig
+	t.Cleanup(func() { AppConfig = oldConfig })
+	oldProvider := vtui.PathHintProvider
+	t.Cleanup(func() { vtui.PathHintProvider = oldProvider })
+	oldAutoCompleteEnabled := vtui.AutoCompleteEnabled
+	t.Cleanup(func() { vtui.AutoCompleteEnabled = oldAutoCompleteEnabled })
+
+	AppConfig.CommandLineAutoComplete = true
+	AppConfig.ConsoleMode = ConsoleViewFar
+	AppConfig.ConsoleOverlayUI = true
+	vtui.PathHintProvider = pathHintProvider
+	vtui.AutoCompleteEnabled = true
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+	pf := setupMockPanelsFrame(t)
+	defer pf.Close()
+	pf.shellMode = ShellModeHost
+	pf.showPanels = false
+	pf.ResizeConsole(80, 25)
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "subdir"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	pf.getActivePanel().vfs = vfs.NewOSVFS(root)
+	pf.cmdLine.Edit.SetText("cd sub")
+	vtui.FrameManager.Push(pf)
+	pf.enterHostConsole()
+
+	mock := pf.pty.(*mockPty)
+	beforePTY := mock.String()
+	if handled := pf.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_TAB,
+	}); !handled {
+		t.Fatal("host console should consume Tab for command completion")
+	}
+	if got := pf.cmdLine.Edit.GetText(); got != "cd subdir/" {
+		t.Fatalf("Tab completion text = %q, want %q", got, "cd subdir/")
+	}
+	if got := mock.String(); got != beforePTY {
+		t.Fatalf("Tab completion leaked to PTY: before=%q after=%q", beforePTY, got)
+	}
+}

--- a/cmd/f4/issue95_followup_test.go
+++ b/cmd/f4/issue95_followup_test.go
@@ -50,8 +50,9 @@ func TestIssue95_HostConsoleTabCompletesBareDirectory(t *testing.T) {
 	}); !handled {
 		t.Fatal("host console should consume Tab for command completion")
 	}
-	if got := pf.cmdLine.Edit.GetText(); got != "cd subdir/" {
-		t.Fatalf("Tab completion text = %q, want %q", got, "cd subdir/")
+	want := "cd subdir" + string(filepath.Separator)
+	if got := pf.cmdLine.Edit.GetText(); got != want {
+		t.Fatalf("Tab completion text = %q, want %q", got, want)
 	}
 	if got := mock.String(); got != beforePTY {
 		t.Fatalf("Tab completion leaked to PTY: before=%q after=%q", beforePTY, got)

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -2031,6 +2031,9 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 
 	// In Far-style host console with an overlay, route editing keys to CommandLine first
 	if !pf.showPanels && pf.shellMode == ShellModeHost && pf.overlayLines() > 0 {
+		if pf.handleHostConsoleTab(e) {
+			return true
+		}
 		if e.VirtualKeyCode != vtinput.VK_RETURN {
 			if pf.cmdLine.ProcessKey(e) {
 				pf.drawHostConsoleOverlay()


### PR DESCRIPTION
## Summary

- Complete plain Tab in the f4-owned command line while a Far-style host console overlay is active.
- Reuse the existing VFS/history completion pipeline; keep the native popup on WinAPI overlays and accept the first match directly on ANSI overlays, where popup repainting is unsafe.
- Add a regression test for the reported `cd <prefix>` flow and document the three-pass solution review.

Fixes #95

## Validation

- `GOTOOLCHAIN=auto go test ./cmd/f4 -count=1`
- `CGO_ENABLED=1 GOTOOLCHAIN=auto go test -race -shuffle=on -timeout 5m -run '^TestIssue95' ./cmd/f4`
- `GOTOOLCHAIN=auto go build -o /tmp/f4-95-live-f4 ./cmd/f4`
- Native ARM64 live check in a host/Far ANSI TTY: `cd .g` + Tab became `cd .github/` and Tab was not forwarded to the shell.
- Incremental and strict `golangci-lint` both report `0 issues`.

The full repository test run passed all packages except the pre-existing X11-dependent `internal/ttyx` tests, which cannot attach/focus their windows in the current KDE/XWayland session.
