### PR TITLE
test: cover netfox URI and proxy helpers

### DIFF
--- a/docs/LUNOBOT/coverage-netfox.md
+++ b/docs/LUNOBOT/coverage-netfox.md
@@ -1,0 +1,9 @@
+# Coverage task: `plugins/netfox`
+
+Origin: § 22.3 custom task. Codecov main was 61.0% overall and 57.61% for
+`plugins/netfox` (30 files, 4454 lines) at task start.
+
+The package had untested pure helpers and URI validation branches in
+`sftp_uri.go` and `proxy_dialog.go`. The tests exercise proxy mode mapping,
+label padding, translated mode item construction, SFTP provider identity, and
+malformed/hostless URI rejection without opening a network connection.

--- a/plugins/netfox/coverage_test.go
+++ b/plugins/netfox/coverage_test.go
@@ -1,0 +1,43 @@
+package netfox
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestProxyHelpersMapModesAndPadLabels(t *testing.T) {
+	if got := padProxyLabel("Host"); got != "Host " {
+		t.Fatalf("padProxyLabel = %q, want trailing space", got)
+	}
+	for i, mode := range proxyModeOrder {
+		if got := proxyModeIndex(mode); got != i {
+			t.Fatalf("proxyModeIndex(%d) = %d, want %d", mode, got, i)
+		}
+	}
+	if got := proxyModeIndex(-1); got != 0 {
+		t.Fatalf("unknown proxy mode index = %d, want 0", got)
+	}
+	if got := proxyModeItems(); len(got) != len(proxyModeOrder) {
+		t.Fatalf("proxyModeItems length = %d, want %d", len(got), len(proxyModeOrder))
+	}
+}
+
+func TestSFTPURIProviderRejectsMalformedAndHostlessURLs(t *testing.T) {
+	provider := &sftpURIProvider{}
+	if provider.Scheme() != "sftp" {
+		t.Fatalf("scheme = %q, want sftp", provider.Scheme())
+	}
+	tests := []struct {
+		raw  string
+		want string
+	}{
+		{raw: "://", want: "sftp:"},
+		{raw: "sftp:///tmp", want: "no host"},
+	}
+	for _, test := range tests {
+		if _, err := provider.OpenURI(context.Background(), nil, test.raw); err == nil || !strings.Contains(err.Error(), test.want) {
+			t.Errorf("OpenURI(%q) error = %v, want substring %q", test.raw, err, test.want)
+		}
+	}
+}


### PR DESCRIPTION
Adds focused coverage for the previously untested netfox helpers and SFTP URI validation branches. The tests avoid network access and document the §22.3 Codecov origin in docs/LUNOBOT/coverage-netfox.md.