### PR TITLE
session: open the folders named on the command line

### DIFF
--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -19,30 +19,84 @@ import (
 	"golang.org/x/term"
 )
 
-// startupDirEnv carries the directory f4 was called from to the process that
-// draws the panels. That process cannot ask itself: the GUI restarts detached
-// and the daemon is spawned by the client, and a Dock start would answer with
-// the bundle's own directory.
-const startupDirEnv = "F4_STARTUP_DIR"
+// startupDirEnv and startupDirRightEnv carry the panel directories of this
+// start to the process that draws them. That process cannot work them out
+// itself: the GUI restarts detached, the daemon is spawned by the client, and a
+// Dock start would answer with the bundle's own directory. The right-hand one
+// is set only when the command line named a directory, which is also what tells
+// the panels that the left one was asked for rather than merely inherited.
+const (
+	startupDirEnv      = "F4_STARTUP_DIR"
+	startupDirRightEnv = "F4_STARTUP_DIR_RIGHT"
+)
 
-// rememberStartupDir records the working directory, but only for a start from a
+// startupDirsFor resolves what `f4`, `f4 dir` and `f4 dir1 dir2` mean, in the
+// order the panels are drawn: left first. One directory leaves the right panel
+// in the current one, matching mc. Relative paths are resolved here, while cwd
+// is still the shell's; a third argument and beyond has no panel to go to.
+func startupDirsFor(cwd string, args []string) (left, right string) {
+	abs := func(path string) string {
+		if filepath.IsAbs(path) {
+			return filepath.Clean(path)
+		}
+		return filepath.Join(cwd, path)
+	}
+	switch len(args) {
+	case 0:
+		return cwd, ""
+	case 1:
+		return abs(args[0]), cwd
+	default:
+		return abs(args[0]), abs(args[1])
+	}
+}
+
+// startupDirArgs picks the panel directories out of a command line: the words
+// before the first switch, plus everything after a "--" separator. --gui and
+// --tty take their backend as a separate word, so a word after a switch could
+// be either that backend or a directory; f4 does not guess between them.
+func startupDirArgs(args []string) []string {
+	var dirs []string
+	beforeSwitches := true
+	for i, arg := range args {
+		switch {
+		case arg == "--":
+			return append(dirs, args[i+1:]...)
+		case strings.HasPrefix(arg, "-"):
+			beforeSwitches = false
+		case beforeSwitches:
+			dirs = append(dirs, arg)
+		}
+	}
+	return dirs
+}
+
+// rememberStartupDirs records those directories, but only for a start from a
 // terminal. It must run before checkAndDetach and before the daemon is spawned:
