### PR TITLE
tests: join marked clipboard worker

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -9,6 +9,9 @@
 
 ## Последний проверенный прогон
 
-- `34187866847` — PR `https://github.com/unxed/f4/pull/948`, commit
-  `77b94a8b4b374b2ea276a31305ffe8d56ea44b42`; завершён успешно. Windows
-  amd64/arm64 builds и Windows amd64 native tests прошли.
+- `34194464508` — commit `561da80e197d14522af3093e08fadc1e8916eafe`; завершён
+  с ошибкой в двух независимых shuffled-проверках: `Race (cmd/f4 rest)` —
+  `TestMacKeysSkipsCommandRulesWithoutTheChannelSplit`, `Test (linux/amd64)` —
+  `TestMainMenuFilePath_HasExpectedSuffix`. Clipboard race из предыдущего
+  прогона этим результатом не подтверждена; follow-up исправляет оставшийся
+  такой же асинхронный helper `waitForMarkedClipboard`.

--- a/cmd/f4/action_marked_clipboard_test.go
+++ b/cmd/f4/action_marked_clipboard_test.go
@@ -22,10 +22,14 @@ func waitForMarkedClipboard(t *testing.T, want string) string {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if got := vtui.GetClipboard(); got == want {
+			// The worker may update the clipboard before it finishes reading
+			// shared f4 state. Join it before the next test replaces that state.
+			waitForAsyncClipboard()
 			return got
 		}
 		time.Sleep(5 * time.Millisecond)
 	}
+	waitForAsyncClipboard()
 	return vtui.GetClipboard()
 }
 

--- a/docs/LUNOBOT/CI-34194464508.md
+++ b/docs/LUNOBOT/CI-34194464508.md
@@ -1,0 +1,26 @@
+# CI run 34194464508 — status
+
+## Scope
+
+The run was triggered by merge commit `561da80e197d14522af3093e08fadc1e8916eafe`.
+It completed with two failures: `Race (cmd/f4 rest)` reported
+`TestMacKeysSkipsCommandRulesWithoutTheChannelSplit`, and `Test (linux/amd64)`
+reported `TestMainMenuFilePath_HasExpectedSuffix`.
+
+## Decision
+
+Neither failure is a clipboard-worker race: the first is an unrelated shuffled
+Mac-key assertion, and the second is an unrelated path-layout assertion. The
+previous clipboard race remains valid because run `34192866098` recorded
+`TestGrabber_EnterCopiesAndExits` racing with `TestConfiguredExternalEditorCommand`.
+
+## Follow-up
+
+The merged fix joined the worker used by the grabber tests, but the parallel
+`waitForMarkedClipboard` helper has the same asynchronous-worker contract. This
+follow-up joins that worker on both the successful-observation and timeout paths,
+so every clipboard test helper leaves no worker reading shared state for the
+next test.
+
+Local builds and tests are intentionally not run; GitHub Actions is the
+acceptance gate.


### PR DESCRIPTION
## Summary

- Join the asynchronous clipboard worker in `waitForMarkedClipboard` after the expected value is observed or the timeout expires.
- Cover the same cross-test lifetime contract as the merged `waitForClipboard` fix, without changing production clipboard behavior.
- Document the triggering main-CI failures and the synchronization invariant.

## Validation

- `git diff --check` passed.
- Local builds and tests were not run per project instruction.
- GitHub Actions is the acceptance gate.