### PR TITLE
fix: keep panels hidden when bat calls nested cmd or user types cmd

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -1981,6 +1981,9 @@ func actionExecute(pf *PanelsFrame, v vfs.VFS, dir, name, path string) {
 					}
 					pf.writePTY(activePty, []byte(cmdToWire))
 					if isWindowsShell {
+						if isBatchCommand(historyCmd) {
+							pf.cmdSession.noteBatchExecution()
+						}
 						pf.noteLocalShellLineSent(activePty)
 					}
 					pf.showPanels = false

--- a/cmd/f4/cmd_session.go
+++ b/cmd/f4/cmd_session.go
@@ -55,6 +55,7 @@ type cmdShellSession struct {
 	promptSeq uint64
 	sentSeq   uint64
 	pending   bool // a typed line (command or directory sync) has no prompt yet
+	inBatch   bool // a .bat/.cmd file is being executed: nested cmd is not the shell
 	observed  promptSnapshot
 	timer     *time.Timer
 	attempts  int
@@ -106,11 +107,10 @@ type childInspector interface {
 // nestedShellImages are children that print a cmd-style prompt and accept
 // the lines f4 types (cd /d "..." & command). Their prompt ends the outer
 // command's wait, and the panels come back with the nested shell as the shell.
-// PowerShell is deliberately absent: it rejects `cd /d`, so it must keep the
-// terminal in raw mode until the user leaves it, like ssh or python.
-var nestedShellImages = map[string]bool{
-	"cmd.exe": true,
-}
+// cmd.exe is deliberately absent: it keeps the terminal in raw mode until
+// the user leaves it (exit), like ssh or python. PowerShell is also absent
+// for the same reason.
+var nestedShellImages = map[string]bool{}
 
 // childHoldsTerminal reports whether one of the shell's children is a console
 // program f4 has to wait for.
@@ -157,6 +157,18 @@ func (s *cmdShellSession) noteSent() {
 	}
 	s.mu.Unlock()
 	s.pf.noteLocalShellBusy(true)
+}
+
+// noteBatchExecution marks the current command as a .bat/.cmd file execution.
+// In batch mode a nested cmd.exe child is not treated as "the shell now"
+// because the batch file will continue after it exits.
+func (s *cmdShellSession) noteBatchExecution() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.inBatch = true
+	s.mu.Unlock()
 }
 
 // idle reports whether every typed line has been answered by a settled
@@ -228,6 +240,7 @@ func (s *cmdShellSession) settle(seq uint64) {
 			return
 		}
 		previous, sentSeq, pending := s.observed, s.sentSeq, s.pending
+		inBatch := s.inBatch
 		s.mu.Unlock()
 
 		pf := s.pf
