### PR TITLE
Preserve previous TempPanel row after F7

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -3197,7 +3197,14 @@ func actionMkDir(pf *PanelsFrame) {
 		// F7 removes references from TempPanel. Do this at the concrete F7
 		// action boundary: PanelActionCreate is also used by Shift+F4 for
 		// creating a new file and must keep its ordinary meaning.
-		if temp.removePanelReferences(selectedPanelActionPaths(panel)) {
+		paths := selectedPanelActionPaths(panel)
+		if len(paths) > 0 {
+			// Unlike a real delete, removing a TempPanel reference is immediate.
+			// Preserve the row above the removed item before the refresh resets
+			// the asynchronously loaded panel contents.
+			panel.pendingSelection = panel.GetPredecessorName()
+		}
+		if temp.removePanelReferences(paths) {
 			pf.RefreshAll()
 			return
 		}

--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -4007,3 +4007,61 @@ func (fp *FileSystemPanel) GetSuccessorName() string {
 	// 3. Fallback to parent directory entry
 	return ".."
 }
+
+// GetPredecessorName returns the first remaining entry before the item (or
+// selected range) that an action is about to remove. If there is no such
+// entry, it falls back to the first remaining entry after it. The fallback
+// keeps the cursor on a useful row when the first item is removed.
+func (fp *FileSystemPanel) GetPredecessorName() string {
+	if len(fp.entries) <= 1 {
+		return ".."
+	}
+
+	anySelected := false
+	for _, e := range fp.entries {
+		if e.Selected && e.Name != ".." {
+			anySelected = true
+			break
+		}
+	}
+
+	var firstIdx, lastIdx int
+	if anySelected {
+		firstIdx = len(fp.entries)
+		lastIdx = -1
+		for i, e := range fp.entries {
+			if e.Selected && e.Name != ".." {
+				if i < firstIdx {
+					firstIdx = i
+				}
+				if i > lastIdx {
+					lastIdx = i
+				}
+			}
+		}
+	} else {
+		firstIdx = fp.cursorIdx
+		lastIdx = fp.cursorIdx
+	}
+
+	isToBeRemoved := func(i int) bool {
+		if anySelected {
+			return fp.entries[i].Selected && fp.entries[i].Name != ".."
+		}
+		return i == fp.cursorIdx
+	}
+
+	for i := firstIdx - 1; i >= 0; i-- {
+		if !isToBeRemoved(i) && fp.entries[i].Name != ".." {
+			return fp.entries[i].Name
+		}
+	}
+
+	for i := lastIdx + 1; i < len(fp.entries); i++ {
+		if !isToBeRemoved(i) && fp.entries[i].Name != ".." {
+			return fp.entries[i].Name
+		}
+	}
+
+	return ".."
+}

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -2419,6 +2419,55 @@ func TestFileSystemPanel_GetSuccessorName(t *testing.T) {
 		t.Errorf("Case 5 failed: expected '..', got %q", res)
 	}
 }
+
+func TestFileSystemPanel_GetPredecessorName(t *testing.T) {
+	fp := &FileSystemPanel{}
+
+	setupEntries := func(names ...string) {
+		fp.cursorIdx = 0
+		fp.entries = []*fileEntry{{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}}}
+		for _, n := range names {
+			fp.entries = append(fp.entries, &fileEntry{VFSItem: vfs.VFSItem{Name: n}})
+		}
+	}
+
+	// A single removal normally moves the cursor to the item above it.
+	setupEntries("A", "B", "C")
+	fp.cursorIdx = 2 // B
+	if res := fp.GetPredecessorName(); res != "A" {
+		t.Errorf("middle item: expected 'A', got %q", res)
+	}
+
+	// At the first item there is no predecessor, so keep the cursor on the
+	// first item that will remain after the removal.
+	setupEntries("A", "B")
+	fp.cursorIdx = 1 // A
+	if res := fp.GetPredecessorName(); res != "B" {
+		t.Errorf("first item: expected 'B', got %q", res)
+	}
+
+	// The same rule applies to a selected range: use the row before its first
+	// member, then fall back to the first remaining row.
+	setupEntries("A", "B", "C", "D")
+	fp.entries[2].Selected = true // B
+	fp.entries[3].Selected = true // C
+	if res := fp.GetPredecessorName(); res != "A" {
+		t.Errorf("selected range: expected 'A', got %q", res)
+	}
+
+	setupEntries("A", "B", "C")
+	fp.entries[1].Selected = true // A
+	fp.entries[2].Selected = true // B
+	if res := fp.GetPredecessorName(); res != "C" {
+		t.Errorf("selected range at start: expected 'C', got %q", res)
+	}
+
+	setupEntries()
+	if res := fp.GetPredecessorName(); res != ".." {
+		t.Errorf("empty list: expected '..', got %q", res)
+	}
+}
+
 func TestGetSelectedNames_ParentSafety(t *testing.T) {
 	fp := &FileSystemPanel{}
 	// Setup entries: 0: "..", 1: "file.txt"


### PR DESCRIPTION
Fixes the TempPanel F7 cursor regression from #878.

When F7 removes one or more top-level TempPanel references, preserve the nearest remaining row above the removed range; if there is no previous row, select the first remaining row. Keep F7 on the parent entry unchanged.

Added focused tests for single removals, first-row fallback, selected ranges, and an empty list.

Per repository instructions, local builds and tests were not run; GitHub Actions are the validation path.