### PR TITLE
session: do not save state that was never loaded

### DIFF
--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -1513,6 +1513,12 @@ func TestSession_DiskPersistence(t *testing.T) {
 	getSessionIniPath = func() string { return filepath.Join(tmpDir, "session.ini") }
 	t.Cleanup(func() { getSessionIniPath = origPathFunc })
 
+	// The test stands in for a process with a UI: the Last* state below is set
+	// by hand, so SaveSession must write it.
+	oldSessionLoaded := sessionLoaded
+	sessionLoaded = true
+	t.Cleanup(func() { sessionLoaded = oldSessionLoaded })
+
 	LastEditorSearch = "disk-test"
 	LastFindFileMask = "*.log"
 	LastLeftPath = "/path/a"

--- a/cmd/f4/autosave_settings_test.go
+++ b/cmd/f4/autosave_settings_test.go
@@ -69,13 +69,17 @@ func TestConfig_AutoSaveCategoriesMigrateLegacyMaster(t *testing.T) {
 func TestSaveSession_DisabledWhenAllCategoriesAreOff(t *testing.T) {
 	oldConfig := AppConfig
 	oldSessionPath := getSessionIniPath
+	oldLoaded := sessionLoaded
 	defer func() {
 		AppConfig = oldConfig
 		getSessionIniPath = oldSessionPath
+		sessionLoaded = oldLoaded
 	}()
 
 	path := filepath.Join(t.TempDir(), "session.ini")
 	getSessionIniPath = func() string { return path }
+	// Otherwise the assertion passes for the wrong reason: unloaded state.
+	sessionLoaded = true
 	AppConfig.AutoSaveSettings = true
 	AppConfig.AutoSaveDialogSettings = false
 	AppConfig.AutoSavePanelSettings = false
@@ -84,6 +88,33 @@ func TestSaveSession_DisabledWhenAllCategoriesAreOff(t *testing.T) {
 	SaveSession()
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
 		t.Fatalf("all-disabled automatic session save created %s, err=%v", path, err)
+	}
+}
+
+// The session client, --version and --help reach SaveSession in main's defer
+// without ever calling LoadSession: their defaults would cost the daemon's file
+// its panel paths and wide mode.
+func TestSaveSession_SkippedWhenStateWasNeverLoaded(t *testing.T) {
+	oldConfig := AppConfig
+	oldSessionPath := getSessionIniPath
+	oldLoaded := sessionLoaded
+	defer func() {
+		AppConfig = oldConfig
+		getSessionIniPath = oldSessionPath
+		sessionLoaded = oldLoaded
+	}()
+
+	path := filepath.Join(t.TempDir(), "session.ini")
+	getSessionIniPath = func() string { return path }
+	sessionLoaded = false
+	AppConfig.AutoSaveSettings = true
+	AppConfig.AutoSaveDialogSettings = true
+	AppConfig.AutoSavePanelSettings = true
+	AppConfig.AutoSaveCurrentPanel = true
+	AppConfig.AutoSaveGUIWindow = true
+	SaveSession()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("session save without a loaded state created %s, err=%v", path, err)
 	}
 }
 

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -853,7 +853,14 @@ var getSessionIniPath = func() string {
 	return filepath.Join(GetF4ConfigDir(), "session.ini")
 }
 
+// sessionLoaded marks the process that read the session and may write it back.
+// LoadSession runs only from SetupUI, but main's defer reaches SaveSession from
+// processes with no UI at all -- the session client, --version, --help -- whose
+// Last* globals are defaults that would overwrite the daemon's file.
+var sessionLoaded bool
+
 func LoadSession() {
+	sessionLoaded = true
 	path := getSessionIniPath()
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		return
@@ -907,6 +914,10 @@ func LoadSession() {
 }
 
 func SaveSession() {
+	if !sessionLoaded {
+		vtui.DebugLog("SESSION: State was never loaded, nothing to save")
+		return
+	}
 	if !AppConfig.AutoSaveSettings {
 		vtui.DebugLog("SESSION: Automatic saving is disabled")
 		return


### PR DESCRIPTION
Пункты 2 и 3 из #882.

## Что было

Настройки панелей не переживали перезапуск: широкий режим сбрасывался, пути панелей пустели, секция `[Workspaces]` из `session.ini` исчезала.

## Причина

До `SaveSession` в `defer` внутри `main()` доходит любой процесс, включая те, у которых UI нет вовсе: клиент в паре клиент+демон, `--version`, `--help`. `LoadSession` вызывается только из `SetupUI`, поэтому у таких процессов в `Last*` лежат значения по умолчанию — и их запись затирала файл, который ведёт демон.

Воспроизводится одной командой: `f4 --version` очищает пути, сбрасывает `WidePanel` и убирает `[Workspaces]`.

На паре клиент+демон две записи гонятся, поэтому потеря выглядела случайной: на десктопе обычно успевает демон, на Termux — достаточно часто клиент.

## Что сделано

Флаг `sessionLoaded`, который выставляет `LoadSession`; `SaveSession` без него молча выходит.

## Проверено

macOS и Termux/Android: широкий режим и пути панелей переживают выход, `f4 --version` и `f4 --help` файл не трогают. Добавлен тест на пропуск сохранения без загруженного состояния.