### PR TITLE
archive: open local SFX containers for browsing

### DIFF
--- a/docs/LUNOBOT/915.md
+++ b/docs/LUNOBOT/915.md
@@ -1,0 +1,16 @@
+# Issue #915 — SFX archive browsing
+
+This slice implements part 1 of 2: a local ZIP, 7z, or RAR self-extracting
+file can be opened as a read-only archive VFS when its archive signature is
+embedded after an executable stub. f4 copies the bytes starting at that
+signature to a private temporary backing file, so the executable is never
+modified and the existing archive readers can index it normally.
+
+The probe scans only the first 64 MiB and recognizes the ZIP, 7z, RAR 4, and
+RAR 5 signatures. Multi-volume SFX handling and archive write/update
+operations remain a separate follow-up slice.
+
+Regression coverage includes signature detection for all three formats and
+opening a ZIP SFX through `ArchiveProvider` to list its root entry. Local
+builds and tests were not run, per `LUNOBOT.md`; GitHub Actions is the
+verification source.

--- a/plugins/archive/provider.go
+++ b/plugins/archive/provider.go
@@ -32,7 +32,18 @@ func (p *ArchiveProvider) CanOpen(ctx context.Context, parent vfs.VFS, path stri
 		}
 	}
 	format := archive.DetectFormat(name)
-	return format != ""
+	if format != "" {
+		return true
+	}
+	if osvfs, ok := parent.(*vfs.OSVFS); ok {
+		localPath, err := osvfs.Abs(path)
+		if err != nil {
+			return false
+		}
+		_, found, err := findEmbeddedArchive(localPath)
+		return err == nil && found
+	}
+	return false
 }
 
 func (p *ArchiveProvider) Open(ctx context.Context, parent vfs.VFS, path string) (vfs.VFS, error) {

--- a/plugins/archive/sfx.go
+++ b/plugins/archive/sfx.go
@@ -1,0 +1,161 @@
+package archive
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"sync"
+)
+
+const sfxProbeLimit = 64 << 20
+
+type sfxSignature struct {
+	magic  []byte
+	format string
+	suffix string
+}
+
+var sfxSignatures = []sfxSignature{
+	{magic: []byte("PK\x03\x04"), format: "zip", suffix: ".zip"},
+	{magic: []byte("PK\x05\x06"), format: "zip", suffix: ".zip"},
+	{magic: []byte("7z\xBC\xAF\x27\x1C"), format: "fallback", suffix: ".7z"},
+	{magic: []byte("Rar!\x1A\x07\x00"), format: "fallback", suffix: ".rar"},
+	{magic: []byte("Rar!\x1A\x07\x01\x00"), format: "fallback", suffix: ".rar"},
+}
+
+type embeddedArchive struct {
+	format string
+	suffix string
+	offset int64
+}
+
+func findEmbeddedArchive(filename string) (embeddedArchive, bool, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return embeddedArchive{}, false, err
+	}
+	defer func() { _ = file.Close() }()
+
+	const chunkSize = 64 << 10
+	maxMagic := 0
+	for _, signature := range sfxSignatures {
+		if len(signature.magic) > maxMagic {
+			maxMagic = len(signature.magic)
+		}
+	}
+
+	chunk := make([]byte, chunkSize)
+	var carry []byte
+	var scanned int64
+	for scanned < sfxProbeLimit {
+		want := int64(len(chunk))
+		if remaining := sfxProbeLimit - scanned; remaining < want {
+			want = remaining
+		}
+		n, readErr := file.Read(chunk[:int(want)])
+		if n > 0 {
+			block := make([]byte, 0, len(carry)+n)
+			block = append(block, carry...)
+			block = append(block, chunk[:n]...)
+			blockStart := scanned - int64(len(carry))
+
+			bestIndex := -1
+			var best sfxSignature
+			for _, signature := range sfxSignatures {
+				index := bytes.Index(block, signature.magic)
+				if index >= 0 && (bestIndex < 0 || index < bestIndex) {
+					bestIndex = index
+					best = signature
+				}
+			}
+			if bestIndex >= 0 {
+				return embeddedArchive{
+					format: best.format,
+					suffix: best.suffix,
+					offset: blockStart + int64(bestIndex),
+				}, true, nil
+			}
+
+			keep := maxMagic - 1
+			if len(block) > keep {
+				carry = append(carry[:0], block[len(block)-keep:]...)
+			} else {
+				carry = append(carry[:0], block...)
+			}
+			scanned += int64(n)
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			return embeddedArchive{}, false, readErr
+		}
+	}
+
+	return embeddedArchive{}, false, nil
+}
+
+type sfxBacking struct {
+	path string
+	once sync.Once
+	err  error
+}
+
+func (b *sfxBacking) Close() error {
+	b.once.Do(func() {
+		b.err = os.Remove(b.path)
+		if errors.Is(b.err, os.ErrNotExist) {
+			b.err = nil
+		}
+	})
+	return b.err
+}
+
+func materializeEmbeddedArchive(filename string, embedded embeddedArchive) (string, io.Closer, error) {
+	if embedded.offset <= 0 {
+		return filename, nil, nil
+	}
+
+	source, err := os.Open(filename)
+	if err != nil {
+		return "", nil, err
+	}
+	stat, err := source.Stat()
+	if err != nil {
+		_ = source.Close()
+		return "", nil, err
+	}
+	if embedded.offset >= stat.Size() {
+		_ = source.Close()
+		return "", nil, os.ErrInvalid
+	}
+
+	target, err := os.CreateTemp("", "f4-sfx-*"+embedded.suffix)
+	if err != nil {
+		_ = source.Close()
+		return "", nil, err
+	}
+	targetName := target.Name()
+	cleanup := func() {
+		_ = source.Close()
+		_ = target.Close()
+		_ = os.Remove(targetName)
+	}
+
+	_, copyErr := io.Copy(target, io.NewSectionReader(source, embedded.offset, stat.Size()-embedded.offset))
+	closeTargetErr := target.Close()
+	closeSourceErr := source.Close()
+	if copyErr != nil || closeTargetErr != nil || closeSourceErr != nil {
+		cleanup()
+		if copyErr != nil {
+			return "", nil, copyErr
+		}
+		if closeTargetErr != nil {
+			return "", nil, closeTargetErr
+		}
+		return "", nil, closeSourceErr
+	}
+
+	return targetName, &sfxBacking{path: targetName}, nil
+}

