### PR TITLE
chore(mcp): заменить CodeGraph на gopls для навигации по коду

### DIFF
--- a/.ai-factory/rules/base.md
+++ b/.ai-factory/rules/base.md
@@ -76,15 +76,20 @@ argument.
 
 ## Code Navigation
 
-- The repository is indexed by CodeGraph (`.mcp.json`, index in `.codegraph/`).
-  For symbol questions use it, not `grep`: `callers`, `callees`, `impact`,
-  `explore`, `node`. The tree is 69 packages and a symbol's package is not
-  always the one its name suggests, so grep over the module is slow and
-  imprecise.
-- The index is git-ignored and the server never builds one on its own, so a fresh
-  clone needs `npx -y @colbymchenry/codegraph@1.6.0 init` once.
-- There is no `codegraph` binary on PATH — always run the full form:
-  `npx -y @colbymchenry/codegraph@1.6.0 <command>`.
+- Navigation runs through the gopls MCP server (`.mcp.json` runs `gopls mcp`)
+  when it is available. Check with `command -v gopls` before relying on it: the
+  server is not part of a clone, and where gopls is missing it never starts and
+  its tools are not offered. Then `grep`, `go doc` and `go list` carry the work,
+  and the answer says navigation ran without gopls.
+- With gopls present, use it for symbol questions instead of `grep`: `go_search`,
+  `go_symbol_references`, `go_package_api`, `go_file_context`, `go_diagnostics`.
+  The tree is 69 packages and a symbol's package is not always the one its name
+  suggests, so grep over the module is slow and imprecise.
+- Answers come from `go/types`, so they match what the compiler sees, including
+  files behind another platform's build tag.
+- Installing it is the developer's choice, not a step an agent takes on its own:
+  `go install golang.org/x/tools/gopls@latest`, with `$(go env GOPATH)/bin` on
+  PATH. Nothing is indexed into the repository and a fresh clone needs no setup.
 - Grep remains correct for non-symbol text: comments, error strings, build tags,
   ini keys.
 

