### PR TITLE
fix(panel): gate SFX entry behind Ctrl+PgDn (#915)

### DIFF
--- a/internal/app/actions_table.go
+++ b/internal/app/actions_table.go
@@ -1888,7 +1888,7 @@ func init() {
 				isArchive = vfs.FindProvider(context.Background(), fsp.Vfs, fullPath) != nil
 			}
 			if isDir || isArchive {
-				pf.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN})
+				fsp.EnterSelectedFromAction()
 			}
 		}),
 	})

--- a/internal/app/actions_table.go
+++ b/internal/app/actions_table.go
@@ -23,7 +23,6 @@ import (
 	"github.com/unxed/f4/internal/toast"
 	"github.com/unxed/f4/internal/viewer"
 	"github.com/unxed/f4/vfs"
-	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
 )
 

--- a/internal/panel/list.go
+++ b/internal/panel/list.go
@@ -3106,6 +3106,22 @@ func shiftSelectDirection(vk uint16) int {
 }
 
 func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
+	return fp.processKey(e, false)
+}
+
+// EnterSelectedFromAction enters the selected directory or archive for an
+// explicit panel action such as Ctrl+PgDn. It is intentionally distinct from
+// ordinary Enter so providers can reserve that action for entries that should
+// not open on Enter or a double-click.
+func (fp *FileSystemPanel) EnterSelectedFromAction() bool {
+	return fp.processKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_RETURN,
+	}, true)
+}
+
+func (fp *FileSystemPanel) processKey(e *vtinput.InputEvent, allowProviderPanelEnter bool) bool {
 	if !e.KeyDown {
 		return false
 	}
@@ -3419,6 +3435,12 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 				directoryProvider, ok := provider.(vfs.VirtualDirectoryProvider)
 				if !ok || !directoryProvider.OpensVirtualDirectories() {
 					provider = nil
+				}
+			}
+			if provider != nil && !allowProviderPanelEnter {
+				if policy, ok := provider.(vfs.PanelEnterPolicyProvider); ok &&
+					!policy.PanelEnterAllowed(context.Background(), fp.Vfs, fullPath) {
+					return true
 				}
 			}
 			if provider != nil {

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -3274,7 +3274,7 @@ func TestFileSystemPanel_SFXRequiresCtrlPgDn(t *testing.T) {
 		t.Fatal(err)
 	}
 	sfxPath := filepath.Join(root, "bundle.exe")
-	if err := os.WriteFile(sfxPath, append([]byte("self-extractor stub\n"), archiveBytes...), 0600); err != nil {
+	if err := os.WriteFile(sfxPath, append([]byte("self-extractor stub\n"), archiveBytes...), 0600); err != nil { // #nosec G703 -- sfxPath is inside the private test temp directory.
 		t.Fatal(err)
 	}
 

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -3262,6 +3262,48 @@ func TestPanelsFrame_NavigateToPath(t *testing.T) {
 	}
 }
 
+func TestFileSystemPanel_SFXRequiresCtrlPgDn(t *testing.T) {
+	vfs.RegisterProvider(&archive.ArchiveProvider{})
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+
+	root := t.TempDir()
+	zipPath := filepath.Join(root, "payload.zip")
+	createTestZipForNav(t, zipPath)
+	archiveBytes, err := os.ReadFile(zipPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sfxPath := filepath.Join(root, "bundle.exe")
+	if err := os.WriteFile(sfxPath, append([]byte("self-extractor stub\n"), archiveBytes...), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fp := NewFileSystemPanel(0, 0, 80, 25, vfs.NewOSVFS(root))
+	t.Cleanup(func() { fp.Close() })
+	waitForLoad(t, fp)
+	fp.Entries = []*FileEntry{{VFSItem: vfs.VFSItem{Name: "bundle.exe"}}}
+	fp.SetCursorIndex(0)
+
+	enter := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN}
+	if !fp.ProcessKey(enter) {
+		t.Fatal("ordinary Enter on an SFX row was not consumed")
+	}
+	if _, ok := fp.Vfs.(*vfs.OSVFS); !ok {
+		t.Fatalf("ordinary Enter changed VFS to %T", fp.Vfs)
+	}
+	if fp.ProviderOpenTask != nil {
+		t.Fatal("ordinary Enter started an SFX provider open")
+	}
+
+	if !fp.EnterSelectedFromAction() {
+		t.Fatal("Ctrl+PgDn action did not start SFX entry")
+	}
+	waitForLoad(t, fp)
+	if _, ok := fp.Vfs.(*archive.ArchiveVFS); !ok {
+		t.Fatalf("Ctrl+PgDn left VFS as %T, want archive VFS", fp.Vfs)
+	}
+}
+
 func TestArchiveBulkExtract_ProgressTracking(t *testing.T) {
 	// Register the Archive VFS provider manually for this unit test
 	vfs.RegisterProvider(&archive.ArchiveProvider{})

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -3279,7 +3279,13 @@ func TestFileSystemPanel_SFXRequiresCtrlPgDn(t *testing.T) {
 	}
 
 	fp := NewFileSystemPanel(0, 0, 80, 25, vfs.NewOSVFS(root))
-	t.Cleanup(func() { fp.Close() })
+	t.Cleanup(func() {
+		fp.cancelProviderOpen()
+		if fp.CancelLoad != nil {
+			fp.CancelLoad()
+		}
+		fp.StopLoadingAnimation()
+	})
 	waitForLoad(t, fp)
 	fp.Entries = []*FileEntry{{VFSItem: vfs.VFSItem{Name: "bundle.exe"}}}
 	fp.SetCursorIndex(0)

--- a/plugins/archive/provider.go
+++ b/plugins/archive/provider.go
@@ -13,6 +13,25 @@ type ArchiveProvider struct{}
 func (p *ArchiveProvider) Name() string  { return "zipper/archive" }
 func (p *ArchiveProvider) Priority() int { return 10 }
 
+// PanelEnterAllowed keeps self-extracting archives out of the ordinary Enter
+// and double-click path. They remain available through the explicit
+// Ctrl+PgDn action, which is the deliberate archive-entry gesture.
+func (p *ArchiveProvider) PanelEnterAllowed(ctx context.Context, parent vfs.VFS, path string) bool {
+	if ctx != nil && ctx.Err() != nil {
+		return false
+	}
+	osvfs, ok := parent.(*vfs.OSVFS)
+	if !ok {
+		return true
+	}
+	localPath, err := osvfs.Abs(path)
+	if err != nil {
+		return true
+	}
+	embedded, found, err := findEmbeddedArchive(localPath)
+	return err != nil || !found || embedded.offset <= 0
+}
+
 func (p *ArchiveProvider) CanOpen(ctx context.Context, parent vfs.VFS, path string) bool {
 	if ctx != nil && ctx.Err() != nil {
 		return false

--- a/plugins/archive/provider_test.go
+++ b/plugins/archive/provider_test.go
@@ -43,6 +43,28 @@ func TestArchiveProvider_CanOpen(t *testing.T) {
 		t.Errorf("Expected CanOpen=false for %q", tmpTxt)
 	}
 }
+
+func TestArchiveProvider_PanelEnterAllowedRejectsSFXOnly(t *testing.T) {
+	root := t.TempDir()
+	sfxPath := filepath.Join(root, "bundle.exe")
+	if err := os.WriteFile(sfxPath, []byte("stubPK\x03\x04"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	plainPath := filepath.Join(root, "bundle.zip")
+	if err := os.WriteFile(plainPath, []byte("PK\x03\x04"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	provider := &ArchiveProvider{}
+	parent := vfs.NewOSVFS(root)
+	if provider.PanelEnterAllowed(context.Background(), parent, "bundle.exe") {
+		t.Fatal("SFX must not open through ordinary panel Enter")
+	}
+	if !provider.PanelEnterAllowed(context.Background(), parent, "bundle.zip") {
+		t.Fatal("ordinary archive must keep ordinary panel Enter")
+	}
+}
+
 func TestArchiveProvider_Open(t *testing.T) {
 	p := &ArchiveProvider{}
 	ctx := context.Background()

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -482,6 +482,14 @@ type VFSProvider interface {
 	Open(ctx context.Context, parent VFS, path string) (VFS, error)
 }
 
+// PanelEnterPolicyProvider lets a provider keep ordinary panel activation
+// separate from its explicit action. A provider may reject Enter/double-click
+// for a path while still allowing an action such as Ctrl+PgDn to call Open.
+type PanelEnterPolicyProvider interface {
+	VFSProvider
+	PanelEnterAllowed(ctx context.Context, parent VFS, path string) bool
+}
+
 // StandalonePathProvider can restore a virtual filesystem from its own
 // user-facing absolute path even when the current panel belongs to another
 // VFS. Implementations must recognize only paths they own.


### PR DESCRIPTION
Fixes the confirmed #915 follow-up slice.

- block ordinary Enter and panel double-click for self-extracting archives only
- keep regular archive Enter behavior unchanged
- route explicit Ctrl+PgDn/ Ctrl+Shift+PgDn through an action-only entry path
- add provider-policy and panel integration regression coverage

Validation: gofmt and git diff --check. Go build/tests are delegated to GitHub Actions per LUNOBOT.md.