### PR TITLE
tests: isolate keyboard and config state

### DIFF
--- a/cmd/f4/mackeys_test.go
+++ b/cmd/f4/mackeys_test.go
@@ -11,6 +11,11 @@ import (
 func withMacKeys(t *testing.T, commandIsDistinct bool) {
 	t.Helper()
 
+	// applyMacKeys deliberately respects the same handover guard as the live
+	// key path. Give every test a neutral manager so a shuffled predecessor
+	// cannot leave a hidden PanelsFrame that suppresses the test's mapping.
+	t.Cleanup(swapFrameManager(t))
+
 	previousMode := AppConfig.MacKeyboard
 	AppConfig.MacKeyboard = MacKeysOn
 	t.Cleanup(func() { AppConfig.MacKeyboard = previousMode })

--- a/cmd/f4/portable_test.go
+++ b/cmd/f4/portable_test.go
@@ -62,14 +62,12 @@ func TestConfig_PortableProfile(t *testing.T) {
 
 	// Имитируем путь исполняемого файла в тестовой директории
 	origExeFunc := osExecutable
-	origConfigDir := GetF4ConfigDir()
-	origPortable := cachedF4Portable
 	t.Cleanup(func() {
 		osExecutable = origExeFunc
+		// Do not restore cachedF4ConfigDir by hand: the preceding test may
+		// have left configDirOnce completed with an empty cache.  A fresh
+		// detection is the only valid state after changing osExecutable.
 		resetConfigDirForTest()
-		cachedF4ConfigDir = origConfigDir
-		cachedF4Portable = origPortable
-		configDirOnce.Do(func() {})
 	})
 	mockExe := filepath.Join(tmpDir, "f4.exe")
 	if err := os.WriteFile(mockExe, []byte(""), 0600); err != nil {

--- a/docs/LUNOBOT/CI-34194464508.md
+++ b/docs/LUNOBOT/CI-34194464508.md
@@ -14,16 +14,13 @@ Mac-key assertion, and the second is an unrelated path-layout assertion. The
 previous clipboard race remains valid because run `34192866098` recorded
 `TestGrabber_EnterCopiesAndExits` racing with `TestConfiguredExternalEditorCommand`.
 
-## Follow-up
+## Existing follow-up
 
 The merged fix joined the worker used by the grabber tests, but the parallel
 `waitForMarkedClipboard` helper has the same asynchronous-worker contract. This
 follow-up joins that worker on both the successful-observation and timeout paths,
 so every clipboard test helper leaves no worker reading shared state for the
 next test.
-
-Local builds and tests are intentionally not run; GitHub Actions is the
-acceptance gate.
 
 ## This follow-up
 
@@ -43,3 +40,6 @@ the next test resolves the normal TestMain profile afresh.
 The configuration-cache invariant is the same as the FrameManager invariant:
 each test must leave shared state either valid and complete or reset so the
 next test can initialize it normally.
+
+Local builds and tests are intentionally not run; GitHub Actions is the
+acceptance gate.

--- a/docs/LUNOBOT/CI-34194464508.md
+++ b/docs/LUNOBOT/CI-34194464508.md
@@ -24,3 +24,22 @@ next test.
 
 Local builds and tests are intentionally not run; GitHub Actions is the
 acceptance gate.
+
+## This follow-up
+
+The Mac-key failure was caused by shuffled test order: a hidden `PanelsFrame`
+from an earlier test made `keyRemapSuspended` correctly suppress the mapping.
+`withMacKeys` now installs a fresh test `FrameManager` and restores the prior
+manager with the existing lifecycle helper. The production handover guard is
+therefore still exercised and no UI behavior changes.
+
+The path failure had a separate global-state cause. `TestConfig_PortableProfile`
+changed `osExecutable`, then manually restored `sync.Once` and its cached
+directory. In one order that produced the impossible state “detector already
+run, cached directory empty”, so the next test saw `settings/user_menu.ini`.
+After restoring `osExecutable`, the test now resets the detector completely;
+the next test resolves the normal TestMain profile afresh.
+
+The configuration-cache invariant is the same as the FrameManager invariant:
+each test must leave shared state either valid and complete or reset so the
+next test can initialize it normally.


### PR DESCRIPTION
## Что изменено

- изолированы Mac-key тесты свежим FrameManager, чтобы скрытые панели от предыдущего теста не подавляли проверяемое преобразование;
- исправлено восстановление portable-profile теста: после подмены osExecutable конфигурационный detector сбрасывается целиком, без ручного восстановления потенциально пустого кэша;
- добавлен статус-документ по падению main CI и зафиксированы инварианты изоляции.

## Проверка

- `git diff --check` — пройден;
- локальные сборки и тесты не запускались по инструкции проекта;
- GitHub Actions — acceptance gate.