### PR TITLE
fix: keep Ctrl+[ and Ctrl+] with panels hidden

### DIFF
--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -2202,6 +2202,30 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 		}
 	}
 
+	// Char fallbacks for terminals that report Ctrl+\\ / Ctrl+[ / Ctrl+]
+	// with an unexpected character or virtual key code. The canonical bindings
+	// live in the action registry (Panel.GoRoot / Panel.InsertLeftPath /
+	// Panel.InsertRightPath). Keep these before raw terminal forwarding so the
+	// f4-owned command line still receives the shortcuts while panels are
+	// hidden; a busy terminal process keeps ownership of the key.
+	if pf.showPanels || !pf.isPtyBusy() {
+		if (e.VirtualKeyCode == vtinput.VK_OEM_5 || e.Char == '\\') && ctrl && !alt && !shift && e.KeyDown {
+			if RunAction("Panel.GoRoot") {
+				return true
+			}
+		}
+		if (e.VirtualKeyCode == vtinput.VK_OEM_4 || e.Char == '[') && ctrl && !alt && !shift && e.KeyDown {
+			if RunAction("Panel.InsertLeftPath") {
+				return true
+			}
+		}
+		if (e.VirtualKeyCode == vtinput.VK_OEM_6 || e.Char == ']') && ctrl && !alt && !shift && e.KeyDown {
+			if RunAction("Panel.InsertRightPath") {
+				return true
+			}
+		}
+	}
+
 	// Raw input mode fallback for active shell commands (non-AltScreen, e.g. ping),
 	// and for any interactive shell session when host console mode is active.
 	// We forward text and navigation to PTY, but let global shortcuts (Ctrl+O) fall through.
@@ -2221,22 +2245,6 @@ func (pf *PanelsFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	// with an unexpected virtual key code: the canonical bindings live
 	// in the action registry (Panel.GoRoot / Panel.InsertLeftPath /
 	// Panel.InsertRightPath).
-	if e.Char == '\\' && ctrl && !alt && !shift && e.KeyDown {
-		if RunAction("Panel.GoRoot") {
-			return true
-		}
-	}
-	if e.Char == '[' && ctrl && !alt && !shift && e.KeyDown {
-		if RunAction("Panel.InsertLeftPath") {
-			return true
-		}
-	}
-	if e.Char == ']' && ctrl && !alt && !shift && e.KeyDown {
-		if RunAction("Panel.InsertRightPath") {
-			return true
-		}
-	}
-
 	// Folder bookmarks, far2l's hotkey scheme: [RightCtrl | Ctrl+Alt] + N
 	// jumps to slot N, Ctrl+Shift+N stores the current directory there, and
 	// [RightCtrl | Ctrl+Alt] + ~ goes home. The ctrl local above merges both

--- a/cmd/f4/panels_frame_test.go
+++ b/cmd/f4/panels_frame_test.go
@@ -1559,6 +1559,55 @@ func TestPanelsFrame_CtrlBrackets_Insertion(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_CtrlBrackets_InsertionWhenPanelsHidden(t *testing.T) {
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+
+	lp := pf.panels[0].(*FileSystemPanel)
+	rp := pf.panels[1].(*FileSystemPanel)
+	tmp := t.TempDir()
+	leftPath := filepath.Join(tmp, "left")
+	rightPath := filepath.Join(tmp, "right")
+	if err := os.MkdirAll(leftPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rightPath, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := lp.vfs.SetPath(leftPath); err != nil {
+		t.Fatal(err)
+	}
+	if err := rp.vfs.SetPath(rightPath); err != nil {
+		t.Fatal(err)
+	}
+
+	pf.showPanels = false
+	pf.cmdLine.Clear()
+	pressKey(pf, &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_OEM_4,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if got := pf.cmdLine.Edit.GetText(); got != leftPath {
+		t.Errorf("hidden-panels Ctrl+[ inserted %q, want %q", got, leftPath)
+	}
+
+	pf.cmdLine.Clear()
+	pressKey(pf, &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  vtinput.VK_OEM_6,
+		ControlKeyState: vtinput.LeftCtrlPressed,
+	})
+	if got := pf.cmdLine.Edit.GetText(); got != rightPath {
+		t.Errorf("hidden-panels Ctrl+] inserted %q, want %q", got, rightPath)
+	}
+}
+
 func TestCtrlBracketsInsertPanelPathsIntoFocusedEdit(t *testing.T) {
 	scr := vtui.NewSilentScreenBuf()
 	scr.AllocBuf(80, 25)

--- a/docs/LUNOBOT/1001.md
+++ b/docs/LUNOBOT/1001.md
@@ -1,0 +1,23 @@
+# Issue #1001 — hidden-panel path shortcuts
+
+## Status
+
+Part 1 of 2 is implemented in this PR. The Ctrl+[ and Ctrl+] shortcuts now
+insert the visual left and right panel paths when the panels are hidden. The
+second report about a leading space on Ctrl+Enter is intentionally left for a
+separate follow-up because the expected behavior with an already non-empty
+command line needs clarification.
+
+## Scope
+
+The hidden terminal view uses the `Terminal` input area, while these actions
+are registered in the `Shell` area. `PanelsFrame` therefore keeps a fallback
+for the shortcuts. The fallback now accepts both the punctuation character and
+the OEM virtual-key code, and runs before raw terminal forwarding only while
+f4 owns the input; a busy terminal process still receives the key.
+
+## Verification
+
+Added a regression test covering both shortcuts with panels hidden. Local
+builds and tests were not run according to LUNOBOT policy; GitHub Actions will
+provide verification for the pull request.


### PR DESCRIPTION
Closes part 1 of #1001.

When panels are hidden, the active input area is Terminal, so Shell-area path shortcuts do not pass through the normal configurable hotkey dispatch. Move the fallback before raw terminal forwarding, recognize both OEM virtual-key codes and punctuation characters, and keep a busy terminal process as the owner of the key.

Added a regression test for inserting both visual panel paths with hidden panels. The Ctrl+Enter leading-space report is left for a separate follow-up because the expected behavior with a non-empty command line needs clarification.

Local builds and tests were not run per LUNOBOT policy.