### PR TITLE
Open files with plain edit: command (#998)

### DIFF
--- a/cmd/f4/edit_command_test.go
+++ b/cmd/f4/edit_command_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestParsePlainEditCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		path string
+		ok   bool
+	}{
+		{name: "plain path", cmd: "edit:notes.txt", path: "notes.txt", ok: true},
+		{name: "case insensitive with spaces", cmd: " EDIT: report final.txt ", path: "report final.txt", ok: true},
+		{name: "empty path", cmd: "edit:", ok: false},
+		{name: "captured command", cmd: "edit:<< echo output", ok: false},
+		{name: "other command", cmd: "view:notes.txt", ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, ok := parsePlainEditCommand(tt.cmd)
+			if path != tt.path || ok != tt.ok {
+				t.Fatalf("parsePlainEditCommand(%q) = (%q, %v), want (%q, %v)", tt.cmd, path, ok, tt.path, tt.ok)
+			}
+		})
+	}
+}

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -2451,6 +2451,21 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 				return true
 			}
 
+			// A plain edit:<path> opens the named file. Keep this after
+			// edit:<< so captured command output keeps its existing meaning.
+			if editPath, ok := parsePlainEditCommand(trimmedCmd); ok {
+				pf.cmdLine.Clear()
+				if pf.searchFirstMode() && !AppConfig.SearchCommandStayFocused {
+					pf.setCommandLineFocus(false)
+				}
+				editPath = expandPathEnv(editPath)
+				if fsp := pf.getActivePanel(); fsp != nil && isLocalOSVFS(fsp.vfs) && !filepath.IsAbs(editPath) {
+					editPath = fsp.vfs.Join(fsp.vfs.GetPath(), editPath)
+				}
+				openEditFileIn(pf, editPath)
+				return true
+			}
+
 			// Apply to panel first
 			if isDirChange {
 				if fsp, ok := pf.panels[pf.activeIdx].(*FileSystemPanel); ok {
@@ -5654,6 +5669,22 @@ func parseDirChangeCommand(trimmedCmd string) (targetPath string, ok bool) {
 		return string(os.PathSeparator), true
 	}
 	return "", false
+}
+
+// parsePlainEditCommand recognizes the file-opening form of the edit:
+// command. The edit:<< capture form is handled before this helper, but it is
+// excluded here as well so the two forms cannot drift into one another.
+func parsePlainEditCommand(trimmedCmd string) (path string, ok bool) {
+	const prefix = "edit:"
+	if len(trimmedCmd) <= len(prefix) || !strings.EqualFold(trimmedCmd[:len(prefix)], prefix) {
+		return "", false
+	}
+
+	path = strings.TrimSpace(trimmedCmd[len(prefix):])
+	if path == "" || strings.HasPrefix(path, "<<") {
+		return "", false
+	}
+	return path, true
 }
 
 func expandPathEnv(s string) string {

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -5676,6 +5676,7 @@ func parseDirChangeCommand(trimmedCmd string) (targetPath string, ok bool) {
 // excluded here as well so the two forms cannot drift into one another.
 func parsePlainEditCommand(trimmedCmd string) (path string, ok bool) {
 	const prefix = "edit:"
+	trimmedCmd = strings.TrimSpace(trimmedCmd)
 	if len(trimmedCmd) <= len(prefix) || !strings.EqualFold(trimmedCmd[:len(prefix)], prefix) {
 		return "", false
 	}

--- a/docs/LUNOBOT/998.md
+++ b/docs/LUNOBOT/998.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented in PR #___ (pending merge).
+Implemented in [PR #999](https://github.com/unxed/f4/pull/999), pending merge.
 
 ## Scope
 

--- a/docs/LUNOBOT/998.md
+++ b/docs/LUNOBOT/998.md
@@ -1,0 +1,22 @@
+# Issue #998 — plain `edit:` command
+
+## Status
+
+Implemented in PR #___ (pending merge).
+
+## Scope
+
+The command line now accepts `edit:<path>` as a request to open that path in
+the normal f4 editor. Relative paths use the active local panel directory;
+environment variables and `~` are expanded first.
+
+The existing `edit:<< <command>` form is checked first and remains the command
+output capture path. Empty `edit:` input is not consumed by the new handler and
+continues through the existing command processing.
+
+## Verification
+
+The parser regression test covers a normal path, case-insensitive prefix,
+spaces in the path, the empty form, the captured-command form, and unrelated
+commands. Local builds and tests are intentionally not run per LUNOBOT policy;
+the required GitHub Actions result will be recorded after the PR is opened.


### PR DESCRIPTION
Fixes #998.

The panel command line now opens `edit:<path>` in the normal f4 editor. Relative paths resolve from the active local panel, with environment variables and `~` expanded. The existing `edit:<< <command>` output-capture form remains first in dispatch.

Includes `docs/LUNOBOT/998.md` and parser regression coverage. Local builds/tests were intentionally not run per LUNOBOT policy.