@@ -276,7 +289,20 @@ func (s *cmdShellSession) settle(seq uint64) {
 		}
 
 		if inspector, ok := pf.localPTY().(childInspector); ok {
-			if children := inspector.ChildProcesses(); childHoldsTerminal(children) {
+			children := inspector.ChildProcesses()
+			held := childHoldsTerminal(children)
+			if !held && inBatch {
+				// In batch mode a nested cmd.exe child is not "the
+				// shell now": the batch file will continue after it
+				// exits, so the terminal is still held.
+				for _, c := range children {
+					if !c.GUI && strings.ToLower(c.Name) == "cmd.exe" {
+						held = true
+						break
+					}
+				}
+			}
+			if held {
 				vtui.DebugLog("CMD_SESSION: prompt %d held by child %v, rechecking", seq, children)
 				s.mu.Lock()
 				if !s.closed && seq == s.promptSeq {
@@ -334,6 +360,7 @@ func (s *cmdShellSession) release() {
 	pf := s.pf
 	s.mu.Lock()
 	s.pending = false
+	s.inBatch = false
 	s.mu.Unlock()
 	pf.shellPromptReady = true
 	pf.ignoreNextPrompt = false

--- a/cmd/f4/cmd_session_test.go
+++ b/cmd/f4/cmd_session_test.go
@@ -217,10 +217,9 @@ func TestCmdSessionConsoleChildHoldsTheTerminal(t *testing.T) {
 	})
 }
 
-// A nested cmd is the shell now. It prints the same prompt, accepts the same
-// lines, and its prompt ends the outer command's wait instead of holding it
-// -- this is the case that hung the terminal until Ctrl+O.
-func TestCmdSessionNestedCmdIsTheShellNow(t *testing.T) {
+// A nested cmd keeps the terminal: its child process holds it until exit.
+// The panels stay hidden while the user interacts with the nested shell.
+func TestCmdSessionNestedCmdHoldsTerminal(t *testing.T) {
 	forEachBuild(t, func(t *testing.T, sim *cmdShellSim) {
 		sim.start()
 		sim.run("cmd")
@@ -228,22 +227,25 @@ func TestCmdSessionNestedCmdIsTheShellNow(t *testing.T) {
 		sim.feed("Microsoft Windows [Version 10.0]\r\n\r\n")
 		sim.prompt("")
 		sim.wait(settledWithin)
-		sim.expectExecuting(false, "at the nested shell's prompt")
+		sim.expectExecuting(true, "at the nested shell's prompt")
 
-		// A command typed into the nested shell works the same way.
+		// A command typed into the nested shell keeps executing.
 		sim.run("dir")
 		sim.feed("file.txt\r\n\r\n")
 		sim.prompt("")
 		sim.wait(settledWithin)
-		sim.expectExecuting(false, "after dir in the nested shell")
+		sim.expectExecuting(true, "after dir in the nested shell")
 
-		// And exit brings the outer prompt back.
+		// exit closes the nested shell; the outer prompt ends the wait.
 		sim.run("exit")
 		sim.pty.setChildren()
 		sim.feed("\r\n")
 		sim.prompt("")
 		sim.wait(settledWithin)
 		sim.expectExecuting(false, "after exit")
+		if !sim.pf.showPanels {
+			t.Error("panels did not come back after exit")
+		}
 	})
 }
 
@@ -339,7 +341,7 @@ func TestChildHoldsTerminal(t *testing.T) {
 		{nil, false},
 		{[]childProcess{childPing}, true},
 		{[]childProcess{childTimeout}, true},
-		{[]childProcess{childNestedCmd}, false},
+		{[]childProcess{childNestedCmd}, true}, // cmd.exe keeps the terminal until exit
 		{[]childProcess{childNotepad}, false},
 		{[]childProcess{childNestedCmd, childPing}, true}, // ping inside the nested cmd
 		{[]childProcess{{Name: "powershell.exe"}}, true},  // rejects cd /d: stays raw
@@ -403,5 +405,38 @@ func TestCmdSessionFlickeringPromptIsReleased(t *testing.T) {
 		}
 		drainUITasks()
 		sim.expectExecuting(false, "after a prompt that never settled was released")
+	})
+}
+
+// When a batch file calls cmd, the nested shell's prompt must not end the
+// batch's execution: the batch will continue after the nested cmd exits.
+// The panels must stay hidden until the batch truly finishes.
+func TestCmdSessionBatchWithNestedCmdDoesNotRelease(t *testing.T) {
+	forEachBuild(t, func(t *testing.T, sim *cmdShellSim) {
+		sim.start()
+		sim.run("foo.bat")
+		sim.pty.setChildren(childNestedCmd)
+		sim.feed("Microsoft Windows [Version 10.0]\r\n\r\n")
+		sim.pf.cmdSession.noteBatchExecution()
+		sim.prompt("")
+		sim.wait(settledWithin)
+		sim.expectExecuting(true, "at the nested cmd prompt inside a batch")
+
+		// Nested cmd exits; batch continues.
+		sim.run("exit")
+		sim.pty.setChildren()
+		sim.feed("\r\n")
+		sim.prompt("echo done\r\ndone\r\n\r\n")
+		sim.wait(settledWithin)
+		sim.expectExecuting(true, "while the batch continues after nested cmd")
+
+		// Batch finishes.
+		sim.feed("\r\n\r\n")
+		sim.prompt("")
+		sim.wait(settledWithin)
+		sim.expectExecuting(false, "after the batch's final prompt")
+		if !sim.pf.showPanels {
+			t.Error("panels did not come back after batch finished")
+		}
 	})
 }

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -2605,6 +2605,9 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 				pf.workspaceCommandTitle = workspaceCommandName(trimmedCmd)
 				pf.writePTY(activePty, []byte(fullWireCmd))
 				if isWindowsShell && integration == nil {
+					if isBatchCommand(cmd) {
+						pf.cmdSession.noteBatchExecution()
+					}
 					pf.noteLocalShellLineSent(activePty)
 				}
 			}

--- a/cmd/f4/resolve_command_other.go
+++ b/cmd/f4/resolve_command_other.go
@@ -6,3 +6,8 @@ package main
 func resolveWindowsCommand(cmd string) string {
 	return cmd
 }
+
+// isBatchCommand is always false on non-Windows platforms.
+func isBatchCommand(cmd string) bool {
+	return false
+}

--- a/cmd/f4/resolve_command_windows.go
+++ b/cmd/f4/resolve_command_windows.go
@@ -111,6 +111,16 @@ func appPathLookup(name string) string {
 	return ""
 }
 
+// isBatchCommand reports whether the first token of cmd is a .bat or .cmd file.
+func isBatchCommand(cmd string) bool {
+	_, _, token, ok := findCmdToken(cmd)
+	if !ok {
+		return false
+	}
+	token = strings.ToUpper(token)
+	return strings.HasSuffix(token, ".BAT") || strings.HasSuffix(token, ".CMD")
+}
+
 func appPathExts() []string {
 	var out []string
 	for _, ext := range strings.Split(os.Getenv("PATHEXT"), ";") {

--- a/cmd/f4/resolve_command_windows_test.go
+++ b/cmd/f4/resolve_command_windows_test.go
@@ -14,3 +14,24 @@ func TestFindCmdTokenRejectsUnmatchedQuote(t *testing.T) {
 		t.Fatalf("findCmdToken did not treat a Windows single quote as a literal token: name=%q ok=%v", name, ok)
 	}
 }
+
+func TestIsBatchCommand(t *testing.T) {
+	cases := map[string]bool{
+		`foo.bat`:                true,
+		`foo.cmd`:                true,
+		`FOO.BAT`:                true,
+		`foo.Bat`:                true,
+		`"my script.bat"`:        true,
+		`"my script.cmd" arg1`:   true,
+		`foo.exe`:                false,
+		`foo.com`:                false,
+		`dir`:                    false,
+		`foo.bat arg1 & bar.exe`: true,
+		``:                       false,
+	}
+	for cmd, want := range cases {
+		if got := isBatchCommand(cmd); got != want {
+			t.Errorf("isBatchCommand(%q) = %v, want %v", cmd, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Two issues with how f4 detects cmd.exe completion:

1. **Batch calling cmd**: When a .bat file calls `cmd` (e.g. `call cmd`), the nested cmd.exe prompt triggers panel return even though the batch is still running. The panels come back while output keeps printing behind them.

2. **Direct cmd**: When the user types `cmd` at the prompt, the panels return immediately at the nested shell prompt instead of staying hidden until the user types `exit`.

## Root cause

`cmd.exe` was listed in `nestedShellImages`, which told `childHoldsTerminal()` to ignore it. This meant any nested cmd.exe child was treated as "the shell now" — the outer command's wait ended immediately, regardless of whether the batch was still running.

## Fix

- **`inBatch` flag**: Added to `cmdShellSession`. Set when the sent command resolves to a .bat/.cmd file via `isBatchCommand()`. In `settle()`, when `inBatch` is true, a nested `cmd.exe` child holds the terminal (panels stay hidden) instead of triggering release.

- **Remove `cmd.exe` from `nestedShellImages`**: Typing `cmd` directly now keeps the terminal busy until the user exits the nested shell. Panels return only after `exit`.

## Files changed

| File | Change |
|------|--------|
| `cmd_session.go` | Add `inBatch` field, `noteBatchExecution()`, batch-aware child check in `settle()`, reset in `release()` |
| `cmd_session.go` | Remove `cmd.exe` from `nestedShellImages` |
| `resolve_command_windows.go` | Add `isBatchCommand()` — checks first token for .bat/.cmd extension |
| `resolve_command_other.go` | Stub `isBatchCommand()` for non-Windows |
| `panels_frame.go` | Call `noteBatchExecution()` before `noteLocalShellLineSent()` when command is a bat file |
| `actions.go` | Same for Enter on a bat file in the panel |
| Tests | `TestCmdSessionBatchWithNestedCmdDoesNotRelease`, `TestCmdSessionNestedCmdHoldsTerminal`, `TestIsBatchCommand` |
