### PR TITLE
cmd: hide panel loading pulse until operation exceeds threshold

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -360,6 +360,10 @@ const (
 	panelModifiedColumnWidth  = 14
 	panelDragScrollInterval   = 75 * time.Millisecond
 	panelLoadingPulseInterval = 100 * time.Millisecond
+	// panelLoadingShowDelay hides the loading pulse until an operation has run
+	// at least this long. Quick loads (fast directory reads, snappy VFS mounts)
+	// then finish without ever showing the spinner, avoiding a brief flash.
+	panelLoadingShowDelay = 200 * time.Millisecond
 )
 
 var panelLoadingPulse = [...]string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
@@ -458,11 +462,12 @@ type FileSystemPanel struct {
 	dragScrollTimer       *time.Timer
 	dragScrollGeneration  uint64
 
-	loadCtx      context.Context
-	cancelLoad   context.CancelFunc
-	isLoading    bool
-	loadingTimer *time.Timer
-	loadingFrame int
+	loadCtx        context.Context
+	cancelLoad     context.CancelFunc
+	isLoading      bool
+	loadingTimer   *time.Timer
+	loadingFrame   int
+	loadingVisible bool
 
 	loadingGeneration          uint64
 	loadQueueMu                sync.Mutex
@@ -1530,7 +1535,7 @@ func (fp *FileSystemPanel) updateTitle(err error) {
 
 	if err != nil && err != context.Canceled {
 		title += " [Error]"
-	} else if fp.isLoading {
+	} else if fp.isLoading && fp.loadingVisible {
 		title += " " + panelLoadingPulse[fp.loadingFrame%len(panelLoadingPulse)]
 	}
 	fp.currentTitle = title
@@ -1543,11 +1548,15 @@ func (fp *FileSystemPanel) stopLoadingAnimation() {
 		fp.loadingTimer.Stop()
 		fp.loadingTimer = nil
 	}
+	fp.loadingVisible = false
 }
 
 func (fp *FileSystemPanel) startLoadingAnimation() {
 	fp.stopLoadingAnimation()
 	fp.loadingFrame = 0
+
+	// Reflect the loading state in the title immediately (path/error text), but
+	// the spinner glyph stays hidden until panelLoadingShowDelay elapses.
 	fp.updateTitle(nil)
 	vtui.FrameManager.Redraw()
 
@@ -1556,16 +1565,43 @@ func (fp *FileSystemPanel) startLoadingAnimation() {
 		return
 	}
 
+	// Defer the visible pulse: only show it once the operation has been loading
+	// for panelLoadingShowDelay. Fast operations finish before this fires and
+	// never flash the spinner.
 	generation := fp.loadingGeneration
-	var scheduleNext func()
-	scheduleNext = func() {
+	frames := vtui.FrameManager
+	fp.loadingTimer = time.AfterFunc(panelLoadingShowDelay, func() {
 		// Read on the goroutine that starts this work, not inside it: the
 		// work outlives the call, and reading the global from it races
 		// anything that reassigns vtui.FrameManager meanwhile.
+		f := frames
+		f.PostTask(func() {
+			if !fp.isLoading || fp.loadingGeneration != generation {
+				return
+			}
+			fp.loadingVisible = true
+			fp.updateTitle(nil)
+			f.Redraw()
+			fp.scheduleLoadingPulse(generation)
+		})
+	})
+}
+
+// scheduleLoadingPulse advances the loading spinner while the panel stays in a
+// loading state. It reuses fp.loadingTimer, so stopLoadingAnimation cancels it.
+func (fp *FileSystemPanel) scheduleLoadingPulse(generation uint64) {
+	var scheduleNext func()
+	scheduleNext = func() {
+		// Read the manager on this goroutine, not inside the posted task: the
+		// work outlives the call and reading the global from it races anything
+		// that reassigns vtui.FrameManager meanwhile.
 		frames := vtui.FrameManager
+		if frames == nil {
+			return
+		}
 		fp.loadingTimer = time.AfterFunc(panelLoadingPulseInterval, func() {
 			frames.PostTask(func() {
-				if !fp.isLoading || fp.loadingGeneration != generation {
+				if !fp.isLoading || fp.loadingGeneration != generation || !fp.loadingVisible {
 					return
 				}
 				fp.loadingFrame = (fp.loadingFrame + 1) % len(panelLoadingPulse)

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -4315,15 +4315,34 @@ func TestFileSystemPanel_CachedEnterStaysResponsiveAndCoalescesRefresh(t *testin
 	if got := remote.GetPath(); got != "/sdcard" {
 		t.Fatalf("path after cached Enter = %q, want /sdcard", got)
 	}
-	if got := fp.currentTitle; !strings.Contains(got, "/sdcard") || !strings.HasSuffix(got, panelLoadingPulse[0]) {
+	// The spinner is deferred (panelLoadingShowDelay), so a just-started load
+	// shows the current path immediately but not the marker yet.
+	if got := fp.currentTitle; !strings.Contains(got, "/sdcard") {
 		t.Fatalf("loading title was not updated immediately: %q", got)
+	}
+	if fp.loadingVisible {
+		t.Fatalf("spinner became visible before the deferred delay: %q", fp.currentTitle)
 	}
 	if got := fp.getRawSelectedName(); got != ".." {
 		t.Fatalf("sdcard cache was not rendered synchronously, cursor = %q", got)
 	}
 
+	// Wait for the deferred spinner to appear (proving the in-flight load keeps
+	// running), then for it to advance at least one frame to confirm it pulses.
+	markerDeadline := time.After(2 * time.Second)
+	for !fp.loadingVisible {
+		select {
+		case task := <-vtui.FrameManager.TaskChan:
+			task()
+		case <-markerDeadline:
+			t.Fatalf("loading spinner never became visible: %q", fp.currentTitle)
+		}
+	}
+	if got := fp.currentTitle; !strings.Contains(got, "/sdcard") || !strings.HasSuffix(got, panelLoadingPulse[0]) {
+		t.Fatalf("first spinner frame was not shown: %q", got)
+	}
 	initialLoadingTitle := fp.currentTitle
-	pulseDeadline := time.After(time.Second)
+	pulseDeadline := time.After(2 * time.Second)
 	for fp.currentTitle == initialLoadingTitle {
 		select {
 		case task := <-vtui.FrameManager.TaskChan:


### PR DESCRIPTION
Add panelLoadingShowDelay (200ms). startLoadingAnimation no longer draws the snake spinner immediately on isLoading; it waits for the delay and only shows the pulse if the panel is still loading then. Quick loads finish before the timer fires and never flash the spinner.

stopLoadingAnimation resets loadingVisible; updateTitle only appends the pulse glyph when isLoading && loadingVisible. loadingGeneration still invalidates pending timers.

ps. Причина изменений: мелькание змейки на очень быстрых операциях только вредит восприятию (например когда бегаем по каталогам локальных дисков).