### PR TITLE
Keep original symlink when target edit fails

### DIFF
--- a/DISPATCH.md
+++ b/DISPATCH.md
@@ -4,3 +4,4 @@
 - Я Лунобот-1 (instance `e0fc97`), закончил задачу https://github.com/unxed/f4/pull/932 (часть 1 из 2).
 - Я Лунобот-1 (instance `e0fc97`), взял задачу номер кастомную задачу (часть 1 из 1).
 - Я Лунобот-1 (instance `e0fc97`), закончил задачу https://github.com/unxed/f4/pull/933 (часть 1 из 1).
+- Я Лунобот-1 (instance `e0fc97`), взял задачу номер https://github.com/unxed/f4/issues/888 (часть 2 из 2).

--- a/cmd/f4/attributes_dialog.go
+++ b/cmd/f4/attributes_dialog.go
@@ -92,6 +92,42 @@ func setUnixAttributesForTargets(ctx context.Context, v vfs.VFS, targets []attri
 	return nil
 }
 
+// replaceSymlinkTarget changes the link itself, never the object it points at.
+// The new link is created only after the old one has been removed because the
+// optional VFS API does not promise replace semantics. If creation fails, put
+// the original link back before returning the error so a failed edit cannot
+// silently delete the user's link.
+func replaceSymlinkTarget(ctx context.Context, v vfs.VFS, path, newTarget string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if newTarget == "" {
+		return fmt.Errorf("symlink target cannot be empty")
+	}
+	symVFS, ok := v.(vfs.SymlinkVFS)
+	if !ok {
+		return fmt.Errorf("VFS does not support symbolic links")
+	}
+	oldTarget, err := symVFS.Readlink(ctx, path)
+	if err != nil {
+		return fmt.Errorf("read symlink %q: %w", path, err)
+	}
+	if oldTarget == newTarget {
+		return nil
+	}
+	if err := v.Remove(ctx, path); err != nil {
+		return fmt.Errorf("remove symlink %q: %w", path, err)
+	}
+	createErr := symVFS.Symlink(ctx, newTarget, path)
+	if createErr == nil {
+		return nil
+	}
+	if restoreErr := symVFS.Symlink(ctx, oldTarget, path); restoreErr != nil {
+		return fmt.Errorf("create symlink %q: %w; restore original target %q: %v", path, createErr, oldTarget, restoreErr)
+	}
+	return fmt.Errorf("create symlink %q: %w (original target restored)", path, createErr)
+}
+
 func setWindowsAttributesForTargets(ctx context.Context, v vfs.VFS, targets []attributesTarget, edited vfs.VFSItem) error {
 	const editableWinAttrs = uint32(1 | 2 | 4 | 32)
 	for _, target := range targets {
@@ -315,18 +351,13 @@ func showAttributesUnixForTargets(pf *PanelsFrame, v vfs.VFS, targets []attribut
 		vtui.FrameManager.Redraw()
 	}
 
-	btnSet.OnClick = func() {
-		if item.IsSymlink && editTarget != nil && len(targets) == 1 {
-			newTarget := editTarget.GetText()
-			oldTarget, _ := vfs.Readlink(context.Background(), v, path)
-			if newTarget != "" && newTarget != oldTarget {
-				if symVFS, ok := v.(vfs.SymlinkVFS); ok {
-					_ = v.Remove(context.Background(), path)
-					_ = symVFS.Symlink(context.Background(), newTarget, path)
-				}
-			}
-		}
+	targetEdited := item.IsSymlink && editTarget != nil && len(targets) == 1
 
+	btnSet.OnClick = func() {
+		newTarget := ""
+		if targetEdited {
+			newTarget = editTarget.GetText()
+		}
 		uidStr := editOwner.GetText()
 		if u, err := user.Lookup(uidStr); err == nil {
 			item.Uid, _ = strconv.Atoi(u.Uid)
@@ -351,6 +382,14 @@ func showAttributesUnixForTargets(pf *PanelsFrame, v vfs.VFS, targets []attribut
 			item.MTime = t
 		}
 		vtui.RunAsync(func(ctx *vtui.TaskContext) {
+			if targetEdited {
+				if err := replaceSymlinkTarget(ctx.Context, v, path, newTarget); err != nil {
+					ctx.RunOnUI(func() {
+						vtui.ShowMessage(" Error ", err.Error(), []string{"&Ok"})
+					})
+					return
+				}
+			}
 			err := setUnixAttributesForTargets(ctx.Context, v, targets, item)
 			ctx.RunOnUI(func() {
 				if err != nil {

--- a/cmd/f4/attributes_dialog.go
+++ b/cmd/f4/attributes_dialog.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
@@ -102,11 +103,11 @@ func replaceSymlinkTarget(ctx context.Context, v vfs.VFS, path, newTarget string
 		return err
 	}
 	if newTarget == "" {
-		return fmt.Errorf("symlink target cannot be empty")
+		return errors.New("symlink target cannot be empty")
 	}
 	symVFS, ok := v.(vfs.SymlinkVFS)
 	if !ok {
-		return fmt.Errorf("VFS does not support symbolic links")
+		return errors.New("VFS does not support symbolic links")
 	}
 	oldTarget, err := symVFS.Readlink(ctx, path)
 	if err != nil {

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -28,6 +29,26 @@ type mockMetadataVFS struct {
 type lstatMetadataVFS struct {
 	*mockMetadataVFS
 	item vfs.VFSItem
+}
+
+type symlinkTargetVFS struct {
+	*vfs.OSVFS
+	failTarget string
+	removeCalls int
+	symlinkArgs []string
+}
+
+func (v *symlinkTargetVFS) Remove(ctx context.Context, path string) error {
+	v.removeCalls++
+	return v.OSVFS.Remove(ctx, path)
+}
+
+func (v *symlinkTargetVFS) Symlink(ctx context.Context, target, linkPath string) error {
+	v.symlinkArgs = append(v.symlinkArgs, target)
+	if target == v.failTarget {
+		return errors.New("test symlink failure")
+	}
+	return v.OSVFS.Symlink(ctx, target, linkPath)
 }
 
 func (m *lstatMetadataVFS) Lstat(context.Context, string) (vfs.VFSItem, error) {
@@ -992,6 +1013,85 @@ func TestAttributesDialog_SymlinkToDirectoryIsIdentifiedAsLink(t *testing.T) {
 	}
 	fm.GetTopFrame().SetExitCode(-1)
 	fm.Pop()
+}
+
+func TestReplaceSymlinkTargetRestoresOriginalOnCreateFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink replacement test requires symlink privileges on Windows")
+	}
+
+	root := t.TempDir()
+	linkPath := filepath.Join(root, "link")
+	if err := os.Symlink("old-target", linkPath); err != nil {
+		t.Skipf("Symlink creation not supported: %v", err)
+	}
+	v := &symlinkTargetVFS{OSVFS: vfs.NewOSVFS(root), failTarget: "new-target"}
+
+	err := replaceSymlinkTarget(context.Background(), v, linkPath, "new-target")
+	if err == nil || !strings.Contains(err.Error(), "original target restored") {
+		t.Fatalf("replaceSymlinkTarget error = %v, want restored-target error", err)
+	}
+	got, readErr := os.Readlink(linkPath)
+	if readErr != nil {
+		t.Fatalf("read restored link: %v", readErr)
+	}
+	if got != "old-target" {
+		t.Fatalf("restored target = %q, want %q", got, "old-target")
+	}
+	if v.removeCalls != 1 || strings.Join(v.symlinkArgs, ",") != "new-target,old-target" {
+		t.Fatalf("replacement calls: removes=%d symlinks=%v, want one remove and create/restore", v.removeCalls, v.symlinkArgs)
+	}
+}
+
+func TestReplaceSymlinkTargetPreservesTargetSpelling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink replacement test requires symlink privileges on Windows")
+	}
+
+	root := t.TempDir()
+	linkPath := filepath.Join(root, "link")
+	if err := os.Symlink("initial-target", linkPath); err != nil {
+		t.Skipf("Symlink creation not supported: %v", err)
+	}
+	v := &symlinkTargetVFS{OSVFS: vfs.NewOSVFS(root)}
+
+	targets := []string{"relative-target", filepath.Join(root, "absolute-target"), "missing-target"}
+	for _, want := range targets {
+		if err := replaceSymlinkTarget(context.Background(), v, linkPath, want); err != nil {
+			t.Fatalf("replaceSymlinkTarget(%q): %v", want, err)
+		}
+		got, err := os.Readlink(linkPath)
+		if err != nil {
+			t.Fatalf("read link after %q: %v", want, err)
+		}
+		if got != want {
+			t.Fatalf("target after %q = %q, want exact spelling %q", want, got, want)
+		}
+	}
+}
+
+func TestReplaceSymlinkTargetRejectsEmptyTargetWithoutMutation(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink replacement test requires symlink privileges on Windows")
+	}
+
+	root := t.TempDir()
+	linkPath := filepath.Join(root, "link")
+	if err := os.Symlink("old-target", linkPath); err != nil {
+		t.Skipf("Symlink creation not supported: %v", err)
+	}
+	v := &symlinkTargetVFS{OSVFS: vfs.NewOSVFS(root)}
+
+	if err := replaceSymlinkTarget(context.Background(), v, linkPath, ""); err == nil {
+		t.Fatal("replaceSymlinkTarget accepted an empty target")
+	}
+	got, readErr := os.Readlink(linkPath)
+	if readErr != nil {
+		t.Fatalf("read unchanged link: %v", readErr)
+	}
+	if got != "old-target" || v.removeCalls != 0 {
+		t.Fatalf("empty-target edit mutated link: target=%q removes=%d", got, v.removeCalls)
+	}
 }
 
 func TestAttributesDialog_WindowsSetTime(t *testing.T) {

--- a/cmd/f4/attributes_test.go
+++ b/cmd/f4/attributes_test.go
@@ -33,7 +33,7 @@ type lstatMetadataVFS struct {
 
 type symlinkTargetVFS struct {
 	*vfs.OSVFS
-	failTarget string
+	failTarget  string
 	removeCalls int
 	symlinkArgs []string
 }


### PR DESCRIPTION
Implements the second atomic slice of #888.

- Moves symlink-target replacement into a cancellable background operation.
- Rejects empty targets and reports unsupported/read/remove/create failures.
- Restores the original target when creating the replacement link fails, so a failed edit does not silently remove the link.
- Adds regression coverage for rollback and exact relative, absolute, broken, and empty-target behavior.

Local builds and tests were intentionally not run per LUNOBOT.md; git diff --check passed and GitHub Actions is the acceptance gate.

This PR does not close #888.