### PR TITLE
archive: preserve SFX volume sets

### DIFF
--- a/docs/LUNOBOT/915.md
+++ b/docs/LUNOBOT/915.md
@@ -1,16 +1,22 @@
 # Issue #915 — SFX archive browsing
 
-This slice implements part 1 of 2: a local ZIP, 7z, or RAR self-extracting
-file can be opened as a read-only archive VFS when its archive signature is
-embedded after an executable stub. f4 copies the bytes starting at that
-signature to a private temporary backing file, so the executable is never
-modified and the existing archive readers can index it normally.
+Part 1 of 2 is merged: a local ZIP, 7z, or RAR self-extracting file can be
+opened as a read-only archive VFS when its archive signature is embedded after
+an executable stub. f4 copies the bytes starting at that signature to a
+private temporary backing file, so the executable is never modified and the
+existing archive readers can index it normally.
+
+Part 2 adds multi-volume SFX backing for the existing ZIP, 7z, and RAR
+readers. When adjacent volume names are present, f4 creates a private
+temporary directory, preserves the embedded first volume under the filename
+expected by the backend, and copies only the matching `.zNN`, `.7z.NNN`, or
+RAR volume files. Closing the archive removes the complete private set.
 
 The probe scans only the first 64 MiB and recognizes the ZIP, 7z, RAR 4, and
-RAR 5 signatures. Multi-volume SFX handling and archive write/update
-operations remain a separate follow-up slice.
+RAR 5 signatures. Archive write/update operations remain a separate follow-up
+slice because an SFX executable must be repacked without losing its stub.
 
-Regression coverage includes signature detection for all three formats and
-opening a ZIP SFX through `ArchiveProvider` to list its root entry. Local
-builds and tests were not run, per `LUNOBOT.md`; GitHub Actions is the
-verification source.
+Regression coverage includes signature detection for all three formats,
+opening single-volume and split ZIP SFX files through `ArchiveProvider`, and
+cleanup of the private multi-volume backing directory. Local builds and tests
+were not run, per `LUNOBOT.md`; GitHub Actions is the verification source.

--- a/docs/LUNOBOT/915.md
+++ b/docs/LUNOBOT/915.md
@@ -11,6 +11,8 @@ readers. When adjacent volume names are present, f4 creates a private
 temporary directory, preserves the embedded first volume under the filename
 expected by the backend, and copies only the matching `.zNN`, `.7z.NNN`, or
 RAR volume files. Closing the archive removes the complete private set.
+For 7z sets, the embedded first volume is materialized as `.7z.001`, which
+is the multi-volume entry point expected by the reader.
 
 The probe scans only the first 64 MiB and recognizes the ZIP, 7z, RAR 4, and
 RAR 5 signatures. Archive write/update operations remain a separate follow-up

--- a/docs/LUNOBOT/915.md
+++ b/docs/LUNOBOT/915.md
@@ -21,4 +21,7 @@ slice because an SFX executable must be repacked without losing its stub.
 Regression coverage includes signature detection for all three formats,
 opening single-volume and split ZIP SFX files through `ArchiveProvider`, and
 cleanup of the private multi-volume backing directory. Local builds and tests
-were not run, per `LUNOBOT.md`; GitHub Actions is the verification source.
+were not run, per `LUNOBOT.md`; GitHub Actions is the verification source. The
+first hosted follow-up run found only the test-path `G703` lint warning in this
+change; its separate linux/arm64 failure was the existing shuffled
+`TestMainMenuFilePath_HasExpectedSuffix` environment-sensitive failure.