--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,17 +1,11 @@
 {
   "mcpServers": {
-    "codegraph": {
+    "gopls": {
       "type": "stdio",
-      "command": "npx",
+      "command": "gopls",
       "args": [
-        "-y",
-        "@colbymchenry/codegraph@1.6.0",
-        "serve",
-        "--mcp"
-      ],
-      "env": {
-        "CODEGRAPH_TELEMETRY": "0"
-      }
+        "mcp"
+      ]
     }
   }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,29 +115,33 @@ artifacts/       # build artifacts
 | `.ai-factory/ARCHITECTURE.md` | Architecture pattern, boundaries and dependency rules |
 | `.ai-factory/rules/base.md` | Detected code conventions: naming, errors, logging, tests |
 | `.ai-factory/config.yaml` | AI Factory configuration: paths, language, git workflow |
-| `.mcp.json` | MCP servers for this project: CodeGraph code-graph index |
+| `.mcp.json` | MCP servers for this project: the gopls Go language server |
 
 ## Agent Rules
 
-### Code graph (CodeGraph MCP)
+### Code navigation (gopls MCP)
 
-- The MCP server is wired in `.mcp.json` and runs through `npx`, so no global
-  install is needed. The index lives in `.codegraph/` and is git-ignored.
-- **A fresh clone has no index.** The server does not build one on its own — if a
-  tool reports `No .codegraph/`, run `npx -y @colbymchenry/codegraph@1.6.0 init`
-  once in the repository root. A new index is picked up live, no restart.
-- There is no `codegraph` binary on PATH. Every invocation takes the form
-  `npx -y @colbymchenry/codegraph@1.6.0 <command>`; the commands below are the
-  `<command>` part.
+- The MCP server is the Go language server itself: `.mcp.json` runs `gopls mcp`.
+  Nothing is indexed into the repository — gopls reuses the same build cache as
+  `go build`.
+- **It is optional, so check before you reach for it:** `command -v gopls`. When
+  it is absent the server never starts and its tools are simply not offered —
+  fall back to `grep`, `go doc` and `go list`, and say that navigation ran
+  without it. Do not install it as a side effect of another task; the one-time
+  setup is `go install golang.org/x/tools/gopls@latest` with
+  `$(go env GOPATH)/bin` on PATH.
+- Answers come from `go/types`, so they are the compiler's view of the code
+  rather than a text match: a symbol resolves inside its own package even where
+  the name repeats, and files behind another platform's build tag still resolve.
 - Use it instead of `grep` for symbol questions. The tree is 69 packages and a
   symbol's package is not always the one its name suggests, so grep over the
   whole module is both slow and imprecise:
-  - `callers <symbol>` — who calls it
-  - `callees <symbol>` — what it calls
-  - `impact <symbol>` — what a change touches
-  - `explore <query>` — relevant symbols with source and call paths
-  - `node <symbol|file>` — one symbol's source plus its caller trail
-- The index auto-syncs on file changes; after a large rebase run `sync`.
+  - `go_search` — find a symbol by name across the workspace
+  - `go_symbol_references` — every reference to one symbol
+  - `go_package_api` — the exported surface of a package
+  - `go_file_context` — what a file declares and what it depends on
+  - `go_diagnostics` — build and vet errors for the files you just changed
+- The server follows edits on its own; there is nothing to rebuild after a rebase.
 - Grep stays the right tool for text that is not a symbol: comments, error
   strings, build tags, config keys.
 

--- a/docs/FILELIST.md
+++ b/docs/FILELIST.md
@@ -352,7 +352,6 @@ Every file tracked in the repository. Regenerate with
     │       ├── golang-performance
     │       ├── golang-security
     │       └── golang-testing
-    ├── .codegraph
     ├── .gitattributes
     ├── .github
     │   ├── actions


### PR DESCRIPTION
## Дефекты CodeGraph 1.6.0, проверенные на этом дереве

**Полей структур нет в модели как класса сущностей.** Типы узлов: `class,
constant, file, function, import, interface, method, route, struct, type_alias,
variable` — `field` отсутствует.

```
codegraph callers PendingSelection        →  ℹ No callers found
gopls  FileSystemPanel.PendingSelection   →  93 references, 0.46 s
```

**`is_exported` равен нулю** у всех методов, констант и переменных:

```
method    0 → 5555      constant  0 → 1309      variable  0 → 522
function  0 → 3519 / 1 → 5118               struct    0 → 883 / 1 → 479
```

**Индекс отстаёт от коммитов** и не сообщает об этом — нужен ручной `sync`.

**`--limit 20` по умолчанию** усекает выдачу без предупреждения: 14 файлов
вместо 34 на `GetF4ConfigDir`.

## Замеры

| | CodeGraph | gopls |
|---|---|---|
| `GetF4ConfigDir` | 34 файла (с `--limit 200`) | 34 файла |
| поле `FileSystemPanel.PendingSelection` | 0 | 93 ссылки, 0.46 с |
| повторный вызов | 1.9 с | 0.03 с |
| данные в рабочем дереве | `.codegraph/`, 131 МБ | нет |

## Использование команд в плане #1028 (9405 строк)

`callers` — 40, `callees` — 3, `impact` / `explore` / `node` — 0. Обратный обход
графа сделан SQL-запросом к базе, мимо CLI.

## Изменения

- `.mcp.json`: `codegraph` → `gopls mcp`
- `AGENTS.md`, `.ai-factory/rules/base.md`: раздел навигации переписан
- удалены `.codegraph/.gitignore` и строка `.codegraph` в `docs/FILELIST.md`
- `.ai-factory/plans/` не тронут

Теряется `callees` — закрывается `go_file_context` и компилятором. Добавляются
`go_diagnostics`, `go_package_api`, `go_vulncheck`, `go_rename_symbol`.

gopls необязателен: без него сервер не стартует и его инструменты не
предлагаются. Правила требуют `command -v gopls`, иначе `grep`, `go doc`,
`go list`. Установка — `go install golang.org/x/tools/gopls@latest`.
