### PR TITLE
fix(terminal): clear stale mouse selections on screen changes

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -1876,6 +1876,16 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	alt := (e.ControlKeyState & (vtinput.LeftAltPressed | vtinput.RightAltPressed)) != 0
 	shift := (e.ControlKeyState & vtinput.ShiftPressed) != 0
 
+	// A keyboard action starts a new terminal interaction. Clear the old
+	// mouse highlight before forwarding the key to a shell or terminal app;
+	// otherwise it remains painted until another mouse click.
+	if !pf.showPanels && e.Type == vtinput.KeyEventType && e.KeyDown && pf.termView.HasSelection() {
+		pf.termView.ClearSelection()
+		if vtui.FrameManager != nil {
+			vtui.FrameManager.Redraw()
+		}
+	}
+
 	// Workspace switching is global and must remain reachable while a child
 	// process owns the terminal. Returning false lets FrameManager handle both
 	// directions instead of forwarding the key to an AltScreen application or

--- a/cmd/f4/terminal_selection_test.go
+++ b/cmd/f4/terminal_selection_test.go
@@ -127,6 +127,70 @@ func TestTerminalSelection_ClearAndEmpty(t *testing.T) {
 	}
 }
 
+func TestTerminalSelection_ClearedWhenScreenLifecycleChanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		change func(*TerminalView)
+	}{
+		{
+			name: "full erase",
+			change: func(tv *TerminalView) {
+				tv.EraseDisplay(2, DefaultTermAttr)
+			},
+		},
+		{
+			name: "reset",
+			change: func(tv *TerminalView) {
+				tv.ResetBuffer(20, 6)
+			},
+		},
+		{
+			name: "resize",
+			change: func(tv *TerminalView) {
+				tv.Resize(21, 7)
+			},
+		},
+		{
+			name: "move",
+			change: func(tv *TerminalView) {
+				tv.SetPosition(1, 0, 20, 5)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tv := newSelectableTV(20, 6)
+			defer tv.Close()
+			tv.StartSelection(1, 1, false)
+			tv.ExtendSelection(4, 1)
+
+			test.change(tv)
+			if tv.HasSelection() {
+				t.Fatalf("selection survived %s", test.name)
+			}
+		})
+	}
+
+	t.Run("alternate screen", func(t *testing.T) {
+		tv := newSelectableTV(20, 6)
+		defer tv.Close()
+		tv.StartSelection(1, 1, false)
+		tv.ExtendSelection(4, 1)
+		tv.SetAltScreen(true)
+		if tv.HasSelection() {
+			t.Fatal("selection survived entering the alternate screen")
+		}
+
+		tv.StartSelection(1, 1, false)
+		tv.ExtendSelection(4, 1)
+		tv.SetAltScreen(false)
+		if tv.HasSelection() {
+			t.Fatal("selection survived returning to the primary screen")
+		}
+	})
+}
+
 func TestTerminalSelection_HighlightInvertsCells(t *testing.T) {
 	tv := newSelectableTV(20, 6)
 	defer tv.Close()
@@ -264,6 +328,22 @@ func TestPanelsFrame_TerminalMouseSelect_Drag(t *testing.T) {
 	}
 	if got := tv.ExtractSelection(); got != "llo w" {
 		t.Errorf("post-release extract: got %q, want %q", got, "llo w")
+	}
+}
+
+func TestPanelsFrame_TerminalMouseSelect_KeyDownClearsHighlight(t *testing.T) {
+	pf, _ := panelsFrameWithMouseSelect(t)
+	tv := pf.termView
+	tv.StartSelection(2, 0, false)
+	tv.ExtendSelection(6, 0)
+
+	pf.ProcessKey(&vtinput.InputEvent{
+		Type:    vtinput.KeyEventType,
+		KeyDown: true,
+		Char:    'x',
+	})
+	if tv.HasSelection() {
+		t.Fatal("a key-down should clear the terminal mouse highlight")
 	}
 }
 