--- a/plugins/archive/sfx.go
+++ b/plugins/archive/sfx.go
@@ -3,8 +3,14 @@ package archive
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -98,18 +104,202 @@ func findEmbeddedArchive(filename string) (embeddedArchive, bool, error) {
 
 type sfxBacking struct {
 	path string
+	dir  string
 	once sync.Once
 	err  error
 }
 
 func (b *sfxBacking) Close() error {
 	b.once.Do(func() {
-		b.err = os.Remove(b.path)
-		if errors.Is(b.err, os.ErrNotExist) {
-			b.err = nil
+		if b.dir != "" {
+			b.err = os.RemoveAll(b.dir)
+		} else {
+			b.err = os.Remove(b.path)
+			if errors.Is(b.err, os.ErrNotExist) {
+				b.err = nil
+			}
 		}
 	})
 	return b.err
+}
+
+type sfxVolume struct {
+	source string
+	target string
+}
+
+type sfxVolumePlan struct {
+	first      string
+	companions []sfxVolume
+}
+
+func sfxVolumePlanFor(filename string, embedded embeddedArchive) (sfxVolumePlan, error) {
+	base := filepath.Base(filename)
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	plan := sfxVolumePlan{first: stem + embedded.suffix}
+
+	entries, err := os.ReadDir(filepath.Dir(filename))
+	if err != nil {
+		return sfxVolumePlan{}, err
+	}
+
+	switch strings.ToLower(embedded.suffix) {
+	case ".zip":
+		for volume := 1; ; volume++ {
+			target := fmt.Sprintf("%s.z%02d", stem, volume)
+			source := findCaseInsensitiveEntry(entries, target)
+			if source == "" {
+				break
+			}
+			plan.companions = append(plan.companions, sfxVolume{
+				source: filepath.Join(filepath.Dir(filename), source),
+				target: target,
+			})
+		}
+	case ".7z":
+		for volume := 2; ; volume++ {
+			target := fmt.Sprintf("%s.7z.%03d", stem, volume)
+			source := findCaseInsensitiveEntry(entries, target)
+			if source == "" {
+				break
+			}
+			plan.companions = append(plan.companions, sfxVolume{
+				source: filepath.Join(filepath.Dir(filename), source),
+				target: target,
+			})
+		}
+	case ".rar":
+		plan = planRARVolumes(filepath.Dir(filename), stem, entries)
+	}
+
+	return plan, nil
+}
+
+func findCaseInsensitiveEntry(entries []os.DirEntry, target string) string {
+	for _, entry := range entries {
+		if strings.EqualFold(entry.Name(), target) {
+			return entry.Name()
+		}
+	}
+	return ""
+}
+
+type rarVolumeMatch struct {
+	name   string
+	part   int
+	width  int
+	total  string
+	legacy bool
+}
+
+func planRARVolumes(dir, stem string, entries []os.DirEntry) sfxVolumePlan {
+	newPattern := regexp.MustCompile(`(?i)^` + regexp.QuoteMeta(stem) + `\.part([0-9]+)(?:of([0-9]+))?\.rar$`)
+	legacyPattern := regexp.MustCompile(`(?i)^` + regexp.QuoteMeta(stem) + `\.r([0-9]+)$`)
+	var modern []rarVolumeMatch
+	var legacy []rarVolumeMatch
+	for _, entry := range entries {
+		name := entry.Name()
+		if match := newPattern.FindStringSubmatch(name); match != nil {
+			part, err := strconv.Atoi(match[1])
+			if err == nil && part >= 2 {
+				modern = append(modern, rarVolumeMatch{
+					name:  name,
+					part:  part,
+					width: len(match[1]),
+					total: match[2],
+				})
+			}
+			continue
+		}
+		if match := legacyPattern.FindStringSubmatch(name); match != nil {
+			part, err := strconv.Atoi(match[1])
+			if err == nil {
+				legacy = append(legacy, rarVolumeMatch{
+					name:   name,
+					part:   part,
+					width:  len(match[1]),
+					legacy: true,
+				})
+			}
+		}
+	}
+
+	plan := sfxVolumePlan{first: stem + ".rar"}
+	if len(modern) > 0 {
+		sort.Slice(modern, func(i, j int) bool { return modern[i].part < modern[j].part })
+		first := modern[0]
+		firstPart := fmt.Sprintf("%0*d", first.width, 1)
+		plan.first = stem + ".part" + firstPart
+		if first.total != "" {
+			plan.first += "of" + first.total
+		}
+		plan.first += ".rar"
+		for _, volume := range modern {
+			part := fmt.Sprintf("%0*d", first.width, volume.part)
+			target := stem + ".part" + part
+			if first.total != "" {
+				target += "of" + first.total
+			}
+			plan.companions = append(plan.companions, sfxVolume{
+				source: filepath.Join(dir, volume.name),
+				target: target + ".rar",
+			})
+		}
+		return plan
+	}
+
+	if len(legacy) > 0 {
+		sort.Slice(legacy, func(i, j int) bool { return legacy[i].part < legacy[j].part })
+		first := legacy[0]
+		for _, volume := range legacy {
+			target := stem + ".r" + fmt.Sprintf("%0*d", first.width, volume.part)
+			plan.companions = append(plan.companions, sfxVolume{
+				source: filepath.Join(dir, volume.name),
+				target: target,
+			})
+		}
+	}
+	return plan
+}
+
+func copySFXFile(dst, source string, offset int64) error {
+	input, err := os.Open(source)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = input.Close() }()
+
+	output, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	removeOutput := true
+	defer func() {
+		_ = output.Close()
+		if removeOutput {
+			_ = os.Remove(dst)
+		}
+	}()
+
+	if offset > 0 {
+		stat, err := input.Stat()
+		if err != nil {
+			return err
+		}
+		if offset >= stat.Size() {
+			return os.ErrInvalid
+		}
+		if _, err := io.Copy(output, io.NewSectionReader(input, offset, stat.Size()-offset)); err != nil {
+			return err
+		}
+	} else if _, err := io.Copy(output, input); err != nil {
+		return err
+	}
+	if err := output.Close(); err != nil {
+		return err
+	}
+	removeOutput = false
+	return nil
 }
 
 func materializeEmbeddedArchive(filename string, embedded embeddedArchive) (string, io.Closer, error) {
@@ -117,45 +307,42 @@ func materializeEmbeddedArchive(filename string, embedded embeddedArchive) (stri
 		return filename, nil, nil
 	}
 
-	source, err := os.Open(filename)
+	plan, err := sfxVolumePlanFor(filename, embedded)
 	if err != nil {
 		return "", nil, err
 	}
-	stat, err := source.Stat()
-	if err != nil {
-		_ = source.Close()
-		return "", nil, err
-	}
-	if embedded.offset >= stat.Size() {
-		_ = source.Close()
-		return "", nil, os.ErrInvalid
+	if len(plan.companions) == 0 {
+		target, err := os.CreateTemp("", "f4-sfx-*"+embedded.suffix)
+		if err != nil {
+			return "", nil, err
+		}
+		targetName := target.Name()
+		if err := target.Close(); err != nil {
+			_ = os.Remove(targetName)
+			return "", nil, err
+		}
+		if err := copySFXFile(targetName, filename, embedded.offset); err != nil {
+			_ = os.Remove(targetName)
+			return "", nil, err
+		}
+		return targetName, &sfxBacking{path: targetName}, nil
 	}
 
-	target, err := os.CreateTemp("", "f4-sfx-*"+embedded.suffix)
+	dir, err := os.MkdirTemp("", "f4-sfx-*")
 	if err != nil {
-		_ = source.Close()
 		return "", nil, err
 	}
-	targetName := target.Name()
-	cleanup := func() {
-		_ = source.Close()
-		_ = target.Close()
-		_ = os.Remove(targetName)
-	}
-
-	_, copyErr := io.Copy(target, io.NewSectionReader(source, embedded.offset, stat.Size()-embedded.offset))
-	closeTargetErr := target.Close()
-	closeSourceErr := source.Close()
-	if copyErr != nil || closeTargetErr != nil || closeSourceErr != nil {
+	cleanup := func() { _ = os.RemoveAll(dir) }
+	targetName := filepath.Join(dir, plan.first)
+	if err := copySFXFile(targetName, filename, embedded.offset); err != nil {
 		cleanup()
-		if copyErr != nil {
-			return "", nil, copyErr
-		}
-		if closeTargetErr != nil {
-			return "", nil, closeTargetErr
-		}
-		return "", nil, closeSourceErr
+		return "", nil, err
 	}
-
-	return targetName, &sfxBacking{path: targetName}, nil
+	for _, volume := range plan.companions {
+		if err := copySFXFile(filepath.Join(dir, volume.target), volume.source, 0); err != nil {
+			cleanup()
+			return "", nil, err
+		}
+	}
+	return targetName, &sfxBacking{path: targetName, dir: dir}, nil
 }

--- a/plugins/archive/sfx.go
+++ b/plugins/archive/sfx.go
@@ -168,6 +168,9 @@ func sfxVolumePlanFor(filename string, embedded embeddedArchive) (sfxVolumePlan,
 				target: target,
 			})
 		}
+		if len(plan.companions) > 0 {
+			plan.first = stem + ".7z.001"
+		}
 	case ".rar":
 		plan = planRARVolumes(filepath.Dir(filename), stem, entries)
 	}

