### PR TITLE
test: cover ZIP filename encoding

### DIFF
--- a/docs/LUNOBOT/coverage-zip-encoding.md
+++ b/docs/LUNOBOT/coverage-zip-encoding.md
@@ -1,0 +1,24 @@
+# Coverage: `plugins/archive/zip_encoding.go`
+
+## Scope
+
+This change covers ZIP filename decoding for:
+
+- names already marked as UTF-8;
+- CP866 names from DOS creators 0, 6, and old OS=11 archives;
+- Windows-1251 names from modern OS=11 archives;
+- CP437 fallback for an unknown creator.
+
+## Baseline
+
+The file was selected from the live Codecov snapshot after the background-jobs
+coverage task: `plugins/archive/zip_encoding.go` had 0% line coverage for 17
+lines of real encoding-selection and decoding logic. The total repository
+coverage in that snapshot was 60.87%.
+
+## Verification
+
+No local Go build or test is run, per the current LUNOBOT passport. Static
+checks are `gofmt` and `git diff --check`; GitHub Actions is the authoritative
+verification environment. CI and merge results will be recorded here after
+the pull request is verified.

--- a/plugins/archive/zip_encoding_test.go
+++ b/plugins/archive/zip_encoding_test.go
@@ -40,7 +40,7 @@ func TestDecodeZipName(t *testing.T) {
 		},
 		{
 			name:           "modern creator OS 11 uses Windows 1251",
-			encoded:        string([]byte{0xe2, 0xe5, 0xf1, 0xe2}),
+			encoded:        string([]byte{0xf2, 0xe5, 0xf1, 0xf2}),
 			want:           "тест",
 			creatorVersion: 0x0b14,
 		},

--- a/plugins/archive/zip_encoding_test.go
+++ b/plugins/archive/zip_encoding_test.go
@@ -1,0 +1,67 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/unxed/zip"
+)
+
+func TestDecodeZipName(t *testing.T) {
+	tests := []struct {
+		name           string
+		encoded        string
+		want           string
+		flags          uint16
+		creatorVersion uint16
+	}{
+		{
+			name:    "utf8 flag preserves name",
+			encoded: "already UTF-8",
+			want:    "already UTF-8",
+			flags:   0x800,
+		},
+		{
+			name:           "creator OS 0 uses code page 866",
+			encoded:        string([]byte{0xe2, 0xa5, 0xe1, 0xe2}),
+			want:           "тест",
+			creatorVersion: 0x0000,
+		},
+		{
+			name:           "creator OS 6 uses code page 866",
+			encoded:        string([]byte{0xe2, 0xa5, 0xe1, 0xe2}),
+			want:           "тест",
+			creatorVersion: 0x0600,
+		},
+		{
+			name:           "old creator OS 11 uses code page 866",
+			encoded:        string([]byte{0xe2, 0xa5, 0xe1, 0xe2}),
+			want:           "тест",
+			creatorVersion: 0x0b13,
+		},
+		{
+			name:           "modern creator OS 11 uses Windows 1251",
+			encoded:        string([]byte{0xe2, 0xe5, 0xf1, 0xe2}),
+			want:           "тест",
+			creatorVersion: 0x0b14,
+		},
+		{
+			name:           "unknown creator uses code page 437",
+			encoded:        string([]byte{0x82}),
+			want:           "é",
+			creatorVersion: 0x0300,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			hdr := &zip.FileHeader{
+				Name:           test.encoded,
+				Flags:          test.flags,
+				CreatorVersion: test.creatorVersion,
+			}
+			if got := DecodeZipName(hdr); got != test.want {
+				t.Fatalf("DecodeZipName() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Кастомная задача Лунобота по § 22 п. 3.

Добавлены focused-тесты для DecodeZipName: UTF-8, CP866, Windows-1251 и CP437.

Локальные Go build/test не запускались по паспорту; статические проверки — gofmt и git diff --check. Полная проверка — GitHub Actions.