-// both hand the next process /dev/null on stdin. An inherited value wins.
-func rememberStartupDir() {
+// both hand the next process /dev/null on stdin. Values inherited from the
+// parent win, they are the answer that process already worked out.
+func rememberStartupDirs(args []string) {
 	if os.Getenv(startupDirEnv) != "" {
 		return
 	}
 	if !term.IsTerminal(int(os.Stdin.Fd())) {
 		return
 	}
-	if dir, err := os.Getwd(); err == nil {
-		_ = os.Setenv(startupDirEnv, dir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		return
+	}
+	left, right := startupDirsFor(cwd, args)
+	_ = os.Setenv(startupDirEnv, left)
+	if right != "" {
+		_ = os.Setenv(startupDirRightEnv, right)
 	}
 }
 
-// startupDir is that directory; empty means the panels keep the restored paths.
-func startupDir() string {
-	return os.Getenv(startupDirEnv)
+// startupDirs are those directories; an empty left one means the panels keep
+// the restored paths, and an empty right one means both take the left.
+func startupDirs() (left, right string) {
+	return os.Getenv(startupDirEnv), os.Getenv(startupDirRightEnv)
 }
 
 // SelectedTTYBackend holds the user-chosen or auto-detected console renderer name ("ansi" or "winapi").
@@ -111,7 +165,6 @@ func sudoStartupMode(args []string, askpassParent bool) (dispatcher string, askp
 
 func main() {
 	vtui.AppName = "f4"
-	rememberStartupDir()
 	configureF4DebugLogPath(GetF4ConfigDir())
 	if archivePath, archiveKind, found, err := parseUpdateHelperArgs(os.Args[1:]); found {
 		if err != nil {
@@ -357,6 +410,7 @@ func main() {
 			}
 		}
 	}
+	rememberStartupDirs(startupDirArgs(os.Args[1:]))
 	configureF4DebugLogPath(GetF4ConfigDir())
 
 	if version {
@@ -366,7 +420,10 @@ func main() {
 	if print_help {
 		fmt.Printf(`f4 version: %s
 f4 is efficient and cozy two-panel file manager in go
-Usage: f4 [switches]
+Usage: f4 [folder1 [folder2]] [switches]
+Folders come before the switches, or after a "--" separator. Without them both
+panels open the current directory; folder1 alone opens in the left panel and
+leaves the right one on the current directory.
 The following switches may be used in the command line:
  -h, -?, --help         This help and exit
  -v, --version          Displays the current version and exit
@@ -749,9 +806,10 @@ func SetupUI() {
 	if len(states) > 0 {
 		applyWorkspaceSession(panels, states[0], width, height, AppConfig.SavePanelPaths)
 	}
-	// The startup directory outranks the restored paths. A client attaching to a
-	// running daemon brings its own instead -- see attachPayload.
-	applyStartupDir(panels, startupDir())
+	// The startup directories outrank the restored paths. A client attaching to
+	// a running daemon brings its own instead -- see attachPayload.
+	startLeft, startRight := startupDirs()
+	applyStartupDirs(panels, startLeft, startRight)
 	vtui.FrameManager.Push(panels)
 	if len(states) > 1 {
 		// AddScreenBackground inserts immediately after the active workspace;

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -16,7 +16,34 @@ import (
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
+	"golang.org/x/term"
 )
+
+// startupDirEnv carries the directory f4 was called from to the process that
+// draws the panels. That process cannot ask itself: the GUI restarts detached
+// and the daemon is spawned by the client, and a Dock start would answer with
+// the bundle's own directory.
+const startupDirEnv = "F4_STARTUP_DIR"
+
+// rememberStartupDir records the working directory, but only for a start from a
+// terminal. It must run before checkAndDetach and before the daemon is spawned:
+// both hand the next process /dev/null on stdin. An inherited value wins.
+func rememberStartupDir() {
+	if os.Getenv(startupDirEnv) != "" {
+		return
+	}
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return
+	}
+	if dir, err := os.Getwd(); err == nil {
+		_ = os.Setenv(startupDirEnv, dir)
+	}
+}
+
+// startupDir is that directory; empty means the panels keep the restored paths.
+func startupDir() string {
+	return os.Getenv(startupDirEnv)
+}
 
 // SelectedTTYBackend holds the user-chosen or auto-detected console renderer name ("ansi" or "winapi").
 var SelectedTTYBackend string
@@ -84,6 +111,7 @@ func sudoStartupMode(args []string, askpassParent bool) (dispatcher string, askp
 
 func main() {
 	vtui.AppName = "f4"
+	rememberStartupDir()
 	configureF4DebugLogPath(GetF4ConfigDir())
 	if archivePath, archiveKind, found, err := parseUpdateHelperArgs(os.Args[1:]); found {
 		if err != nil {
@@ -721,6 +749,9 @@ func SetupUI() {
 	if len(states) > 0 {
 		applyWorkspaceSession(panels, states[0], width, height, AppConfig.SavePanelPaths)
 	}
+	// The startup directory outranks the restored paths. A client attaching to a
+	// running daemon brings its own instead -- see attachPayload.
+	applyStartupDir(panels, startupDir())
 	vtui.FrameManager.Push(panels)
 	if len(states) > 1 {
 		// AddScreenBackground inserts immediately after the active workspace;

--- a/cmd/f4/session_attach_payload_test.go
+++ b/cmd/f4/session_attach_payload_test.go
@@ -1,0 +1,31 @@
+//go:build !windows
+
+package main
+
+import "testing"
+
+func TestAttachPayloadRoundTrip(t *testing.T) {
+	cases := []struct {
+		name           string
+		editPath, cwd  string
+		wantWire       string
+		wantEdit, want string
+	}{
+		{name: "plain", wantWire: "ATTACH"},
+		{name: "cwd", cwd: "/home/u/dir", wantWire: "ATTACH\nCWD /home/u/dir", want: "/home/u/dir"},
+		// -e keeps the single-line wire format an older daemon understands.
+		{name: "edit", editPath: "/tmp/f.txt", cwd: "/home/u/dir", wantWire: "ATTACH /tmp/f.txt", wantEdit: "/tmp/f.txt"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire := string(attachPayload(tc.editPath, tc.cwd))
+			if wire != tc.wantWire {
+				t.Fatalf("attachPayload = %q, want %q", wire, tc.wantWire)
+			}
+			edit, cwd := parseAttachPayload(wire)
+			if edit != tc.wantEdit || cwd != tc.want {
+				t.Fatalf("parseAttachPayload(%q) = (%q, %q), want (%q, %q)", wire, edit, cwd, tc.wantEdit, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/f4/session_attach_payload_test.go
+++ b/cmd/f4/session_attach_payload_test.go
@@ -6,26 +6,54 @@ import "testing"
 
 func TestAttachPayloadRoundTrip(t *testing.T) {
 	cases := []struct {
-		name           string
-		editPath, cwd  string
-		wantWire       string
-		wantEdit, want string
+		name                  string
+		editPath, left, right string
+		wantWire              string
+		wantEdit              string
+		wantLeft, wantRight   string
 	}{
 		{name: "plain", wantWire: "ATTACH"},
-		{name: "cwd", cwd: "/home/u/dir", wantWire: "ATTACH\nCWD /home/u/dir", want: "/home/u/dir"},
+		{
+			name: "one directory", left: "/home/u/dir",
+			wantWire: "ATTACH\nCWD /home/u/dir", wantLeft: "/home/u/dir",
+		},
+		{
+			// Both panels going to the same place is what a plain start looks
+			// like, and it stays a one-line datagram.
+			name: "same on both sides", left: "/home/u/dir", right: "/home/u/dir",
+			wantWire: "ATTACH\nCWD /home/u/dir", wantLeft: "/home/u/dir",
+		},
+		{
+			name: "two directories", left: "/home/u/a", right: "/home/u/b",
+			wantWire: "ATTACH\nCWD /home/u/a\nCWD2 /home/u/b",
+			wantLeft: "/home/u/a", wantRight: "/home/u/b",
+		},
 		// -e keeps the single-line wire format an older daemon understands.
-		{name: "edit", editPath: "/tmp/f.txt", cwd: "/home/u/dir", wantWire: "ATTACH /tmp/f.txt", wantEdit: "/tmp/f.txt"},
+		{
+			name: "edit", editPath: "/tmp/f.txt", left: "/home/u/a", right: "/home/u/b",
+			wantWire: "ATTACH /tmp/f.txt", wantEdit: "/tmp/f.txt",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			wire := string(attachPayload(tc.editPath, tc.cwd))
+			wire := string(attachPayload(tc.editPath, tc.left, tc.right))
 			if wire != tc.wantWire {
 				t.Fatalf("attachPayload = %q, want %q", wire, tc.wantWire)
 			}
-			edit, cwd := parseAttachPayload(wire)
-			if edit != tc.wantEdit || cwd != tc.want {
-				t.Fatalf("parseAttachPayload(%q) = (%q, %q), want (%q, %q)", wire, edit, cwd, tc.wantEdit, tc.want)
+			edit, left, right := parseAttachPayload(wire)
+			if edit != tc.wantEdit || left != tc.wantLeft || right != tc.wantRight {
+				t.Fatalf("parseAttachPayload(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					wire, edit, left, right, tc.wantEdit, tc.wantLeft, tc.wantRight)
 			}
 		})
+	}
+}
+
+// A datagram from a client that speaks of something this build knows nothing
+// about must still attach, with the lines it does understand.
+func TestParseAttachPayloadIgnoresUnknownLines(t *testing.T) {
+	edit, left, right := parseAttachPayload("ATTACH\nCWD /home/u/a\nSOMETHING new\nCWD2 /home/u/b")
+	if edit != "" || left != "/home/u/a" || right != "/home/u/b" {
+		t.Fatalf("got (%q, %q, %q), want (\"\", \"/home/u/a\", \"/home/u/b\")", edit, left, right)
 	}
 }

--- a/cmd/f4/session_unix.go
+++ b/cmd/f4/session_unix.go
@@ -320,7 +320,8 @@ func runClient(sockPath string, serverPID int) {
 	oob := syscall.UnixRights(0, 1, notifyPipe[1])
 	vtui.DebugLog("CLIENT: FDs to send: In:0 Out:1 Pipe:%d", notifyPipe[1])
 
-	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath, startupDir()), oob, raddr)
+	startLeft, startRight := startupDirs()
+	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath, startLeft, startRight), oob, raddr)
 	if err != nil {
 		vtui.DebugLog("CLIENT: ATTACH FAILURE: Failed to send FDs to daemon at %s: %v", sockPath, err)
 		fmt.Fprintf(os.Stderr, "f4: failed to attach to session at %s: %v\n", sockPath, err)
@@ -380,7 +381,8 @@ type attachRequest struct {
 	notifyPipeWriteEnd int
 	rawFds             []int
 	editPath           string
-	startDir           string
+	startLeft          string
+	startRight         string
 }
 
 // attachPayload builds the ATTACH datagram body. Plain "ATTACH" when no
@@ -389,30 +391,39 @@ type attachRequest struct {
 // server and vice versa); "ATTACH <path>" when -e named a file, parsed
 // back out in runServer's accept loop below.
 //
-// The working directory rides on a second line, so an older server still reads
-// exactly "ATTACH" on the first. It is left out next to -e, where that server
-// would take the whole datagram as the file name.
-func attachPayload(editPath, cwd string) []byte {
+// The panel directories ride on further lines, so an older server still reads
+// exactly "ATTACH" on the first. They are left out next to -e, where that
+// server would take the whole datagram as the file name.
+func attachPayload(editPath, left, right string) []byte {
 	if editPath != "" {
 		return []byte("ATTACH " + editPath)
 	}
-	if cwd == "" {
+	if left == "" {
 		return []byte("ATTACH")
 	}
-	return []byte("ATTACH\nCWD " + cwd)
+	msg := "ATTACH\nCWD " + left
+	if right != "" && right != left {
+		msg += "\nCWD2 " + right
+	}
+	return []byte(msg)
 }
 
-// parseAttachPayload reads back what attachPayload wrote. An unknown extra
-// line is ignored rather than refused, so a future client stays attachable.
-func parseAttachPayload(msg string) (editPath, cwd string) {
-	head, rest, _ := strings.Cut(msg, "\n")
-	if strings.HasPrefix(head, "ATTACH ") {
-		editPath = head[len("ATTACH "):]
+// parseAttachPayload reads back what attachPayload wrote. Unknown lines are
+// ignored rather than refused, so a future client stays attachable.
+func parseAttachPayload(msg string) (editPath, left, right string) {
+	lines := strings.Split(msg, "\n")
+	if strings.HasPrefix(lines[0], "ATTACH ") {
+		editPath = lines[0][len("ATTACH "):]
 	}
-	if strings.HasPrefix(rest, "CWD ") {
-		cwd = rest[len("CWD "):]
+	for _, line := range lines[1:] {
+		switch {
+		case strings.HasPrefix(line, "CWD2 "):
+			right = line[len("CWD2 "):]
+		case strings.HasPrefix(line, "CWD "):
+			left = line[len("CWD "):]
+		}
 	}
-	return editPath, cwd
+	return editPath, left, right
 }
 
 func runServer(sockPath string) {
@@ -481,7 +492,7 @@ func runServer(sockPath string) {
 
 			setCloseOnExec(fds)
 
-			editPath, startDir := parseAttachPayload(string(buf[:n]))
+			editPath, startLeft, startRight := parseAttachPayload(string(buf[:n]))
 
 			req := attachRequest{
 				in:                 os.NewFile(uintptr(fds[0]), "/dev/stdin"),
@@ -489,7 +500,8 @@ func runServer(sockPath string) {
 				notifyPipeWriteEnd: fds[2],
 				rawFds:             fds,
 				editPath:           editPath,
-				startDir:           startDir,
+				startLeft:          startLeft,
+				startRight:         startRight,
 			}
 
 			// Preempt the current attached session (if any) so the new client takes over.
@@ -518,7 +530,7 @@ func runServer(sockPath string) {
 		newStdout := req.out
 		notifyPipeWriteEnd := req.notifyPipeWriteEnd
 		attachEditPath := req.editPath
-		attachStartDir := req.startDir
+		attachStartLeft, attachStartRight := req.startLeft, req.startRight
 
 		vtui.DebugLog("SERVER: FDs received (In:%d Out:%d Pipe:%d). Goroutines: %d. Attaching terminal.", fds[0], fds[1], fds[2], runtime.NumGoroutine())
 
@@ -620,10 +632,10 @@ func runServer(sockPath string) {
 
 		// A client that attached to a running daemon moves its workspace to its
 		// own directory, as a normal start would.
-		if attachStartDir != "" {
+		if attachStartLeft != "" {
 			if top := vtui.FrameManager.GetTopFrame(); top != nil {
 				if pf, ok := top.(*PanelsFrame); ok && pf != nil {
-					applyStartupDir(pf, attachStartDir)
+					applyStartupDirs(pf, attachStartLeft, attachStartRight)
 				}
 			}
 		}

--- a/cmd/f4/session_unix.go
+++ b/cmd/f4/session_unix.go
@@ -320,7 +320,7 @@ func runClient(sockPath string, serverPID int) {
 	oob := syscall.UnixRights(0, 1, notifyPipe[1])
 	vtui.DebugLog("CLIENT: FDs to send: In:0 Out:1 Pipe:%d", notifyPipe[1])
 
-	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath), oob, raddr)
+	n, oobn, err := conn.WriteMsgUnix(attachPayload(editFilePath, startupDir()), oob, raddr)
 	if err != nil {
 		vtui.DebugLog("CLIENT: ATTACH FAILURE: Failed to send FDs to daemon at %s: %v", sockPath, err)
 		fmt.Fprintf(os.Stderr, "f4: failed to attach to session at %s: %v\n", sockPath, err)
@@ -380,6 +380,7 @@ type attachRequest struct {
 	notifyPipeWriteEnd int
 	rawFds             []int
 	editPath           string
+	startDir           string
 }
 
 // attachPayload builds the ATTACH datagram body. Plain "ATTACH" when no
@@ -387,11 +388,31 @@ type attachRequest struct {
 // binary already speaks, so an old client can still attach to a new
 // server and vice versa); "ATTACH <path>" when -e named a file, parsed
 // back out in runServer's accept loop below.
-func attachPayload(editPath string) []byte {
-	if editPath == "" {
+//
+// The working directory rides on a second line, so an older server still reads
+// exactly "ATTACH" on the first. It is left out next to -e, where that server
+// would take the whole datagram as the file name.
+func attachPayload(editPath, cwd string) []byte {
+	if editPath != "" {
+		return []byte("ATTACH " + editPath)
+	}
+	if cwd == "" {
 		return []byte("ATTACH")
 	}
-	return []byte("ATTACH " + editPath)
+	return []byte("ATTACH\nCWD " + cwd)
+}
+
+// parseAttachPayload reads back what attachPayload wrote. An unknown extra
+// line is ignored rather than refused, so a future client stays attachable.
+func parseAttachPayload(msg string) (editPath, cwd string) {
+	head, rest, _ := strings.Cut(msg, "\n")
+	if strings.HasPrefix(head, "ATTACH ") {
+		editPath = head[len("ATTACH "):]
+	}
+	if strings.HasPrefix(rest, "CWD ") {
+		cwd = rest[len("CWD "):]
+	}
+	return editPath, cwd
 }
 
 func runServer(sockPath string) {
@@ -460,10 +481,7 @@ func runServer(sockPath string) {
 
 			setCloseOnExec(fds)
 
-			var editPath string
-			if msg := string(buf[:n]); strings.HasPrefix(msg, "ATTACH ") {
-				editPath = msg[len("ATTACH "):]
-			}
+			editPath, startDir := parseAttachPayload(string(buf[:n]))
 
 			req := attachRequest{
 				in:                 os.NewFile(uintptr(fds[0]), "/dev/stdin"),
@@ -471,6 +489,7 @@ func runServer(sockPath string) {
 				notifyPipeWriteEnd: fds[2],
 				rawFds:             fds,
 				editPath:           editPath,
+				startDir:           startDir,
 			}
 
 			// Preempt the current attached session (if any) so the new client takes over.
@@ -499,6 +518,7 @@ func runServer(sockPath string) {
 		newStdout := req.out
 		notifyPipeWriteEnd := req.notifyPipeWriteEnd
 		attachEditPath := req.editPath
+		attachStartDir := req.startDir
 
 		vtui.DebugLog("SERVER: FDs received (In:%d Out:%d Pipe:%d). Goroutines: %d. Attaching terminal.", fds[0], fds[1], fds[2], runtime.NumGoroutine())
 
@@ -594,6 +614,16 @@ func runServer(sockPath string) {
 			if pf, ok := top.(*PanelsFrame); ok && pf != nil {
 				if pf.shellMode == ShellModeHost && !pf.showPanels {
 					pf.enterHostConsole()
+				}
+			}
+		}
+
+		// A client that attached to a running daemon moves its workspace to its
+		// own directory, as a normal start would.
+		if attachStartDir != "" {
+			if top := vtui.FrameManager.GetTopFrame(); top != nil {
+				if pf, ok := top.(*PanelsFrame); ok && pf != nil {
+					applyStartupDir(pf, attachStartDir)
 				}
 			}
 		}

--- a/cmd/f4/startup_dir_test.go
+++ b/cmd/f4/startup_dir_test.go
@@ -1,0 +1,23 @@
+package main
+
+import "testing"
+
+// A start with no terminal -- Dock, the detached GUI copy, the daemon -- names
+// no startup directory, so the panels keep what the session restored. `go test`
+// runs without a terminal on stdin, which is exactly that case.
+func TestRememberStartupDirIgnoresStartWithoutTerminal(t *testing.T) {
+	t.Setenv(startupDirEnv, "")
+	rememberStartupDir()
+	if got := startupDir(); got != "" {
+		t.Fatalf("startupDir() = %q, want empty for a start without a terminal", got)
+	}
+}
+
+// The parent's answer travels through the environment; the child inherits it.
+func TestRememberStartupDirKeepsInheritedValue(t *testing.T) {
+	t.Setenv(startupDirEnv, "/from/parent")
+	rememberStartupDir()
+	if got := startupDir(); got != "/from/parent" {
+		t.Fatalf("startupDir() = %q, want the inherited value", got)
+	}
+}

--- a/cmd/f4/startup_dir_test.go
+++ b/cmd/f4/startup_dir_test.go
@@ -1,23 +1,99 @@
 package main
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 // A start with no terminal -- Dock, the detached GUI copy, the daemon -- names
 // no startup directory, so the panels keep what the session restored. `go test`
 // runs without a terminal on stdin, which is exactly that case.
-func TestRememberStartupDirIgnoresStartWithoutTerminal(t *testing.T) {
+func TestRememberStartupDirsIgnoresStartWithoutTerminal(t *testing.T) {
 	t.Setenv(startupDirEnv, "")
-	rememberStartupDir()
-	if got := startupDir(); got != "" {
-		t.Fatalf("startupDir() = %q, want empty for a start without a terminal", got)
+	t.Setenv(startupDirRightEnv, "")
+	rememberStartupDirs([]string{"/home/u/a"})
+	if left, right := startupDirs(); left != "" || right != "" {
+		t.Fatalf("startupDirs() = (%q, %q), want empty for a start without a terminal", left, right)
 	}
 }
 
 // The parent's answer travels through the environment; the child inherits it.
-func TestRememberStartupDirKeepsInheritedValue(t *testing.T) {
+func TestRememberStartupDirsKeepsInheritedValue(t *testing.T) {
 	t.Setenv(startupDirEnv, "/from/parent")
-	rememberStartupDir()
-	if got := startupDir(); got != "/from/parent" {
-		t.Fatalf("startupDir() = %q, want the inherited value", got)
+	t.Setenv(startupDirRightEnv, "/from/parent/right")
+	rememberStartupDirs([]string{"/ignored"})
+	left, right := startupDirs()
+	if left != "/from/parent" || right != "/from/parent/right" {
+		t.Fatalf("startupDirs() = (%q, %q), want the inherited values", left, right)
+	}
+}
+
+func TestStartupDirsForCommandLine(t *testing.T) {
+	// Real absolute paths of this platform: what counts as absolute, and which
+	// separator joins the parts, is what the answer is made of.
+	cwd := t.TempDir()
+	other := t.TempDir()
+	cases := []struct {
+		name       string
+		args       []string
+		left, righ string
+	}{
+		{name: "no arguments", left: cwd},
+		{name: "one directory", args: []string{other}, left: other, righ: cwd},
+		{name: "relative", args: []string{"src"}, left: filepath.Join(cwd, "src"), righ: cwd},
+		{
+			name: "dot", args: []string{filepath.Join(".", "a"), "."},
+			left: filepath.Join(cwd, "a"), righ: cwd,
+		},
+		{
+			name: "parent", args: []string{other, filepath.Join("..", "other")},
+			left: other, righ: filepath.Join(filepath.Dir(cwd), "other"),
+		},
+		// A third argument has no panel to go to.
+		{
+			name: "extra arguments", args: []string{other, cwd, other},
+			left: other, righ: cwd,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			left, right := startupDirsFor(cwd, tc.args)
+			if left != tc.left || right != tc.righ {
+				t.Fatalf("startupDirsFor(%q, %v) = (%q, %q), want (%q, %q)",
+					cwd, tc.args, left, right, tc.left, tc.righ)
+			}
+		})
+	}
+}
+
+func TestStartupDirArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{name: "nothing"},
+		{name: "one folder", args: []string{"src"}, want: []string{"src"}},
+		{name: "two folders", args: []string{"a", "b"}, want: []string{"a", "b"}},
+		{name: "folders then switches", args: []string{"a", "b", "--tty", "ansi"}, want: []string{"a", "b"}},
+		// --tty takes its backend as a separate word, so nothing after a switch
+		// is read as a folder.
+		{name: "after a switch", args: []string{"--tty", "a", "b"}},
+		{name: "separator", args: []string{"--debug", "--", "a", "b"}, want: []string{"a", "b"}},
+		{name: "separator keeps dashed names", args: []string{"--", "-weird-dir"}, want: []string{"-weird-dir"}},
+		{name: "unknown switch", args: []string{"--nope", "a"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := startupDirArgs(tc.args)
+			if len(got) != len(tc.want) {
+				t.Fatalf("startupDirArgs(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Fatalf("startupDirArgs(%v) = %v, want %v", tc.args, got, tc.want)
+				}
+			}
+		})
 	}
 }

--- a/cmd/f4/workspace_session.go
+++ b/cmd/f4/workspace_session.go
@@ -292,19 +292,30 @@ func navigatePanelTo(pf *PanelsFrame, panel *FileSystemPanel, path string) {
 	panel.ReadDirectory()
 }
 
-// applyStartupDir opens dir in both panels, so `cd dir && f4` shows dir and not
-// session.ini's paths. It runs after applyWorkspaceSession and therefore wins;
-// an empty dir changes nothing.
-func applyStartupDir(pf *PanelsFrame, dir string) {
-	if pf == nil || dir == "" {
+// applyStartupDirs opens left and right in the two panels, so `cd dir && f4`
+// shows dir and `f4 dir1 dir2` shows both, rather than session.ini's paths. It
+// runs after applyWorkspaceSession and therefore wins; an empty left changes
+// nothing, and an empty right sends both panels to left.
+//
+// A right that differs from left only ever comes from the command line, so it
+// also says the focus belongs on the directory named first.
+func applyStartupDirs(pf *PanelsFrame, left, right string) {
+	if pf == nil || left == "" {
 		return
 	}
-	for _, p := range pf.panels {
-		if fsp, ok := p.(*FileSystemPanel); ok && fsp != nil {
+	fromCommandLine := right != "" && right != left
+	if right == "" {
+		right = left
+	}
+	for idx, dir := range [2]string{left, right} {
+		if fsp, ok := pf.panels[idx].(*FileSystemPanel); ok && fsp != nil {
 			navigatePanelTo(pf, fsp, dir)
 			// The pending cursor names a file of the directory just left.
 			fsp.pendingSelection = ""
 		}
+	}
+	if fromCommandLine {
+		pf.activeIdx = 0
 	}
 }
 

--- a/cmd/f4/workspace_session.go
+++ b/cmd/f4/workspace_session.go
@@ -273,6 +273,41 @@ func validSessionViewMode(mode int) ViewMode {
 	return viewMode
 }
 
+// navigatePanelTo moves a panel to path. What does not open as an object of its
+// own (an archive, a provider resource) stays a plain path in the current VFS;
+// a URI without its plugin is not even that.
+func navigatePanelTo(pf *PanelsFrame, panel *FileSystemPanel, path string) {
+	if path == "" || pf.NavigateToPath(panel, path) {
+		return
+	}
+	if vfs.IsURIPath(path) {
+		return
+	}
+	// A path that no longer exists leaves the VFS where it was, so re-reading
+	// the directory would only redraw the one already on screen.
+	if err := panel.vfs.SetPath(path); err != nil {
+		vtui.DebugLog("SESSION: cannot open %s: %v", path, err)
+		return
+	}
+	panel.ReadDirectory()
+}
+
+// applyStartupDir opens dir in both panels, so `cd dir && f4` shows dir and not
+// session.ini's paths. It runs after applyWorkspaceSession and therefore wins;
+// an empty dir changes nothing.
+func applyStartupDir(pf *PanelsFrame, dir string) {
+	if pf == nil || dir == "" {
+		return
+	}
+	for _, p := range pf.panels {
+		if fsp, ok := p.(*FileSystemPanel); ok && fsp != nil {
+			navigatePanelTo(pf, fsp, dir)
+			// The pending cursor names a file of the directory just left.
+			fsp.pendingSelection = ""
+		}
+	}
+}
+
 func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, height int, restorePaths bool) {
 	if pf == nil {
 		return
@@ -296,18 +331,9 @@ func applyWorkspaceSession(pf *PanelsFrame, state workspaceSessionState, width, 
 	left.sortMode, right.sortMode = SortMode(state.Left.SortMode), SortMode(state.Right.SortMode)
 	left.sortReverse, right.sortReverse = state.Left.SortReverse, state.Right.SortReverse
 
-	navigate := func(panel *FileSystemPanel, path string) {
-		if path == "" || pf.NavigateToPath(panel, path) {
-			return
-		}
-		if !vfs.IsURIPath(path) {
-			panel.vfs.SetPath(path)
-			panel.ReadDirectory()
-		}
-	}
 	if restorePaths {
-		navigate(left, state.Left.Path)
-		navigate(right, state.Right.Path)
+		navigatePanelTo(pf, left, state.Left.Path)
+		navigatePanelTo(pf, right, state.Right.Path)
 		left.pendingSelection, right.pendingSelection = state.Left.Cursor, state.Right.Cursor
 	}
 


### PR DESCRIPTION
Второе требование из #822: понимать папки в аргументах, как это делает mc.

Построен поверх #919, поэтому диф здесь показывает и его коммит. После вливания #919 останется только второй коммит — ребейзну по просьбе.

## Что делает

```
f4                 обе панели: текущая папка
f4 dir             слева dir, справа текущая, курсор слева
f4 dir1 dir2       слева dir1, справа dir2, курсор слева
```

Относительные пути и `.` разрешаются в момент запуска, пока рабочая директория ещё шелловская. Третий аргумент и дальше игнорируются — панелей всего две.

## Порядок аргументов

Папки берутся до первого флага либо после разделителя `--`:

```
f4 dir1 dir2 --tty=ansi     работает
f4 --tty=ansi -- dir1 dir2  работает
f4 --tty=ansi dir1 dir2     папками не считаются
```

Причина последней строки: `--gui` и `--tty` принимают имя бэкенда отдельным словом, так что слово после флага может принадлежать и флагу, и панели. Угадывать по списку известных бэкендов — значит сделать поведение зависимым от опечатки, поэтому f4 просто не берёт папки после флагов. Разбор самих флагов при этом не изменился.

## Как передаётся

Тем же путём, что и стартовая директория из #919 — через окружение, потому что рисующий процесс (отсоединённая копия GUI или демон сессии) командной строки клиента не видит. Клиент, подключающийся к уже работающему демону, передаёт вторую папку строкой `CWD2`; демон, который о ней не знает, читает только `CWD`, а совсем старый — по-прежнему видит ровно `ATTACH`.

## Проверено

macOS, TTY: все четыре формы выше, один аргумент, подключение к живому демону через диалог выбора сессии (панели уходят в названные папки), `ActivePanel = 0` в session.ini после выхода. Тесты: разбор командной строки, разрешение путей, round-trip ATTACH с двумя папками и с незнакомой строкой. На Termux пока не прогонял.