### PR TITLE
fix: skip GUI children in PTY.IsBusy()

### DIFF
--- a/cmd/f4/pty_windows.go
+++ b/cmd/f4/pty_windows.go
@@ -225,6 +225,12 @@ func (p *PTY) IsBusy() bool {
 
 	for {
 		if pe32.ParentProcessID == p.process.ProcessId {
+			if processIsGUI(pe32.ProcessID) {
+				if err := windows.Process32Next(snapshot, &pe32); err != nil {
+					break
+				}
+				continue
+			}
 			p.lastBusyState = true
 			p.lastBusyCheck = time.Now()
 			return true


### PR DESCRIPTION
## Problem

When a GUI program (e.g. notepad, mspaint) is running inside the f4 terminal, pressing **Esc** (or **Del**) does not toggle the panels back on. Ctrl+O works fine.

## Root cause

\PTY.IsBusy()\ counts every child process of cmd.exe as a sign that the terminal is occupied. GUI subsystem programs are children of cmd but they do **not** hold the console — cmd does not wait for them, and the alternate screen is not engaged.

The \EscToggle\ condition checks \!isPtyBusy()\, so it fails when a GUI child is present, and Esc gets forwarded to PTY instead of toggling the panels.

## Fix

Filter out GUI children in \IsBusy()\ using the existing \processIsGUI()\ helper, mirroring the logic already used by \childHoldsTerminal()\ in \cmd_session.go\.

## Impact

| Before | After |
|--------|-------|
| \IsBusy()\ = true with GUI child running | \IsBusy()\ = false — GUI ignored |
| Esc forwarded to PTY | Esc toggles panels |
| Del forwarded to PTY | Del toggles panels |

No behavioral change for console children (mc, htop, python, etc.).