### PR TITLE
plugin: open registered drives from command prefixes (#976)

### DIFF
--- a/cmd/f4/command_prefix_registry.go
+++ b/cmd/f4/command_prefix_registry.go
@@ -138,9 +138,10 @@ func (r *commandPrefixRegistration) Unregister() {
 	})
 }
 
-// dispatchCommandPrefix consumes input only when the text before its first
-// colon names a registered prefix. The argument is deliberately left raw so
-// each plugin can apply its own quoting rules.
+// dispatchCommandPrefix consumes input when the text before its first colon
+// names either a registered prefix or a plugin drive. Registered prefixes get
+// the raw argument so each plugin can apply its own quoting rules; drive
+// prefixes intentionally accept only the bare form (for example, "Android:").
 func dispatchCommandPrefix(app vfs.App, input string) bool {
 	colon := strings.IndexByte(input, ':')
 	if colon <= 0 {
@@ -156,5 +157,43 @@ func dispatchCommandPrefix(app vfs.App, input string) bool {
 		return true
 	}
 	commandPrefixRegistry.RUnlock()
+	return dispatchDriveCommandPrefix(app, normalized, input[colon+1:])
+}
+
+// dispatchDriveCommandPrefix opens a registered plugin drive in the active
+// panel. Drive names are already the user-facing names shown by the drive
+// menu, so exposing the same names as command prefixes keeps the two entry
+// points consistent. The AI drive is deliberately excluded: its ai: prefix
+// is an established command language of its own.
+func dispatchDriveCommandPrefix(app vfs.App, prefix, argument string) bool {
+	if strings.TrimSpace(argument) != "" || prefix == "ai" {
+		return false
+	}
+
+	pf, ok := app.(*PanelsFrame)
+	if !ok || pf == nil || pf.closed {
+		return false
+	}
+	fsp := pf.getActivePanel()
+	if fsp == nil {
+		return false
+	}
+
+	if prefix == "tmp" {
+		actionOpenTempPanel(pf)
+		return true
+	}
+
+	for _, drive := range driveRegistrySnapshot() {
+		if strings.ToLower(strings.TrimSpace(drive.Name)) != prefix || drive.Factory == nil {
+			continue
+		}
+		newVFS := drive.Factory()
+		if newVFS == nil {
+			return false
+		}
+		pf.switchToVFS(fsp, newVFS)
+		return true
+	}
 	return false
 }

--- a/cmd/f4/command_prefix_registry_test.go
+++ b/cmd/f4/command_prefix_registry_test.go
@@ -97,3 +97,48 @@ func TestPanelsFrameCommandPrefixIsConsumedBeforePTY(t *testing.T) {
 		t.Fatal("prefix command unexpectedly hid panels")
 	}
 }
+
+func TestCommandPrefixOpensRegisteredDrive(t *testing.T) {
+	pf := setupMockPanelsFrame(t)
+	defer pf.Close()
+
+	pluginRegistryMu.Lock()
+	previous := append([]DriveEntry(nil), DriveRegistry...)
+	DriveRegistry = []DriveEntry{{Name: "ExampleDrive", Factory: func() vfs.VFS {
+		return vfs.NewNullVFS(0)
+	}}}
+	pluginRegistryMu.Unlock()
+	t.Cleanup(func() {
+		pluginRegistryMu.Lock()
+		DriveRegistry = previous
+		pluginRegistryMu.Unlock()
+	})
+
+	if !dispatchCommandPrefix(pf, "EXAMPLEDRIVE:") {
+		t.Fatal("drive prefix was not consumed")
+	}
+	if _, ok := pf.getActivePanel().vfs.(*vfs.NullVFS); !ok {
+		t.Fatalf("active panel VFS = %T, want *vfs.NullVFS", pf.getActivePanel().vfs)
+	}
+}
+
+func TestCommandPrefixDriveRequiresBarePrefix(t *testing.T) {
+	pf := setupMockPanelsFrame(t)
+	defer pf.Close()
+
+	pluginRegistryMu.Lock()
+	previous := append([]DriveEntry(nil), DriveRegistry...)
+	DriveRegistry = []DriveEntry{{Name: "ExampleDrive", Factory: func() vfs.VFS {
+		return vfs.NewNullVFS(0)
+	}}}
+	pluginRegistryMu.Unlock()
+	t.Cleanup(func() {
+		pluginRegistryMu.Lock()
+		DriveRegistry = previous
+		pluginRegistryMu.Unlock()
+	})
+
+	if dispatchCommandPrefix(pf, "ExampleDrive:/child") {
+		t.Fatal("drive prefix with an argument was consumed")
+	}
+}

--- a/docs/LUNOBOT/976.md
+++ b/docs/LUNOBOT/976.md
@@ -1,0 +1,28 @@
+# Issue #976 — prefixes for plugin panels
+
+## Status
+
+This PR implements the first and only atomic slice: pressing Enter on a bare
+registered plugin drive prefix opens that drive in the active panel. Matching
+is case-insensitive, so `Android:`, `android:`, and `ANDROID:` select the same
+drive. The temporary panel is available through `tmp:` as well.
+
+The `ai:` prefix remains owned by VTVibe's existing command language and is
+intentionally excluded, as requested in the issue discussion. A non-empty
+suffix is left for the normal command-line pipeline; this keeps paths and
+plugin-specific command arguments from being silently reinterpreted.
+
+## Invariants
+
+- The drive registry and command palette continue to use the same drive names.
+- A drive prefix only changes the active panel and never writes the command to
+  the PTY.
+- A missing or nil drive factory does not consume the command.
+- The prefix resolver does not replace an explicitly registered command
+  prefix, including `ai:`.
+
+## Verification
+
+The change adds regression coverage for opening a registered drive and for
+leaving argument-bearing forms untouched. Local builds and tests are not run
+by instruction; GitHub Actions is the acceptance environment.


### PR DESCRIPTION
## Что изменено\n\n- bare-префикс зарегистрированного plugin drive (Android:, iOS:, CloudFox:, NetFox: и внешние drive-плагины) открывает drive в активной панели;\n- 	mp: открывает временную панель;\n- i: оставлен VTVibe-командой; формы с аргументом после : не перехватываются;\n- добавлены регрессионные тесты и статусный документ docs/LUNOBOT/976.md.\n\nКритерий приёмки из обсуждения #976: префикс i: не менять.\n\nЛокальные сборки и тесты не запускались по инструкции Lunobot; проверка выполняется GitHub Actions.\n\nRefs #976