### PR TITLE
docs: refresh Lunobot branch inventory

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,7 +1,7 @@
 # Ветки Лунобота
 
 Инвентарь веток и рабочих деревьев, проверенный 08-09-2026 по текущему `main`
-(`32565287b60f4be156b2cea2f1c0dde98556d1ad`), списку PR GitHub и локальному
+(`3030f014e1127d886c590e143b878e1832d530d0`), списку PR GitHub и локальному
 `git worktree list`.
 
 Статус `слита` означает, что соответствующий PR уже в `main`. Статус
@@ -29,6 +29,7 @@
 | `codex/lunobot-2-882-status` | PR #938, слита; remote ref ещё существует |
 | `codex/lunobot-2-882-termux-docs` | PR #936, слита; remote ref ещё существует |
 | `codex/lunobot2-672-status` | PR #939, слита; remote ref ещё существует |
+| `codex/lunobot2-607-status` | PR #958, слита; remote ref ещё существует |
 | `codex/lunobot2-901-status` | PR #956, слита; remote ref ещё существует |
 | `codex/lunobot-1-511-status` | PR #947, слита; remote ref ещё существует |
 | `codex/lunobot-1-screen-dump` | PR #933, слита; remote ref ещё существует |
@@ -36,6 +37,7 @@
 | `codex/lunobot2-320-status` | PR #957, слита; remote ref после merge не обнаружен |
 | `codex/lunobot2-368-status` | PR #944, слита; remote ref ещё существует |
 | `codex/lunobot2-885-ci-status` | PR #950, слита; remote ref ещё существует |
+| `codex/lunobot2-885-conpty` | PR #948, слита; локальное рабочее дерево ещё существует, remote ref удалён |
 | `codex/lunobot2-885-status` | PR #945, слита; remote ref ещё существует |
 | `codex/232-codepage-cycle` | PR #830, #841 и #844, слита; сохранилась локально |
 | `codex/878-220-temp-panel` | PR #879, слита; сохранилась локально и в рабочем дереве |
@@ -58,6 +60,12 @@
 | `codex/fix-836-bookmark-ctrl` | локальная ветка и рабочее дерево `/tmp/f4-issue-836`, prunable |
 | `codex/fix-manual-update-ci` | локальная ветка и рабочее дерево `/tmp/f4-fix-manual-update-ci`, prunable |
 | `codex/conpty-idea-c` | устаревший remote-tracking ref, активного PR не найдено |
+
+## Ветка текущего обновления
+
+| Ветка | Назначение |
+| --- | --- |
+| `codex/lunobot2-branches-fix` | исправление этого реестра после PR #959; PR ещё не создан |
 
 ## Правило обновления
 


### PR DESCRIPTION
## Summary

- refresh `BRANCHES.md` to the current `main` SHA after PR #959;
- add the merged `codex/lunobot2-607-status` / PR #958 entry;
- add the previously created `codex/lunobot2-885-conpty` branch and its local-only state;
- record this maintenance branch itself while its PR is pending.

## Verification

- `git diff --check`
- compared the inventory with `git worktree list`, GitHub PR state, and remote refs;
- no local build or tests, per repository instruction.
