### PR TITLE
updater: install updates from the command line (--update)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@
 
 *These builds are automated and represent the current state of the `main` branch.*
 
+An installed f4 updates itself from the command line, no browser needed:
+
+```sh
+f4 --update nightly   # newest nightly build
+f4 --update stable    # newest tagged release
+f4 --update           # whichever channel is configured (Options > Auto update)
+```
+
+A named channel also becomes the one f4 checks automatically from then on.
+
 ### 🍺 Install on macOS via Homebrew
 
 Tagged releases (`vX.Y.Z`) are published to a Homebrew tap, so you can install with one command:

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ brew install unxed/tap/f4
 
 To upgrade later: `brew upgrade f4`. Both Apple Silicon (arm64) and Intel (amd64) Macs are supported.
 
+The tap carries tagged releases only, so a nightly build has to come from f4 itself: `f4 --update nightly` writes it into the Cellar directory brew installed to. That works, and `brew upgrade` or `brew reinstall` puts the tagged release back whenever you want it.
+
 **The Core:** Creating an experimental, cross-platform TUI (Terminal User Interface) file manager that aims to fully replicate the features, UX, data structures, and rendering logic of `far2l` and Far Manager, but implemented entirely in Go.
 
 ### Philosophy & Goals

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -271,6 +271,8 @@ func main() {
 	var attachedMode bool
 	var wineProbe bool
 	var dumpScreenAfter float64
+	var updateRequested bool
+	var updateChannelArg string
 
 	exeName := filepath.Base(absExecPath)
 	if strings.Contains(strings.ToLower(exeName), "gui") {
@@ -296,6 +298,14 @@ func main() {
 			version = true
 		case "--debug":
 			os.Setenv("VTUI_DEBUG", "1")
+		case "--update":
+			updateRequested = true
+			if flagVal != "" {
+				updateChannelArg = flagVal
+			} else if i+1 < len(os.Args) && !strings.HasPrefix(os.Args[i+1], "-") {
+				updateChannelArg = os.Args[i+1]
+				i++
+			}
 		case "--gui":
 			guiMode = true
 			startupChoiceGiven = true
@@ -417,6 +427,11 @@ func main() {
 		fmt.Println(getFormattedVersionInfo())
 		return
 	}
+	// Обновление — команда, а не способ запустить файловый менеджер: ни
+	// панелей, ни сессии здесь не поднимается.
+	if updateRequested {
+		os.Exit(runUpdateCLI(updateChannelArg))
+	}
 	if print_help {
 		fmt.Printf(`f4 version: %s
 f4 is efficient and cozy two-panel file manager in go
@@ -451,6 +466,11 @@ The following switches may be used in the command line:
  --new-plugin [pluginName]
  --server [serverPath]
  -test-plugins          Plugin test mode
+ --update [Channel]     Download and install the newest build, then exit;
+                         [Channel] values: "stable" (or "latest"), "nightly";
+                         if Channel omited, the configured update channel is
+                         used ([Update] Channel, Options > Auto update), and
+                         a named channel becomes the configured one
  --tty [Backend]        Force run in TTY-mode
                          [Backend] values: "ansi", "winapi" (or "win32"),
                          "auto"; if Backend omited, the configured default

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -492,10 +492,9 @@ see in vtinput project: https://github.com/unxed/vtinput
 		return
 	}
 
-	// Обновление — команда, а не способ запустить файловый менеджер: ни
-	// панелей, ни сессии здесь не поднимается. Выход через os.Exit минует
-	// отложенный SaveSession намеренно: сессии этот запуск не касался, и
-	// перезаписывать её сохранённым при загрузке состоянием нечем.
+	// Updating is a command, not a way to start the file manager: no panels
+	// and no session come up here. os.Exit skips the deferred SaveSession on
+	// purpose, this run never touched the session.
 	if updateRequested {
 		os.Exit(runUpdateCLI(updateChannelArg))
 	}

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -427,11 +427,6 @@ func main() {
 		fmt.Println(getFormattedVersionInfo())
 		return
 	}
-	// Обновление — команда, а не способ запустить файловый менеджер: ни
-	// панелей, ни сессии здесь не поднимается.
-	if updateRequested {
-		os.Exit(runUpdateCLI(updateChannelArg))
-	}
 	if print_help {
 		fmt.Printf(`f4 version: %s
 f4 is efficient and cozy two-panel file manager in go
@@ -466,15 +461,15 @@ The following switches may be used in the command line:
  --new-plugin [pluginName]
  --server [serverPath]
  -test-plugins          Plugin test mode
+ --tty [Backend]        Force run in TTY-mode
+                         [Backend] values: "ansi", "winapi" (or "win32"),
+                         "auto"; if Backend omited, the configured default
+                         is used ([Startup] TTYBackend)
  --update [Channel]     Download and install the newest build, then exit;
                          [Channel] values: "stable" (or "latest"), "nightly";
                          if Channel omited, the configured update channel is
                          used ([Update] Channel, Options > Auto update), and
                          a named channel becomes the configured one
- --tty [Backend]        Force run in TTY-mode
-                         [Backend] values: "ansi", "winapi" (or "win32"),
-                         "auto"; if Backend omited, the configured default
-                         is used ([Startup] TTYBackend)
  --wine-probe           Print console/terminal environment facts and exit
                          (renderer backend, console geometry, shell mode)
 
@@ -495,6 +490,14 @@ see in vtinput project: https://github.com/unxed/vtinput
 `,
 			getFormattedVersionInfo())
 		return
+	}
+
+	// Обновление — команда, а не способ запустить файловый менеджер: ни
+	// панелей, ни сессии здесь не поднимается. Выход через os.Exit минует
+	// отложенный SaveSession намеренно: сессии этот запуск не касался, и
+	// перезаписывать её сохранённым при загрузке состоянием нечем.
+	if updateRequested {
+		os.Exit(runUpdateCLI(updateChannelArg))
 	}
 
 	for _, arg := range os.Args {

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -21,7 +21,7 @@ func parseUpdateChannelArg(arg string, configured int) (channel int, explicit bo
 	switch strings.ToLower(strings.TrimSpace(arg)) {
 	case "":
 		return configured, false, nil
-	case "stable", "latest", "release":
+	case "stable", "latest":
 		return updateChannelStable, true, nil
 	case "nightly":
 		return updateChannelNightly, true, nil

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/term"
 )
 
-// updateChannelName называет канал так, как он пишется в командной строке.
+// updateChannelName spells a channel the way the command line does.
 func updateChannelName(channel int) string {
 	if channel == updateChannelNightly {
 		return "nightly"
@@ -18,8 +18,8 @@ func updateChannelName(channel int) string {
 	return "stable"
 }
 
-// parseUpdateChannelArg переводит аргумент `--update` в номер канала.
-// Пустой аргумент означает канал из настроек.
+// parseUpdateChannelArg turns the `--update` argument into a channel number.
+// An empty argument means the configured channel.
 func parseUpdateChannelArg(arg string, configured int) (channel int, explicit bool, err error) {
 	switch strings.ToLower(strings.TrimSpace(arg)) {
 	case "":
@@ -32,12 +32,11 @@ func parseUpdateChannelArg(arg string, configured int) (channel int, explicit bo
 	return 0, false, fmt.Errorf("unknown update channel %q (expected \"stable\" or \"nightly\")", arg)
 }
 
-// runUpdateCLI обслуживает `f4 --update [stable|nightly]`: тот же механизм,
-// что и диалог обновления, но без интерфейса — скачивает и ставит сразу.
-// Возвращает код завершения процесса.
+// runUpdateCLI serves `f4 --update [stable|nightly]`: the machinery behind the
+// update dialog, without the UI. Returns the process exit code.
 //
-// Весь вывод идёт в stdout: к этому моменту vtui.SetupStderrLog уже увёл
-// stderr в файл лога, и написанное туда пользователь не увидит.
+// Everything goes to stdout, because vtui.SetupStderrLog has already sent
+// stderr to the log file where the user would never see it.
 func runUpdateCLI(channelArg string) int {
 	channel, explicit, err := parseUpdateChannelArg(channelArg, AppConfig.UpdateChannel)
 	if err != nil {
@@ -46,16 +45,15 @@ func runUpdateCLI(channelArg string) int {
 	}
 
 	if explicit && AppConfig.UpdateChannel != channel {
-		// Названный каналом становится каналом автопроверок сразу, до
-		// опроса GitHub: выход по «уже актуально» или сетевой сбой иначе
-		// оставит проверки на прежнем канале, и ближайшая же позовёт
-		// обратно на него.
+		// The named channel is configured before GitHub is asked: an "already
+		// up to date" exit or a network failure would otherwise leave the
+		// automatic checks on the old channel, calling the user back to it.
 		AppConfig.UpdateChannel = channel
 		SaveConfig()
 	}
 
-	// Ночной архив на медленном канале качается минутами, поэтому здесь
-	// таймаут щедрее десяти секунд, отведённых на опрос API.
+	// A nightly archive takes minutes over a slow link, so this timeout is far
+	// wider than the ten seconds an API query gets.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 
@@ -76,9 +74,8 @@ func runUpdateCLI(channelArg string) int {
 	}
 
 	fmt.Printf("Installing %s\n", cand.displayVersion)
-	// Проценты перерисовываются возвратом каретки, поэтому в файл или в
-	// журнал CI они не печатаются вовсе: там от них остаётся мусорная
-	// строка вместо хода загрузки.
+	// Percentages are redrawn with a carriage return, so a redirected run gets
+	// none: in a file they pile into one unreadable line.
 	showProgress := term.IsTerminal(int(os.Stdout.Fd()))
 	lastPct := -1
 	data, err := downloadUpdateArchive(ctx, cand.downloadURL, func(percent int) {

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -3,8 +3,11 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // updateChannelName называет канал так, как он пишется в командной строке.
@@ -73,15 +76,21 @@ func runUpdateCLI(channelArg string) int {
 	}
 
 	fmt.Printf("Installing %s\n", cand.displayVersion)
+	// Проценты перерисовываются возвратом каретки, поэтому в файл или в
+	// журнал CI они не печатаются вовсе: там от них остаётся мусорная
+	// строка вместо хода загрузки.
+	showProgress := term.IsTerminal(int(os.Stdout.Fd()))
 	lastPct := -1
 	data, err := downloadUpdateArchive(ctx, cand.downloadURL, func(percent int) {
-		if percent == lastPct {
+		if !showProgress || percent == lastPct {
 			return
 		}
 		lastPct = percent
 		fmt.Printf("\rDownloading... %d%%", percent)
 	})
-	fmt.Println()
+	if showProgress {
+		fmt.Println()
+	}
 	if err != nil {
 		fmt.Printf("f4: download failed: %v\n", err)
 		return 1

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -67,6 +67,11 @@ func runUpdateCLI(channelArg string) int {
 		return 0
 	}
 
+	if _, err := updateTargetDir(); err != nil {
+		fmt.Printf("f4: %v\n", err)
+		return 1
+	}
+
 	fmt.Printf("Installing %s\n", cand.displayVersion)
 	lastPct := -1
 	data, err := downloadUpdateArchive(ctx, cand.downloadURL, func(percent int) {

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -42,6 +42,15 @@ func runUpdateCLI(channelArg string) int {
 		return 2
 	}
 
+	if explicit && AppConfig.UpdateChannel != channel {
+		// Названный каналом становится каналом автопроверок сразу, до
+		// опроса GitHub: выход по «уже актуально» или сетевой сбой иначе
+		// оставит проверки на прежнем канале, и ближайшая же позовёт
+		// обратно на него.
+		AppConfig.UpdateChannel = channel
+		SaveConfig()
+	}
+
 	// Ночной архив на медленном канале качается минутами, поэтому здесь
 	// таймаут щедрее десяти секунд, отведённых на опрос API.
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
@@ -80,12 +89,6 @@ func runUpdateCLI(channelArg string) int {
 
 	AppConfig.LastUpdateVersion = cand.updateKey
 	AppConfig.LastUpdateCheck = time.Now().Unix()
-	if explicit {
-		// Названный в командной строке канал становится каналом
-		// автопроверок, иначе ближайшая же проверка предложит уйти
-		// обратно на прежний.
-		AppConfig.UpdateChannel = channel
-	}
 	SaveConfig()
 
 	fmt.Printf("Installed %s. Restart f4 to use it.\n", cand.displayVersion)

--- a/cmd/f4/update_cli.go
+++ b/cmd/f4/update_cli.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// updateChannelName называет канал так, как он пишется в командной строке.
+func updateChannelName(channel int) string {
+	if channel == updateChannelNightly {
+		return "nightly"
+	}
+	return "stable"
+}
+
+// parseUpdateChannelArg переводит аргумент `--update` в номер канала.
+// Пустой аргумент означает канал из настроек.
+func parseUpdateChannelArg(arg string, configured int) (channel int, explicit bool, err error) {
+	switch strings.ToLower(strings.TrimSpace(arg)) {
+	case "":
+		return configured, false, nil
+	case "stable", "latest", "release":
+		return updateChannelStable, true, nil
+	case "nightly":
+		return updateChannelNightly, true, nil
+	}
+	return 0, false, fmt.Errorf("unknown update channel %q (expected \"stable\" or \"nightly\")", arg)
+}
+
+// runUpdateCLI обслуживает `f4 --update [stable|nightly]`: тот же механизм,
+// что и диалог обновления, но без интерфейса — скачивает и ставит сразу.
+// Возвращает код завершения процесса.
+//
+// Весь вывод идёт в stdout: к этому моменту vtui.SetupStderrLog уже увёл
+// stderr в файл лога, и написанное туда пользователь не увидит.
+func runUpdateCLI(channelArg string) int {
+	channel, explicit, err := parseUpdateChannelArg(channelArg, AppConfig.UpdateChannel)
+	if err != nil {
+		fmt.Printf("f4: %v\n", err)
+		return 2
+	}
+
+	// Ночной архив на медленном канале качается минутами, поэтому здесь
+	// таймаут щедрее десяти секунд, отведённых на опрос API.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	fmt.Printf("Checking the %s channel...\n", updateChannelName(channel))
+	cand, err := fetchUpdateCandidate(ctx, channel)
+	if err != nil {
+		fmt.Printf("f4: update check failed: %v\n", err)
+		return 1
+	}
+	if !cand.needsUpdate {
+		fmt.Printf("Already up to date: %s\n", cand.displayVersion)
+		return 0
+	}
+
+	fmt.Printf("Installing %s\n", cand.displayVersion)
+	lastPct := -1
+	data, err := downloadUpdateArchive(ctx, cand.downloadURL, func(percent int) {
+		if percent == lastPct {
+			return
+		}
+		lastPct = percent
+		fmt.Printf("\rDownloading... %d%%", percent)
+	})
+	fmt.Println()
+	if err != nil {
+		fmt.Printf("f4: download failed: %v\n", err)
+		return 1
+	}
+
+	if err := installUpdateArchive(data, cand.archiveKind); err != nil {
+		fmt.Printf("f4: install failed: %v\n", err)
+		return 1
+	}
+
+	AppConfig.LastUpdateVersion = cand.updateKey
+	AppConfig.LastUpdateCheck = time.Now().Unix()
+	if explicit {
+		// Названный в командной строке канал становится каналом
+		// автопроверок, иначе ближайшая же проверка предложит уйти
+		// обратно на прежний.
+		AppConfig.UpdateChannel = channel
+	}
+	SaveConfig()
+
+	fmt.Printf("Installed %s. Restart f4 to use it.\n", cand.displayVersion)
+	return 0
+}

--- a/cmd/f4/update_cli_test.go
+++ b/cmd/f4/update_cli_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseUpdateChannelArg(t *testing.T) {
+	cases := []struct {
+		arg      string
+		want     int
+		explicit bool
+		wantErr  bool
+	}{
+		{"", updateChannelNightly, false, false}, // пусто — канал из настроек
+		{"stable", updateChannelStable, true, false},
+		{"latest", updateChannelStable, true, false},
+		{"Nightly", updateChannelNightly, true, false},
+		{" nightly ", updateChannelNightly, true, false},
+		{"beta", 0, false, true},
+	}
+	for _, c := range cases {
+		got, explicit, err := parseUpdateChannelArg(c.arg, updateChannelNightly)
+		if (err != nil) != c.wantErr {
+			t.Fatalf("%q: err = %v, wantErr %v", c.arg, err, c.wantErr)
+		}
+		if err != nil {
+			continue
+		}
+		if got != c.want || explicit != c.explicit {
+			t.Errorf("%q: got channel %d explicit %v, want %d %v", c.arg, got, explicit, c.want, c.explicit)
+		}
+	}
+}
+
+// Канал решает, какой конечной точки спрашивать и как называть сборку —
+// именно это отличает `--update nightly` от `--update stable`.
+func TestFetchUpdateCandidateFollowsChannel(t *testing.T) {
+	oldCfg := AppConfig
+	origOS, origArch, origAPI := currentOS, currentArch, githubAPIURL
+	t.Cleanup(func() {
+		AppConfig = oldCfg
+		currentOS, currentArch, githubAPIURL = origOS, origArch, origAPI
+	})
+	currentOS, currentArch = "linux", "amd64"
+	AppConfig.LastUpdateVersion = ""
+
+	var asked string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = r.URL.Path
+		release := githubRelease{
+			TagName:     "v100.0.0",
+			PublishedAt: "2030-01-01T00:00:00Z",
+			Body:        "**Commit:** `abc1234`\n**Built on:** `2030-01-01 00:00`",
+			Assets: []githubAsset{{
+				Name:               "f4-linux-amd64.tar.gz",
+				BrowserDownloadURL: "http://mock/f4.tar.gz",
+				UpdatedAt:          "2030-01-01T00:00:00Z",
+			}},
+		}
+		if err := json.NewEncoder(w).Encode(release); err != nil {
+			t.Errorf("encode release: %v", err)
+		}
+	}))
+	defer ts.Close()
+	githubAPIURL = ts.URL + "/repos/unxed/f4/releases"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cand, err := fetchUpdateCandidate(ctx, updateChannelNightly)
+	if err != nil {
+		t.Fatalf("nightly: %v", err)
+	}
+	if asked != "/repos/unxed/f4/releases/tags/nightly" {
+		t.Errorf("nightly asked %q", asked)
+	}
+	// Время сборки показывается в местной зоне, поэтому сверяется коммит.
+	if !strings.HasPrefix(cand.displayVersion, "Nightly (abc1234 [") {
+		t.Errorf("nightly display version %q", cand.displayVersion)
+	}
+	if cand.updateKey != "2030-01-01T00:00:00Z" || !cand.needsUpdate {
+		t.Errorf("nightly key %q needsUpdate %v", cand.updateKey, cand.needsUpdate)
+	}
+	if cand.archiveKind != "targz" || cand.downloadURL != "http://mock/f4.tar.gz" {
+		t.Errorf("nightly asset %q %q", cand.archiveKind, cand.downloadURL)
+	}
+
+	cand, err = fetchUpdateCandidate(ctx, updateChannelStable)
+	if err != nil {
+		t.Fatalf("stable: %v", err)
+	}
+	if asked != "/repos/unxed/f4/releases/latest" {
+		t.Errorf("stable asked %q", asked)
+	}
+	if cand.displayVersion != "v100.0.0" || cand.updateKey != "v100.0.0" {
+		t.Errorf("stable version %q key %q", cand.displayVersion, cand.updateKey)
+	}
+}
+
+// 403 от исчерпанного лимита должен объясняться словами, а не номером:
+// именно в него упирается всякий, кто проверяет обновления часто.
+func TestFetchUpdateCandidateExplainsRateLimit(t *testing.T) {
+	origAPI := githubAPIURL
+	t.Cleanup(func() { githubAPIURL = origAPI })
+
+	reset := time.Now().Add(42 * time.Minute)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Remaining", "0")
+		w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(reset.Unix(), 10))
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer ts.Close()
+	githubAPIURL = ts.URL
+
+	_, err := fetchUpdateCandidate(context.Background(), updateChannelStable)
+	if err == nil {
+		t.Fatal("rate-limited check must fail")
+	}
+	if !strings.Contains(err.Error(), "60 per hour") || !strings.Contains(err.Error(), reset.Format("15:04")) {
+		t.Errorf("unhelpful rate limit message: %q", err)
+	}
+}

--- a/cmd/f4/update_cli_test.go
+++ b/cmd/f4/update_cli_test.go
@@ -18,7 +18,7 @@ func TestParseUpdateChannelArg(t *testing.T) {
 		explicit bool
 		wantErr  bool
 	}{
-		{"", updateChannelNightly, false, false}, // пусто — канал из настроек
+		{"", updateChannelNightly, false, false}, // empty means the configured channel
 		{"stable", updateChannelStable, true, false},
 		{"latest", updateChannelStable, true, false},
 		{"Nightly", updateChannelNightly, true, false},
@@ -39,8 +39,8 @@ func TestParseUpdateChannelArg(t *testing.T) {
 	}
 }
 
-// Канал решает, какой конечной точки спрашивать и как называть сборку —
-// именно это отличает `--update nightly` от `--update stable`.
+// The channel decides which endpoint is asked and how the build is named,
+// which is the whole difference between --update nightly and --update stable.
 func TestFetchUpdateCandidateFollowsChannel(t *testing.T) {
 	oldCfg := AppConfig
 	origOS, origArch, origAPI := currentOS, currentArch, githubAPIURL
@@ -81,7 +81,7 @@ func TestFetchUpdateCandidateFollowsChannel(t *testing.T) {
 	if asked != "/repos/unxed/f4/releases/tags/nightly" {
 		t.Errorf("nightly asked %q", asked)
 	}
-	// Время сборки показывается в местной зоне, поэтому сверяется коммит.
+	// The build time renders in local time, so match on the commit instead.
 	if !strings.HasPrefix(cand.displayVersion, "Nightly (abc1234 [") {
 		t.Errorf("nightly display version %q", cand.displayVersion)
 	}
@@ -104,8 +104,8 @@ func TestFetchUpdateCandidateFollowsChannel(t *testing.T) {
 	}
 }
 
-// 403 от исчерпанного лимита должен объясняться словами, а не номером:
-// именно в него упирается всякий, кто проверяет обновления часто.
+// A 403 from the spent request limit has to explain itself rather than show a
+// number: it is what anyone who checks for updates often runs into.
 func TestFetchUpdateCandidateExplainsRateLimit(t *testing.T) {
 	origAPI := githubAPIURL
 	t.Cleanup(func() { githubAPIURL = origAPI })

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -119,28 +120,38 @@ func shouldCheck() bool {
 	return false
 }
 
-func CheckForUpdates(pf *PanelsFrame, manual bool) {
-	if !manual && !shouldCheck() {
-		return
-	}
+// Каналы обновления перечислены в том же порядке, что комбобокс в настройках.
+const (
+	updateChannelStable  = 0
+	updateChannelNightly = 1
+)
 
-	AppConfig.LastUpdateCheck = time.Now().Unix()
-	SaveConfig()
+// updateCandidate — сборка, которую канал предлагает поставить.
+type updateCandidate struct {
+	downloadURL    string
+	archiveKind    string
+	displayVersion string
+	tagName        string
+	// updateKey расходится с tagName только на ночном канале: тег там
+	// всегда "nightly", поэтому отметкой уже поставленной сборки служит
+	// время загрузки asset'а.
+	updateKey   string
+	needsUpdate bool
+}
 
+// fetchUpdateCandidate спрашивает GitHub, что предлагает канал, и решает,
+// новее ли это запущенной сборки. Общая часть для диалога и для --update.
+func fetchUpdateCandidate(ctx context.Context, channel int) (updateCandidate, error) {
 	url := githubAPIURL + "/latest"
-	if AppConfig.UpdateChannel == 1 {
+	if channel == updateChannelNightly {
 		url = githubAPIURL + "/tags/nightly"
 	}
 
 	vtui.DebugLog("UPDATER: Checking for updates at %s", url)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		reportUpdateError(manual, "Failed to create request: "+err.Error())
-		return
+		return updateCandidate{}, fmt.Errorf("failed to create request: %w", err)
 	}
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 	req.Header.Set("User-Agent", "f4-updater")
@@ -148,8 +159,7 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 	// Everything f4 fetches goes through the configured proxy, if any.
 	resp, err := netproxy.HTTPClient(0).Do(req)
 	if err != nil {
-		reportUpdateError(manual, "Network error: "+err.Error())
-		return
+		return updateCandidate{}, fmt.Errorf("network error: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -158,65 +168,103 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		vtui.DebugLog("UPDATER ERROR: HTTP %d from %s (Proxy: %s, Proxy-Authenticate: %q)",
 			resp.StatusCode, url, netproxy.Global().Describe(), proxyAuthHeader)
 		if resp.StatusCode == http.StatusProxyAuthRequired {
-			reportUpdateError(manual, fmt.Sprintf("GitHub API returned status 407 (Proxy Authentication Required).\nProxy: %s, Proxy-Authenticate: %s", netproxy.Global().Describe(), proxyAuthHeader))
-			return
+			return updateCandidate{}, fmt.Errorf("GitHub API returned status 407 (Proxy Authentication Required).\nProxy: %s, Proxy-Authenticate: %s", netproxy.Global().Describe(), proxyAuthHeader)
 		}
-		reportUpdateError(manual, fmt.Sprintf("GitHub API returned status %d", resp.StatusCode))
-		return
+		if msg := githubRateLimitMessage(resp); msg != "" {
+			return updateCandidate{}, fmt.Errorf("%s", msg)
+		}
+		return updateCandidate{}, fmt.Errorf("GitHub API returned status %d", resp.StatusCode)
 	}
 
 	var release githubRelease
 	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
-		reportUpdateError(manual, "Failed to parse API response: "+err.Error())
-		return
+		return updateCandidate{}, fmt.Errorf("failed to parse API response: %w", err)
 	}
 
-	assetSuffixes := updateAssetSuffixes(currentOS, currentArch, currentLibc)
-
-	downloadURL, assetUpdated, archiveKind := pickAsset(release.Assets, assetSuffixes)
-
+	downloadURL, assetUpdated, archiveKind := pickAsset(release.Assets, updateAssetSuffixes(currentOS, currentArch, currentLibc))
 	if downloadURL == "" {
-		reportUpdateError(manual, "No suitable build found for your OS/Arch.")
+		return updateCandidate{}, fmt.Errorf("no suitable build found for your OS/Arch")
+	}
+
+	cand := updateCandidate{
+		downloadURL:    downloadURL,
+		archiveKind:    archiveKind,
+		displayVersion: release.TagName,
+		tagName:        release.TagName,
+		updateKey:      release.TagName,
+	}
+
+	if channel == updateChannelNightly {
+		cand.updateKey = assetUpdated
+		cand.displayVersion = nightlyDisplayVersion(release, assetUpdated)
+		cand.needsUpdate = AppConfig.LastUpdateVersion != cand.updateKey
+		return cand, nil
+	}
+
+	_, _, buildTimeText := getVCSInfo()
+	cand.needsUpdate = stableReleaseNeedsUpdate(release, getCurrentVersion(), parseUpdateBuildTime(buildTimeText))
+	return cand, nil
+}
+
+// nightlyDisplayVersion называет ночную сборку так же, как её потом покажет
+// F1 > Help Index.
+//
+// Asset'у известно только время окончания загрузки, которое отстаёт от
+// коммита на всё время многоплатформенной сборки; ночной workflow кладёт в
+// тело релиза сам коммит и время сборки, поэтому предпочитаем их. См. #343.
+func nightlyDisplayVersion(release githubRelease, assetUpdated string) string {
+	if commit, builtOn := commitInfoFromReleaseBody(release.Body); commit != "" {
+		if builtOn != "" {
+			return "Nightly (" + commit + " [" + formatBuildTimeForDisplay(builtOn) + "])"
+		}
+		return "Nightly (" + commit + ")"
+	}
+
+	displayTime := assetUpdated
+	if t, err := time.Parse(time.RFC3339, assetUpdated); err == nil {
+		displayTime = t.Local().Format("2006-01-02 15:04")
+	} else if len(displayTime) >= 16 {
+		displayTime = strings.Replace(displayTime[:16], "T", " ", 1)
+	}
+	return "Nightly (" + displayTime + ")"
+}
+
+// githubRateLimitMessage объясняет 403 от GitHub, если тот пришёл из-за
+// исчерпанного лимита запросов: без токена на один IP отводится 60 запросов
+// в час, поэтому упереться в лимит можно из общей сети, ничего не нажимая
+// самому. Пустая строка означает, что 403 пришёл по другой причине.
+func githubRateLimitMessage(resp *http.Response) string {
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
+		return ""
+	}
+	if resp.Header.Get("X-RateLimit-Remaining") != "0" {
+		return ""
+	}
+	msg := "GitHub limits anonymous requests to 60 per hour per address,\nand this address has used them all up."
+	if sec, err := strconv.ParseInt(resp.Header.Get("X-RateLimit-Reset"), 10, 64); err == nil && sec > 0 {
+		msg += "\nTry again after " + time.Unix(sec, 0).Local().Format("15:04") + "."
+	}
+	return msg
+}
+
+func CheckForUpdates(pf *PanelsFrame, manual bool) {
+	if !manual && !shouldCheck() {
 		return
 	}
 
-	needsUpdate := false
-	displayVersion := release.TagName
-	updateKey := release.TagName
+	AppConfig.LastUpdateCheck = time.Now().Unix()
+	SaveConfig()
 
-	if AppConfig.UpdateChannel == 1 {
-		updateKey = assetUpdated
-		displayTime := assetUpdated
-		if t, err := time.Parse(time.RFC3339, assetUpdated); err == nil {
-			displayTime = t.Local().Format("2006-01-02 15:04")
-		} else if len(displayTime) >= 16 {
-			displayTime = strings.Replace(displayTime[:16], "T", " ", 1)
-		}
-		displayVersion = "Nightly (" + displayTime + ")"
-		// The asset's updated_at is when the upload finished, which can
-		// trail the actual commit by however long the full multi-OS build
-		// matrix took — the nightly workflow embeds the commit hash and
-		// its own build time in the release body, which is what F1's Help
-		// Index shows after installing. Prefer that so the prompt and the
-		// post-update version line agree. See #343.
-		if commit, builtOn := commitInfoFromReleaseBody(release.Body); commit != "" {
-			if builtOn != "" {
-				builtOn = formatBuildTimeForDisplay(builtOn)
-				displayVersion = "Nightly (" + commit + " [" + builtOn + "])"
-			} else {
-				displayVersion = "Nightly (" + commit + ")"
-			}
-		}
-		if AppConfig.LastUpdateVersion != updateKey {
-			needsUpdate = true
-		}
-	} else {
-		current := getCurrentVersion()
-		_, _, buildTimeText := getVCSInfo()
-		needsUpdate = stableReleaseNeedsUpdate(release, current, parseUpdateBuildTime(buildTimeText))
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cand, err := fetchUpdateCandidate(ctx, AppConfig.UpdateChannel)
+	if err != nil {
+		reportUpdateError(manual, err.Error())
+		return
 	}
 
-	if !needsUpdate {
+	if !cand.needsUpdate {
 		if manual {
 			vtui.FrameManager.PostTask(func() {
 				vtui.ShowMessage(" Auto Update ", "You are using the latest version.", []string{"&Ok"})
@@ -230,17 +278,17 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 	// the next interval-driven check does not nag; a manual "Check
 	// for updates" from the settings dialog goes through regardless
 	// (see #374).
-	if !manual && sessionDismissedUpdateKey == updateKey {
-		vtui.DebugLog("UPDATER: skipping prompt — update %q dismissed this session", updateKey)
+	if !manual && sessionDismissedUpdateKey == cand.updateKey {
+		vtui.DebugLog("UPDATER: skipping prompt — update %q dismissed this session", cand.updateKey)
 		return
 	}
 
 	vtui.FrameManager.PostTask(func() {
-		msg := fmt.Sprintf("An update is available: %s\n\nDo you want to download and install it now?", displayVersion)
+		msg := fmt.Sprintf("An update is available: %s\n\nDo you want to download and install it now?", cand.displayVersion)
 		dlg := vtui.ShowMessage(" Auto Update ", msg, []string{"&Yes", "&No"})
 		dlg.OnResult = func(code int) {
 			if code == 0 {
-				performUpdate(pf, downloadURL, archiveKind, release.TagName, updateKey)
+				performUpdate(pf, cand.downloadURL, cand.archiveKind, cand.tagName, cand.updateKey)
 				return
 			}
 			// User declined. Remember only for this session — the
@@ -249,7 +297,7 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 			// here: that field is the "we already installed this
 			// version" marker and must survive across restarts, while
 			// a declined prompt must not (see #374).
-			sessionDismissedUpdateKey = updateKey
+			sessionDismissedUpdateKey = cand.updateKey
 		}
 	})
 }
@@ -331,79 +379,16 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 		return
 	}
 	pf.RunProgressTask(" Updating f4 ", "Downloading...", false, func(ctx context.Context, update func(msg string, percent int)) error {
-		exePath, err := osExecutable()
-		if err != nil {
-			return fmt.Errorf("failed to get executable path: %w", err)
-		}
-		exePath, err = filepath.EvalSymlinks(exePath)
-		if err != nil {
-			return fmt.Errorf("failed to resolve symlinks for executable: %w", err)
-		}
-
-		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+		data, err := downloadUpdateArchive(ctx, url, func(percent int) {
+			update("Downloading update...", percent)
+		})
 		if err != nil {
 			return err
-		}
-		req.Header.Set("User-Agent", "f4-updater")
-
-		resp, err := netproxy.HTTPClient(0).Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != 200 {
-			proxyAuthHeader := resp.Header.Get("Proxy-Authenticate")
-			vtui.DebugLog("UPDATER ERROR: Download failed HTTP %d from %s (Proxy: %s, Proxy-Authenticate: %q)",
-				resp.StatusCode, url, netproxy.Global().Describe(), proxyAuthHeader)
-			if resp.StatusCode == http.StatusProxyAuthRequired {
-				return fmt.Errorf("download failed with status 407 (Proxy Authentication Required).\nProxy: %s, Proxy-Authenticate: %s", netproxy.Global().Describe(), proxyAuthHeader)
-			}
-			return fmt.Errorf("download failed with status %d", resp.StatusCode)
-		}
-
-		contentLength := resp.ContentLength
-		var archiveData bytes.Buffer
-		buf := make([]byte, 32*1024)
-		var downloaded int64
-
-		for {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			n, readErr := readUpdateChunk(ctx, resp.Body, buf)
-			if n > 0 {
-				archiveData.Write(buf[:n])
-				downloaded += int64(n)
-				pct := 0
-				if contentLength > 0 {
-					pct = int((downloaded * 100) / contentLength)
-				}
-				update("Downloading update...", pct)
-			}
-			if readErr != nil {
-				if readErr == io.EOF {
-					break
-				}
-				return readErr
-			}
 		}
 
 		update("Extracting and installing...", -1)
 
-		exeDir := filepath.Dir(exePath)
-		if updateDirNeedsElevation(exeDir) {
-			vtui.DebugLog("UPDATER: %q is not writable, requesting UAC elevation", exeDir)
-			err = runElevatedUpdate(archiveData.Bytes(), archiveKind)
-		} else {
-			err = extractUpdateArchive(archiveData.Bytes(), archiveKind, exeDir)
-			if err != nil && isPermissionErrorForUpdate(err) {
-				vtui.DebugLog("UPDATER: extraction needs elevation, retrying through UAC: %v", err)
-				err = runElevatedUpdate(archiveData.Bytes(), archiveKind)
-			}
-		}
-
-		if err != nil {
+		if err := installUpdateArchive(data, archiveKind); err != nil {
 			return fmt.Errorf("failed to extract/install update: %w\n(Close other f4 instances, check Task Manager for ghost f4 processes, or try running as admin/root)", err)
 		}
 
@@ -416,7 +401,7 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			return
 		}
 
-		if AppConfig.UpdateChannel == 1 {
+		if AppConfig.UpdateChannel == updateChannelNightly {
 			AppConfig.LastUpdateVersion = publishedAt
 		} else {
 			AppConfig.LastUpdateVersion = newTag
@@ -431,6 +416,87 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			}
 		}
 	})
+}
+
+// downloadUpdateArchive забирает архив релиза целиком в память, сообщая ход
+// загрузки в процентах. Общая часть для диалога обновления и для --update.
+func downloadUpdateArchive(ctx context.Context, url string, progress func(percent int)) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "f4-updater")
+
+	resp, err := netproxy.HTTPClient(0).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		proxyAuthHeader := resp.Header.Get("Proxy-Authenticate")
+		vtui.DebugLog("UPDATER ERROR: Download failed HTTP %d from %s (Proxy: %s, Proxy-Authenticate: %q)",
+			resp.StatusCode, url, netproxy.Global().Describe(), proxyAuthHeader)
+		if resp.StatusCode == http.StatusProxyAuthRequired {
+			return nil, fmt.Errorf("download failed with status 407 (Proxy Authentication Required).\nProxy: %s, Proxy-Authenticate: %s", netproxy.Global().Describe(), proxyAuthHeader)
+		}
+		return nil, fmt.Errorf("download failed with status %d", resp.StatusCode)
+	}
+
+	contentLength := resp.ContentLength
+	var archiveData bytes.Buffer
+	buf := make([]byte, 32*1024)
+	var downloaded int64
+
+	for {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		n, readErr := readUpdateChunk(ctx, resp.Body, buf)
+		if n > 0 {
+			archiveData.Write(buf[:n])
+			downloaded += int64(n)
+			pct := 0
+			if contentLength > 0 {
+				pct = int((downloaded * 100) / contentLength)
+			}
+			progress(pct)
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				break
+			}
+			return nil, readErr
+		}
+	}
+
+	return archiveData.Bytes(), nil
+}
+
+// installUpdateArchive распаковывает архив поверх каталога работающего
+// бинарника, при отказе в правах — через эскалацию.
+func installUpdateArchive(data []byte, archiveKind string) error {
+	exePath, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("failed to get executable path: %w", err)
+	}
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve symlinks for executable: %w", err)
+	}
+
+	exeDir := filepath.Dir(exePath)
+	if updateDirNeedsElevation(exeDir) {
+		vtui.DebugLog("UPDATER: %q is not writable, requesting UAC elevation", exeDir)
+		return runElevatedUpdate(data, archiveKind)
+	}
+
+	err = extractUpdateArchive(data, archiveKind, exeDir)
+	if err != nil && isPermissionErrorForUpdate(err) {
+		vtui.DebugLog("UPDATER: extraction needs elevation, retrying through UAC: %v", err)
+		return runElevatedUpdate(data, archiveKind)
+	}
+	return err
 }
 
 func extractUpdateArchive(data []byte, archiveKind, destDir string) error {

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -379,6 +379,10 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 		return
 	}
 	pf.RunProgressTask(" Updating f4 ", "Downloading...", false, func(ctx context.Context, update func(msg string, percent int)) error {
+		if _, err := updateTargetDir(); err != nil {
+			return err
+		}
+
 		data, err := downloadUpdateArchive(ctx, url, func(percent int) {
 			update("Downloading update...", percent)
 		})
@@ -473,19 +477,29 @@ func downloadUpdateArchive(ctx context.Context, url string, progress func(percen
 	return archiveData.Bytes(), nil
 }
 
-// installUpdateArchive распаковывает архив поверх каталога работающего
-// бинарника, при отказе в правах — через эскалацию.
-func installUpdateArchive(data []byte, archiveKind string) error {
+// updateTargetDir — каталог, поверх которого ляжет обновление. Вызывается
+// до загрузки тоже: узнать про нечитаемый путь дешевле, чем после
+// скачанных мегабайт.
+func updateTargetDir() (string, error) {
 	exePath, err := osExecutable()
 	if err != nil {
-		return fmt.Errorf("failed to get executable path: %w", err)
+		return "", fmt.Errorf("failed to get executable path: %w", err)
 	}
 	exePath, err = filepath.EvalSymlinks(exePath)
 	if err != nil {
-		return fmt.Errorf("failed to resolve symlinks for executable: %w", err)
+		return "", fmt.Errorf("failed to resolve symlinks for executable: %w", err)
+	}
+	return filepath.Dir(exePath), nil
+}
+
+// installUpdateArchive распаковывает архив поверх каталога работающего
+// бинарника, при отказе в правах — через эскалацию.
+func installUpdateArchive(data []byte, archiveKind string) error {
+	exeDir, err := updateTargetDir()
+	if err != nil {
+		return err
 	}
 
-	exeDir := filepath.Dir(exePath)
 	if updateDirNeedsElevation(exeDir) {
 		vtui.DebugLog("UPDATER: %q is not writable, requesting UAC elevation", exeDir)
 		return runElevatedUpdate(data, archiveKind)

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -131,10 +131,9 @@ type updateCandidate struct {
 	downloadURL    string
 	archiveKind    string
 	displayVersion string
-	tagName        string
-	// updateKey расходится с tagName только на ночном канале: тег там
-	// всегда "nightly", поэтому отметкой уже поставленной сборки служит
-	// время загрузки asset'а.
+	// updateKey — отметка «эта сборка уже стоит»: тег на стабильном
+	// канале и время загрузки asset'а на ночном, где тег всегда
+	// "nightly" и потому ничего не различает.
 	updateKey   string
 	needsUpdate bool
 }
@@ -190,7 +189,6 @@ func fetchUpdateCandidate(ctx context.Context, channel int) (updateCandidate, er
 		downloadURL:    downloadURL,
 		archiveKind:    archiveKind,
 		displayVersion: release.TagName,
-		tagName:        release.TagName,
 		updateKey:      release.TagName,
 	}
 
@@ -288,7 +286,7 @@ func CheckForUpdates(pf *PanelsFrame, manual bool) {
 		dlg := vtui.ShowMessage(" Auto Update ", msg, []string{"&Yes", "&No"})
 		dlg.OnResult = func(code int) {
 			if code == 0 {
-				performUpdate(pf, cand.downloadURL, cand.archiveKind, cand.tagName, cand.updateKey)
+				performUpdate(pf, cand)
 				return
 			}
 			// User declined. Remember only for this session — the
@@ -374,7 +372,7 @@ func reportUpdateError(manual bool, msg string) {
 	}
 }
 
-func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string) {
+func performUpdate(pf *PanelsFrame, cand updateCandidate) {
 	if pf == nil {
 		return
 	}
@@ -383,7 +381,7 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			return err
 		}
 
-		data, err := downloadUpdateArchive(ctx, url, func(percent int) {
+		data, err := downloadUpdateArchive(ctx, cand.downloadURL, func(percent int) {
 			update("Downloading update...", percent)
 		})
 		if err != nil {
@@ -392,7 +390,7 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 
 		update("Extracting and installing...", -1)
 
-		if err := installUpdateArchive(data, archiveKind); err != nil {
+		if err := installUpdateArchive(data, cand.archiveKind); err != nil {
 			return fmt.Errorf("failed to extract/install update: %w\n(Close other f4 instances, check Task Manager for ghost f4 processes, or try running as admin/root)", err)
 		}
 
@@ -405,11 +403,7 @@ func performUpdate(pf *PanelsFrame, url, archiveKind, newTag, publishedAt string
 			return
 		}
 
-		if AppConfig.UpdateChannel == updateChannelNightly {
-			AppConfig.LastUpdateVersion = publishedAt
-		} else {
-			AppConfig.LastUpdateVersion = newTag
-		}
+		AppConfig.LastUpdateVersion = cand.updateKey
 		SaveConfig()
 
 		dlg := vtui.ShowMessage(" Update Successful ", "f4 has been updated successfully.\nPlease restart the application to apply changes.", []string{"E&xit now", "&Later"})

--- a/cmd/f4/updater.go
+++ b/cmd/f4/updater.go
@@ -120,26 +120,26 @@ func shouldCheck() bool {
 	return false
 }
 
-// Каналы обновления перечислены в том же порядке, что комбобокс в настройках.
+// Update channels, in the order the settings combo box lists them.
 const (
 	updateChannelStable  = 0
 	updateChannelNightly = 1
 )
 
-// updateCandidate — сборка, которую канал предлагает поставить.
+// updateCandidate is the build a channel offers to install.
 type updateCandidate struct {
 	downloadURL    string
 	archiveKind    string
 	displayVersion string
-	// updateKey — отметка «эта сборка уже стоит»: тег на стабильном
-	// канале и время загрузки asset'а на ночном, где тег всегда
-	// "nightly" и потому ничего не различает.
+	// updateKey marks a build as already installed: the tag on stable, the
+	// asset upload time on nightly, where the tag is always "nightly" and
+	// tells builds apart not at all.
 	updateKey   string
 	needsUpdate bool
 }
 
-// fetchUpdateCandidate спрашивает GitHub, что предлагает канал, и решает,
-// новее ли это запущенной сборки. Общая часть для диалога и для --update.
+// fetchUpdateCandidate asks GitHub what a channel offers and whether that is
+// newer than the running build. Shared by the dialog and by --update.
 func fetchUpdateCandidate(ctx context.Context, channel int) (updateCandidate, error) {
 	url := githubAPIURL + "/latest"
 	if channel == updateChannelNightly {
@@ -204,12 +204,12 @@ func fetchUpdateCandidate(ctx context.Context, channel int) (updateCandidate, er
 	return cand, nil
 }
 
-// nightlyDisplayVersion называет ночную сборку так же, как её потом покажет
-// F1 > Help Index.
+// nightlyDisplayVersion names a nightly build the way F1 > Help Index names it
+// after installing.
 //
-// Asset'у известно только время окончания загрузки, которое отстаёт от
-// коммита на всё время многоплатформенной сборки; ночной workflow кладёт в
-// тело релиза сам коммит и время сборки, поэтому предпочитаем их. См. #343.
+// The asset only knows when its upload finished, which trails the commit by the
+// whole build matrix; the nightly workflow records the commit and the build
+// time in the release body, so prefer those. See #343.
 func nightlyDisplayVersion(release githubRelease, assetUpdated string) string {
 	if commit, builtOn := commitInfoFromReleaseBody(release.Body); commit != "" {
 		if builtOn != "" {
@@ -227,10 +227,10 @@ func nightlyDisplayVersion(release githubRelease, assetUpdated string) string {
 	return "Nightly (" + displayTime + ")"
 }
 
-// githubRateLimitMessage объясняет 403 от GitHub, если тот пришёл из-за
-// исчерпанного лимита запросов: без токена на один IP отводится 60 запросов
-// в час, поэтому упереться в лимит можно из общей сети, ничего не нажимая
-// самому. Пустая строка означает, что 403 пришёл по другой причине.
+// githubRateLimitMessage explains a 403 that came from the request limit:
+// GitHub allows 60 anonymous requests an hour per address, so a shared network
+// can spend them without the user touching anything. An empty string means the
+// 403 had another cause.
 func githubRateLimitMessage(resp *http.Response) string {
 	if resp.StatusCode != http.StatusForbidden && resp.StatusCode != http.StatusTooManyRequests {
 		return ""
@@ -416,8 +416,8 @@ func performUpdate(pf *PanelsFrame, cand updateCandidate) {
 	})
 }
 
-// downloadUpdateArchive забирает архив релиза целиком в память, сообщая ход
-// загрузки в процентах. Общая часть для диалога обновления и для --update.
+// downloadUpdateArchive reads a release archive into memory, reporting progress
+// in percent. Shared by the update dialog and by --update.
 func downloadUpdateArchive(ctx context.Context, url string, progress func(percent int)) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
@@ -471,9 +471,9 @@ func downloadUpdateArchive(ctx context.Context, url string, progress func(percen
 	return archiveData.Bytes(), nil
 }
 
-// updateTargetDir — каталог, поверх которого ляжет обновление. Вызывается
-// до загрузки тоже: узнать про нечитаемый путь дешевле, чем после
-// скачанных мегабайт.
+// updateTargetDir is the directory an update unpacks over. Callers ask before
+// downloading as well: an unreadable path is cheaper to learn about now than
+// after the megabytes.
 func updateTargetDir() (string, error) {
 	exePath, err := osExecutable()
 	if err != nil {
@@ -486,8 +486,8 @@ func updateTargetDir() (string, error) {
 	return filepath.Dir(exePath), nil
 }
 
-// installUpdateArchive распаковывает архив поверх каталога работающего
-// бинарника, при отказе в правах — через эскалацию.
+// installUpdateArchive unpacks the archive over the running binary's directory,
+// escalating when permissions deny it.
 func installUpdateArchive(data []byte, archiveKind string) error {
 	exeDir, err := updateTargetDir()
 	if err != nil {

--- a/cmd/f4/updater_issue635_test.go
+++ b/cmd/f4/updater_issue635_test.go
@@ -40,7 +40,12 @@ func TestIssue635NetworkDropWhileProgressScreenIsBackground(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 	pf.ResizeConsole(80, 25)
-	performUpdate(pf, ts.URL, "zip", "v9.9.9", "2026-08-22")
+	performUpdate(pf, updateCandidate{
+		downloadURL: ts.URL,
+		archiveKind: "zip",
+		updateKey:   "v9.9.9",
+		needsUpdate: true,
+	})
 
 	backgrounded := false
 	deadline := time.After(5 * time.Second)

--- a/cmd/f4/updater_repro_test.go
+++ b/cmd/f4/updater_repro_test.go
@@ -103,7 +103,12 @@ func TestUpdateFailureMessageRepro(t *testing.T) {
 	pf := NewPanelsFrame()
 	pf.ResizeConsole(80, 25)
 
-	performUpdate(pf, ts.URL, "zip", "v9.9.9", "2026-08-05T12:00:00Z")
+	performUpdate(pf, updateCandidate{
+		downloadURL: ts.URL,
+		archiveKind: "zip",
+		updateKey:   "v9.9.9",
+		needsUpdate: true,
+	})
 
 	// 7. Wait for the background task to hit the error and show the dialog by pumping TaskChan
 	var capturedError string

--- a/cmd/f4/updater_test.go
+++ b/cmd/f4/updater_test.go
@@ -764,7 +764,12 @@ func TestUpdater_PerformUpdate(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()
 
-	performUpdate(pf, ts.URL, "targz", "v9.9.9", "2026-01-01")
+	performUpdate(pf, updateCandidate{
+		downloadURL: ts.URL,
+		archiveKind: "targz",
+		updateKey:   "v9.9.9",
+		needsUpdate: true,
+	})
 
 	timeout := time.After(3 * time.Second)
 	successDialogFound := false


### PR DESCRIPTION
`f4 --update [stable|nightly]` скачивает и ставит свежую сборку для текущей платформы и выходит, не поднимая панели. Проверка, загрузка и распаковка вынесены в общие функции — те же, что у диалога обновления. Названный канал становится каналом автопроверок.

403 из-за анонимного лимита GitHub показывался как `GitHub API returned status 403`; теперь сообщение называет причину и время сброса из заголовков `X-RateLimit-*`.

Остальные коммиты — правки по итогам `/aif-review`: `--help` выигрывает у `--update`; канал сохраняется до опроса GitHub; нечитаемый путь установки отказывает до загрузки; `performUpdate` получает кандидата целиком; проценты печатаются только в терминал.

Проверка: новые тесты на разбор канала, выбор endpoint и сообщение о лимите; загрузка и распаковка прогнаны на настоящем nightly-архиве.