### PR TITLE
Termux: запускать демона через системный линкер и паковать deb через xz

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -627,7 +627,11 @@ jobs:
         Homepage: https://github.com/unxed/f4
         Description: efficient and cozy two-panel file manager
         EOF
-        dpkg-deb --build --root-owner-group "$DEB" "$ASSET.deb"
+        # -Zxz: apt in Termux reads only control.tar{.zst,.lz4,.xz,.lzma,} and
+        # rejects the zstd member dpkg-deb writes by default with "Could not
+        # read meta data", which leaves `pkg install ./file.deb` broken. Only
+        # `dpkg -i` takes the default.
+        dpkg-deb -Zxz --build --root-owner-group "$DEB" "$ASSET.deb"
         dpkg-deb --info "$ASSET.deb"
         dpkg-deb --contents "$ASSET.deb"
 

--- a/cmd/f4/self_exec.go
+++ b/cmd/f4/self_exec.go
@@ -47,6 +47,9 @@ func selfCommand(self string, args ...string) *exec.Cmd {
 	// Callers that want more of their own add to cmd.Env rather than to
 	// os.Environ(), so that what selfExecEnv puts there survives.
 	cmd.Env = selfExecEnv()
+	// On Android (Termux) the command has to go through the system loader; it needs
+	// argv[0] and the environment, which selfExecArgv does not return.
+	applySystemLinkerExec(cmd)
 	return cmd
 }
 
