### PR TITLE
tests: join asynchronous clipboard workers

### DIFF
--- a/cmd/f4/grabber_test.go
+++ b/cmd/f4/grabber_test.go
@@ -17,10 +17,16 @@ func waitForClipboard(t *testing.T, want string) string {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if got := vtui.GetClipboard(); got == want {
+			// The worker updates the process-local clipboard before it finishes
+			// reading other global state. Join it before the next test changes
+			// those globals, otherwise the race detector can report a false
+			// cross-test failure.
+			waitForAsyncClipboard()
 			return got
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	waitForAsyncClipboard()
 	return vtui.GetClipboard()
 }
 

--- a/docs/LUNOBOT/CI-34192866098.md
+++ b/docs/LUNOBOT/CI-34192866098.md
@@ -1,0 +1,28 @@
+# CI run 34192866098 — status
+
+## Scope
+
+The run was triggered by `main` commit `a1b600f088320d97fcfdd9745fae9f9c50573801`.
+All jobs passed except `Race (cmd/f4 B-L)`, which reported a data race between
+`TestConfiguredExternalEditorCommand` writing the global `runningGUI` and an
+asynchronous clipboard worker spawned by `TestGrabber_EnterCopiesAndExits`.
+
+## Decision and invariant
+
+The process-local clipboard is intentionally updated before the asynchronous
+worker has completed its remaining platform checks. A test that observes the
+new clipboard value must therefore join the worker before the next test is
+allowed to mutate shared f4 globals. The production clipboard path is not
+changed; the synchronization belongs in the test helper that observes its
+completion.
+
+## Change
+
+`waitForClipboard` now calls `waitForAsyncClipboard` both after observing the
+expected value and on timeout. This covers every existing `Grabber` test that
+starts asynchronous clipboard work and prevents the following test from
+overlapping the worker's read of `runningGUI`.
+
+No UI behavior changes; a text screen dump is not relevant to this
+test-lifecycle-only fix. Local builds and tests are intentionally not run;
+GitHub Actions is the acceptance gate.


### PR DESCRIPTION
## Summary

- Join asynchronous clipboard workers after the Grabber test observes the expected clipboard value.
- Prevent the next test from racing the worker's read of the global `runningGUI`.
- Document CI run 34192866098 and the synchronization invariant in `docs/LUNOBOT/CI-34192866098.md`.

## Validation

- `git diff --check` passed.
- Local builds and tests were not run per project instruction.
- GitHub Actions is the acceptance gate.