### PR TITLE
docs: close background jobs coverage status

### DIFF
--- a/docs/LUNOBOT/coverage-background-jobs.md
+++ b/docs/LUNOBOT/coverage-background-jobs.md
@@ -4,8 +4,8 @@
 
 - [x] Selected from the live Codecov report: 0% coverage for 64 lines of real UI logic.
 - [x] Added tests for running, finished, and empty job lists, cancel, open-refresh, open-result, and close actions.
-- [ ] Verify the change in GitHub Actions.
-- [ ] Merge the pull request after the required checks pass.
+- [x] Verified the change in GitHub Actions run [34334385313](https://github.com/unxed/f4/actions/runs/34334385313); all build, test, race, lint, vet, Quality, and Codecov checks passed.
+- [x] Merged in PR [#1043](https://github.com/unxed/f4/pull/1043), merge commit `4bd54ecec3c1b231731a2d8647b6e5e7605772d8`.
 
 Local builds and tests are intentionally not run; the repository passport
 requires GitHub Actions as the build and test environment.


### PR DESCRIPTION
## Summary

Close the status record for the completed §22.3 coverage task.

- record the successful GitHub Actions run `34334385313`;
- record PR #1043 and merge commit `4bd54ecec3c1b231731a2d8647b6e5e7605772d8`;
- documentation-only follow-up; no production behavior changes.

The project workflow intentionally skips docs-only pull requests. The production coverage change was already verified by the full CI run above.