--- a/cmd/f4/terminal_view.go
+++ b/cmd/f4/terminal_view.go
@@ -208,6 +208,10 @@ func (tv *TerminalView) CloneStateFrom(other *TerminalView) {
 	tv.ScrollTop, tv.ScrollBottom = other.ScrollTop, other.ScrollBottom
 	tv.KittyFlags = other.KittyFlags
 	tv.KittyFlagsStack = append([]int(nil), other.KittyFlagsStack...)
+	// Selection coordinates belong to the old viewport and are not part of
+	// the cloned terminal state. Keeping them would paint a stale highlight
+	// over the clone's first screen.
+	tv.selActive = false
 	// The PTY is an ownership handle, not terminal display state. A cloned
 	// PanelsFrame starts its own shell asynchronously; copying this field would
 	// briefly route input from the clone into the source workspace until that
@@ -228,6 +232,10 @@ func (tv *TerminalView) CloneStateFrom(other *TerminalView) {
 func (tv *TerminalView) ResetBuffer(w, h int) {
 	tv.mu.Lock()
 	defer tv.mu.Unlock()
+
+	// RIS replaces both terminal screens, so any screen-coordinate selection
+	// from before the reset is no longer meaningful.
+	tv.selActive = false
 
 	// Инициализация PieceTable (только один раз)
 	if tv.pt == nil {
@@ -753,6 +761,11 @@ func (tv *TerminalView) EraseDisplay(mode int, attr uint64) {
 	if tv.Muted {
 		return
 	}
+	if mode == 2 {
+		// ED 2 replaces the visible screen. Do not keep painting the old
+		// screen-coordinate selection over the newly cleared contents.
+		tv.selActive = false
+	}
 
 	if (mode == 2 || mode == 3) && !tv.UseAltScreen {
 		// Сохраняем экран в историю перед очисткой (игнорируя пустоту снизу)
@@ -847,6 +860,9 @@ func (tv *TerminalView) SetAltScreen(enable bool) {
 	if tv.UseAltScreen == enable {
 		return
 	}
+	// The alternate and primary screens have independent contents and can
+	// have different geometry, so a selection cannot safely cross the switch.
+	tv.selActive = false
 	if enable {
 		tv.savedX, tv.savedY = tv.CursorX, tv.CursorY
 		tv.CursorX, tv.CursorY = 0, 0
@@ -973,6 +989,19 @@ func (tv *TerminalView) Show(scr *vtui.ScreenBuf) {
 	} else if tv.IsVisible() && tv.IsFocused() {
 		scr.SetCursorVisible(false)
 	}
+}
+
+// SetPosition keeps a mouse selection tied to the viewport it came from.
+// ResizeConsole changes the terminal's position before it knows whether the
+// dimensions also changed, so clearing only from Resize would leave a stale
+// highlight when panels are hidden or restored at the same size.
+func (tv *TerminalView) SetPosition(x1, y1, x2, y2 int) {
+	tv.mu.Lock()
+	defer tv.mu.Unlock()
+	if tv.X1 != x1 || tv.Y1 != y1 || tv.X2 != x2 || tv.Y2 != y2 {
+		tv.selActive = false
+	}
+	tv.ScreenObject.SetPosition(x1, y1, x2, y2)
 }
 
 // selectionScreenRect returns the normalised screen-coordinate
@@ -1397,6 +1426,10 @@ func (tv *TerminalView) Resize(w, h int) {
 
 	tv.mu.Lock()
 	defer tv.mu.Unlock()
+
+	// Resizing changes the mapping between screen coordinates and grid cells;
+	// retaining the old selection is what lets it spill into a new layout.
+	tv.selActive = false
 
 	tv.engine.SetWidth(w)
 


### PR DESCRIPTION
Fixes #864

The terminal mouse highlight used absolute viewport coordinates but survived full-screen clears, terminal reset, alternate-screen transitions, and viewport geometry changes. That left the old selection painted over blank output or a nested `f4 --tty` screen, and keyboard input could not dismiss it.

This clears stale selection state whenever the screen or viewport is replaced, and on the next key-down while panels are hidden. Partial erase operations retain their existing selection semantics. Regression tests cover all lifecycle paths and the mouse event pipeline.

Validation on Linux aarch64 (Fedora Asahi Remix 44, KDE Plasma Wayland with XWayland):
- `GOTOOLCHAIN=auto go test ./... -count=1` (all packages except pre-existing XWayland-dependent `internal/ttyx` BadMatch/geometry tests)
- focused selection tests, package tests, race tests, and `go vet` passed
- native ARM64 X11 GUI run reproduced the stale highlight before the fix and confirmed drag selection followed by `Ctrl+L` removes it after the fix

— zoin-bot