### PR TITLE
docs: finalize branch inventory status

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -1,7 +1,7 @@
 # Ветки Лунобота
 
 Инвентарь веток и рабочих деревьев, проверенный 08-09-2026 по текущему `main`
-(`3030f014e1127d886c590e143b878e1832d530d0`), списку PR GitHub и локальному
+(`a782f44766b4f7d96d4218ea5a45ea6274f4c7c5`), списку PR GitHub и локальному
 `git worktree list`.
 
 Статус `слита` означает, что соответствующий PR уже в `main`. Статус
@@ -39,6 +39,7 @@
 | `codex/lunobot2-885-ci-status` | PR #950, слита; remote ref ещё существует |
 | `codex/lunobot2-885-conpty` | PR #948, слита; локальное рабочее дерево ещё существует, remote ref удалён |
 | `codex/lunobot2-885-status` | PR #945, слита; remote ref ещё существует |
+| `codex/lunobot2-branches-fix` | PR #960, слита; remote ref ещё существует |
 | `codex/232-codepage-cycle` | PR #830, #841 и #844, слита; сохранилась локально |
 | `codex/878-220-temp-panel` | PR #879, слита; сохранилась локально и в рабочем дереве |
 | `codex/fix-492-right-ctrl-default-hotkeys` | PR #829, слита; сохранилась локально |
@@ -60,12 +61,6 @@
 | `codex/fix-836-bookmark-ctrl` | локальная ветка и рабочее дерево `/tmp/f4-issue-836`, prunable |
 | `codex/fix-manual-update-ci` | локальная ветка и рабочее дерево `/tmp/f4-fix-manual-update-ci`, prunable |
 | `codex/conpty-idea-c` | устаревший remote-tracking ref, активного PR не найдено |
-
-## Ветка текущего обновления
-
-| Ветка | Назначение |
-| --- | --- |
-| `codex/lunobot2-branches-fix` | исправление этого реестра после PR #959; PR ещё не создан |
 
 ## Правило обновления
 


### PR DESCRIPTION
## Summary

- refresh `BRANCHES.md` to the current `main` SHA after PR #960;
- mark the already merged branch-inventory PR #960 as complete;
- remove the stale “PR ещё не создан” entry.

## Verification

- `git diff --check`
- compared the inventory with current GitHub `main` and branch state;
- no local build or tests, per repository instruction.
