### PR TITLE
feat: add registry drive command prefix (#976)

### DIFF
--- a/cmd/f4/command_prefix_registry.go
+++ b/cmd/f4/command_prefix_registry.go
@@ -139,9 +139,10 @@ func (r *commandPrefixRegistration) Unregister() {
 }
 
 // dispatchCommandPrefix consumes input when the text before its first colon
-// names either a registered prefix or a plugin drive. Registered prefixes get
-// the raw argument so each plugin can apply its own quoting rules; drive
-// prefixes intentionally accept only the bare form (for example, "Android:").
+// names either a registered prefix or a plugin/platform drive. Registered
+// prefixes get the raw argument so each plugin can apply its own quoting
+// rules; drive prefixes intentionally accept only the bare form (for example,
+// "Android:" or the platform alias "reg:").
 func dispatchCommandPrefix(app vfs.App, input string) bool {
 	colon := strings.IndexByte(input, ':')
 	if colon <= 0 {
@@ -195,5 +196,28 @@ func dispatchDriveCommandPrefix(app vfs.App, prefix, argument string) bool {
 		pf.switchToVFS(fsp, newVFS)
 		return true
 	}
+
+	for _, drive := range getPlatformDrives() {
+		if platformDriveCommandPrefix(drive.Name) != prefix || drive.Factory == nil {
+			continue
+		}
+		newVFS := drive.Factory()
+		if newVFS == nil {
+			return false
+		}
+		pf.switchToVFS(fsp, newVFS)
+		return true
+	}
 	return false
+}
+
+// platformDriveCommandPrefix exposes the short command-line aliases for
+// platform drives that cannot use their menu labels as bare prefixes.
+func platformDriveCommandPrefix(name string) string {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "windows registry":
+		return "reg"
+	default:
+		return ""
+	}
 }

--- a/cmd/f4/command_prefix_registry_test.go
+++ b/cmd/f4/command_prefix_registry_test.go
@@ -142,3 +142,15 @@ func TestCommandPrefixDriveRequiresBarePrefix(t *testing.T) {
 		t.Fatal("drive prefix with an argument was consumed")
 	}
 }
+
+func TestPlatformDriveCommandPrefixAliases(t *testing.T) {
+	if got := platformDriveCommandPrefix("Windows Registry"); got != "reg" {
+		t.Fatalf("Windows Registry prefix = %q, want reg", got)
+	}
+	if got := platformDriveCommandPrefix("windows registry"); got != "reg" {
+		t.Fatalf("case-insensitive Windows Registry prefix = %q, want reg", got)
+	}
+	if got := platformDriveCommandPrefix("Physical Disks"); got != "" {
+		t.Fatalf("unexpected platform drive prefix = %q", got)
+	}
+}

--- a/cmd/f4/command_prefix_registry_windows_test.go
+++ b/cmd/f4/command_prefix_registry_windows_test.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package main
+
+import (
+	"testing"
+
+	"github.com/unxed/f4/vfs"
+)
+
+func TestCommandPrefixOpensWindowsRegistryDrive(t *testing.T) {
+	pf := setupMockPanelsFrame(t)
+	defer pf.Close()
+
+	if !dispatchCommandPrefix(pf, "REG:") {
+		t.Fatal("reg prefix was not consumed")
+	}
+	if _, ok := pf.getActivePanel().vfs.(*vfs.RegistryVFS); !ok {
+		t.Fatalf("active panel VFS = %T, want *vfs.RegistryVFS", pf.getActivePanel().vfs)
+	}
+}

--- a/docs/LUNOBOT/976.md
+++ b/docs/LUNOBOT/976.md
@@ -2,10 +2,11 @@
 
 ## Status
 
-This PR implements the first and only atomic slice: pressing Enter on a bare
-registered plugin drive prefix opens that drive in the active panel. Matching
-is case-insensitive, so `Android:`, `android:`, and `ANDROID:` select the same
-drive. The temporary panel is available through `tmp:` as well.
+This PR implements the first atomic slice: pressing Enter on a bare registered
+plugin drive prefix opens that drive in the active panel. Matching is
+case-insensitive, so `Android:`, `android:`, and `ANDROID:` select the same
+drive. The temporary panel is available through `tmp:` as well. The Windows
+Registry platform drive additionally has the short `reg:` alias.
 
 The `ai:` prefix remains owned by VTVibe's existing command language and is
 intentionally excluded, as requested in the issue discussion. A non-empty
@@ -20,6 +21,8 @@ plugin-specific command arguments from being silently reinterpreted.
 - A missing or nil drive factory does not consume the command.
 - The prefix resolver does not replace an explicitly registered command
   prefix, including `ai:`.
+- `reg:` is consumed only when the platform exposes the Windows Registry drive;
+  it is not a Linux or Wine alias.
 
 ## Verification
 


### PR DESCRIPTION
## Что изменено

- добавлен bare-префикс `reg:` для platform drive `Windows Registry`;
- алиас работает только когда этот drive доступен, поэтому в Linux/Wine не перехватывает ввод;
- существующие plugin-префиксы, `ai:` и формы с аргументами не изменены;
- добавлены общий тест алиаса и Windows-интеграционный регрессионный тест.

## Проверка

Локальные сборки и тесты не запускались по инструкции Лунобота. Выполнены форматирование и `git diff --check`; полная проверка — GitHub Actions.

Closes #976
