### PR TITLE
fix(panel): keep hidden menu out of terminal mouse hits (#1093)

### DIFF
--- a/internal/panel/frame.go
+++ b/internal/panel/frame.go
@@ -1366,7 +1366,12 @@ func (pf *PanelsFrame) ResizeConsole(w, h int) {
 	pf.LastW, pf.LastH = w, h
 	pf.SetPosition(0, 0, w-1, h-1) // Update hit-box for FrameManager hit-testing
 	topInset := vtui.FrameManager.WorkspaceTopInset()
-	pf.MenuBar.SetPosition(0, topInset, w-1, topInset)
+	menuY := -2 // Keep a hidden menu outside FrameManager's mouse hit-test area.
+	if config.App.AlwaysShowMenuBar && pf.ShowPanels {
+		menuY = topInset
+	}
+	pf.MenuBar.SetPosition(0, menuY, w-1, menuY)
+	pf.MenuBar.SetVisible(menuY >= 0)
 
 	contentY1 := topInset
 	if config.App.AlwaysShowMenuBar && pf.ShowPanels {
@@ -1754,6 +1759,10 @@ func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 	if config.App.AlwaysShowMenuBar && pf.ShowPanels {
 		pf.MenuBar.SetVisible(true)
 		pf.MenuBar.Show(scr)
+	} else {
+		// MenuBar.HitTest is geometry-only in vtui, so visibility alone is not
+		// enough to keep the hidden bar from intercepting terminal row 0.
+		pf.MenuBar.SetVisible(false)
 	}
 
 	// Command line logic depends on terminal state and editor visibility

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -974,6 +974,10 @@ func TestPanelsFrame_AlwaysShowMenuBar(t *testing.T) {
 	if fspL.Y1 != 0 {
 		t.Errorf("Expected panels to start at row 0 by default, got %d", fspL.Y1)
 	}
+	_, menuY, _, _ := pf.MenuBar.GetPosition()
+	if menuY >= 0 || pf.MenuBar.IsVisible() {
+		t.Errorf("hidden menu bar occupies row %d (visible=%v), want off-screen and hidden", menuY, pf.MenuBar.IsVisible())
+	}
 
 	// 2. Test when AlwaysShowMenuBar is true (panels shifted down)
 	config.App.AlwaysShowMenuBar = true
@@ -981,6 +985,10 @@ func TestPanelsFrame_AlwaysShowMenuBar(t *testing.T) {
 
 	if fspL.Y1 != 1 {
 		t.Errorf("Expected panels to start at row 1 when AlwaysShowMenuBar is true, got %d", fspL.Y1)
+	}
+	_, menuY, _, _ = pf.MenuBar.GetPosition()
+	if menuY != 0 || !pf.MenuBar.IsVisible() {
+		t.Errorf("visible menu bar position/visibility = (%d, %v), want (0, true)", menuY, pf.MenuBar.IsVisible())
 	}
 
 	// 3. Test that hiding panels collapses the menu bar space for terminal
@@ -990,7 +998,47 @@ func TestPanelsFrame_AlwaysShowMenuBar(t *testing.T) {
 	if pf.TermView.Y1 != 0 {
 		t.Errorf("Expected terminal to start at row 0 when panels are hidden, got %d", pf.TermView.Y1)
 	}
+	_, menuY, _, _ = pf.MenuBar.GetPosition()
+	if menuY >= 0 || pf.MenuBar.IsVisible() {
+		t.Errorf("hidden terminal menu bar occupies row %d (visible=%v), want off-screen and hidden", menuY, pf.MenuBar.IsVisible())
+	}
 }
+
+// TestPanelsFrame_HiddenTerminalFirstRowDoesNotOpenMenu covers issue #1093:
+// a click on the first line of micro (or far2l started from f4) used to hit
+// f4's stale menu-bar geometry and open the f4 menu over the terminal app.
+func TestPanelsFrame_HiddenTerminalFirstRowDoesNotOpenMenu(t *testing.T) {
+	t.Cleanup(swapFrameManager())
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	theme.SetDefaultF4Palette()
+	oldAlways := config.App.AlwaysShowMenuBar
+	config.App.AlwaysShowMenuBar = true
+	t.Cleanup(func() { config.App.AlwaysShowMenuBar = oldAlways })
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	waitForLoad(t, pf.Panels[0].(*FileSystemPanel))
+	waitForLoad(t, pf.Panels[1].(*FileSystemPanel))
+	pf.ShowPanels = false
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+
+	vtui.FrameManager.InjectEvents([]*vtinput.InputEvent{{
+		Type: vtinput.MouseEventType, KeyDown: true,
+		MouseX: 5, MouseY: 0,
+		ButtonState: vtinput.FromLeft1stButtonPressed,
+	}})
+	vtui.FrameManager.Step(0)
+
+	if vtui.FrameManager.GetTopFrame() != pf {
+		t.Fatalf("first-row terminal click opened %T, want PanelsFrame terminal view", vtui.FrameManager.GetTopFrame())
+	}
+	if pf.MenuBar.Active {
+		t.Fatal("first-row terminal click activated the hidden f4 menu bar")
+	}
+}
+
 func TestPanelsFrame_Clone_TerminalData(t *testing.T) {
 	pf := NewPanelsFrame()
 	defer pf.Close()

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -1008,7 +1008,7 @@ func TestPanelsFrame_AlwaysShowMenuBar(t *testing.T) {
 // a click on the first line of micro (or far2l started from f4) used to hit
 // f4's stale menu-bar geometry and open the f4 menu over the terminal app.
 func TestPanelsFrame_HiddenTerminalFirstRowDoesNotOpenMenu(t *testing.T) {
-	t.Cleanup(swapFrameManager())
+	t.Cleanup(swapFrameManager(t))
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 	theme.SetDefaultF4Palette()
 	oldAlways := config.App.AlwaysShowMenuBar


### PR DESCRIPTION
Closes #1093\n\nСкрытое меню f4 больше не занимает строку 0 в геометрии hit-test. Поэтому клики по первой строке micro и far2l, запущенных из f4, остаются внутри терминального приложения. Добавлен regression-тест полного dispatch-сценария.\n\nЛокальные Go-тесты не запускались по инструкции Lunobot; обязательная проверка — GitHub CI.