--- a/plugins/archive/sfx_test.go
+++ b/plugins/archive/sfx_test.go
@@ -1,0 +1,191 @@
+package archive
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestFindEmbeddedArchive(t *testing.T) {
+	tests := []struct {
+		name   string
+		magic  []byte
+		format string
+		suffix string
+	}{
+		{name: "zip", magic: []byte("PK\x03\x04"), format: "zip", suffix: ".zip"},
+		{name: "7z", magic: []byte("7z\xBC\xAF\x27\x1C"), format: "fallback", suffix: ".7z"},
+		{name: "rar", magic: []byte("Rar!\x1A\x07\x00"), format: "fallback", suffix: ".rar"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stub := []byte("self-extractor stub")
+			filename := filepath.Join(t.TempDir(), "payload.exe")
+			if err := os.WriteFile(filename, append(stub, test.magic...), 0600); err != nil {
+				t.Fatal(err)
+			}
+
+			got, found, err := findEmbeddedArchive(filename)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !found {
+				t.Fatal("embedded archive was not detected")
+			}
+			if got.offset != int64(len(stub)) || got.format != test.format || got.suffix != test.suffix {
+				t.Fatalf("probe = %#v, want offset %d, format %q, suffix %q", got, len(stub), test.format, test.suffix)
+			}
+		})
+	}
+}
+
+func TestArchiveProviderOpensZipSFX(t *testing.T) {
+	var archiveBytes bytes.Buffer
+	zipWriter := zip.NewWriter(&archiveBytes)
+	entry, err := zipWriter.Create("inside.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte("from sfx\n")); err != nil {
+		t.Fatal(err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	root := t.TempDir()
+	filename := filepath.Join(root, "archive.exe")
+	stub := []byte("stub bytes before the archive\n")
+	if err := os.WriteFile(filename, append(stub, archiveBytes.Bytes()...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := vfs.NewOSVFS(root)
+	provider := &ArchiveProvider{}
+	if !provider.CanOpen(context.Background(), parent, "archive.exe") {
+		t.Fatal("ArchiveProvider rejected a ZIP SFX")
+	}
+	opened, err := provider.Open(context.Background(), parent, "archive.exe")
+	if err != nil {
+		t.Fatalf("open ZIP SFX: %v", err)
+	}
+	archiveVFS, ok := opened.(*ArchiveVFS)
+	if !ok {
+		t.Fatalf("opened VFS = %T, want *ArchiveVFS", opened)
+	}
+	t.Cleanup(func() { _ = archiveVFS.Close() })
+
+	var items []vfs.VFSItem
+	if err := archiveVFS.ReadDir(context.Background(), archiveVFS.GetPath(), func(chunk []vfs.VFSItem) {
+		items = append(items, chunk...)
+	}); err != nil {
+		t.Fatalf("read ZIP SFX root: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "inside.txt" {
+		t.Fatalf("root entries = %#v, want inside.txt", items)
+	}
+	if archiveVFS.sfxOffset != int64(len(stub)) || archiveVFS.sfxSuffix != ".zip" {
+		t.Fatalf("SFX metadata = offset %d, suffix %q", archiveVFS.sfxOffset, archiveVFS.sfxSuffix)
+	}
+
+	clone, ok := archiveVFS.Clone().(*ArchiveVFS)
+	if !ok {
+		t.Fatal("SFX clone did not return *ArchiveVFS")
+	}
+	t.Cleanup(func() { _ = clone.Close() })
+	var cloneItems []vfs.VFSItem
+	if err := clone.ReadDir(context.Background(), clone.GetPath(), func(chunk []vfs.VFSItem) {
+		cloneItems = append(cloneItems, chunk...)
+	}); err != nil {
+		t.Fatalf("read cloned ZIP SFX root: %v", err)
+	}
+	if len(cloneItems) != 1 || cloneItems[0].Name != "inside.txt" {
+		t.Fatalf("cloned root entries = %#v, want inside.txt", cloneItems)
+	}
+}
+
+func TestFindEmbeddedArchiveRejectsPlainFile(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "plain.exe")
+	if err := os.WriteFile(filename, []byte("not an archive"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := findEmbeddedArchive(filename); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("plain file was detected as an embedded archive")
+	}
+}
+
+func TestFindEmbeddedArchiveAcrossProbeChunks(t *testing.T) {
+	stub := bytes.Repeat([]byte{'x'}, 64<<10-2)
+	filename := filepath.Join(t.TempDir(), "split.exe")
+	if err := os.WriteFile(filename, append(stub, []byte("7z\xBC\xAF\x27\x1C")...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, found, err := findEmbeddedArchive(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || got.offset != int64(len(stub)) || got.suffix != ".7z" {
+		t.Fatalf("probe = %#v, found=%t; want offset %d and .7z", got, found, len(stub))
+	}
+}
+
+func TestMaterializeEmbeddedArchive(t *testing.T) {
+	stub := []byte("stub")
+	payload := []byte("archive payload")
+	filename := filepath.Join(t.TempDir(), "archive.exe")
+	if err := os.WriteFile(filename, append(stub, payload...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	materialized, closer, err := materializeEmbeddedArchive(filename, embeddedArchive{
+		format: "fallback",
+		suffix: ".7z",
+		offset: int64(len(stub)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closer == nil {
+		t.Fatal("materialized archive has no cleanup closer")
+	}
+	got, err := os.ReadFile(materialized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("materialized payload = %q, want %q", got, payload)
+	}
+	if err := closer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(materialized); !os.IsNotExist(err) {
+		t.Fatalf("materialized file still exists after cleanup: %v", err)
+	}
+
+	same, noCloser, err := materializeEmbeddedArchive(filename, embeddedArchive{offset: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if same != filename || noCloser != nil {
+		t.Fatalf("zero-offset materialization = %q, closer=%v", same, noCloser)
+	}
+}
+
+func TestMaterializeEmbeddedArchiveRejectsPastEnd(t *testing.T) {
+	filename := filepath.Join(t.TempDir(), "short.exe")
+	if err := os.WriteFile(filename, []byte("short"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := materializeEmbeddedArchive(filename, embeddedArchive{offset: 100, suffix: ".zip"}); !errors.Is(err, os.ErrInvalid) {
+		t.Fatalf("error = %v, want os.ErrInvalid", err)
+	}
+}

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -1906,6 +1906,7 @@ func (v *ArchiveVFS) Clone() vfs.VFS {
 	}
 	parent, arcPath, backingPath := v.parent, v.arcPath, v.backingPath
 	displayName, format, password, innerPath := v.displayName, v.format, v.password, v.innerPath
+	sfxOffset, sfxSuffix := v.sfxOffset, v.sfxSuffix
 	v.mu.Unlock()
 
 	var finalPath string

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -175,7 +175,7 @@ func NewArchiveVFSContext(ctx context.Context, parent vfs.VFS, archivePath strin
 		if format == "" {
 			if embedded, found, probeErr := findEmbeddedArchive(finalPath); probeErr != nil {
 				return nil, probeErr
-			} else if found {
+			} else if found && embedded.offset > 0 {
 				format = embedded.format
 				sfxOffset = embedded.offset
 				sfxSuffix = embedded.suffix

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -75,6 +75,8 @@ type ArchiveVFS struct {
 	backingPath string
 	displayName string
 	format      string
+	sfxOffset   int64
+	sfxSuffix   string
 	innerPath   string
 	password    string
 	// passwordGen counts installed password changes so a concurrent operation
@@ -158,11 +160,30 @@ func NewArchiveVFSContext(ctx context.Context, parent vfs.VFS, archivePath strin
 	format := archive.DetectFormat(displayName)
 	var finalPath string
 	var closer io.Closer
+	var sfxOffset int64
+	var sfxSuffix string
 	if osvfs, ok := parent.(*vfs.OSVFS); ok {
 		var err error
 		finalPath, err = osvfs.Abs(archivePath)
 		if err != nil {
 			return nil, err
+		}
+		// SFX files commonly have an executable extension, so the regular
+		// extension-based archive detector never sees them. Probe local files
+		// and normalize a discovered archive to a private backing file; the
+		// original executable remains untouched.
+		if format == "" {
+			if embedded, found, probeErr := findEmbeddedArchive(finalPath); probeErr != nil {
+				return nil, probeErr
+			} else if found {
+				format = embedded.format
+				sfxOffset = embedded.offset
+				sfxSuffix = embedded.suffix
+				finalPath, closer, err = materializeEmbeddedArchive(finalPath, embedded)
+				if err != nil {
+					return nil, err
+				}
+			}
 		}
 	} else {
 		lease, err := acquireArchiveMaterialization(ctx, parent, archivePath, displayName)
@@ -183,7 +204,8 @@ func NewArchiveVFSContext(ctx context.Context, parent vfs.VFS, archivePath strin
 
 	return &ArchiveVFS{
 		parent: parent, arcPath: canonicalPath, backingPath: finalPath, displayName: displayName,
-		format: format, password: password, innerPath: ".", fsys: fsys, closer: closer,
+		format: format, sfxOffset: sfxOffset, sfxSuffix: sfxSuffix,
+		password: password, innerPath: ".", fsys: fsys, closer: closer,
 	}, nil
 }
 
@@ -1889,14 +1911,29 @@ func (v *ArchiveVFS) Clone() vfs.VFS {
 	var finalPath string
 	var closer io.Closer
 	if osvfs, ok := parent.(*vfs.OSVFS); ok {
-		// The local archive file is already independently owned by its parent
-		// VFS, so a second decoder can use the same immutable path safely.
-		finalPath = backingPath
-		if finalPath == "" {
-			var err error
-			finalPath, err = osvfs.Abs(arcPath)
+		if sfxOffset > 0 {
+			originalPath, err := osvfs.Abs(arcPath)
 			if err != nil {
 				return vfs.NewNullVFS(0)
+			}
+			finalPath, closer, err = materializeEmbeddedArchive(originalPath, embeddedArchive{
+				format: format,
+				suffix: sfxSuffix,
+				offset: sfxOffset,
+			})
+			if err != nil {
+				return vfs.NewNullVFS(0)
+			}
+		} else {
+			// The local archive file is already independently owned by its
+			// parent VFS, so a second decoder can use the same immutable path.
+			finalPath = backingPath
+			if finalPath == "" {
+				var err error
+				finalPath, err = osvfs.Abs(arcPath)
+				if err != nil {
+					return vfs.NewNullVFS(0)
+				}
 			}
 		}
 	} else {
@@ -1919,7 +1956,8 @@ func (v *ArchiveVFS) Clone() vfs.VFS {
 	}
 	return &ArchiveVFS{
 		parent: parent, arcPath: arcPath, backingPath: finalPath, displayName: displayName,
-		format: format, password: password, innerPath: innerPath, fsys: fsys, closer: closer,
+		format: format, sfxOffset: sfxOffset, sfxSuffix: sfxSuffix,
+		password: password, innerPath: innerPath, fsys: fsys, closer: closer,
 	}
 }
 
@@ -2179,8 +2217,11 @@ func (v *ArchiveVFS) copyBulkFrom(ctx context.Context, srcDir string, useSrcDir 
 
 func (v *ArchiveVFS) openArchiveFile(ctx context.Context) (vfs.ReadAtCloser, error) {
 	if osvfs, ok := v.parent.(*vfs.OSVFS); ok {
-		absPath, _ := osvfs.Abs(v.arcPath)
-		f, err := os.Open(absPath)
+		archivePath := v.backingPath
+		if archivePath == "" {
+			archivePath, _ = osvfs.Abs(v.arcPath)
+		}
+		f, err := os.Open(archivePath)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Что изменено

- обнаруживает локальные ZIP/7z/RAR SFX по встроенной сигнатуре после executable stub;
- открывает найденный контейнер через приватный временный backing-файл, не изменяя исходный executable;
- сохраняет backing-файл для чтения и создаёт независимый backing при Clone;
- добавляет регрессионные тесты и статусный документ для #915.

Это часть 1 из 2: просмотр содержимого локальных SFX. Многотомные SFX и операции изменения архива остаются отдельной частью.

## Проверка

Локальные сборка и тесты не запускались по инструкции LUNOBOT.md; форматирование и git diff --check пройдены. Полная проверка — GitHub Actions.

Refs #915