### PR TITLE
Show symlink destination in panel footer (#888)

### DIFF
--- a/cmd/f4/file_panel.go
+++ b/cmd/f4/file_panel.go
@@ -2849,8 +2849,16 @@ func (fp *FileSystemPanel) Show(scr *vtui.ScreenBuf) {
 					curStr = "UP-DIR"
 				}
 			}
+			if e.IsSymlink && fp.vfs != nil {
+				if target, err := vfs.Readlink(context.Background(), fp.vfs, fp.vfs.Join(fp.vfs.GetPath(), e.Name)); err == nil && target != "" {
+					curStr = "→ " + target
+				}
+			}
 			curStr = " ▸ " + curStr + " "
-			if curW := runewidth.StringWidth(curStr); fp.X1+1+curW < totalStart {
+			if maxCurW := totalStart - (fp.X1 + 1); maxCurW > 0 {
+				if runewidth.StringWidth(curStr) > maxCurW {
+					curStr = runewidth.Truncate(curStr, maxCurW, "")
+				}
 				p := vtui.NewPainter(scr)
 				p.DrawString(fp.X1+1, fp.Y2, curStr, vtui.Palette[ColPanelText])
 			}

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -4917,17 +4917,12 @@ func TestFileSystemPanel_BottomFrameShowsCursorEntry(t *testing.T) {
 	AppConfig.ShowPanelFileInfo = false
 	t.Cleanup(func() { AppConfig.ShowPanelFileInfo = was })
 
-	root := t.TempDir()
-	if err := os.Symlink("target.txt", filepath.Join(root, "link.txt")); err != nil {
-		t.Skipf("symlinks unavailable: %v", err)
-	}
-	fp := NewFileSystemPanel(0, 0, 60, 20, vfs.NewOSVFS(root))
+	fp := NewFileSystemPanel(0, 0, 60, 20, vfs.NewOSVFS(t.TempDir()))
 	waitForLoad(t, fp)
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
 		{VFSItem: vfs.VFSItem{Name: "sub", IsDir: true}},
 		{VFSItem: vfs.VFSItem{Name: "big.bin", Size: 1234567}},
-		{VFSItem: vfs.VFSItem{Name: "link.txt", Size: 10, IsSymlink: true}},
 	}
 	fp.isLoading = false
 	if fp.loadingTimer != nil {
@@ -4957,17 +4952,50 @@ func TestFileSystemPanel_BottomFrameShowsCursorEntry(t *testing.T) {
 	if got := bottom(); !strings.Contains(got, "▸ UP-DIR") {
 		t.Errorf("bottom frame for the up-dir: %q", got)
 	}
-	fp.SetCursorIndex(3)
-	fp.Show(scr)
-	if got := bottom(); !strings.Contains(got, "▸ → target.txt") {
-		t.Errorf("bottom frame for a symlink: %q", got)
-	}
-
 	// With the far2l status line on, the marker steps aside.
 	AppConfig.ShowPanelFileInfo = true
 	fp.Show(scr)
 	if got := bottom(); strings.Contains(got, "▸") {
 		t.Errorf("marker should be dropped when the status line is on: %q", got)
+	}
+}
+
+func TestFileSystemPanel_BottomFrameShowsSymlinkTarget(t *testing.T) {
+	oldCfg := AppConfig
+	defer func() { AppConfig = oldCfg }()
+	AppConfig.ShowPanelFileInfo = false
+
+	vtui.SetDefaultPalette()
+	SetDefaultF4Palette()
+	scr := vtui.NewSilentScreenBuf()
+	scr.AllocBuf(140, 25)
+	vtui.FrameManager.Init(scr)
+
+	root := t.TempDir()
+	if err := os.Symlink("target.txt", filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	fp := NewFileSystemPanel(0, 0, 100, 20, vfs.NewOSVFS(root))
+	waitForLoad(t, fp)
+	fp.entries = []*fileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "link.txt", Size: 10, IsSymlink: true}},
+	}
+	fp.isLoading = false
+	if fp.loadingTimer != nil {
+		fp.loadingTimer.Stop()
+	}
+	fp.Refresh()
+	fp.SetCursorIndex(1)
+	fp.Show(scr)
+
+	status := ScreenRow(scr, fp.Y2, fp.X1, fp.X2)
+	if !strings.Contains(status, "▸ → target.txt") {
+		t.Fatalf("symlink bottom frame = %q, want unresolved target", status)
+	}
+	if strings.Contains(status, "▸ 10") {
+		t.Fatalf("symlink bottom frame still shows link size: %q", status)
 	}
 }
 

