### PR TITLE
Открывать панели плагинов по префиксу командной строки

### DIFF
--- a/cmd/f4/api.go
+++ b/cmd/f4/api.go
@@ -40,6 +40,7 @@ func (c *coreAPI) RegisterHighlighter(p vtui.HighlighterProvider) {
 }
 func (c *coreAPI) RegisterDrive(name string, factory func() vfs.VFS) {
 	RegisterDrive(name, factory)
+	registerDriveCommandPrefix(name)
 }
 
 func (c *coreAPI) RegisterGlobalHotkey(vk uint16, mods vtinput.ControlKeyState, handler func(app vfs.App)) {

--- a/cmd/f4/command_prefix_drives.go
+++ b/cmd/f4/command_prefix_drives.go
@@ -1,0 +1,114 @@
+package main
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/unxed/f4/vfs"
+	"github.com/unxed/vtui"
+)
+
+var driveCommandPrefixState = struct {
+	sync.Mutex
+	ids map[string]struct{}
+}{ids: make(map[string]struct{})}
+
+// registerCommandPrefixOnce adds a core-owned prefix without making repeated
+// plugin initialization report a duplicate registration. The handler opens
+// the corresponding drive in the active panel; its argument is intentionally
+// ignored because these prefixes are panel selectors, not path resolvers.
+func registerCommandPrefixOnce(id, prefix, driveName string) {
+	id = strings.TrimSpace(id)
+	prefix = strings.TrimSpace(prefix)
+	if id == "" || prefix == "" {
+		return
+	}
+
+	driveCommandPrefixState.Lock()
+	defer driveCommandPrefixState.Unlock()
+	if _, exists := driveCommandPrefixState.ids[id]; exists {
+		return
+	}
+	_, err := (&coreAPI{}).RegisterCommandPrefix(id, prefix, func(app vfs.App, _ string) {
+		pf, ok := app.(*PanelsFrame)
+		if !ok || !pf.OpenDrive(driveName) {
+			vtui.DebugLog("PREFIX: cannot open drive %q", driveName)
+		}
+	})
+	if err != nil {
+		vtui.DebugLog("PREFIX: cannot register %q as %q: %v", prefix, id, err)
+		return
+	}
+	driveCommandPrefixState.ids[id] = struct{}{}
+}
+
+func registerDriveCommandPrefix(name string) {
+	name = strings.TrimSpace(name)
+	prefix, err := normalizeCommandPrefix(name)
+	if err != nil || prefix == "" || prefix == "ai" {
+		return
+	}
+	registerCommandPrefixOnce("drive:"+prefix, prefix, name)
+}
+
+func registerBuiltInCommandPrefixes() {
+	registerCommandPrefixOnce("builtin.temp-panel", "tmp", "tmp")
+	registerPlatformCommandPrefixes()
+}
+
+// OpenDrive switches the active panel to a registered plugin or platform
+// drive. The two short aliases are core-owned: tmp is the temporary panel and
+// reg is the Windows Registry drive. Keeping the lookup here means command
+// prefixes and the drive menu use the same factories and lifecycle rules.
+func (pf *PanelsFrame) OpenDrive(name string) bool {
+	if pf == nil || pf.closed {
+		return false
+	}
+	fsp := pf.getActivePanel()
+	if fsp == nil {
+		return false
+	}
+
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	if normalized == "tmp" {
+		pf.switchToVFS(fsp, newTempPanelVFS(nil, globalTempPanelStore, 0))
+		pf.revealPanelsAfterCommand()
+		return true
+	}
+	if normalized == "reg" {
+		name = "Windows Registry"
+	}
+
+	var factory func() vfs.VFS
+	for _, drive := range getPlatformDrives() {
+		if strings.EqualFold(strings.TrimSpace(drive.Name), strings.TrimSpace(name)) {
+			factory = drive.Factory
+			break
+		}
+	}
+	if factory == nil {
+		for _, drive := range driveRegistrySnapshot() {
+			if strings.EqualFold(strings.TrimSpace(drive.Name), strings.TrimSpace(name)) {
+				factory = drive.Factory
+				break
+			}
+		}
+	}
+	if factory == nil {
+		return false
+	}
+
+	opened := factory()
+	if opened == nil {
+		return false
+	}
+	pf.switchToVFS(fsp, opened)
+	pf.revealPanelsAfterCommand()
+	return true
+}
+
+func (pf *PanelsFrame) revealPanelsAfterCommand() {
+	if !pf.showPanels {
+		pf.togglePanelsVisibility()
+	}
+}

