### PR TITLE
docs: record earlier Lunobot slice status

### DIFF
--- a/docs/LUNOBOT/878.md
+++ b/docs/LUNOBOT/878.md
@@ -1,0 +1,17 @@
+# Issue 878 — TempPanel F7 status
+
+## Current status
+
+Issue: https://github.com/unxed/f4/issues/878 (kept open).
+
+PR https://github.com/unxed/f4/pull/934 (`0f2117b0`) implements the first recorded slice: after F7 removes one or more top-level TempPanel references, the cursor stays on the nearest remaining row above the removed range; if no previous row exists, it selects the first remaining row. F7 on the parent entry is unchanged.
+
+## Decisions and invariants
+
+- Single removals, removal of the first row, selected ranges, and an empty list are covered by focused tests.
+- Selection is based on the remaining TempPanel rows, not on a stale numeric index.
+- No ticket was closed automatically; further behavior remains a separate slice.
+
+## Verification
+
+GitHub Actions run `34181304015` passed the required build, lint, quality, race, test, and platform checks. Local builds and tests were not run; GitHub Actions is the acceptance gate.

--- a/docs/LUNOBOT/888.md
+++ b/docs/LUNOBOT/888.md
@@ -1,0 +1,22 @@
+# Issue 888 — symlink target status
+
+## Current status
+
+Issue: https://github.com/unxed/f4/issues/888 (kept open until the author confirms the behavior).
+
+Two atomic parts are merged in `main`:
+
+- PR https://github.com/unxed/f4/pull/932 (`ef3640c7`): the local panel status line shows a symlink target instead of `<LNK>`/`<LNK-DIR>` while preserving date and filesystem details; `net://` keeps its existing target-in-name behavior.
+- PR https://github.com/unxed/f4/pull/935 (`e17dfa9e`): editing a symlink target runs as a cancellable operation, rejects an empty target, reports failures, and restores the original link if replacement creation fails.
+
+## Decisions and invariants
+
+- A failed edit must never silently remove or corrupt the original link.
+- Relative, absolute, broken, and empty targets are distinct cases covered by regression tests.
+- Display and edit behavior are separate atomic slices; the display slice does not change link mutation.
+
+## Verification
+
+GitHub Actions passed for PR #932 in run `34177155071` and for PR #935 in run `34181753947`, including build, test, race, quality, lint, and platform checks. Local builds and tests were intentionally not run.
+
+The user should try both the status display and target editing, including a deliberately failing replacement, and report the result. This document does not close the issue.

--- a/docs/LUNOBOT/904.md
+++ b/docs/LUNOBOT/904.md
@@ -1,0 +1,17 @@
+# Issue 904 — context help status
+
+## Current status
+
+Issue: https://github.com/unxed/f4/issues/904 (kept open for follow-up slices).
+
+PR https://github.com/unxed/f4/pull/928 (`3f73b33d`) is the first atomic slice. In the Portable mode dialog, F1 opens the dedicated `PortableSettings` help topic. The topic documents the actual `f4.ini`/`<binary>.ini` selection, profile layout, copy behavior, and restart requirement; focused regression coverage was added for topic registration and opening.
+
+## Decisions and invariants
+
+- This slice is limited to Portable mode and does not silently expand into the Hotkey Configurator or other settings dialogs.
+- The help describes the behavior that exists in `main`; it is not a replacement for changing configuration semantics.
+- The broader follow-up slice remains separately scoped and requires its own acceptance confirmation.
+
+## Verification
+
+GitHub Actions run `34167923852` passed the required build, lint, quality, race, test, and platform checks. Local builds and tests were intentionally not run. The issue remains open; the author should verify F1 from `Options → Portable mode`.

--- a/docs/LUNOBOT/933.md
+++ b/docs/LUNOBOT/933.md
@@ -1,0 +1,17 @@
+# PR 933 — vtui screen-dump decoder status
+
+## Current status
+
+PR: https://github.com/unxed/f4/pull/933 (`8cb6f9fe`), merged into `main`. This is a custom support task for the screen-dump requirement in `LUNOBOT.md`, not a production behavior change tied to one issue.
+
+The repository now contains `tools/vtui-screen`, which decodes the existing `VTUI_SCREEN_DUMP_V1` output from `vtui.ScreenBuf.Dump` into a compact P6 PPM bitmap. It validates the header, dimensions, RLE completeness, indexed and 24-bit colors, reverse video, and dim rendering; parser/error/color tests are included.
+
+## Decisions and invariants
+
+- The existing capture mechanism and `Debug.ScreenDump` output are unchanged.
+- The decoder rejects malformed headers, dimensions, incomplete RLE rows, and invalid color data rather than producing a misleading image.
+- One terminal cell becomes one bitmap tile, preserving a model-readable layout while keeping the result compact.
+
+## Verification
+
+GitHub Actions run `34179163106` passed the required build, lint, quality, race, test, and platform checks. Local builds and tests were intentionally not run.


### PR DESCRIPTION
Добавляет обязательные status-документы для уже слитых атомарных срезов: #888, #904, #878 и custom screen-dump PR #933. Production-код не изменяется; зафиксированы решения, инварианты и проверенные CI-прогоны. Тикеты не закрываются.