@@ -69,5 +72,16 @@ func selfExecArgv(self string, args []string) (string, []string) {
 func loaderArgv(libc, image string, args []string) []string {
 	argv := make([]string, 0, len(args)+3)
 	argv = append(argv, "--preload", libc, image)
+	return append(argv, args...)
+}
+
+// linkerArgv is the argument vector for running image through Android's system
+// loader, which takes the image path as its first argument and hands the rest
+// to the image. argv0 stays in front because the loader consumes one entry, so
+// the image still finds its own arguments from argv[1] on -- the positions
+// ManageSessions() indexes for "--server".
+func linkerArgv(argv0, image string, args []string) []string {
+	argv := make([]string, 0, len(args)+2)
+	argv = append(argv, argv0, image)
 	return append(argv, args...)
 }

--- a/cmd/f4/self_exec_linux.go
+++ b/cmd/f4/self_exec_linux.go
@@ -59,6 +59,11 @@ var errExecutableUnknown = errors.New(
 // carry on without knowing (portable-config detection, say) already fall back
 // to os.Args[0]; callers that cannot must refuse.
 func f4Executable() (string, error) {
+	// On Android f4 comes up through the system loader, so /proc/self/exe names
+	// linker64 and os.Executable would point callers at /system/bin.
+	if p, ok := systemLinkerExecutable(); ok {
+		return p, nil
+	}
 	if os.Getenv(goffiUniversalGuard) == "" {
 		return os.Executable()
 	}

--- a/cmd/f4/self_exec_termux.go
+++ b/cmd/f4/self_exec_termux.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/unxed/vtui"
+)
+
+// termuxSelfExeEnv is where Termux records the path of the image that was
+// launched. Going through the loader leaves /proc/self/exe naming linker64, so
+// this is the only thing that still answers "where is f4".
+const termuxSelfExeEnv = "TERMUX_EXEC__PROC_SELF_EXE"
+
+// systemLinker is the loader an image of this architecture is launched through.
+func systemLinker() string {
+	if runtime.GOARCH == "arm" || runtime.GOARCH == "386" {
+		return "/system/bin/linker"
+	}
+	return "/system/bin/linker64"
+}
+
+func isELF(path string) bool {
+	f, err := os.Open(path) // #nosec G304 -- path is the program f4 is about to exec.
+	if err != nil {
+		return false
+	}
+	defer f.Close()
+
+	var magic [4]byte
+	if n, err := f.Read(magic[:]); err != nil || n < 4 {
+		return false
+	}
+	return magic[0] == 0x7f && magic[1] == 'E' && magic[2] == 'L' && magic[3] == 'F'
+}
+
+// setTermuxSelfExe replaces the inherited value rather than appending a second
+// one: ours describes this process and would be read first.
+func setTermuxSelfExe(env []string, exe string) []string {
+	prefix := termuxSelfExeEnv + "="
+	for i, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			env[i] = prefix + exe
+			return env
+		}
+	}
+	return append(env, prefix+exe)
+}
+
+// applySystemLinkerExec runs cmd's program through the system loader.
+//
+// Android refuses to execute a file in an app's own data directory once the app
+// targets API 29 or later, so execve on $PREFIX/bin/f4 returns EACCES. Termux
+// hides that by intercepting the exec() family through libtermux-exec.so, but
+// that hook is in libc and Go issues execve directly with RawSyscall, so f4's
+// own re-execs never reach it. Termux's Go package patches os.startProcess for
+// the same reason; a binary built with an unpatched toolchain does it here.
+//
+// Anything that cannot be launched this way -- no loader, not an ELF -- is left
+// alone, so the caller keeps whatever behaviour it had.
+func applySystemLinkerExec(cmd *exec.Cmd) {
+	if runtime.GOOS != "android" || cmd == nil || cmd.Path == "" || len(cmd.Args) == 0 {
+		return
+	}
+
+	linker := systemLinker()
+	if _, err := os.Stat(linker); err != nil {
+		vtui.DebugLog("SELFEXEC: no system linker at %s (%v); running %s directly", linker, err, cmd.Path)
+		return
+	}
+	if !isELF(cmd.Path) {
+		vtui.DebugLog("SELFEXEC: %s is not an ELF image; running it directly", cmd.Path)
+		return
+	}
+
+	image := cmd.Path
+	cmd.Path = linker
+	cmd.Args = linkerArgv(cmd.Args[0], image, cmd.Args[1:])
+	cmd.Env = setTermuxSelfExe(cmd.Env, image)
+
+	vtui.DebugLog("SELFEXEC: launching %s through %s, argv=%q", image, linker, cmd.Args)
+}
+
+// systemLinkerExecutable is the path f4 was launched from when it came up
+// through the loader. Relative values are made absolute because callers resolve
+// files next to the binary.
+func systemLinkerExecutable() (string, bool) {
+	if runtime.GOOS != "android" {
+		return "", false
+	}
+	exe := os.Getenv(termuxSelfExeEnv)
+	if exe == "" {
+		return "", false
+	}
+	if abs, err := filepath.Abs(exe); err == nil {
+		return abs, true
+	}
+	return exe, true
+}

--- a/cmd/f4/self_exec_test.go
+++ b/cmd/f4/self_exec_test.go
@@ -21,6 +21,41 @@ func TestLoaderArgvWithoutArguments(t *testing.T) {
 	}
 }
 
+func TestLinkerArgv(t *testing.T) {
+	got := linkerArgv("f4", "/usr/bin/f4", []string{"--server", "/tmp/f4.sock"})
+	want := []string{"f4", "/usr/bin/f4", "--server", "/tmp/f4.sock"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("linkerArgv() = %q, want %q", got, want)
+	}
+}
+
+func TestLinkerArgvWithoutArguments(t *testing.T) {
+	got := linkerArgv("f4", "/usr/bin/f4", nil)
+	want := []string{"f4", "/usr/bin/f4"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("linkerArgv() = %q, want %q", got, want)
+	}
+}
+
+// ManageSessions() reads the daemon's arguments by position, so the shift the
+// loader introduces has to land "--server" on os.Args[1] and the socket on
+// os.Args[2]; otherwise a daemon comes up as an ordinary client.
+func TestLinkerArgvKeepsServerArgumentPositions(t *testing.T) {
+	sock := "/tmp/f4-new-1-2.sock"
+	argv := linkerArgv("f4", "/usr/bin/f4", []string{"--server", sock})
+
+	seen := argv[1:] // the loader consumes its own argv[0]
+	if len(seen) < 3 {
+		t.Fatalf("image would see %q, too short to carry --server", seen)
+	}
+	if seen[1] != "--server" {
+		t.Errorf("os.Args[1] = %q, want %q", seen[1], "--server")
+	}
+	if seen[2] != sock {
+		t.Errorf("os.Args[2] = %q, want %q", seen[2], sock)
+	}
+}
+
 // Outside a universal build -- which is every test run that is not itself
 // started through goffi's bridge -- selfExecArgv must hand back exactly what
 // the caller asked for.


