### PR TITLE
test: cover id3 editor plugin paths

### DIFF
--- a/docs/LUNOBOT/coverage-id3editor.md
+++ b/docs/LUNOBOT/coverage-id3editor.md
@@ -1,0 +1,7 @@
+# Coverage: `plugins/id3editor`
+
+## Status
+
+This slice adds regression coverage for the plugin's legacy close path, failed
+ID3 file opening, and comment updates for ID3v2.2 and ID3v2.3 tags. The package
+still has UI-only dialog interaction outside this slice.

--- a/docs/LUNOBOT/coverage-id3editor.md
+++ b/docs/LUNOBOT/coverage-id3editor.md
@@ -4,4 +4,6 @@
 
 This slice adds regression coverage for the plugin's legacy close path, failed
 ID3 file opening, and comment updates for ID3v2.2 and ID3v2.3 tags. The package
-still has UI-only dialog interaction outside this slice.
+still has UI-only dialog interaction outside this slice. ID3v2 comment frames
+include their language/description prefix, so the regression checks the stored
+comment content rather than requiring a presentation-specific prefix.

--- a/plugins/id3editor/plugin_paths_test.go
+++ b/plugins/id3editor/plugin_paths_test.go
@@ -3,6 +3,7 @@ package id3editor
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/unxed/f4/vfs"
@@ -59,7 +60,7 @@ func TestSetCommentSupportsID3v2Versions(t *testing.T) {
 			tag := v2.NewTag(version)
 			setComment(tag, "updated comment")
 			comments := tag.Comments()
-			if len(comments) != 1 || comments[0] != "updated comment" {
+			if len(comments) != 1 || !strings.HasSuffix(comments[0], "updated comment") {
 				t.Fatalf("comments = %#v, want one updated comment", comments)
 			}
 		})

--- a/plugins/id3editor/plugin_paths_test.go
+++ b/plugins/id3editor/plugin_paths_test.go
@@ -29,7 +29,7 @@ func (a *id3AppStub) Message(_ string, msg string, _ []string) int {
 	return 0
 }
 func (*id3AppStub) InputBox(string, string, string, func(string)) {}
-func (*id3AppStub) Menu(string, []string, func(int))         {}
+func (*id3AppStub) Menu(string, []string, func(int))              {}
 
 func TestPluginCloseClearsLegacyRegistrationState(t *testing.T) {
 	host := &id3HostMock{}

--- a/plugins/id3editor/plugin_paths_test.go
+++ b/plugins/id3editor/plugin_paths_test.go
@@ -1,0 +1,67 @@
+package id3editor
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+	v2 "github.com/unxed/id3-go/v2"
+)
+
+type id3AppStub struct {
+	messages []string
+}
+
+func (*id3AppStub) GetActivePanelVFS() vfs.VFS  { return nil }
+func (*id3AppStub) GetPassivePanelVFS() vfs.VFS { return nil }
+func (*id3AppStub) GetSelectedNames() []string  { return nil }
+func (*id3AppStub) GetSelectedName() string     { return "" }
+func (*id3AppStub) RefreshAll()                 {}
+func (*id3AppStub) SetPendingSelection(string)  {}
+func (*id3AppStub) RunProgressTask(string, string, bool, func(context.Context, func(string, int)) error, func(error)) {
+}
+func (*id3AppStub) RunAdvancedProgressTask(string, bool, func(context.Context, vfs.TaskReporter) error, func(error)) {
+}
+func (a *id3AppStub) Message(_ string, msg string, _ []string) int {
+	a.messages = append(a.messages, msg)
+	return 0
+}
+func (*id3AppStub) InputBox(string, string, string, func(string)) {}
+func (*id3AppStub) Menu(string, []string, func(int))         {}
+
+func TestPluginCloseClearsLegacyRegistrationState(t *testing.T) {
+	host := &id3HostMock{}
+	plugin := &ID3EditorPlugin{}
+	if err := plugin.Init(host); err != nil {
+		t.Fatal(err)
+	}
+	if err := plugin.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if plugin.api != nil || plugin.registration != nil {
+		t.Fatal("Close retained legacy plugin state")
+	}
+}
+
+func TestShowEditorDialogReportsOpenError(t *testing.T) {
+	app := &id3AppStub{}
+	plugin := &ID3EditorPlugin{}
+	plugin.showEditorDialog(app, filepath.Join(t.TempDir(), "missing.mp3"))
+	if len(app.messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(app.messages))
+	}
+}
+
+func TestSetCommentSupportsID3v2Versions(t *testing.T) {
+	for _, version := range []byte{2, 3} {
+		t.Run(string(rune('0'+version)), func(t *testing.T) {
+			tag := v2.NewTag(version)
+			setComment(tag, "updated comment")
+			comments := tag.Comments()
+			if len(comments) != 1 || comments[0] != "updated comment" {
+				t.Fatalf("comments = %#v, want one updated comment", comments)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Coverage slice for plugins/id3editor. Adds regression tests for legacy plugin close cleanup, failed ID3 file opening, and comment updates for ID3v2.2 and ID3v2.3 tags. The scope and remaining UI-only paths are recorded in docs/LUNOBOT/coverage-id3editor.md. Local builds and tests were not run per LUNOBOT.md; please use GitHub Actions for verification.