### PR TITLE
fix: preserve native workspace shortcuts in menus

### DIFF
--- a/cmd/f4/action_menu.go
+++ b/cmd/f4/action_menu.go
@@ -51,9 +51,7 @@ func BuildMenuBarItems(area string) []vtui.MenuBarItem {
 			OnClick:  func() { RunAction(a.Name) },
 			UserData: menuHistoryItemKey(a.Name),
 		}
-		if hm := GlobalHotkeysMgr; hm != nil {
-			item.Shortcut = FormatKeyForUI(hm.GetKeyForAction(area, a.Name))
-		}
+		item.Shortcut = MenuShortcutsForAction(area, a.Name)
 		if a.MenuLast {
 			if a.MenuSeparatorBefore {
 				m.pinned = append(m.pinned, vtui.MenuItem{Separator: true})

--- a/cmd/f4/hotkeys.go
+++ b/cmd/f4/hotkeys.go
@@ -340,6 +340,23 @@ func NativeShortcutsForAction(area string, action Action) []string {
 	return shortcuts
 }
 
+// MenuShortcutsForAction combines configurable and framework-owned shortcuts
+// for a menu item. Native shortcuts deliberately do not live in
+// HotkeyManager.Defaults, because the focused frame must get first chance to
+// consume them; menu presentation still needs to advertise them.
+func MenuShortcutsForAction(area, actionName string) string {
+	var groups [][]string
+	if GlobalHotkeysMgr != nil {
+		if key := GlobalHotkeysMgr.GetKeyForAction(area, actionName); key != "" {
+			groups = append(groups, []string{FormatKeyForUI(key)})
+		}
+	}
+	if action, ok := GetAction(actionName); ok {
+		groups = append(groups, NativeShortcutsForAction(area, action))
+	}
+	return strings.Join(mergeCommandPaletteShortcuts(groups...), ", ")
+}
+
 // nativeShortcutOwnedByCurrentContext filters framework fallbacks that never
 // reach the advertised action in the active frame. This is separate from
 // HotkeyManager overrides: these keys are consumed directly by the frame
@@ -348,7 +365,7 @@ func nativeShortcutOwnedByCurrentContext(actionName, key string) bool {
 	if vtui.FrameManager == nil {
 		return false
 	}
-	top := vtui.FrameManager.GetTopFrame()
+	top := nativeShortcutContextFrame()
 	if top == nil {
 		return false
 	}
@@ -398,6 +415,24 @@ func nativeShortcutOwnedByCurrentContext(actionName, key string) bool {
 		return true
 	}
 	return false
+}
+
+// nativeShortcutContextFrame returns the frame whose input context is being
+// described by a menu. A VMenu is temporarily placed above its owner while it
+// is painted, but it must not make the owner's native shortcuts disappear
+// from the menu labels themselves.
+func nativeShortcutContextFrame() vtui.Frame {
+	top := vtui.FrameManager.GetTopFrame()
+	if top == nil || top.GetType() != vtui.TypeMenu {
+		return top
+	}
+	frames := vtui.FrameManager.GetActiveFrames(vtui.FrameManager.ActiveIdx)
+	for i := len(frames) - 1; i >= 0; i-- {
+		if frames[i] != nil && frames[i].GetType() != vtui.TypeMenu {
+			return frames[i]
+		}
+	}
+	return nil
 }
 
 func nativeShortcutConditionTrue(area, condition string) bool {

--- a/cmd/f4/panel_menu_test.go
+++ b/cmd/f4/panel_menu_test.go
@@ -95,3 +95,50 @@ func TestPanelsFrame_SideMenuExposesWorkspaceHotkeys(t *testing.T) {
 		}
 	}
 }
+
+func TestPanelsFrame_GetMenuBarKeepsNativeWorkspaceHotkeys(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	oldHotkeys := GlobalHotkeysMgr
+	GlobalHotkeysMgr = NewHotkeyManager("")
+	t.Cleanup(func() { GlobalHotkeysMgr = oldHotkeys })
+
+	pf := setupMockPanelsFrame(t)
+	t.Cleanup(pf.Close)
+	vtui.FrameManager.Push(pf)
+	menuFrame := vtui.NewVMenu("test")
+	vtui.FrameManager.Push(menuFrame)
+	t.Cleanup(func() { vtui.FrameManager.Pop() })
+
+	find := func(command int) *vtui.MenuItem {
+		menu := pf.GetMenuBar()
+		for i := range menu.Items[0].SubItems {
+			item := &menu.Items[0].SubItems[i]
+			if item.Command == command {
+				return item
+			}
+		}
+		return nil
+	}
+
+	if item := find(CmWorkspaceNew); item == nil || item.Shortcut != "Ctrl+N" {
+		if item == nil {
+			t.Fatal("Left menu has no New workspace item after GetMenuBar refresh")
+		}
+		t.Fatalf("New workspace shortcut after GetMenuBar refresh = %q, want Ctrl+N", item.Shortcut)
+	}
+	if item := find(CmWorkspaceClose); item == nil || item.Shortcut != "Ctrl+W" {
+		if item == nil {
+			t.Fatal("Left menu has no Close workspace item after GetMenuBar refresh")
+		}
+		t.Fatalf("Close workspace shortcut after GetMenuBar refresh = %q, want Ctrl+W", item.Shortcut)
+	}
+
+	GlobalHotkeysMgr.Bind("Shell", "CtrlN", "None")
+	if item := find(CmWorkspaceNew); item == nil || item.Shortcut != "" {
+		if item == nil {
+			t.Fatal("Left menu lost New workspace item after explicit unbind")
+		}
+		t.Fatalf("explicitly unbound New workspace shortcut = %q, want empty", item.Shortcut)
+	}
+}

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -808,7 +808,9 @@ func (pf *PanelsFrame) updateMenuCheckmarks() {
 		pf.menuBar.Items[4].SubItems[i+5].Text = getSortMenuText(rSort, item.mode, "&"+Msg("Menu."+item.key))
 	}
 
-	// Update shortcuts dynamically from HotkeyManager
+	// Update shortcuts dynamically from the action registry. Framework-owned
+	// native keys are intentionally absent from HotkeyManager defaults, but
+	// custom side menus must still advertise them (issue #651).
 	if hm := GlobalHotkeysMgr; hm != nil {
 		area := "Shell"
 		for i := range pf.menuBar.Items {
@@ -818,11 +820,7 @@ func (pf *PanelsFrame) updateMenuCheckmarks() {
 					if shortcutAction, exists := commandShortcutActionName[sub.Command]; exists {
 						actName = shortcutAction
 					}
-					if key := hm.GetKeyForAction(area, actName); key != "" {
-						sub.Shortcut = FormatKeyForUI(key)
-					} else {
-						sub.Shortcut = ""
-					}
+					sub.Shortcut = MenuShortcutsForAction(area, actName)
 				}
 			}
 		}

--- a/docs/ISSUES/ISSUE_651_SOLUTION_REVIEW.md
+++ b/docs/ISSUES/ISSUE_651_SOLUTION_REVIEW.md
@@ -140,3 +140,30 @@ Submit the generic initial-window fix to vtui and keep the disputed Panel
 settings layout out of scope. Do not change f4's already-correct Left-menu
 bindings or invent a second GUI-mode setting until a backend-neutral native
 window-state API exists.
+
+## Follow-up: the refreshed Left menu erased native workspace shortcuts
+
+The reporter's next retest identified a real regression in the previous
+workspace-menu coverage. `leftMenu` initially supplied `Ctrl+N` and `Ctrl+W`,
+but `GetMenuBar` rebuilt the menu and then replaced those values with the
+empty result of `HotkeyManager.GetKeyForAction`. The two shortcuts are
+framework-owned `NativeKeys`, not configurable defaults, so the displayed
+keys disappeared even though the actions still worked.
+
+### Three solution passes
+
+1. Keep the literal `Ctrl+N`/`Ctrl+W` values in the side menu. Rejected: the
+   dynamic refresh still erases them and it would ignore user overrides,
+   terminal ownership, queue vetoes, and future native actions.
+2. Install native workspace keys as ordinary hotkey defaults. Rejected: the
+   focused frame must receive these keys before the framework fallback, and
+   turning them into configurable defaults changes dispatch precedence.
+3. Resolve menu shortcuts through the action registry, merging the active
+   configurable binding with `NativeShortcutsForAction`. Selected: it keeps
+   dispatch ownership unchanged while making every menu refresh truthful and
+   respecting explicit unbinds or context-specific ownership.
+
+The follow-up regression covers the actual `GetMenuBar` refresh path for both
+Left-menu workspace entries and verifies that an explicit `Ctrl+N=None`
+override is reflected. The disputed Panel settings layout remains out of
+scope.


### PR DESCRIPTION
I am zoin-bot. This PR fixes the remaining actionable part of issue #651: native workspace shortcuts disappeared from the Left menu after the menu bar was refreshed.

Root cause: `GetMenuBar` refreshed custom side-menu items through configurable hotkey bindings only. `Workspace.New` and `Workspace.Close` intentionally expose `Ctrl+N` and `Ctrl+W` as framework-owned `NativeKeys`, so the refresh replaced their labels with empty shortcuts.

The fix centralizes menu shortcut resolution through the action registry, combines configurable and native shortcuts, preserves explicit `None` overrides, and evaluates native ownership against the frame below an open `VMenu`. The same resolver is used by generated action menus. A regression test covers refresh while a menu frame is on top and explicit unbinding. The existing disputed Panel settings layout is unchanged.

Validation on Windows 11 x64:
- targeted menu/action tests pass;
- the built native ANSI binary launched, opened the main menu with F9, navigated to Left, and rendered `New workspace    Ctrl+N` and `Close workspace  Ctrl+W`; F10 exit confirmation also completed;
- `go test ./... -count=1` reaches all packages; unrelated pre-existing Windows codepage tests still fail in `cmd/f4/TestEditorView_PasteConvertsInternalClipboardCodepage` and `vfs/TestCodepages_DetectEncoding`;
- `go vet ./...` reports only the repository's existing unsafe-pointer warnings.

Refs #651

— zoin-bot