### PR TITLE
test: cover background jobs window

### DIFF
--- a/cmd/f4/background_jobs_window_test.go
+++ b/cmd/f4/background_jobs_window_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unxed/vtui"
+)
+
+func TestShowBackgroundJobs_RendersAndControlsJobs(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldRegistry := GlobalBackgroundJobs
+	t.Cleanup(func() { GlobalBackgroundJobs = oldRegistry })
+	registry := NewBackgroundJobRegistry()
+	GlobalBackgroundJobs = registry
+
+	cancelled := false
+	running := registry.Start("Long task", func() { cancelled = true })
+	running.SetStatus("halfway")
+	finished := registry.Start("Done task", nil)
+	opened := false
+	finished.FinishWith("answer", func() { opened = true })
+
+	ShowBackgroundJobs(nil)
+	top := vtui.FrameManager.GetTopFrame()
+	container, ok := top.(interface{ GetChildren() []vtui.UIElement })
+	if !ok {
+		t.Fatal("background jobs dialog does not expose its controls")
+	}
+
+	var list *vtui.ListBox
+	var buttons []*vtui.Button
+	for _, child := range container.GetChildren() {
+		switch item := child.(type) {
+		case *vtui.ListBox:
+			list = item
+		case *vtui.Button:
+			buttons = append(buttons, item)
+		}
+	}
+	if list == nil || len(buttons) != 3 {
+		t.Fatalf("dialog controls = list %v, buttons %d; want one list and three buttons", list != nil, len(buttons))
+	}
+	if len(list.Items) != 2 || !strings.Contains(list.Items[0], "running") || !strings.Contains(list.Items[0], "halfway") || !strings.Contains(list.Items[1], "finished") || !strings.Contains(list.Items[1], "answer") {
+		t.Fatalf("job rows = %#v, want running/finished rows with statuses", list.Items)
+	}
+
+	list.SelectPos = 0
+	buttons[1].OnClick()
+	if !cancelled || registry.List()[0].Status != "cancelling" {
+		t.Fatalf("cancel result = cancelled %v, jobs %#v", cancelled, registry.List())
+	}
+
+	// A running job cannot be opened; the dialog refreshes the rows and stays up.
+	buttons[0].OnClick()
+	if top.IsDone() || len(registry.List()) != 2 {
+		t.Fatalf("opening running job changed dialog/list: done=%v jobs=%#v", top.IsDone(), registry.List())
+	}
+
+	list.SelectPos = 1
+	buttons[0].OnClick()
+	if !opened || !top.IsDone() {
+		t.Fatalf("opening finished job = opened %v, dialog done %v", opened, top.IsDone())
+	}
+	if len(registry.List()) != 1 || registry.List()[0].ID != running.ID() {
+		t.Fatalf("remaining jobs = %#v, want only running job", registry.List())
+	}
+}
+
+func TestShowBackgroundJobs_EmptyListAndClose(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	SetDefaultF4Palette()
+
+	oldRegistry := GlobalBackgroundJobs
+	t.Cleanup(func() { GlobalBackgroundJobs = oldRegistry })
+	GlobalBackgroundJobs = NewBackgroundJobRegistry()
+
+	ShowBackgroundJobs(nil)
+	top := vtui.FrameManager.GetTopFrame()
+	container := top.(interface{ GetChildren() []vtui.UIElement })
+	var list *vtui.ListBox
+	var buttons []*vtui.Button
+	for _, child := range container.GetChildren() {
+		switch item := child.(type) {
+		case *vtui.ListBox:
+			list = item
+		case *vtui.Button:
+			buttons = append(buttons, item)
+		}
+	}
+	if list == nil || len(list.Items) != 1 || list.Items[0] != Msg("Jobs.Empty") {
+		t.Fatalf("empty rows = %#v, want the empty marker", list)
+	}
+
+	list.SelectPos = 99
+	buttons[0].OnClick()
+	buttons[1].OnClick()
+	if top.IsDone() {
+		t.Fatal("invalid selection closed the empty dialog")
+	}
+	buttons[2].OnClick()
+	if !top.IsDone() {
+		t.Fatal("close button did not close the dialog")
+	}
+}

--- a/docs/LUNOBOT/coverage-background-jobs.md
+++ b/docs/LUNOBOT/coverage-background-jobs.md
@@ -1,0 +1,11 @@
+# Coverage: `cmd/f4/background_jobs_window.go`
+
+## Status
+
+- [x] Selected from the live Codecov report: 0% coverage for 64 lines of real UI logic.
+- [x] Added tests for running, finished, and empty job lists, cancel, open-refresh, open-result, and close actions.
+- [ ] Verify the change in GitHub Actions.
+- [ ] Merge the pull request after the required checks pass.
+
+Local builds and tests are intentionally not run; the repository passport
+requires GitHub Actions as the build and test environment.


### PR DESCRIPTION
## Summary

Custom coverage task under LUNOBOT.md §22.3 for `cmd/f4/background_jobs_window.go`.

- add tests for running, finished, and empty job lists;
- cover cancel, failed-open refresh, successful result opening, and close actions;
- document the Codecov baseline and the GitHub-CI-only verification boundary;
- no production behavior is changed.

Codecov baseline: 0% for 64 lines of this file; overall `main` coverage was 60.59%.

Local builds and tests were not run; the f4 passport requires GitHub Actions for build and test verification.
