### PR TITLE
fix: skip VT mouse tracking reset in Windows Terminal on console toggle

### DIFF
--- a/cmd/f4/console_passthrough.go
+++ b/cmd/f4/console_passthrough.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/unxed/vtinput"
@@ -444,7 +445,15 @@ func (pf *PanelsFrame) leaveHostConsole() {
 	if pf.termView != nil && pf.termView.UseAltScreen {
 		resetSeq.WriteString("\x1b[?1049l")
 	}
-	resetSeq.WriteString("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l\x1b[r\x1b[0m\x1b[?25h")
+	// In Windows Terminal, sending VT mouse tracking disable sequences
+	// (1000/1002/1003/1006) before switching back to the alt screen
+	// confuses WT's internal input routing: mouse buttons get swapped
+	// and the Shift modifier gets stuck.  Skip them when running inside
+	// WT; the basic resets (scroll region, attributes, cursor) are safe.
+	if os.Getenv("WT_SESSION") == "" {
+		resetSeq.WriteString("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\x1b[?2004l")
+	}
+	resetSeq.WriteString("\x1b[r\x1b[0m\x1b[?25h")
 	vtui.WritePassthrough([]byte(resetSeq.String()))
 
 	vtui.SetAltScreen(true)


### PR DESCRIPTION
## Problem

In **Console host** mode, pressing Esc or Ctrl+O to toggle between panels and host console, then returning back, breaks mouse input in Windows Terminal:

- **RClick** starts text selection (LClick behavior)
- **LClick** shows Windows Terminal context menu (RClick behavior)
- Shift modifier appears stuck

This does **not** happen in openconsole/conhost.

## Root cause

leaveHostConsole() sends VT sequences to disable mouse tracking modes (1000l/1002l/1003l/1006l/2004l) **before** switching back to the alt screen. In openconsole these are harmless no-ops. In Windows Terminal, they confuse WT's internal input routing — the terminal changes how it generates MOUSE_EVENT_RECORD events, swapping button roles and sticking the modifier state.

## Fix

Skip the VT mouse tracking disable sequences when WT_SESSION is set (Windows Terminal detected). The basic resets (scroll region, attributes, cursor) are left intact and are safe on all terminals.

WT cleans up child-process modes via ConPTY on its own, so the explicit disable is redundant there.