--- a/cmd/f4/file_panel_test.go
+++ b/cmd/f4/file_panel_test.go
@@ -4917,12 +4917,17 @@ func TestFileSystemPanel_BottomFrameShowsCursorEntry(t *testing.T) {
 	AppConfig.ShowPanelFileInfo = false
 	t.Cleanup(func() { AppConfig.ShowPanelFileInfo = was })
 
-	fp := NewFileSystemPanel(0, 0, 60, 20, vfs.NewOSVFS(t.TempDir()))
+	root := t.TempDir()
+	if err := os.Symlink("target.txt", filepath.Join(root, "link.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	fp := NewFileSystemPanel(0, 0, 60, 20, vfs.NewOSVFS(root))
 	waitForLoad(t, fp)
 	fp.entries = []*fileEntry{
 		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
 		{VFSItem: vfs.VFSItem{Name: "sub", IsDir: true}},
 		{VFSItem: vfs.VFSItem{Name: "big.bin", Size: 1234567}},
+		{VFSItem: vfs.VFSItem{Name: "link.txt", Size: 10, IsSymlink: true}},
 	}
 	fp.isLoading = false
 	if fp.loadingTimer != nil {
@@ -4951,6 +4956,11 @@ func TestFileSystemPanel_BottomFrameShowsCursorEntry(t *testing.T) {
 	fp.Show(scr)
 	if got := bottom(); !strings.Contains(got, "▸ UP-DIR") {
 		t.Errorf("bottom frame for the up-dir: %q", got)
+	}
+	fp.SetCursorIndex(3)
+	fp.Show(scr)
+	if got := bottom(); !strings.Contains(got, "▸ → target.txt") {
+		t.Errorf("bottom frame for a symlink: %q", got)
 	}
 
 	// With the far2l status line on, the marker steps aside.

--- a/docs/LUNOBOT/888.md
+++ b/docs/LUNOBOT/888.md
@@ -35,6 +35,6 @@ The panel bottom line now shows a selected symbolic link's unresolved destinatio
 
 The regression test covers the bottom-line destination display. Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
 
-PR and final CI result are pending.
+The first PR CI run (`34248501903`) exposed a test-fixture mistake: the new symlink had been added to an existing total-count scenario. The fixture is now isolated in its own regression test; the new CI result is pending.
 
 *Лунобот-1 (node a721a6d1487257292ae00780; LNX)*

--- a/docs/LUNOBOT/888.md
+++ b/docs/LUNOBOT/888.md
@@ -4,7 +4,7 @@
 
 Issue: https://github.com/unxed/f4/issues/888 (kept open until the author confirms the behavior).
 
-Two atomic parts are merged in `main`:
+Earlier atomic parts are merged in `main`:
 
 - PR https://github.com/unxed/f4/pull/932 (`ef3640c7`): the local panel status line shows a symlink target instead of `<LNK>`/`<LNK-DIR>` while preserving date and filesystem details; `net://` keeps its existing target-in-name behavior.
 - PR https://github.com/unxed/f4/pull/935 (`e17dfa9e`): editing a symlink target runs as a cancellable operation, rejects an empty target, reports failures, and restores the original link if replacement creation fails.
@@ -28,3 +28,13 @@ The Files menu now has a separate `Edit symbolic link` command next to `Create l
 Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
 
 *Лунобот-2 (node f33f64cd91460430a21da326; MSW)*
+
+## Follow-up slice 4 of 4
+
+The panel bottom line now shows a selected symbolic link's unresolved destination instead of its link-size placeholder. Long destinations are truncated to the available space without overlapping the panel total; ordinary files and directories keep their existing display.
+
+The regression test covers the bottom-line destination display. Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
+
+PR and final CI result are pending.
+
+*Лунобот-1 (node a721a6d1487257292ae00780; LNX)*


### PR DESCRIPTION
## Что изменено

- в нижней строке панели для выбранной символьной ссылки показывается её неразрешённая цель вместо размера ссылки;
- длинные цели обрезаются по доступной ширине и не перекрывают итог панели;
- добавлен регрессионный тест для footer, обычные файлы и каталоги сохраняют прежнее отображение.

Локальные сборки и тесты не запускались по инструкции LUNOBOT.md; проверка выполняется GitHub Actions.

Связано с #888

*Лунобот-1 (node a721a6d1487257292ae00780; LNX)*