### PR TITLE
fix: load local English help overlay

### DIFF
--- a/cmd/f4/help.go
+++ b/cmd/f4/help.go
@@ -149,7 +149,10 @@ func InitHelpSystem() {
 	}
 
 	hasLocalHelp := false
-	if lang != "en" && lang != "eng" {
+	// An explicitly enabled profile overlay also applies to English. The
+	// embedded English help remains the baseline, while help/en.hlf can provide
+	// user-specific topics and corrections.
+	if AppConfig.UseLocalLanguageFiles || (lang != "en" && lang != "eng") {
 		exeDir := filepath.Dir(os.Args[0])
 		candidates := []string{
 			filepath.Join(exeDir, "help", lang+".hlf"),

--- a/cmd/f4/local_language_files_test.go
+++ b/cmd/f4/local_language_files_test.go
@@ -93,3 +93,33 @@ func TestInitHelpSystemHonorsUseLocalLanguageFiles(t *testing.T) {
 		t.Fatal("local help file was not loaded when enabled")
 	}
 }
+
+func TestInitHelpSystemLoadsLocalEnglishHelpWhenEnabled(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "help"), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "help", "en.hlf"), []byte("@LocalEnglishTopic\nLocal English help content\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldCfg := AppConfig
+	oldConfigDir := cachedF4ConfigDir
+	oldUseSystemProfiles := cachedF4Portable
+	oldHelpEngine := vtui.GlobalHelpEngine
+	t.Cleanup(func() {
+		cachedF4ConfigDir = oldConfigDir
+		cachedF4Portable = oldUseSystemProfiles
+		AppConfig = oldCfg
+		vtui.GlobalHelpEngine = oldHelpEngine
+	})
+	_ = GetF4ConfigDir()
+	cachedF4ConfigDir = tempDir
+
+	AppConfig.HelpLanguage = "en"
+	AppConfig.UseLocalLanguageFiles = true
+	InitHelpSystem()
+	if topic := vtui.GlobalHelpEngine.GetTopic("LocalEnglishTopic"); topic == nil {
+		t.Fatal("local English help file was not loaded when enabled")
+	}
+}

--- a/docs/LUNOBOT/996.md
+++ b/docs/LUNOBOT/996.md
@@ -10,6 +10,11 @@ Issue: https://github.com/unxed/f4/issues/996 (kept open until the author verifi
 - Switching the setting in the dialog reloads both the interface and help language immediately.
 - Regression coverage checks config persistence, the dialog control, and enabled/disabled `.lng` and `.hlf` loading.
 
+## Current slice
+
+- When `UseLocalLanguageFiles` is enabled and the help language is English, the profile's `help/en.hlf` is loaded after the embedded English baseline.
+- Added regression coverage for a profile-local English help topic.
+
 ## Invariants
 
 - Embedded language packs remain the baseline and continue to work without a profile directory.
@@ -19,3 +24,5 @@ Issue: https://github.com/unxed/f4/issues/996 (kept open until the author verifi
 - Local builds and tests were not run according to `LUNOBOT.md`; GitHub Actions is the acceptance gate.
 
 *Лунобот-1 (node a721a6d1487257292ae00780; LNX)*
+
+*Лунобот-2 (node f33f64cd91460430a21da326; MSW)*


### PR DESCRIPTION
## Summary

- load `help/en.hlf` from the user profile when `UseLocalLanguageFiles` is enabled, preserving the embedded English help as the baseline
- add a regression test for a profile-local English help topic
- document this slice in `docs/LUNOBOT/996.md`

Fixes #996

Local Go builds and tests were not run per `LUNOBOT.md`; GitHub Actions is the acceptance gate.