### PR TITLE
fix: keep FreeBSD tty sessions attached

### DIFF
--- a/cmd/f4/external_editor_process_freebsd.go
+++ b/cmd/f4/external_editor_process_freebsd.go
@@ -1,0 +1,10 @@
+//go:build freebsd
+
+package main
+
+import "os/exec"
+
+// FreeBSD's terminal is already the controlling terminal of the shell
+// session. The TTY session stays attached on this platform, so the editor
+// must inherit that session instead of trying to acquire the terminal again.
+func configureExternalEditorProcess(cmd *exec.Cmd) {}

--- a/cmd/f4/external_editor_process_freebsd_test.go
+++ b/cmd/f4/external_editor_process_freebsd_test.go
@@ -1,0 +1,16 @@
+//go:build freebsd
+
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestConfigureExternalEditorProcessInheritsFreeBSDTTYSession(t *testing.T) {
+	cmd := exec.Command("true")
+	configureExternalEditorProcess(cmd)
+	if cmd.SysProcAttr != nil {
+		t.Fatalf("FreeBSD editor process attributes = %+v, want inherited terminal session", cmd.SysProcAttr)
+	}
+}

--- a/cmd/f4/external_editor_process_unix.go
+++ b/cmd/f4/external_editor_process_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !freebsd
 
 package main
 

--- a/cmd/f4/external_editor_process_unix_test.go
+++ b/cmd/f4/external_editor_process_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !freebsd
 
 package main
 

--- a/cmd/f4/session_unix.go
+++ b/cmd/f4/session_unix.go
@@ -107,7 +107,15 @@ func ManageSessions() {
 		runServer(os.Args[2])
 		return
 	}
-
+	// FreeBSD does not let a new session steal a terminal that is already
+	// controlled by the shell session. The normal Unix session daemon would
+	// therefore leave external TTY editors without /dev/tty. Keep the TTY
+	// session attached on FreeBSD so both f4 and its editor stay in the shell's
+	// controlling session.
+	if runtime.GOOS == "freebsd" {
+		runAttachedSession()
+		return
+	}
 	if os.Getenv("F4_NESTED") != "" {
 		startNewSession()
 		return
@@ -135,6 +143,36 @@ func ManageSessions() {
 		}
 	}
 	startNewSession()
+}
+
+// runAttachedSession is the Unix equivalent of the Windows one-process TTY
+// path. It is used on FreeBSD because its TIOCSCTTY rules reject acquiring a
+// terminal that is already the controlling terminal of the shell session;
+// keeping this process attached lets external editors inherit the real TTY.
+func runAttachedSession() {
+	scr := InitCore()
+
+	restore, err := vtui.PrepareTerminal()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return
+	}
+	if restore != nil {
+		defer restore()
+	}
+
+	ProbeHostTextArea()
+	PreferCompatibleGraphicsProtocol(scr)
+	InstallX11Overlay()
+	openDashEFileIfRequested()
+
+	ttyxKeys := startTTYXKeyboard()
+	if ttyxKeys != nil {
+		defer ttyxKeys.Close()
+	}
+
+	reader := vtinput.NewReader(os.Stdin, false)
+	vtui.FrameManager.Run(reader)
 }
 
 func startNewSession() {

--- a/docs/LUNOBOT/889.md
+++ b/docs/LUNOBOT/889.md
@@ -1,0 +1,7 @@
+# Issue #889
+
+## Current slice
+
+FreeBSD TTY sessions now stay attached to the shell process instead of using f4's detached Unix session daemon. External console editors therefore inherit the existing controlling terminal and can open `/dev/tty`. The detached process setup remains enabled for other Unix platforms, while FreeBSD has a platform-specific regression test documenting the inherited-session requirement.
+
+*Lunobot-2 (node f33f64cd91460430a21da326; MSW)*


### PR DESCRIPTION
## Summary
- keep FreeBSD TTY sessions in the process that owns the shell's controlling terminal
- let external console editors inherit that terminal instead of reacquiring it from a detached daemon
- add FreeBSD-specific process setup coverage and Lunobot status documentation

## Validation
- git diff --check
- local Go builds/tests intentionally not run; GitHub Actions is the validation authority