### PR TITLE
help: add Portable mode context help

### DIFF
--- a/cmd/f4/help/en.hlf
+++ b/cmd/f4/help/en.hlf
@@ -5,6 +5,7 @@ f4 — efficient and cozy file manager in go
 ~Viewer / Editor keys~ViewerEditor@
 ~Panel navigation~PanelNav@
 ~Mouse wheel settings~MouseWheel@
+~Portable mode~PortableSettings@
 ~Visual File Renamer (VisRen)~VisRen@
 ~View README.md~README@
 
@@ -795,3 +796,36 @@ lines per notch.
 
 Other scrolling surfaces (the help viewer, multi-line edits in dialogs)
 always follow the system setting.
+
+@PortableSettings
+$Portable mode
+
+Portable mode keeps f4's profile next to the program. It is useful when the
+program and its settings need to be moved together or stored on removable
+media.
+
+The mode is selected before the profile is opened, using an INI file beside
+the executable:
+
+  f4.ini          shared by f4, f4-gui, f4.exe and f4-gui.exe
+  <binary>.ini    for example f4.exe.ini; takes precedence over f4.ini
+
+The dialog shows the current profile and the mode file. Enabling the first
+option writes this setting to the mode file:
+
+  [General]
+  UseSystemProfiles=0
+
+The default portable profile directory is Profile beside the executable.
+The [General] Profile= option can select another directory. %F4HOME% (or
+the Unix forms $F4HOME and ${F4HOME}) means the executable directory;
+relative paths are also relative to it. UseSystemProfiles=1 selects the
+normal per-user profile.
+
+Copy the current profile when switching locations if its settings, history,
+macros, plugins and styles should be available there. Existing files are
+kept, and crash logs are not copied. Switching back does not delete the
+portable profile.
+
+Restart f4 after saving. The mode file is read before the profile is located,
+so this setting cannot be stored inside the profile itself.

--- a/cmd/f4/portable.go
+++ b/cmd/f4/portable.go
@@ -216,6 +216,7 @@ func actionPortableSettings(pf *PanelsFrame) {
 	width, height := 70, 14
 	dlg := vtui.NewCenteredDialog(width, height, Msg("PortableSettings.Title"))
 	dlg.ShowClose = true
+	dlg.SetHelp("PortableSettings")
 
 	chkPortable := vtui.NewCheckbox(0, 0, Msg("PortableSettings.Enable"), false)
 	if wasPortable {

--- a/cmd/f4/portable_test.go
+++ b/cmd/f4/portable_test.go
@@ -5,7 +5,57 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/unxed/vtui"
 )
+
+func TestPortableSettingsDialogUsesContextHelp(t *testing.T) {
+	initFrameworkActionTestScreen(t)
+	tmpDir := t.TempDir()
+	exe := filepath.Join(tmpDir, "f4")
+	if err := os.WriteFile(exe, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldExecutable := osExecutable
+	oldUserConfigDir := userConfigDir
+	osExecutable = func() (string, error) { return exe, nil }
+	userConfigDir = func() (string, error) { return tmpDir, nil }
+	resetConfigDirForTest()
+	t.Cleanup(func() {
+		osExecutable = oldExecutable
+		userConfigDir = oldUserConfigDir
+		resetConfigDirForTest()
+	})
+
+	actionPortableSettings(nil)
+	top := vtui.FrameManager.GetTopFrame()
+	if top == nil {
+		t.Fatal("portable settings did not open a dialog")
+	}
+	if got := top.GetHelp(); got != "PortableSettings" {
+		t.Fatalf("portable settings help topic = %q, want PortableSettings", got)
+	}
+}
+
+func TestPortableSettingsHelpTopicIsRegistered(t *testing.T) {
+	engine := vtui.NewHelpEngine(&memoryHelpVFS{files: map[string]string{
+		"help.hlf": defaultHelpData,
+	}})
+	if err := engine.LoadFile("help.hlf"); err != nil {
+		t.Fatal(err)
+	}
+	topic := engine.GetTopic("PortableSettings")
+	if topic == nil {
+		t.Fatal("PortableSettings help topic is missing")
+	}
+	content := strings.Join(topic.Lines, "\n")
+	for _, want := range []string{"UseSystemProfiles=0", "f4.exe.ini", "Restart f4"} {
+		if !strings.Contains(content, want) {
+			t.Errorf("PortableSettings help does not mention %q", want)
+		}
+	}
+}
 
 func TestConfig_PortableProfile(t *testing.T) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Implements the first atomic slice of #904.

- F1 in the Portable mode dialog now opens a dedicated `PortableSettings` topic.
- The help explains the actual `f4.ini`/`<binary>.ini` selection, profile layout, copy behavior, and restart requirement.
- Adds focused regression coverage for the dialog topic and help registration.

This intentionally leaves the broader Hotkey Configurations and other settings dialogs for separate follow-up slices; it does not close #904.
