### PR TITLE
docs: record zip encoding coverage verification

### DIFF
--- a/docs/LUNOBOT/coverage-zip-encoding.md
+++ b/docs/LUNOBOT/coverage-zip-encoding.md
@@ -20,5 +20,14 @@ coverage in that snapshot was 60.87%.
 
 No local Go build or test is run, per the current LUNOBOT passport. Static
 checks are `gofmt` and `git diff --check`; GitHub Actions is the authoritative
-verification environment. CI and merge results will be recorded here after
-the pull request is verified.
+verification environment.
+
+## Verification
+
+The first CI attempt `34336394992` was cancelled after its Windows-1251 test
+fixture used the CP866 byte for `т`. The corrected head
+`af2339823b0d1aa61bfa3a75f0984c2787195ded` passed all build, test, race, lint,
+vet, Quality, and Codecov checks in run [34336700811](https://github.com/unxed/f4/actions/runs/34336700811).
+
+The change was merged in PR [#1046](https://github.com/unxed/f4/pull/1046),
+merge commit `0501d966a772b52c28ee92252bd6f6a2197df36e`.


### PR DESCRIPTION
Docs-only follow-up to PR #1046.

Записывает baseline, исправление тестовой фикстуры, зелёный CI run 34336700811 и merge commit 0501d966a772b52c28ee92252bd6f6a2197df36e. По настройке workflow docs-only изменения не запускают CI.