### PR TITLE
session: open the directory f4 was started from

### DIFF
--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -16,7 +16,34 @@ import (
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
+	"golang.org/x/term"
 )
+
+// startupDirEnv carries the directory f4 was called from to the process that
+// draws the panels. That process cannot ask itself: the GUI restarts detached
+// and the daemon is spawned by the client, and a Dock start would answer with
+// the bundle's own directory.
+const startupDirEnv = "F4_STARTUP_DIR"
+
+// rememberStartupDir records the working directory, but only for a start from a
+// terminal. It must run before checkAndDetach and before the daemon is spawned:
+// both hand the next process /dev/null on stdin. An inherited value wins.
+func rememberStartupDir() {
+	if os.Getenv(startupDirEnv) != "" {
+		return
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return
+	}
+	if dir, err := os.Getwd(); err == nil {
+		_ = os.Setenv(startupDirEnv, dir)
+	}
+}
+
+// startupDir is that directory; empty means the panels keep the restored paths.
+func startupDir() string {
+	return os.Getenv(startupDirEnv)
+}
 
 // SelectedTTYBackend holds the user-chosen or auto-detected console renderer name ("ansi" or "winapi").
 var SelectedTTYBackend string
@@ -84,6 +111,7 @@ func sudoStartupMode(args []string, askpassParent bool) (dispatcher string, askp
 
 func main() {
 	vtui.AppName = "f4"
+	rememberStartupDir()
 	configureF4DebugLogPath(GetF4ConfigDir())
 	if archivePath, archiveKind, found, err := parseUpdateHelperArgs(os.Args[1:]); found {
 		if err != nil {
@@ -721,6 +749,9 @@ func SetupUI() {
 	if len(states) > 0 {
 		applyWorkspaceSession(panels, states[0], width, height, AppConfig.SavePanelPaths)
 	}
+	// The startup directory outranks the restored paths. A client attaching to a
+	// running daemon brings its own instead -- see attachPayload.
+	applyStartupDir(panels, startupDir())
 	vtui.FrameManager.Push(panels)
 	if len(states) > 1 {
 		// AddScreenBackground inserts immediately after the active workspace;

--- a/cmd/f4/session_attach_payload_test.go
+++ b/cmd/f4/session_attach_payload_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import "testing"
+
+func TestAttachPayloadRoundTrip(t *testing.T) {
+	cases := []struct {
+		name           string
+		editPath, cwd  string
+		wantWire       string
+		wantEdit, want string
+	}{
+		{name: "plain", wantWire: "ATTACH"},
+		{name: "cwd", cwd: "/home/u/dir", wantWire: "ATTACH\nCWD /home/u/dir", want: "/home/u/dir"},
+		// -e keeps the single-line wire format an older daemon understands.
+		{name: "edit", editPath: "/tmp/f.txt", cwd: "/home/u/dir", wantWire: "ATTACH /tmp/f.txt", wantEdit: "/tmp/f.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire := string(attachPayload(tc.editPath, tc.cwd))
+			if wire != tc.wantWire {
+				t.Fatalf("attachPayload = %q, want %q", wire, tc.wantWire)
+			}
+			edit, cwd := parseAttachPayload(wire)
+			if edit != tc.wantEdit || cwd != tc.want {
+				t.Fatalf("parseAttachPayload(%q) = (%q, %q), want (%q, %q)", wire, edit, cwd, tc.wantEdit, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/f4/session_unix.go
+++ b/cmd/f4/session_unix.go
@@ -320,7 +320,7 @@ func runClient(sockPath string, serverPID int) {
 	oob := syscall.UnixRights(0, 1, notifyPipe[1])
 	vtui.DebugLog("CLIENT: FDs to send: In:0 Out:1 Pipe:%d", notifyPipe[1])
 
-	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath), oob, raddr)
+	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath, startupDir()), oob, raddr)
 	if err != nil {
 		vtui.DebugLog("CLIENT: ATTACH FAILURE: Failed to send FDs to daemon at %s: %v", sockPath, err)
 		fmt.Fprintf(os.Stderr, "f4: failed to attach to session at %s: %v\n", sockPath, err)
@@ -380,6 +380,7 @@ type attachRequest struct {
 	notifyPipeWriteEnd int
 	rawFds             []int
 	editPath           string
+	startDir           string
 }
 
 // attachPayload builds the ATTACH datagram body. Plain "ATTACH" when no
@@ -387,11 +388,31 @@ type attachRequest struct {
 // binary already speaks, so an old client can still attach to a new
 // server and vice versa); "ATTACH <path>" when -e named a file, parsed
 // back out in runServer's accept loop below.
-func attachPayload(editPath string) []byte {
-	if editPath == "" {
+//
+// The working directory rides on a second line, so an older server still reads
+// exactly "ATTACH" on the first. It is left out next to -e, where that server
+// would take the whole datagram as the file name.
+func attachPayload(editPath, cwd string) []byte {
+	if editPath != "" {
+		return []byte("ATTACH " + editPath)
+	}
+	if cwd == "" {
 		return []byte("ATTACH")
 	}
-	return []byte("ATTACH " + editPath)
+	return []byte("ATTACH\nCWD " + cwd)
+}
+
+// parseAttachPayload reads back what attachPayload wrote. An unknown extra
+// line is ignored rather than refused, so a future client stays attachable.
+func parseAttachPayload(msg string) (editPath, cwd string) {
+	head, rest, _ := strings.Cut(msg, "\n")
+	if strings.HasPrefix(head, "ATTACH ") {
+		editPath = head[len("ATTACH "):]
+	}
+	if strings.HasPrefix(rest, "CWD ") {
+		cwd = rest[len("CWD "):]
+	}
+	return editPath, cwd
 }
 
 func runServer(sockPath string) {
@@ -460,10 +481,7 @@ func runServer(sockPath string) {
 
 			setCloseOnExec(fds)
 
-			var editPath string
-			if msg := string(buf[:n]); strings.HasPrefix(msg, "ATTACH ") {
-				editPath = msg[len("ATTACH "):]
-			}
+			editPath, startDir := parseAttachPayload(string(buf[:n]))
 
 			req := attachRequest{
 				in:                 os.NewFile(uintptr(fds[0]), "/dev/stdin"),
@@ -471,6 +489,7 @@ func runServer(sockPath string) {
 				notifyPipeWriteEnd: fds[2],
 				rawFds:             fds,
 				editPath:           editPath,
+				startDir:           startDir,
 			}
 
 			// Preempt the current attached session (if any) so the new client takes over.
@@ -499,6 +518,7 @@ func runServer(sockPath string) {
 		newStdout := req.out
 		notifyPipeWriteEnd := req.notifyPipeWriteEnd
 		attachEditPath := req.editPath
+		attachStartDir := req.startDir
 
 		vtui.DebugLog("SERVER: FDs received (In:%d Out:%d Pipe:%d). Goroutines: %d. Attaching terminal.", fds[0], fds[1], fds[2], runtime.NumGoroutine())
 
@@ -594,6 +614,16 @@ func runServer(sockPath string) {
 			if pf, ok := top.(*PanelsFrame); ok && pf != nil {
 				if pf.shellMode == ShellModeHost && !pf.showPanels {
 					pf.enterHostConsole()
+				}
+			}
+		}
+
+		// A client that attached to a running daemon moves its workspace to its
+		// own directory, as a normal start would.
+		if attachStartDir != "" {
+			if top := vtui.FrameManager.GetTopFrame(); top != nil {
+				if pf, ok := top.(*PanelsFrame); ok && pf != nil {
+					applyStartupDir(pf, attachStartDir)
 				}
 			}
 		}

--- a/cmd/f4/startup_dir_test.go
+++ b/cmd/f4/startup_dir_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+// A start with no terminal -- Dock, the detached GUI copy, the daemon -- names
+// no startup directory, so the panels keep what the session restored. `go test`
+// runs without a terminal on stdin, which is exactly that case.
+func TestRememberStartupDirIgnoresStartWithoutTerminal(t *testing.T) {
+	t.Setenv(startupDirEnv, "")
+	rememberStartupDir()
+	if got := startupDir(); got != "" {
+		t.Fatalf("startupDir() = %q, want empty for a start without a terminal", got)
+	}
+}
+
+// The parent's answer travels through the environment; the child inherits it.
+func TestRememberStartupDirKeepsInheritedValue(t *testing.T) {
+	t.Setenv(startupDirEnv, "/from/parent")
+	rememberStartupDir()
+	if got := startupDir(); got != "/from/parent" {
+		t.Fatalf("startupDir() = %q, want the inherited value", got)
+	}
+}

--- a/cmd/f4/workspace_session.go
+++ b/cmd/f4/workspace_session.go
@@ -273,6 +273,41 @@ func validSessionViewMode(mode int) ViewMode {
 	return viewMode
 }
 
+// navigatePanelTo moves a panel to path. What does not open as an object of its
+// own (an archive, a provider resource) stays a plain path in the current VFS;
+// a URI without its plugin is not even that.
+func navigatePanelTo(pf *PanelsFrame, panel *FileSystemPanel, path string) {
+	if path == "" || pf.NavigateToPath(panel, path) {
+		return
+	}
+	if vfs.IsURIPath(path) {
+		return
+	}
+	// A path that no longer exists leaves the VFS where it was, so re-reading
+	// the directory would only redraw the one already on screen.
+	if err := panel.vfs.SetPath(path); err != nil {
+		vtui.DebugLog("SESSION: cannot open %s: %v", path, err)
+		return
+	}
+	panel.ReadDirectory()
+}
+
+// applyStartupDir opens dir in both panels, so `cd dir && f4` shows dir and not
+// session.ini's paths. It runs after applyWorkspaceSession and therefore wins;
+// an empty dir changes nothing.
+func applyStartupDir(pf *PanelsFrame, dir string) {
+	if pf == nil || dir == "" {
+		return
+	}
+	for _, p := range pf.panels {
+		if fsp, ok := p.(*FileSystemPanel); ok && fsp != nil {
+			navigatePanelTo(pf, fsp, dir)
+			// The pending cursor names a file of the directory just left.
+			fsp.pendingSelection = ""
+		}
+	}
+}
+
 func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, height int, restorePaths bool) {
 	if pf == nil {
 		return
@@ -296,18 +331,9 @@ func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, 
 	left.sortMode, right.sortMode = SortMode(state.Left.SortMode), SortMode(state.Right.SortMode)
 	left.sortReverse, right.sortReverse = state.Left.SortReverse, state.Right.SortReverse
 
-	navigate := func(panel *FileSystemPanel, path string) {
-		if path == "" || pf.NavigateToPath(panel, path) {
-			return
-		}
-		if !vfs.IsURIPath(path) {
-			panel.vfs.SetPath(path)
-			panel.ReadDirectory()
-		}
-	}
 	if restorePaths {
-		navigate(left, state.Left.Path)
-		navigate(right, state.Right.Path)
+		navigatePanelTo(pf, left, state.Left.Path)
+		navigatePanelTo(pf, right, state.Right.Path)
 		left.pendingSelection, right.pendingSelection = state.Left.Cursor, state.Right.Cursor
 	}
 


### PR DESCRIPTION
Закрывает #822, первый пункт из #882.

## Что было

Панели восстанавливались из `session.ini`, а директория запуска игнорировалась: `cd dir && f4` показывал то место, где была прошлая сессия.

## Что сделано

Директория запоминается один раз в начале `main()` и только если за запуском стоит терминал. Спросить позже нельзя: GUI перезапускает себя отсоединённым (`checkAndDetach`), а демон сессии порождается клиентом — у обоих на stdin `/dev/null`. Запуск из Dock при этом приходит с рабочей директорией внутри `.app`-бандла, и открывать её никто не просил.

Значение едет к рисующему процессу через окружение (`F4_STARTUP_DIR`). Клиент, подключающийся к уже работающему демону, передаёт свою директорию второй строкой ATTACH-датаграммы — демон, который о ней не знает, читает на первой ровно прежнее `ATTACH`.

Заодно сбрасывается `pendingSelection`: курсор указывал на файл директории, которую панель только что покинула.

## Проверено

- macOS: запуск из терминала (и TTY, и GUI) открывает текущую папку; `open F4.app` — сохранённые пути, а не нутро бандла
- Termux/Android arm64: чистый старт, а также подключение к уже живому демону — панели уходят в папку нового клиента
- новые тесты: round-trip ATTACH-датаграммы и запоминание стартовой директории