### PR TITLE
fix(text): hide UTF-8 BOM in viewer and editor

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -773,6 +773,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 	var mapped *MappedFile
 	cpID := AppConfig.EditorDefaultCodePage
 	binary := false
+	dataOffset := int64(0)
 
 	if f != nil {
 		size := f.Size()
@@ -794,6 +795,9 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 		if binary {
 			cpID = 65001
 		}
+		if cpID == 65001 && !binary && vfs.HasUTF8BOM(header) {
+			dataOffset = vfs.UTF8BOMSize
+		}
 
 		if cpID == 65001 {
 			// A local file is mapped rather than read: the mapping is one
@@ -803,7 +807,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 			// refused — keeps the lazily fetched chunk buffer.
 			if AppConfig.EditorMemoryMap {
 				var mapErr error
-				mapped, mapErr = MapEditorFile(v, f)
+				mapped, mapErr = MapEditorFileWithOffset(v, f, dataOffset)
 				if mapErr != nil && mapErr != errNotMappable {
 					vtui.DebugLog("EDITOR: memory mapping %s failed, reading lazily instead: %v", path, mapErr)
 				}
@@ -811,7 +815,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 			if mapped != nil {
 				pt = piecetable.New(mapped.Bytes())
 			} else {
-				buf = NewAsyncBuffer(context.Background(), f)
+				buf = NewAsyncBufferWithOffset(context.Background(), f, dataOffset)
 				buf.prewarm()
 				pt = piecetable.NewWithBuffer(buf)
 			}
@@ -840,6 +844,7 @@ func showEditor(pf *PanelsFrame, v vfs.VFS, path string, f vfs.ReadAtCloser) {
 	}
 	editor.Codepage = cpID
 	editor.binaryFile = binary
+	editor.utf8BOM = cpID == 65001 && dataOffset != 0
 	// StartIndexing skips hex, so binary files open without a line scan.
 	if _, isDisks := v.(*vfs.DisksVFS); isDisks || binary {
 		editor.HexMode = true
@@ -1231,11 +1236,15 @@ func actionSwitchViewerToEditor(vv *ViewerView) {
 	var buf *AsyncBuffer
 	var mapped *MappedFile
 	cpID := vv.Codepage
+	dataOffset := int64(0)
+	if vv.backend != nil {
+		dataOffset = vv.backend.dataOffset
+	}
 
 	if cpID == 65001 {
 		if AppConfig.EditorMemoryMap {
 			var mapErr error
-			mapped, mapErr = MapEditorFile(vv.vfs, f)
+			mapped, mapErr = MapEditorFileWithOffset(vv.vfs, f, dataOffset)
 			if mapErr != nil && mapErr != errNotMappable {
 				vtui.DebugLog("EDITOR: memory mapping %s failed, reading lazily instead: %v", vv.path, mapErr)
 			}
@@ -1243,7 +1252,7 @@ func actionSwitchViewerToEditor(vv *ViewerView) {
 		if mapped != nil {
 			pt = piecetable.New(mapped.Bytes())
 		} else {
-			buf = NewAsyncBuffer(ctx, f)
+			buf = NewAsyncBufferWithOffset(ctx, f, dataOffset)
 			buf.prewarm()
 			pt = piecetable.NewWithBuffer(buf)
 		}
@@ -1274,6 +1283,7 @@ func actionSwitchViewerToEditor(vv *ViewerView) {
 	editor.mapped = mapped
 	editor.Codepage = cpID
 	editor.binaryFile = vv.HexMode
+	editor.utf8BOM = cpID == 65001 && vv.backend != nil && vv.backend.dataOffset != 0
 	editor.WordWrap = vv.WrapMode
 	editor.HexMode = vv.HexMode
 	editor.DecodeMode = vv.DecodeMode

--- a/cmd/f4/async_buffer.go
+++ b/cmd/f4/async_buffer.go
@@ -13,10 +13,11 @@ import (
 // AsyncBuffer provides non-blocking access to a file, returning ErrLoading
 // and triggering background fetches when data is missing.
 type AsyncBuffer struct {
-	file      vfs.ReadAtCloser
-	size      int
-	ctx       context.Context
-	cancelCtx context.CancelFunc
+	file       vfs.ReadAtCloser
+	size       int
+	fileOffset int64
+	ctx        context.Context
+	cancelCtx  context.CancelFunc
 
 	mu        sync.Mutex
 	loaded    map[int][]byte // Chunk index -> Data
@@ -25,15 +26,34 @@ type AsyncBuffer struct {
 }
 
 func NewAsyncBuffer(ctx context.Context, f vfs.ReadAtCloser) *AsyncBuffer {
+	return NewAsyncBufferWithOffset(ctx, f, 0)
+}
+
+// NewAsyncBufferWithOffset presents the file from fileOffset onward. This is
+// used for text files whose on-disk UTF-8 BOM is metadata rather than editor
+// content; all buffer offsets remain logical offsets into the displayed text.
+func NewAsyncBufferWithOffset(ctx context.Context, f vfs.ReadAtCloser, fileOffset int64) *AsyncBuffer {
+	if fileOffset < 0 {
+		fileOffset = 0
+	}
+	rawSize := int64(0)
+	if f != nil {
+		rawSize = f.Size()
+	}
+	size := rawSize - fileOffset
+	if size < 0 {
+		size = 0
+	}
 	bCtx, bCancel := context.WithCancel(ctx)
 	return &AsyncBuffer{
-		file:      f,
-		size:      int(f.Size()),
-		ctx:       bCtx,
-		cancelCtx: bCancel,
-		loaded:    make(map[int][]byte),
-		fetching:  make(map[int]bool),
-		chunkSize: 32 * 1024, // 32 KB chunks
+		file:       f,
+		size:       int(size),
+		fileOffset: fileOffset,
+		ctx:        bCtx,
+		cancelCtx:  bCancel,
+		loaded:     make(map[int][]byte),
+		fetching:   make(map[int]bool),
+		chunkSize:  32 * 1024, // 32 KB chunks
 	}
 }
 
@@ -56,7 +76,7 @@ func (b *AsyncBuffer) prewarm() {
 		sz = b.size
 	}
 	data := make([]byte, sz)
-	n, err := b.file.ReadAt(b.ctx, data, 0)
+	n, err := b.file.ReadAt(b.ctx, data, b.fileOffset)
 	if b.ctx.Err() != nil {
 		return
 	}
@@ -128,7 +148,7 @@ func (b *AsyncBuffer) fetchChunk(idx int, frames *vtui.FrameManagerType) {
 	}
 
 	buf := make([]byte, sz)
-	n, err := b.file.ReadAt(b.ctx, buf, off)
+	n, err := b.file.ReadAt(b.ctx, buf, b.fileOffset+off)
 
 	b.mu.Lock()
 	delete(b.fetching, idx)

--- a/cmd/f4/async_buffer_test.go
+++ b/cmd/f4/async_buffer_test.go
@@ -178,6 +178,27 @@ func TestAsyncBuffer_PartialChunkAtEOF(t *testing.T) {
 		t.Errorf("EOF chunk failed: expected 'Short', got %q", string(data))
 	}
 }
+
+func TestAsyncBuffer_WithOffsetHidesFilePrefix(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	raw := append([]byte{0xEF, 0xBB, 0xBF}, []byte("visible text")...)
+	f := &vfs.MemoryReadAtCloser{Data: raw}
+	buf := NewAsyncBufferWithOffset(context.Background(), f, vfs.UTF8BOMSize)
+	defer buf.Close()
+
+	if got, want := buf.Size(), len("visible text"); got != want {
+		t.Fatalf("logical size = %d, want %d", got, want)
+	}
+	buf.prewarm()
+	data, err := buf.Read(0, len("visible text"))
+	if err != nil {
+		t.Fatalf("Read = %v", err)
+	}
+	if string(data) != "visible text" {
+		t.Fatalf("logical data = %q, want %q", string(data), "visible text")
+	}
+}
+
 func TestAsyncBuffer_ConcurrentAccess(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 

--- a/cmd/f4/bom_test.go
+++ b/cmd/f4/bom_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+func TestShowEditor_UTF8BOMIsNotDisplayedOrLostOnSave(t *testing.T) {
+	for _, memoryMap := range []bool{false, true} {
+		t.Run(map[bool]string{false: "async", true: "mapped"}[memoryMap], func(t *testing.T) {
+			vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+			drainPendingTasks()
+
+			dir := t.TempDir()
+			path := filepath.Join(dir, "bom.txt")
+			text := "first line\nsecond line\n"
+			raw := append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...)
+			if err := os.WriteFile(path, raw, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			oldMemoryMap := AppConfig.EditorMemoryMap
+			AppConfig.EditorMemoryMap = memoryMap
+			defer func() { AppConfig.EditorMemoryMap = oldMemoryMap }()
+
+			filesystem := vfs.NewOSVFS(dir)
+			pf := NewPanelsFrame()
+			pf.panels[0] = NewFileSystemPanel(0, 0, 40, 20, filesystem)
+			pf.panels[1] = NewFileSystemPanel(40, 0, 40, 20, filesystem.Clone())
+			pf.ResizeConsole(120, 60)
+			vtui.FrameManager.Push(pf)
+
+			f, err := filesystem.Open(context.Background(), path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			showEditor(pf, filesystem, path, f)
+
+			ev, _ := findOpenedEditor(filesystem, path)
+			if ev == nil {
+				t.Fatal("editor was not opened")
+			}
+			defer ev.Close()
+			if !ev.utf8BOM {
+				t.Fatal("editor did not remember the UTF-8 BOM")
+			}
+			if ev.HexMode {
+				t.Fatal("BOM-marked UTF-8 text opened in hex mode")
+			}
+			if memoryMap && ev.mapped == nil {
+				t.Fatal("mapped editor fell back to async buffer")
+			}
+			if !memoryMap && ev.asyncBuf == nil {
+				t.Fatal("async editor did not create a chunk buffer")
+			}
+
+			got, err := ev.pt.GetRange(0, ev.pt.Size())
+			if err != nil {
+				t.Fatalf("read logical editor text: %v", err)
+			}
+			if string(got) != text {
+				t.Fatalf("editor text = %q, want %q", string(got), text)
+			}
+
+			ev.modified = true
+			ev.SaveToFile(nil)
+			waitEditorSave(t, ev)
+			drainPendingTasks()
+			if ev.modified {
+				t.Fatal("editor remained modified after saving BOM-marked text")
+			}
+			got, err = os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != string(raw) {
+				t.Fatalf("saved bytes = %x, want %x", got, raw)
+			}
+		})
+	}
+}
+
+func TestQuickView_UTF8BOMIsNotDisplayed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bom.txt")
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("first\nsecond\n")...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := loadDefaultQuickView(context.Background(), vfs.NewOSVFS(dir), path)
+	if result.err != nil {
+		t.Fatalf("quick view load: %v", result.err)
+	}
+	if result.binary {
+		t.Fatal("BOM-marked UTF-8 text opened as binary in Quick View")
+	}
+	if len(result.lines) < 2 || result.lines[0] != "first" || result.lines[1] != "second" {
+		t.Fatalf("quick view lines = %#v, want first/second", result.lines)
+	}
+}

--- a/cmd/f4/bom_test.go
+++ b/cmd/f4/bom_test.go
@@ -67,6 +67,13 @@ func TestShowEditor_UTF8BOMIsNotDisplayedOrLostOnSave(t *testing.T) {
 				t.Fatalf("editor text = %q, want %q", string(got), text)
 			}
 
+			// SaveToFile replaces the buffers that the background indexer reads.
+			// Stop and join that worker first so the regression test also remains
+			// race-clean when the race shard schedules it during indexing.
+			ev.cancelIndexing()
+			ev.indexWG.Wait()
+			drainPendingTasks()
+
 			ev.modified = true
 			ev.SaveToFile(nil)
 			waitEditorSave(t, ev)

--- a/cmd/f4/bom_test.go
+++ b/cmd/f4/bom_test.go
@@ -20,7 +20,7 @@ func TestShowEditor_UTF8BOMIsNotDisplayedOrLostOnSave(t *testing.T) {
 			path := filepath.Join(dir, "bom.txt")
 			text := "first line\nsecond line\n"
 			raw := append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...)
-			if err := os.WriteFile(path, raw, 0644); err != nil {
+			if err := os.WriteFile(path, raw, 0600); err != nil {
 				t.Fatal(err)
 			}
 
@@ -88,7 +88,7 @@ func TestShowEditor_UTF8BOMIsNotDisplayedOrLostOnSave(t *testing.T) {
 func TestQuickView_UTF8BOMIsNotDisplayed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bom.txt")
-	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("first\nsecond\n")...), 0644); err != nil {
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("first\nsecond\n")...), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/editor_view.go
+++ b/cmd/f4/editor_view.go
@@ -157,6 +157,9 @@ type EditorView struct {
 	// editor was opened. Plugin-generated reports use this for their first
 	// save; normal editors continue to replace the file they opened.
 	createNewTarget bool
+	// utf8BOM records that the source file had a UTF-8 BOM. The marker is
+	// hidden from the logical editor buffer but is preserved when saving.
+	utf8BOM bool
 
 	// Autocomplete state
 	acEnabled    bool
@@ -4819,7 +4822,7 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 		// disk, which is only true for a raw UTF-8 load.
 		saved := false
 		if err == nil {
-			if patcher, ok := ev.vfs.(vfs.InPlacePatcher); ok && ev.Codepage == 65001 && !createNewTarget {
+			if patcher, ok := ev.vfs.(vfs.InPlacePatcher); ok && ev.Codepage == 65001 && !ev.utf8BOM && !createNewTarget {
 				if pieces, ok := patchPiecesFromTable(ev.pt); ok {
 					perr := patcher.PatchInPlace(ctx.Context, ev.filePath, pieces)
 					if perr == nil {
@@ -4840,7 +4843,7 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 		}
 
 		if !saved && err == nil {
-			if delta, isDelta := ev.vfs.(vfs.DeltaWriter); isDelta && useTemp && ev.Codepage == 65001 {
+			if delta, isDelta := ev.vfs.(vfs.DeltaWriter); isDelta && useTemp && ev.Codepage == 65001 && !ev.utf8BOM {
 				if pieces, ok := patchPiecesFromTable(ev.pt); ok {
 					perr := delta.PatchFile(vfs.WithDestinationOverwrite(ctx.Context, false), ev.filePath, tempPath, pieces)
 					if perr == nil {
@@ -4890,9 +4893,14 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 		if saved {
 			// The file system already wrote it.
 		} else if ev.Codepage == 65001 {
+			if ev.utf8BOM {
+				if _, errWrite := f.Write([]byte{0xEF, 0xBB, 0xBF}); errWrite != nil {
+					saveErr = errWrite
+				}
+			}
 			curr := 0
 			total := ev.pt.Size()
-			for curr < total {
+			for curr < total && saveErr == nil {
 				if ctx.Err() != nil {
 					saveErr = ctx.Err()
 					break
@@ -5015,19 +5023,28 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 		var newMapped *MappedFile
 
 		if err == nil {
+			newUTF8BOM := ev.Codepage == 65001 && ev.utf8BOM
 			if ev.Codepage == 65001 {
 				// Re-map rather than fall back to lazy chunks: a saved file is
 				// as mappable as the one that was opened, and dropping to the
 				// chunk buffer here would quietly cost every later search the
 				// copy that mapping avoids.
 				if ev.mapped != nil && AppConfig.EditorMemoryMap {
-					if m, mapErr := MapEditorFile(ev.vfs, newFile); mapErr == nil {
+					mapOffset := int64(0)
+					if newUTF8BOM {
+						mapOffset = vfs.UTF8BOMSize
+					}
+					if m, mapErr := MapEditorFileWithOffset(ev.vfs, newFile, mapOffset); mapErr == nil {
 						newMapped = m
 						newPt = piecetable.New(m.Bytes())
 					}
 				}
 				if newPt == nil {
-					newBuf = NewAsyncBuffer(ctx.Context, newFile)
+					fileOffset := int64(0)
+					if newUTF8BOM {
+						fileOffset = vfs.UTF8BOMSize
+					}
+					newBuf = NewAsyncBufferWithOffset(ctx.Context, newFile, fileOffset)
 					newPt = piecetable.NewWithBuffer(newBuf)
 				}
 			} else {
@@ -5084,6 +5101,7 @@ func (ev *EditorView) SaveToFile(afterSave func()) {
 				}
 				ev.file = newFile
 				ev.asyncBuf = newBuf
+				ev.utf8BOM = ev.Codepage == 65001 && ev.utf8BOM
 				// The old mapping described the file as it was before the
 				// save. Nothing reads through it once the piece table below
 				// points at the new one, and this runs on the UI thread, so

--- a/cmd/f4/mapped_file.go
+++ b/cmd/f4/mapped_file.go
@@ -18,7 +18,8 @@ import (
 // are clean and file-backed — which is what lets the editor hold a file larger
 // than the memory it is allowed to keep.
 type MappedFile struct {
-	data []byte
+	data   []byte
+	mapped []byte
 }
 
 // Bytes returns the mapped contents. The result aliases the mapping and must
@@ -41,11 +42,15 @@ func (m *MappedFile) Size() int {
 // Close releases the mapping. Every window handed out by Bytes becomes invalid,
 // so callers must be done reading before this runs.
 func (m *MappedFile) Close() error {
-	if m == nil || m.data == nil {
+	if m == nil || (m.data == nil && m.mapped == nil) {
 		return nil
 	}
-	data := m.data
+	data := m.mapped
+	if data == nil {
+		data = m.data
+	}
 	m.data = nil
+	m.mapped = nil
 	return unmapFileRegion(data)
 }
 
@@ -65,11 +70,19 @@ type fileDescriptor interface {
 // non-local backing has no descriptor to map, and a file too large for the
 // address space cannot be described by one slice.
 func MapEditorFile(v vfs.VFS, f vfs.ReadAtCloser) (*MappedFile, error) {
+	return MapEditorFileWithOffset(v, f, 0)
+}
+
+// MapEditorFileWithOffset maps an already opened local file and exposes it
+// from fileOffset onward. The complete mapping is retained separately so a
+// logical slice that skips a UTF-8 BOM can still be unmapped from its true
+// platform-specific base address.
+func MapEditorFileWithOffset(v vfs.VFS, f vfs.ReadAtCloser, fileOffset int64) (*MappedFile, error) {
 	if f == nil || !isLocalOSVFS(v) {
 		return nil, errNotMappable
 	}
 	size := f.Size()
-	if size <= 0 {
+	if size <= 0 || fileOffset < 0 || fileOffset >= size {
 		return nil, errNotMappable
 	}
 	if int64(int(size)) != size {
@@ -84,7 +97,7 @@ func MapEditorFile(v vfs.VFS, f vfs.ReadAtCloser) (*MappedFile, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &MappedFile{data: data}, nil
+	return &MappedFile{data: data[fileOffset:], mapped: data}, nil
 }
 
 // guardMappedFaults makes a fault on mapped memory recoverable for the calling

--- a/cmd/f4/mapped_file_test.go
+++ b/cmd/f4/mapped_file_test.go
@@ -56,6 +56,34 @@ func TestMapEditorFile_BacksThePieceTableWithoutCopying(t *testing.T) {
 	}
 }
 
+func TestMapEditorFileWithOffsetKeepsLogicalTextAndReleasesMapping(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bom.txt")
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("text")...), 0644); err != nil {
+		t.Fatal(err)
+	}
+	v := vfs.NewOSVFS(dir)
+	f, err := v.Open(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	m, err := MapEditorFileWithOffset(v, f, vfs.UTF8BOMSize)
+	if err != nil {
+		t.Fatalf("MapEditorFileWithOffset: %v", err)
+	}
+	if got := string(m.Bytes()); got != "text" {
+		t.Fatalf("mapped logical text = %q, want %q", got, "text")
+	}
+	if got := m.Size(); got != len("text") {
+		t.Fatalf("mapped logical size = %d, want %d", got, len("text"))
+	}
+	if err := m.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
 func TestMapEditorFile_DeclinesWhatItShouldNotMap(t *testing.T) {
 	dir := t.TempDir()
 

--- a/cmd/f4/mapped_file_test.go
+++ b/cmd/f4/mapped_file_test.go
@@ -59,7 +59,7 @@ func TestMapEditorFile_BacksThePieceTableWithoutCopying(t *testing.T) {
 func TestMapEditorFileWithOffsetKeepsLogicalTextAndReleasesMapping(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bom.txt")
-	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("text")...), 0644); err != nil {
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte("text")...), 0600); err != nil {
 		t.Fatal(err)
 	}
 	v := vfs.NewOSVFS(dir)
@@ -67,7 +67,11 @@ func TestMapEditorFileWithOffsetKeepsLogicalTextAndReleasesMapping(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Errorf("close source file: %v", err)
+		}
+	}()
 
 	m, err := MapEditorFileWithOffset(v, f, vfs.UTF8BOMSize)
 	if err != nil {

--- a/cmd/f4/quick_view_panel.go
+++ b/cmd/f4/quick_view_panel.go
@@ -1173,6 +1173,7 @@ func loadDefaultQuickView(parent context.Context, filesystem vfs.VFS, path strin
 	if looksBinary(decodedBuf) {
 		return quickViewFileResult{raw: append([]byte{}, buf...), codepage: cpID, autoDetect: autoDetect, binary: true, lines: hexDumpLines(buf)}
 	}
+	decodedBuf = vfs.StripUTF8BOM(decodedBuf)
 	return quickViewFileResult{
 		raw:        append([]byte{}, buf...),
 		codepage:   cpID,

--- a/cmd/f4/viewer_backend.go
+++ b/cmd/f4/viewer_backend.go
@@ -12,9 +12,10 @@ import (
 
 // ViewerBackend provides async random access to a file using small cache window.
 type ViewerBackend struct {
-	file     vfs.ReadAtCloser
-	size     int64
-	codepage int
+	file       vfs.ReadAtCloser
+	size       int64
+	codepage   int
+	dataOffset int64 // bytes skipped from the on-disk file (the UTF-8 BOM)
 
 	path    string
 	owner   vfs.VFS
@@ -76,10 +77,15 @@ func (b *ViewerBackend) Size() int64 {
 	// refreshing the size -- jumpToEnd runs Size through RunAsync while Show
 	// is calling it too. Both go through the mutex now.
 	if b.file != nil {
-		newSize := b.file.Size()
+		newSize := b.file.Size() - b.dataOffset
+		if newSize < 0 {
+			newSize = 0
+		}
 		b.mu.Lock()
 		b.size = newSize
+		size := b.size
 		b.mu.Unlock()
+		return size
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -129,7 +135,7 @@ func (b *ViewerBackend) ReadAt(offset int64, length int) ([]byte, error) {
 		frames := vtui.FrameManager
 		go func() {
 			buf := make([]byte, fetchLen)
-			n, err := b.file.ReadAt(b.ctx, buf, fetchOff)
+			n, err := b.file.ReadAt(b.ctx, buf, b.dataOffset+fetchOff)
 
 			var cached []byte
 			if n > 0 {
@@ -181,8 +187,9 @@ func (b *ViewerBackend) SearchFrom(ctx context.Context, pattern string, off int6
 		return 0, false
 	}
 	for at := range matches {
-		if at >= off {
-			return at, true
+		logicalAt := at - b.dataOffset
+		if logicalAt >= off {
+			return logicalAt, true
 		}
 	}
 	return -1, true
@@ -200,8 +207,9 @@ func (b *ViewerBackend) SearchBefore(ctx context.Context, pattern string, off in
 	}
 	last := int64(-1)
 	for at := range matches {
-		if at < off && at > last {
-			last = at
+		logicalAt := at - b.dataOffset
+		if logicalAt < off && logicalAt > last {
+			last = logicalAt
 		}
 	}
 	return last, true
@@ -223,7 +231,11 @@ func (b *ViewerBackend) LineStart(ctx context.Context, line int64) (int64, bool)
 		idx, err := b.indexer.LineIndex(ctx, b.path, line, 1)
 		if err == nil {
 			if len(idx.Offsets) > 0 {
-				return idx.Offsets[0], true
+				start := idx.Offsets[0] - b.dataOffset
+				if start < 0 {
+					start = 0
+				}
+				return start, true
 			}
 			// The far side counted the file and the line is not in it.
 			if idx.Total >= 0 && line > idx.Total {
@@ -240,7 +252,7 @@ func (b *ViewerBackend) LineStart(ctx context.Context, line int64) (int64, bool)
 		if ctx.Err() != nil {
 			return 0, false
 		}
-		n, err := b.file.ReadAt(ctx, buf, off)
+		n, err := b.file.ReadAt(ctx, buf, b.dataOffset+off)
 		for i := 0; i < n; i++ {
 			if buf[i] != '\n' {
 				continue
@@ -305,7 +317,11 @@ func (b *ViewerBackend) LineStartFromEnd(ctx context.Context, n int64) (int64, b
 	if err != nil || len(idx.Offsets) == 0 {
 		return 0, false
 	}
-	return idx.Offsets[0], true
+	start := idx.Offsets[0] - b.dataOffset
+	if start < 0 {
+		start = 0
+	}
+	return start, true
 }
 func (b *ViewerBackend) FindLineStart(offset int64) int64 {
 	if offset <= 0 {

--- a/cmd/f4/viewer_backend_test.go
+++ b/cmd/f4/viewer_backend_test.go
@@ -380,7 +380,7 @@ func TestViewerBackend_UTF8BOMUsesLogicalOffsets(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bom.txt")
 	text := "first\nsecond needle\n"
-	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0644); err != nil {
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0600); err != nil {
 		t.Fatal(err)
 	}
 
@@ -393,7 +393,12 @@ func TestViewerBackend_UTF8BOMUsesLogicalOffsets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vb.Close()
+	indexedBackend := vb
+	defer func() {
+		if err := indexedBackend.Close(); err != nil {
+			t.Errorf("close viewer backend: %v", err)
+		}
+	}()
 	vb.dataOffset = vfs.UTF8BOMSize
 	vb.size = int64(len(text))
 
@@ -412,14 +417,18 @@ func TestViewerBackend_UTF8BOMUsesLogicalOffsets(t *testing.T) {
 		offsets: []int64{16}, // raw offset: BOM (3) + len("first\nsecond ") (13)
 		can:     true,
 	}
-	vb, err = NewViewerBackend(context.Background(), searching, path)
+	searchBackend, err := NewViewerBackend(context.Background(), searching, path)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer vb.Close()
-	vb.dataOffset = vfs.UTF8BOMSize
-	vb.size = int64(len(text))
-	if got, ok := vb.SearchFrom(context.Background(), "needle", 0); !ok || got != 13 {
+	defer func() {
+		if err := searchBackend.Close(); err != nil {
+			t.Errorf("close viewer backend: %v", err)
+		}
+	}()
+	searchBackend.dataOffset = vfs.UTF8BOMSize
+	searchBackend.size = int64(len(text))
+	if got, ok := searchBackend.SearchFrom(context.Background(), "needle", 0); !ok || got != 13 {
 		t.Fatalf("SearchFrom = %d, %v; want 13, true", got, ok)
 	}
 }

--- a/cmd/f4/viewer_backend_test.go
+++ b/cmd/f4/viewer_backend_test.go
@@ -375,6 +375,55 @@ func TestViewerSearchOffsetBothDirections(t *testing.T) {
 		t.Fatalf("backward previous offset = %d, want 5", got)
 	}
 }
+
+func TestViewerBackend_UTF8BOMUsesLogicalOffsets(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bom.txt")
+	text := "first\nsecond needle\n"
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	indexed := &indexingVFS{
+		VFS:     vfs.NewOSVFS(dir),
+		offsets: []int64{3, 9},
+		total:   2,
+	}
+	vb, err := NewViewerBackend(context.Background(), indexed, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vb.Close()
+	vb.dataOffset = vfs.UTF8BOMSize
+	vb.size = int64(len(text))
+
+	if got := vb.Size(); got != int64(len(text)) {
+		t.Fatalf("logical size = %d, want %d", got, len(text))
+	}
+	if got, ok := vb.LineStart(context.Background(), 2); !ok || got != int64(len("first\n")) {
+		t.Fatalf("LineStart(2) = %d, %v; want %d, true", got, ok, len("first\n"))
+	}
+	if got, ok := vb.LineStartFromEnd(context.Background(), 1); !ok || got != int64(len("first\n")) {
+		t.Fatalf("LineStartFromEnd(1) = %d, %v; want %d, true", got, ok, len("first\n"))
+	}
+
+	searching := &searchingVFS{
+		VFS:     vfs.NewOSVFS(dir),
+		offsets: []int64{16}, // raw offset: BOM (3) + len("first\nsecond ") (13)
+		can:     true,
+	}
+	vb, err = NewViewerBackend(context.Background(), searching, path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vb.Close()
+	vb.dataOffset = vfs.UTF8BOMSize
+	vb.size = int64(len(text))
+	if got, ok := vb.SearchFrom(context.Background(), "needle", 0); !ok || got != 13 {
+		t.Fatalf("SearchFrom = %d, %v; want 13, true", got, ok)
+	}
+}
+
 func TestViewerBackendLineStart(t *testing.T) {
 	dir := t.TempDir()
 	tmp := filepath.Join(dir, "test.txt")

--- a/cmd/f4/viewer_view.go
+++ b/cmd/f4/viewer_view.go
@@ -61,10 +61,12 @@ func NewViewerView(ctx context.Context, v vfs.VFS, path string) (*ViewerView, er
 		detectLen = int(size)
 	}
 	header := make([]byte, detectLen)
-	if _, err := f.ReadAt(ctx, header, 0); err != nil && err != io.EOF {
+	n, err := f.ReadAt(ctx, header, 0)
+	if err != nil && err != io.EOF {
 		_ = f.Close()
 		return nil, fmt.Errorf("read file header: %w", err)
 	}
+	header = header[:n]
 
 	cpID := vfs.DetectEncoding(header, AppConfig.ViewerAutodetectCodePage, AppConfig.ViewerDefaultCodePage)
 	binary := viewerHeaderLooksBinary(header, cpID)
@@ -73,8 +75,12 @@ func NewViewerView(ctx context.Context, v vfs.VFS, path string) (*ViewerView, er
 		// handle lets the hex viewer fetch only its small visible windows.
 		cpID = 65001
 	}
+	dataOffset := int64(0)
+	if cpID == 65001 && !binary && vfs.HasUTF8BOM(header) {
+		dataOffset = vfs.UTF8BOMSize
+	}
 
-	backend, err := newViewerBackend(ctx, v, path, f, cpID)
+	backend, err := newViewerBackend(ctx, v, path, f, cpID, dataOffset)
 	if err != nil {
 		_ = f.Close()
 		return nil, err
@@ -791,7 +797,25 @@ func (vv *ViewerView) ReloadWithCodepage(cpID int) {
 		// those bytes with a decoded text stream.
 		backendCP = 65001
 	}
-	backend, err := newViewerBackend(context.Background(), vv.vfs, vv.path, f, backendCP)
+	dataOffset := int64(0)
+	if backendCP == 65001 && !vv.HexMode {
+		size := f.Size()
+		detectLen := 16 * 1024
+		if int64(detectLen) > size {
+			detectLen = int(size)
+		}
+		header := make([]byte, detectLen)
+		n, readErr := f.ReadAt(context.Background(), header, 0)
+		if readErr != nil && readErr != io.EOF {
+			_ = f.Close()
+			return
+		}
+		header = header[:n]
+		if !viewerHeaderLooksBinary(header, backendCP) && vfs.HasUTF8BOM(header) {
+			dataOffset = vfs.UTF8BOMSize
+		}
+	}
+	backend, err := newViewerBackend(context.Background(), vv.vfs, vv.path, f, backendCP, dataOffset)
 	if err != nil {
 		_ = f.Close()
 		return
@@ -843,7 +867,7 @@ func (vv *ViewerView) ReloadWithCodepage(cpID int) {
 // followed by an F8 switch. Non-UTF-8 files are materialized into the same
 // memory-backed stream that the old viewer used, while UTF-8 keeps the lazy
 // windowed backend for large files and remote VFSes.
-func newViewerBackend(ctx context.Context, owner vfs.VFS, path string, f vfs.ReadAtCloser, cpID int) (*ViewerBackend, error) {
+func newViewerBackend(ctx context.Context, owner vfs.VFS, path string, f vfs.ReadAtCloser, cpID int, dataOffset int64) (*ViewerBackend, error) {
 	if cpID != 65001 {
 		size := f.Size()
 		maxInt := int64(int(^uint(0) >> 1))
@@ -872,14 +896,18 @@ func newViewerBackend(ctx context.Context, owner vfs.VFS, path string, f vfs.Rea
 		}, nil
 	}
 
-	size := f.Size()
+	logicalSize := f.Size() - dataOffset
+	if logicalSize < 0 {
+		logicalSize = 0
+	}
 	bCtx, bCancel := context.WithCancel(context.Background())
 	backend := &ViewerBackend{
 		file:         f,
-		size:         size,
+		size:         logicalSize,
 		path:         path,
 		owner:        owner,
 		codepage:     cpID,
+		dataOffset:   dataOffset,
 		totalLines:   -1,
 		totalForSize: -1,
 		ctx:          bCtx,
@@ -904,7 +932,8 @@ func (vv *ViewerView) ReloadWithAutoDetect() {
 		detectLen = int(size)
 	}
 	header := make([]byte, detectLen)
-	_, _ = f.ReadAt(context.Background(), header, 0)
+	n, _ := f.ReadAt(context.Background(), header, 0)
+	header = header[:n]
 
 	cpID := vfs.DetectEncoding(header, AppConfig.ViewerAutodetectCodePage, AppConfig.ViewerDefaultCodePage)
 	vv.ReloadWithCodepage(cpID)

--- a/cmd/f4/viewer_view_test.go
+++ b/cmd/f4/viewer_view_test.go
@@ -953,7 +953,7 @@ func TestViewerView_UTF8BOMIsNotDisplayed(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "bom.txt")
 	text := "first line\nsecond line\n"
-	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0644); err != nil {
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/cmd/f4/viewer_view_test.go
+++ b/cmd/f4/viewer_view_test.go
@@ -947,6 +947,56 @@ func TestViewerView_Codepages_Load(t *testing.T) {
 		t.Errorf("Viewer failed to decode CP866: expected 'Привет', got %q", string(data))
 	}
 }
+
+func TestViewerView_UTF8BOMIsNotDisplayed(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bom.txt")
+	text := "first line\nsecond line\n"
+	if err := os.WriteFile(path, append([]byte{0xEF, 0xBB, 0xBF}, []byte(text)...), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	vv, err := NewViewerView(context.Background(), vfs.NewOSVFS(dir), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer vv.Close()
+
+	if vv.backend.dataOffset != vfs.UTF8BOMSize {
+		t.Fatalf("viewer data offset = %d, want %d", vv.backend.dataOffset, vfs.UTF8BOMSize)
+	}
+	if got, want := vv.backend.Size(), int64(len(text)); got != want {
+		t.Fatalf("viewer logical size = %d, want %d", got, want)
+	}
+
+	var data []byte
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if time.Now().After(deadline) {
+			t.Fatal("timeout waiting for BOM-stripped viewer data")
+		}
+		data, err = vv.backend.ReadAt(0, len(text))
+		if err == nil {
+			break
+		}
+		if err != piecetable.ErrLoading {
+			t.Fatalf("viewer ReadAt = %v", err)
+		}
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	if string(data) != text {
+		t.Fatalf("viewer text = %q, want %q", string(data), text)
+	}
+	if got, ok := vv.backend.LineStart(context.Background(), 2); !ok || got != int64(len("first line\n")) {
+		t.Fatalf("LineStart(2) = %d, %v; want %d, true", got, ok, len("first line\n"))
+	}
+}
+
 func TestViewerView_Codepages_AutoDetect(t *testing.T) {
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	tmpDir := t.TempDir()

--- a/vfs/codepages.go
+++ b/vfs/codepages.go
@@ -24,6 +24,8 @@ type Codepage struct {
 
 var AvailableCodepages []Codepage
 
+const UTF8BOMSize = 3
+
 func init() {
 	AvailableCodepages = []Codepage{
 		{65001, "UTF-8", unicode.UTF8},
@@ -119,7 +121,7 @@ func EncodeBytes(data []byte, cpID int) ([]byte, error) {
 }
 
 func DetectBOM(data []byte) (int, bool) {
-	if len(data) >= 3 && data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF {
+	if HasUTF8BOM(data) {
 		return 65001, true
 	}
 	if len(data) >= 2 {
@@ -131,6 +133,24 @@ func DetectBOM(data []byte) (int, bool) {
 		}
 	}
 	return 65001, false
+}
+
+// HasUTF8BOM reports whether data starts with the UTF-8 byte-order mark.
+// Detection and removal are separate because the marker is useful for
+// choosing the codepage, while it is not part of the text shown to a user.
+func HasUTF8BOM(data []byte) bool {
+	return len(data) >= UTF8BOMSize &&
+		data[0] == 0xEF && data[1] == 0xBB && data[2] == 0xBF
+}
+
+// StripUTF8BOM returns data without a leading UTF-8 byte-order mark. It keeps
+// the original slice when there is no marker, so callers can use it on hot
+// paths without an allocation.
+func StripUTF8BOM(data []byte) []byte {
+	if !HasUTF8BOM(data) {
+		return data
+	}
+	return data[UTF8BOMSize:]
 }
 
 func DetectEncoding(data []byte, autodetect bool, defaultCP int) int {

--- a/vfs/codepages_test.go
+++ b/vfs/codepages_test.go
@@ -34,6 +34,25 @@ func TestCodepages_Basic(t *testing.T) {
 	}
 }
 
+func TestCodepages_StripUTF8BOM(t *testing.T) {
+	withBOM := []byte{0xEF, 0xBB, 0xBF, 't', 'e', 'x', 't'}
+	if !HasUTF8BOM(withBOM) {
+		t.Fatal("UTF-8 BOM was not detected")
+	}
+	if got := string(StripUTF8BOM(withBOM)); got != "text" {
+		t.Fatalf("stripped text = %q, want %q", got, "text")
+	}
+
+	withoutBOM := []byte("text")
+	if HasUTF8BOM(withoutBOM) {
+		t.Fatal("plain UTF-8 was reported as BOM-marked")
+	}
+	stripped := StripUTF8BOM(withoutBOM)
+	if &stripped[0] != &withoutBOM[0] {
+		t.Fatal("stripping a missing BOM allocated or copied the input")
+	}
+}
+
 func TestCodepages_GetSystemEncoding(t *testing.T) {
 	oem := GetSystemOEMEncoding()
 	ansi := GetSystemANSIEncoding()


### PR DESCRIPTION
Fixes #865

I, zoin-bot, fixed the UTF-8 BOM display bug in both Editor and Viewer.

Root cause:
- UTF-8 BOM bytes were used for detection but remained in the logical text stream, so the first line rendered U+FEFF.

Fix:
- keep the BOM as file metadata and expose text from a logical offset in lazy and memory-mapped buffers;
- apply the same offset to Viewer, Editor, Viewer-to-Editor conversion, reloads, line/search offsets, and Quick View;
- preserve the BOM when saving UTF-8 files while retaining raw bytes for binary/hex mode;
- add regression coverage for the shared helper, buffers, viewer offsets, editor open/save, and Quick View.

Validation on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland with XWayland):
- focused BOM tests, the cmd/f4 and vfs package tests, race tests, and go vet passed locally;
- built and ran the ARM64 binary in a real attached ANSI TTY: a UTF-8 BOM file opened directly in Editor showed `first line` without a leading marker; switching to Viewer in `Text` mode showed `first line`, `second line`, and `third line` without the marker;
- after the live run, the source file still began with `ef bb bf`;
- all GitHub CI test, race, lint, vet, quality, cross-build, and packaging checks passed.

— zoin-bot