--- a/plugins/archive/sfx_test.go
+++ b/plugins/archive/sfx_test.go
@@ -138,7 +138,7 @@ func TestArchiveProviderOpensZipSFXMultiVolume(t *testing.T) {
 		t.Fatal(err)
 	}
 	sfxPath := filepath.Join(root, "bundle.exe")
-	if err := os.WriteFile(sfxPath, append([]byte("stub bytes before the archive\n"), archiveBytes...), 0600); err != nil {
+	if err := os.WriteFile(sfxPath, append([]byte("stub bytes before the archive\n"), archiveBytes...), 0600); err != nil { // #nosec G703 -- sfxPath is inside the per-test directory created by testing.T.TempDir.
 		t.Fatal(err)
 	}
 
@@ -241,7 +241,7 @@ func TestMaterializeEmbeddedArchiveCopiesZipVolumes(t *testing.T) {
 	if err := os.WriteFile(filename, []byte("stubarchive"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "bundle.z01"), []byte("volume one"), 0600); err != nil {
+	if err := os.WriteFile(filepath.Join(root, "bundle.z01"), []byte("volume one"), 0600); err != nil { // #nosec G703 -- root is the per-test directory created by testing.T.TempDir.
 		t.Fatal(err)
 	}
 

--- a/plugins/archive/sfx_test.go
+++ b/plugins/archive/sfx_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/unxed/f4/vfs"
+	zipvolume "github.com/unxed/zip"
 )
 
 func TestFindEmbeddedArchive(t *testing.T) {
@@ -110,6 +111,60 @@ func TestArchiveProviderOpensZipSFX(t *testing.T) {
 	}
 }
 
+func TestArchiveProviderOpensZipSFXMultiVolume(t *testing.T) {
+	root := t.TempDir()
+	mainPath := filepath.Join(root, "bundle.zip")
+	multiWriter, err := zipvolume.NewMultiVolumeWriter(mainPath, 64)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zipWriter := zip.NewWriter(multiWriter)
+	entry, err := zipWriter.Create("inside.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write(bytes.Repeat([]byte("from split sfx\n"), 32)); err != nil {
+		t.Fatal(err)
+	}
+	if err := zipWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := multiWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	archiveBytes, err := os.ReadFile(mainPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sfxPath := filepath.Join(root, "bundle.exe")
+	if err := os.WriteFile(sfxPath, append([]byte("stub bytes before the archive\n"), archiveBytes...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	parent := vfs.NewOSVFS(root)
+	provider := &ArchiveProvider{}
+	opened, err := provider.Open(context.Background(), parent, "bundle.exe")
+	if err != nil {
+		t.Fatalf("open multi-volume ZIP SFX: %v", err)
+	}
+	archiveVFS, ok := opened.(*ArchiveVFS)
+	if !ok {
+		t.Fatalf("opened VFS = %T, want *ArchiveVFS", opened)
+	}
+	t.Cleanup(func() { _ = archiveVFS.Close() })
+
+	var items []vfs.VFSItem
+	if err := archiveVFS.ReadDir(context.Background(), archiveVFS.GetPath(), func(chunk []vfs.VFSItem) {
+		items = append(items, chunk...)
+	}); err != nil {
+		t.Fatalf("read multi-volume ZIP SFX root: %v", err)
+	}
+	if len(items) != 1 || items[0].Name != "inside.txt" {
+		t.Fatalf("root entries = %#v, want inside.txt", items)
+	}
+}
+
 func TestFindEmbeddedArchiveRejectsPlainFile(t *testing.T) {
 	filename := filepath.Join(t.TempDir(), "plain.exe")
 	if err := os.WriteFile(filename, []byte("not an archive"), 0600); err != nil {
@@ -177,6 +232,49 @@ func TestMaterializeEmbeddedArchive(t *testing.T) {
 	}
 	if same != filename || noCloser != nil {
 		t.Fatalf("zero-offset materialization = %q, closer=%v", same, noCloser)
+	}
+}
+
+func TestMaterializeEmbeddedArchiveCopiesZipVolumes(t *testing.T) {
+	root := t.TempDir()
+	filename := filepath.Join(root, "bundle.exe")
+	if err := os.WriteFile(filename, []byte("stubarchive"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bundle.z01"), []byte("volume one"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	materialized, closer, err := materializeEmbeddedArchive(filename, embeddedArchive{
+		format: "zip",
+		suffix: ".zip",
+		offset: int64(len("stub")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if closer == nil {
+		t.Fatal("multi-volume materialization has no cleanup closer")
+	}
+	if filepath.Base(materialized) != "bundle.zip" {
+		t.Fatalf("materialized name = %q, want bundle.zip", filepath.Base(materialized))
+	}
+	if got, err := os.ReadFile(materialized); err != nil {
+		t.Fatal(err)
+	} else if string(got) != "archive" {
+		t.Fatalf("materialized payload = %q, want archive", got)
+	}
+	if got, err := os.ReadFile(filepath.Join(filepath.Dir(materialized), "bundle.z01")); err != nil {
+		t.Fatal(err)
+	} else if string(got) != "volume one" {
+		t.Fatalf("materialized volume = %q, want volume one", got)
+	}
+	targetDir := filepath.Dir(materialized)
+	if err := closer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+		t.Fatalf("materialized directory still exists after cleanup: %v", err)
 	}
 }
 


### PR DESCRIPTION
Часть 2 из 2 по issue #915.

Изменения:
- сохраняет соседние тома локального ZIP-SFX (`.zNN`), 7z-SFX (`.7z.NNN`) и RAR-SFX (новая и старая схемы имён);
- материализует первый embedded volume под именем, которое ожидает существующий backend;
- удаляет весь private multi-volume backing при закрытии;
- добавляет CI-регрессию открытия split ZIP SFX через ArchiveProvider.

Архивный stub не изменяется. Archive write/update для SFX остаётся отдельным следующим срезом: для него нужно безопасно перепаковать payload, не потеряв executable stub.

Локальные build/test не запускались по LUNOBOT.md; проверка — GitHub Actions.