--- a/cmd/f4/command_prefix_drives_test.go
+++ b/cmd/f4/command_prefix_drives_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestRegisterDriveCommandPrefixOpensRegisteredDrive(t *testing.T) {
+	pf := setupMockPanelsFrame(t)
+	defer pf.Close()
+
+	const driveName = "TestPrefixDrive976"
+	oldDrives := driveRegistrySnapshot()
+	t.Cleanup(func() {
+		pluginRegistryMu.Lock()
+		DriveRegistry = oldDrives
+		pluginRegistryMu.Unlock()
+	})
+
+	factoryCalls := 0
+	drivePath := t.TempDir()
+	(&coreAPI{}).RegisterDrive(driveName, func() vfs.VFS {
+		factoryCalls++
+		return vfs.NewOSVFS(drivePath)
+	})
+
+	if !dispatchCommandPrefix(pf, strings.ToLower(driveName)+":") {
+		t.Fatal("registered drive prefix was not consumed")
+	}
+	if factoryCalls != 1 {
+		t.Fatalf("drive factory calls = %d, want 1", factoryCalls)
+	}
+	active, ok := pf.Active().(*FileSystemPanel)
+	if !ok || active.vfs == nil || active.vfs.GetPath() != drivePath {
+		t.Fatalf("active panel VFS = %#v, want %q", active, drivePath)
+	}
+}
+
+func TestRegisterDriveCommandPrefixLeavesAICommandAlone(t *testing.T) {
+	commandPrefixRegistry.RLock()
+	before := commandPrefixRegistry.byID["drive:ai"]
+	commandPrefixRegistry.RUnlock()
+
+	registerDriveCommandPrefix("AI")
+
+	commandPrefixRegistry.RLock()
+	after := commandPrefixRegistry.byID["drive:ai"]
+	commandPrefixRegistry.RUnlock()
+	if after != before {
+		t.Fatal("AI drive prefix registration changed the existing ai: command")
+	}
+}
+
+func TestBuiltInTemporaryPanelPrefix(t *testing.T) {
+	registerBuiltInCommandPrefixes()
+	prefixFrame := setupMockPanelsFrame(t)
+	defer prefixFrame.Close()
+
+	if !dispatchCommandPrefix(prefixFrame, "TMP:") {
+		t.Fatal("tmp: prefix was not consumed")
+	}
+	if _, ok := prefixFrame.Active().(*FileSystemPanel).vfs.(*TempPanelVFS); !ok {
+		t.Fatalf("active panel VFS = %T, want *TempPanelVFS", prefixFrame.Active().(*FileSystemPanel).vfs)
+	}
+}
+
+func TestOpenDriveRevealsHiddenPanels(t *testing.T) {
+	prefixFrame := setupMockPanelsFrame(t)
+	defer prefixFrame.Close()
+	prefixFrame.showPanels = false
+	prefixFrame.showLeftPanel = false
+	prefixFrame.showRightPanel = false
+	prefixFrame.shellMode = ShellModeSimpleCaptured
+
+	if !prefixFrame.OpenDrive("tmp") {
+		t.Fatal("tmp drive was not opened")
+	}
+	if !prefixFrame.showPanels {
+		t.Fatal("opening a drive from a hidden terminal did not reveal panels")
+	}
+}

--- a/cmd/f4/command_prefixes_other.go
+++ b/cmd/f4/command_prefixes_other.go
@@ -1,0 +1,5 @@
+//go:build !windows
+
+package main
+
+func registerPlatformCommandPrefixes() {}

--- a/cmd/f4/command_prefixes_windows.go
+++ b/cmd/f4/command_prefixes_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+func registerPlatformCommandPrefixes() {
+	registerCommandPrefixOnce("builtin.registry", "reg", "reg")
+}

--- a/cmd/f4/main.go
+++ b/cmd/f4/main.go
@@ -826,6 +826,7 @@ func SetupUI() {
 		GlobalPluginManager = nil
 		vtui.DebugLog("CORE: Plugins disabled by --no-plugins flag")
 	}
+	registerBuiltInCommandPrefixes()
 
 	LoadSession()
 	vtui.ManageCursorStyle = !AppConfig.KeepTerminalCursor

--- a/docs/LUNOBOT/976.md
+++ b/docs/LUNOBOT/976.md
@@ -1,0 +1,22 @@
+# Issue 976 — command prefixes for plugin panels
+
+## First atomic slice
+
+The accepted scope is to make the panel command line open the corresponding
+plugin drive when the user enters a bare prefix and presses Enter:
+
+- `Android:` → Android;
+- `iOS:` → iOS;
+- `CloudFox:` → CloudFox;
+- `NetFox:` → NetFox;
+- `tmp:` → the first temporary panel;
+- `reg:` → Windows Registry on Windows.
+
+The existing `ai:` command prefix is intentionally unchanged, as requested by
+the issue author. Unknown prefixes and ordinary shell commands retain their
+current behavior.
+
+The implementation registers prefixes from the same drive factories used by
+the drive menu, so a plugin drive cannot open a stale factory snapshot. The
+prefix handler changes only the active panel and leaves its argument unused.
+Verification is delegated to GitHub Actions; no local build or test was run.


### PR DESCRIPTION
## Что сделано

- добавлены префиксы `Android:`, `iOS:`, `CloudFox:`, `NetFox:` на основе зарегистрированных drive-фабрик;
- добавлены `tmp:` и Windows-only `reg:`;
- существующий `ai:` намеренно не изменён;
- при скрытых панелях используется штатный путь возврата к панелям;
- добавлены регрессионные тесты и acceptance-документ для #976.

## Проверка

Локальные сборка и тесты не запускались по инструкции LUNOBOT.md. Ожидается проверка GitHub Actions.

Связано с #976