### PR TITLE
fix: insert file names at cursor without a space

### DIFF
--- a/cmd/f4/action_copyname_parent_test.go
+++ b/cmd/f4/action_copyname_parent_test.go
@@ -145,6 +145,27 @@ func TestAction_PanelInsertPath_CursorOnFile(t *testing.T) {
 	}
 }
 
+func TestAction_PanelInsertFileName_DoesNotAddSeparator(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "a.txt"), []byte("x"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	p := seedPanelForCopyName(t, tmp)
+	fsp := p.getActivePanel()
+	fsp.SetCursorIndex(1) // "a.txt"
+
+	base := tmp + string(filepath.Separator)
+	p.cmdLine.Edit.SetText(base)
+	if !RunAction("Panel.InsertFileName") {
+		t.Fatal("Panel.InsertFileName did not run")
+	}
+
+	want := base + "a.txt"
+	if got := p.cmdLine.Edit.GetText(); got != want {
+		t.Errorf("command line = %q, want %q", got, want)
+	}
+}
+
 func TestAction_PanelCopyName_CursorOnParentUsesCurrentFolderName(t *testing.T) {
 	// t.TempDir() returns a stable, existing dir; take its basename to know
 	// what the far2l "cursor on .. = current folder name" rule should yield.

--- a/cmd/f4/panels_frame.go
+++ b/cmd/f4/panels_frame.go
@@ -542,10 +542,6 @@ func (pf *PanelsFrame) insertSelectedFileName() bool {
 			name = "'" + strings.ReplaceAll(name, "'", "'\\''") + "'"
 		}
 	}
-	txt := pf.cmdLine.Edit.GetText()
-	if len(txt) > 0 && txt[len(txt)-1] != ' ' {
-		pf.cmdLine.InsertString(" ")
-	}
 	pf.cmdLine.InsertString(name)
 	return true
 }

--- a/docs/LUNOBOT/1001.md
+++ b/docs/LUNOBOT/1001.md
@@ -2,11 +2,10 @@
 
 ## Status
 
-Part 1 of 2 is implemented in this PR. The Ctrl+[ and Ctrl+] shortcuts now
-insert the visual left and right panel paths when the panels are hidden. The
-second report about a leading space on Ctrl+Enter is intentionally left for a
-separate follow-up because the expected behavior with an already non-empty
-command line needs clarification.
+Part 1 of 2 is already in `main`: the Ctrl+[ and Ctrl+] shortcuts now insert
+the visual left and right panel paths when the panels are hidden. Part 2 is
+implemented in the follow-up PR for the clarified Ctrl+Enter behavior: the
+selected filename is inserted at the cursor without an implicit separator.
 
 ## Scope
 
@@ -18,6 +17,7 @@ f4 owns the input; a busy terminal process still receives the key.
 
 ## Verification
 
-Added a regression test covering both shortcuts with panels hidden. Local
-builds and tests were not run according to LUNOBOT policy; GitHub Actions will
-provide verification for the pull request.
+Added a regression test covering both shortcuts with panels hidden and a
+regression test for inserting a filename after a path separator. Local builds
+and tests were not run according to LUNOBOT policy; GitHub Actions will
+provide verification for the follow-up pull request.


### PR DESCRIPTION
Closes the remaining part of #1001.

`Panel.InsertFileName` now inserts the selected filename exactly at the command-line cursor instead of prepending an implicit space. This lets `Ctrl+[` followed by `Ctrl+Enter` form a path without an unwanted separator; users can still type a space explicitly when they need one.

Added a regression test for a command line that already ends with a path separator.

Validation: `gofmt -d` and `git diff --check`; full validation is delegated to GitHub Actions per LUNOBOT.md.