### PR TITLE
feat: make local language files optional (#996)

### DIFF
--- a/cmd/f4/actions.go
+++ b/cmd/f4/actions.go
@@ -5250,7 +5250,7 @@ func actionLanguage(pf *PanelsFrame) {
 	uiLangs := listAvailableUILanguages()
 	helpLangs := listAvailableHelpLanguages()
 
-	width, height := 54, 13
+	width, height := 54, 15
 	dlg := vtui.NewCenteredDialog(width, height, Msg("LanguageSettings.Title"))
 	dlg.ShowClose = true
 
@@ -5281,6 +5281,8 @@ func actionLanguage(pf *PanelsFrame) {
 	comboHelp.Menu.SetSelectPos(selectedHelp)
 	comboHelp.Edit.SetText(helpNames[selectedHelp])
 	lblHelp := vtui.NewLabel(0, 0, Msg("HelpLanguage.Title")+":", comboHelp)
+	chkLocalFiles := vtui.NewCheckbox(0, 0, Msg("LanguageSettings.UseLocalFiles"), false)
+	chkLocalFiles.State = boolToCheckboxState(AppConfig.UseLocalLanguageFiles)
 
 	btnOk := vtui.NewButton(0, 0, Msg("vtui.Ok"))
 	btnOk.IsDefault = true
@@ -5290,6 +5292,7 @@ func actionLanguage(pf *PanelsFrame) {
 	dlg.AddItem(comboUI)
 	dlg.AddItem(lblHelp)
 	dlg.AddItem(comboHelp)
+	dlg.AddItem(chkLocalFiles)
 	dlg.AddItem(btnOk)
 	dlg.AddItem(btnCancel)
 
@@ -5305,6 +5308,8 @@ func actionLanguage(pf *PanelsFrame) {
 	rowHelp.Add(comboHelp, vtui.Margins{}, vtui.AlignLeft)
 	vbox.Add(rowHelp, vtui.Margins{Top: 1}, vtui.AlignFill)
 
+	vbox.Add(chkLocalFiles, vtui.Margins{Top: 1}, vtui.AlignFill)
+
 	hbox := vtui.NewHBoxLayout(0, 0, width-4, 1)
 	hbox.HorizontalAlign = vtui.AlignCenter
 	hbox.Spacing = 2
@@ -5318,6 +5323,7 @@ func actionLanguage(pf *PanelsFrame) {
 	btnOk.OnClick = func() {
 		uiChanged := false
 		helpChanged := false
+		localFilesChanged := AppConfig.UseLocalLanguageFiles != (chkLocalFiles.State != 0)
 		suggestFontChoice := false
 		if idx := comboUI.Menu.SelectPos; idx >= 0 && idx < len(uiLangs) {
 			if AppConfig.Language != uiLangs[idx].code {
@@ -5332,7 +5338,10 @@ func actionLanguage(pf *PanelsFrame) {
 				helpChanged = true
 			}
 		}
-		if uiChanged || helpChanged {
+		if localFilesChanged {
+			AppConfig.UseLocalLanguageFiles = chkLocalFiles.State != 0
+		}
+		if uiChanged || helpChanged || localFilesChanged {
 			SaveConfig()
 			InitLang()
 			InitHelpSystem()

--- a/cmd/f4/actions_test.go
+++ b/cmd/f4/actions_test.go
@@ -1818,8 +1818,15 @@ func TestActionLanguage_Flow(t *testing.T) {
 
 	foundUICombo := false
 	foundHelpCombo := false
+	foundLocalFilesCheckbox := false
 
 	for _, child := range dlg.GetChildren() {
+		if checkbox, ok := child.(*vtui.Checkbox); ok {
+			foundLocalFilesCheckbox = true
+			if checkbox.State != boolToCheckboxState(AppConfig.UseLocalLanguageFiles) {
+				t.Errorf("local language files checkbox state = %d, want %d", checkbox.State, boolToCheckboxState(AppConfig.UseLocalLanguageFiles))
+			}
+		}
 		if combo, ok := child.(*vtui.ComboBox); ok {
 			for _, item := range combo.Menu.Items {
 				if item.Text == "English" {
@@ -1834,8 +1841,8 @@ func TestActionLanguage_Flow(t *testing.T) {
 		}
 	}
 
-	if !foundUICombo || !foundHelpCombo {
-		t.Errorf("Language dialog missing UI/Help comboboxes. UICombo: %v, HelpCombo: %v", foundUICombo, foundHelpCombo)
+	if !foundUICombo || !foundHelpCombo || !foundLocalFilesCheckbox {
+		t.Errorf("Language dialog missing UI/Help controls. UICombo: %v, HelpCombo: %v, local-files checkbox: %v", foundUICombo, foundHelpCombo, foundLocalFilesCheckbox)
 	}
 
 	top.SetExitCode(-1)

--- a/cmd/f4/command_palette_i18n.go
+++ b/cmd/f4/command_palette_i18n.go
@@ -85,9 +85,11 @@ func buildCommandPaletteTranslationIndex(packs []vtui.LanguagePack) map[string][
 func loadInstalledCommandPaletteLanguagePacks() []vtui.LanguagePack {
 	exeDir := filepath.Dir(os.Args[0])
 	directories := []string{
-		filepath.Join(GetF4ConfigDir(), "lang"),
 		filepath.Join(exeDir, "lang"),
 		"lang",
+	}
+	if AppConfig.UseLocalLanguageFiles {
+		directories = append([]string{filepath.Join(GetF4ConfigDir(), "lang")}, directories...)
 	}
 
 	seenPaths := make(map[string]bool)

--- a/cmd/f4/config.go
+++ b/cmd/f4/config.go
@@ -187,6 +187,7 @@ type F4Config struct {
 	Language                 string
 	FallbackLanguage         string
 	HelpLanguage             string
+	UseLocalLanguageFiles    bool
 	AlwaysShowMenuBar        bool
 	WorkspaceTabMode         int
 	WorkspaceTabsOverlay     bool
@@ -354,6 +355,7 @@ var AppConfig = F4Config{
 	Language:                 "en",
 	FallbackLanguage:         "",
 	HelpLanguage:             "en",
+	UseLocalLanguageFiles:    false,
 	AlwaysShowMenuBar:        false,
 	WorkspaceTabMode:         int(vtui.WorkspaceTabsAlways),
 	WorkspaceTabsOverlay:     true,
@@ -526,6 +528,7 @@ func LoadConfig() {
 	AppConfig.Language = ini.GetString("Interface", "Language", "en")
 	AppConfig.FallbackLanguage = ini.GetString("Interface", "FallbackLanguage", "")
 	AppConfig.HelpLanguage = ini.GetString("Interface", "HelpLanguage", "en")
+	AppConfig.UseLocalLanguageFiles = ini.GetString("Interface", "UseLocalLanguageFiles", "0") == "1"
 	AppConfig.ConsoleTitleTemplate = ini.GetString("Interface", "ConsoleTitleTemplate", "f4 %Ver %Platform %Admin - %State")
 	AppConfig.DisplayFullPathInTitle = ini.GetString("Interface", "DisplayFullPathInTitle", "0") == "1"
 	AppConfig.AlwaysShowMenuBar = ini.GetString("Interface", "AlwaysShowMenuBar", "0") == "1"
@@ -828,6 +831,7 @@ func saveConfigWithWindowSize(windowSize bool) {
 	fmt.Fprintf(&sb, "Language = %s\n", AppConfig.Language)
 	fmt.Fprintf(&sb, "FallbackLanguage = %s\n", AppConfig.FallbackLanguage)
 	fmt.Fprintf(&sb, "HelpLanguage = %s\n", AppConfig.HelpLanguage)
+	fmt.Fprintf(&sb, "UseLocalLanguageFiles = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.UseLocalLanguageFiles])
 	fmt.Fprintf(&sb, "ConsoleTitleTemplate = %s\n", AppConfig.ConsoleTitleTemplate)
 	fmt.Fprintf(&sb, "DisplayFullPathInTitle = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.DisplayFullPathInTitle])
 	fmt.Fprintf(&sb, "AlwaysShowMenuBar = %d\n", map[bool]int{true: 1, false: 0}[AppConfig.AlwaysShowMenuBar])

--- a/cmd/f4/config_test.go
+++ b/cmd/f4/config_test.go
@@ -54,6 +54,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.ApplyCommandParallelism = 0
 	AppConfig.AutoSaveSettings = false
 	AppConfig.DisplayFullPathInTitle = true
+	AppConfig.UseLocalLanguageFiles = true
 	AppConfig.EditorAutodetectCodePage = false
 	AppConfig.EditorDefaultCodePage = 1251
 	AppConfig.ViewerAutodetectCodePage = true
@@ -85,6 +86,7 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	AppConfig.ApplyCommandParallelism = 1
 	AppConfig.AutoSaveSettings = true
 	AppConfig.DisplayFullPathInTitle = false
+	AppConfig.UseLocalLanguageFiles = false
 	AppConfig.EditorAutodetectCodePage = true
 	AppConfig.EditorDefaultCodePage = 65001
 	AppConfig.ViewerAutodetectCodePage = false
@@ -102,6 +104,9 @@ func TestConfig_SaveAndLoad(t *testing.T) {
 	}
 	if AppConfig.WorkspaceTabMode != int(vtui.WorkspaceTabsNever) {
 		t.Errorf("LoadConfig failed to restore workspace tab mode: %d", AppConfig.WorkspaceTabMode)
+	}
+	if !AppConfig.UseLocalLanguageFiles {
+		t.Error("LoadConfig failed to restore enabled local language files")
 	}
 	if AppConfig.WorkspaceTabsOverlay {
 		t.Error("LoadConfig failed to restore disabled workspace tab overlay")

--- a/cmd/f4/help.go
+++ b/cmd/f4/help.go
@@ -120,11 +120,13 @@ func loadHelpLangStrings(code string) map[string]string {
 		return nil
 	}
 	exeDir := filepath.Dir(os.Args[0])
-	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 	candidates := []string{
-		filepath.Join(userDir, code+".lng"),
 		filepath.Join(exeDir, "lang", code+".lng"),
 		filepath.Join("lang", code+".lng"),
+	}
+	if AppConfig.UseLocalLanguageFiles {
+		userDir := filepath.Join(GetF4ConfigDir(), "lang")
+		candidates = append([]string{filepath.Join(userDir, code+".lng")}, candidates...)
 	}
 	for _, cand := range candidates {
 		// #nosec G703 -- safeLanguageCode rejects separators and ".." before code is used as a path component.
@@ -149,12 +151,13 @@ func InitHelpSystem() {
 	hasLocalHelp := false
 	if lang != "en" && lang != "eng" {
 		exeDir := filepath.Dir(os.Args[0])
-		userDir := filepath.Join(GetF4ConfigDir(), "help")
-
 		candidates := []string{
-			filepath.Join(userDir, lang+".hlf"),
 			filepath.Join(exeDir, "help", lang+".hlf"),
 			filepath.Join("help", lang+".hlf"), // Fallback for "go run ." development
+		}
+		if AppConfig.UseLocalLanguageFiles {
+			userDir := filepath.Join(GetF4ConfigDir(), "help")
+			candidates = append([]string{filepath.Join(userDir, lang+".hlf")}, candidates...)
 		}
 
 		var helpContent string

--- a/cmd/f4/help_lang_test.go
+++ b/cmd/f4/help_lang_test.go
@@ -34,13 +34,16 @@ func TestHelpLanguageSwitch(t *testing.T) {
 	_ = GetF4ConfigDir()
 	oldF4ConfigDir := cachedF4ConfigDir
 	oldHelpLanguage := AppConfig.HelpLanguage
+	oldUseLocalLanguageFiles := AppConfig.UseLocalLanguageFiles
 	cachedF4ConfigDir = tempDir
 	t.Cleanup(func() {
 		cachedF4ConfigDir = oldF4ConfigDir
 		AppConfig.HelpLanguage = oldHelpLanguage
+		AppConfig.UseLocalLanguageFiles = oldUseLocalLanguageFiles
 	})
 
 	AppConfig.HelpLanguage = "ru"
+	AppConfig.UseLocalLanguageFiles = true
 	InitHelpSystem()
 
 	topic := vtui.GlobalHelpEngine.GetTopic("TestTopic")

--- a/cmd/f4/lang.go
+++ b/cmd/f4/lang.go
@@ -100,7 +100,6 @@ func InitLang() {
 	vtui.ReplaceStrings(allBaseStrings)
 
 	exeDir := filepath.Dir(os.Args[0])
-	userDir := filepath.Join(GetF4ConfigDir(), "lang")
 
 	loadLang := func(code string) {
 		if !safeLanguageCode(code) {
@@ -114,9 +113,12 @@ func InitLang() {
 			vtui.AddStrings(embedded)
 		}
 		candidates := []string{
-			filepath.Join(userDir, code+".lng"),
 			filepath.Join(exeDir, "lang", code+".lng"),
 			filepath.Join("lang", code+".lng"), // Fallback for "go run ." development
+		}
+		if AppConfig.UseLocalLanguageFiles {
+			userDir := filepath.Join(GetF4ConfigDir(), "lang")
+			candidates = append([]string{filepath.Join(userDir, code+".lng")}, candidates...)
 		}
 		var langIni *IniFile
 		for _, cand := range candidates {

--- a/cmd/f4/lang/en.lng
+++ b/cmd/f4/lang/en.lng
@@ -987,6 +987,7 @@ LanguageSettings.Title= Language Settings
 LanguageSettings.Primary=Primary language:
 LanguageSettings.Fallback=Fallback language:
 LanguageSettings.None=<none>
+LanguageSettings.UseLocalFiles=Use local language files
 
 HelpLanguage.Title=Help Languages
 HelpLanguage.Changed=Help language changed.

--- a/cmd/f4/lang/ru.lng
+++ b/cmd/f4/lang/ru.lng
@@ -969,6 +969,7 @@ LanguageSettings.Title= Настройки языка
 LanguageSettings.Primary=Основной язык:
 LanguageSettings.Fallback=Резервный язык:
 LanguageSettings.None=<нет>
+LanguageSettings.UseLocalFiles=Использовать локальные файлы языков
 
 HelpLanguage.Title=Язык справки
 HelpLanguage.Changed=Язык справки изменен.

--- a/cmd/f4/local_language_files_test.go
+++ b/cmd/f4/local_language_files_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestInitLangHonorsUseLocalLanguageFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "lang"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "lang", "ru.lng"), []byte("[Language]\nName=Русский\nCode=ru\n\n[Strings]\nLanguageSettings.Title=LOCAL LANGUAGE\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCfg := AppConfig
+	oldConfigDir := cachedF4ConfigDir
+	oldUseSystemProfiles := cachedF4Portable
+	t.Cleanup(func() {
+		cachedF4ConfigDir = oldConfigDir
+		cachedF4Portable = oldUseSystemProfiles
+		AppConfig = oldCfg
+		InitLang()
+	})
+	_ = GetF4ConfigDir()
+	cachedF4ConfigDir = tempDir
+
+	AppConfig.Language = "ru"
+	AppConfig.FallbackLanguage = ""
+	AppConfig.UseLocalLanguageFiles = false
+	InitLang()
+	if got := Msg("LanguageSettings.Title"); got == "LOCAL LANGUAGE" {
+		t.Fatal("local language file was loaded while the option was disabled")
+	}
+
+	AppConfig.UseLocalLanguageFiles = true
+	InitLang()
+	if got := Msg("LanguageSettings.Title"); got != "LOCAL LANGUAGE" {
+		t.Fatalf("local language file was not loaded when enabled: %q", got)
+	}
+}
+
+func TestInitHelpSystemHonorsUseLocalLanguageFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "help"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tempDir, "lang"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "help", "zz-test.hlf"), []byte("@LocalTopic\nLocal help content\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "lang", "zz-test.lng"), []byte("[Language]\nName=Test\nCode=zz-test\n\n[Strings]\nHelp.PanelNav=LOCAL HELP LANGUAGE\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCfg := AppConfig
+	oldConfigDir := cachedF4ConfigDir
+	oldUseSystemProfiles := cachedF4Portable
+	oldHelpEngine := vtui.GlobalHelpEngine
+	oldHelpActionStrings := helpActionStrings
+	t.Cleanup(func() {
+		cachedF4ConfigDir = oldConfigDir
+		cachedF4Portable = oldUseSystemProfiles
+		AppConfig = oldCfg
+		vtui.GlobalHelpEngine = oldHelpEngine
+		helpActionStrings = oldHelpActionStrings
+	})
+	_ = GetF4ConfigDir()
+	cachedF4ConfigDir = tempDir
+
+	AppConfig.HelpLanguage = "zz-test"
+	AppConfig.UseLocalLanguageFiles = false
+	if got := loadHelpLangStrings("zz-test"); got != nil {
+		t.Fatal("local help language strings were loaded while the option was disabled")
+	}
+	InitHelpSystem()
+	if topic := vtui.GlobalHelpEngine.GetTopic("LocalTopic"); topic != nil {
+		t.Fatal("local help file was loaded while the option was disabled")
+	}
+
+	AppConfig.UseLocalLanguageFiles = true
+	if got := loadHelpLangStrings("zz-test"); got["Help.PanelNav"] != "LOCAL HELP LANGUAGE" {
+		t.Fatalf("local help language strings were not loaded when enabled: %#v", got)
+	}
+	InitHelpSystem()
+	if topic := vtui.GlobalHelpEngine.GetTopic("LocalTopic"); topic == nil {
+		t.Fatal("local help file was not loaded when enabled")
+	}
+}

--- a/docs/LUNOBOT/996.md
+++ b/docs/LUNOBOT/996.md
@@ -1,0 +1,20 @@
+# Issue 996 — language settings and local language files
+
+Issue: https://github.com/unxed/f4/issues/996 (kept open until the author verifies the behavior).
+
+## Implemented
+
+- The existing language settings dialog now includes a persisted `UseLocalLanguageFiles` checkbox, disabled by default.
+- The setting controls user-profile overrides in `<f4 config dir>/lang/<code>.lng` and `<f4 config dir>/help/<code>.hlf`.
+- When disabled, f4 uses embedded language resources (plus executable/development-time language files); when enabled, the user-profile file is preferred as an overlay.
+- Switching the setting in the dialog reloads both the interface and help language immediately.
+- Regression coverage checks config persistence, the dialog control, and enabled/disabled `.lng` and `.hlf` loading.
+
+## Invariants
+
+- Embedded language packs remain the baseline and continue to work without a profile directory.
+- The user-profile file is never loaded when the checkbox is disabled.
+- Existing fallback-language ordering and the selected help language are unchanged.
+- Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
+
+*Лунобот-1 (node a721a6d1487257292ae00780; LNX)*

--- a/docs/LUNOBOT/996.md
+++ b/docs/LUNOBOT/996.md
@@ -15,6 +15,7 @@ Issue: https://github.com/unxed/f4/issues/996 (kept open until the author verifi
 - Embedded language packs remain the baseline and continue to work without a profile directory.
 - The user-profile file is never loaded when the checkbox is disabled.
 - Existing fallback-language ordering and the selected help language are unchanged.
+- The first hosted CI run exposed an existing test that created a user-profile help file without enabling the new option; that test now opts in explicitly.
 - Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
 
 *Лунобот-1 (node a721a6d1487257292ae00780; LNX)*


### PR DESCRIPTION
Closes no issue: #996 remains open for author verification. This PR adds a persisted UseLocalLanguageFiles checkbox in the existing combined language dialog, default off; gates user-profile lang/<code>.lng and help/<code>.hlf overlays behind the setting; keeps embedded resources and executable/development fallback paths; applies the same setting to command-palette translation discovery; and includes regression coverage plus docs/LUNOBOT/996.md. Local builds and tests were intentionally not run per LUNOBOT.md; GitHub Actions is the acceptance gate.