### PR TITLE
test: cover ttyx key state

### DIFF
--- a/docs/LUNOBOT/coverage-internal-ttyx.md
+++ b/docs/LUNOBOT/coverage-internal-ttyx.md
@@ -9,4 +9,8 @@ server; the existing X11-backed tests remain responsible for server behavior.
 The second slice adds deterministic checks for source labels, cached session
 queries, and process-id matching. It also does not require an X11 server.
 
-The package's broader coverage work remains outside this slice.
+The third slice adds deterministic checks for modifier-mask conversion, input
+state conversion, and the session key-state accessors. It also does not
+require an X11 server.
+
+The package's broader coverage work remains outside these slices.

--- a/internal/ttyx/ttyx_test.go
+++ b/internal/ttyx/ttyx_test.go
@@ -7,7 +7,80 @@ import (
 
 	"github.com/jezek/xgb"
 	"github.com/jezek/xgb/xproto"
+	"github.com/unxed/vtinput"
 )
+
+func TestModifierXMask(t *testing.T) {
+	cases := []struct {
+		name string
+		mods Modifier
+		want uint16
+	}{
+		{name: "none", want: 0},
+		{name: "shift", mods: ModShift, want: xproto.ModMaskShift},
+		{name: "control", mods: ModCtrl, want: xproto.ModMaskControl},
+		{name: "alt", mods: ModAlt, want: xproto.ModMask1},
+		{name: "all", mods: ModShift | ModCtrl | ModAlt, want: xproto.ModMaskShift | xproto.ModMaskControl | xproto.ModMask1},
+		{name: "unknown bits ignored", mods: Modifier(1 << 15), want: 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.mods.xmask(); got != tc.want {
+				t.Fatalf("xmask(%#x) = %#x, want %#x", tc.mods, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestModsFromState(t *testing.T) {
+	cases := []struct {
+		name  string
+		state uint16
+		want  vtinput.ControlKeyState
+	}{
+		{name: "none"},
+		{name: "shift", state: xproto.ModMaskShift, want: vtinput.ShiftPressed},
+		{name: "control", state: xproto.ModMaskControl, want: vtinput.LeftCtrlPressed},
+		{name: "alt", state: xproto.ModMask1, want: vtinput.LeftAltPressed},
+		{name: "locks", state: xproto.ModMaskLock | xproto.ModMask2, want: vtinput.CapsLockOn | vtinput.NumLockOn},
+		{name: "all", state: xproto.ModMaskShift | xproto.ModMaskControl | xproto.ModMask1 | xproto.ModMaskLock | xproto.ModMask2, want: vtinput.ShiftPressed | vtinput.LeftCtrlPressed | vtinput.LeftAltPressed | vtinput.CapsLockOn | vtinput.NumLockOn},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := modsFromState(tc.state); got != tc.want {
+				t.Fatalf("modsFromState(%#x) = %#x, want %#x", tc.state, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestKeyStateAccessors(t *testing.T) {
+	var empty Session
+	if empty.Keys() != nil || empty.GrabReport() != nil || empty.Dropped() != 0 || empty.grabsHeld() {
+		t.Fatal("an unconfigured session must expose empty key state")
+	}
+
+	events := make(chan *vtinput.InputEvent, 1)
+	original := []GrabResult{{Keysym: 42, Mods: ModCtrl, Code: 24}}
+	s := Session{keys: &keyState{events: events, dropped: 3, held: true, report: original}}
+	if s.Keys() != events {
+		t.Fatal("Keys must return the configured event stream")
+	}
+	if got := s.Dropped(); got != 3 {
+		t.Fatalf("Dropped = %d, want 3", got)
+	}
+	if !s.grabsHeld() {
+		t.Fatal("grabsHeld must report the key state")
+	}
+	report := s.GrabReport()
+	if len(report) != 1 || report[0] != original[0] {
+		t.Fatalf("GrabReport = %#v, want %#v", report, original)
+	}
+	report[0].Mods = ModAlt
+	if original[0].Mods != ModCtrl {
+		t.Fatal("GrabReport must return a copy")
+	}
+}
 
 func TestAncestorPIDs(t *testing.T) {
 	tree := map[int]int{100: 50, 50: 20, 20: 1, 1: 0}


### PR DESCRIPTION
## Что сделано

Добавлены детерминированные тесты для преобразования модификаторов X11, преобразования состояния клавиш и accessor-ов состояния клавиш сессии в internal/ttyx. Обновлён статус покрытия в docs/LUNOBOT/coverage-internal-ttyx.md.

Локальные сборки и тесты не запускались согласно LUNOBOT.md; проверка выполняется GitHub Actions.