### PR DESCRIPTION
Закрывает часть #882: собранный в CI бинарник для Termux не запускался, а собранный `.deb` не ставился обещанным способом.

## 1. Демон не стартовал

```
$ f4
Failed to start daemon: fork/exec /data/data/com.termux/files/usr/bin/f4: permission denied
```

Android с targetSdk 29 и выше не даёт исполнять файл из каталога данных приложения, поэтому `execve` на `$PREFIX/bin/f4` возвращает EACCES. Termux скрывает это, перехватывая семейство `exec()` через `libtermux-exec.so` в `LD_PRELOAD` и подставляя вместо файла системный линкер. Но перехват живёт в libc, а Go вызывает `execve` напрямую через `RawSyscall` — и собственные перезапуски f4 мимо него проходят. В документации Termux это сказано прямым текстом:

> termux-exec … will not override direct calls to the execve() system call via syscall(2)

Локальная сборка при этом работала, и это сбивало с толку: Termux из Google Play ставит `golang` с собственным патчем `os.startProcess` (`termux-play-store/termux-packages`, `packages/golang/src-os-exec_posix.go.patch`), который делает ровно это. В обычном `termux/termux-packages` патча нет, официальный Go его тоже не содержит — значит бинарник, собранный любым другим тулчейном, должен позаботиться о себе сам.

Правка сделана в `selfCommand`, поэтому покрывает оба места, где f4 перезапускает себя, — запуск демона и detach. Не-ELF файл и отсутствующий линкер оставляются как есть, так что на прочих платформах поведение не меняется.

Отдельно `f4Executable` учитывает `TERMUX_EXEC__PROC_SELF_EXE`: после запуска через линкер `/proc/self/exe` указывает на `linker64`, и без этого поиск `help/`, `lang/` и самого бинарника уходил бы в `/system/bin` — что ломало бы и раскладку из `.deb`, где бинарник лежит в `share/f4/`, а `bin/f4` symlink на него.

Проверено на устройстве (Android 15, arm64, Termux googleplay.2026.06.21, targetSdk 37):

```
execve("/system/bin/linker64", ["…/f4", "…/f4", "--server", "…/f4-new-18561-….sock"]) = 0
```

`--server` и путь к сокету остаются на тех позициях, которые индексирует `ManageSessions()`; на это добавлен тест.

## 2. `pkg install` не брал пакет

```
Error: Internal error, could not locate member control.tar{.zst,.lz4,.xz,.lzma,}
Error: Could not read meta data from f4-termux-arm64.deb
```

apt в Termux читает только перечисленные форматы, а `dpkg-deb` по умолчанию пишет zstd-член, который он всё равно не принимает. Через `dpkg -i` пакет ставился, из-за чего выглядел рабочим. gzip не годится — его в списке нет вовсе. `xz` принимают и dpkg, и apt в Termux, проверено установкой на устройстве.

## Что остаётся за пределами этого PR

Ещё два дефекта нашлись в библиотеках, на них отдельные PR:

- unxed/vtinput#7 — выключение far2l терминируется BEL, из-за чего Termux остаётся в far2l-режиме после выхода и терминал перестаёт принимать ввод;
- unxed/vtui#109 — захват мыши снимается только по пустому `ButtonState`, из-за чего после первого касания меню перестаёт реагировать.

Со всеми тремя правками f4 на Termux запускается, работает мышью и корректно отдаёт терминал при выходе.