### PR TITLE
fix: require explicit entry for archives (#915)

### DIFF
--- a/internal/app/actions_table.go
+++ b/internal/app/actions_table.go
@@ -1888,7 +1888,12 @@ func init() {
 				isArchive = vfs.FindProvider(context.Background(), fsp.Vfs, fullPath) != nil
 			}
 			if isDir || isArchive {
-				pf.ProcessKey(&vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN})
+				pf.ProcessKey(&vtinput.InputEvent{
+					Type:           vtinput.KeyEventType,
+					KeyDown:        true,
+					VirtualKeyCode: vtinput.VK_RETURN,
+					InputSource:    panel.PanelEnterDirectoryInputSource,
+				})
 			}
 		}),
 	})

--- a/internal/app/panels_frame_app_test.go
+++ b/internal/app/panels_frame_app_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/unxed/f4/internal/plughost"
 	"github.com/unxed/f4/internal/testutil"
 	"github.com/unxed/f4/internal/theme"
+	"github.com/unxed/f4/plugins/archive"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/vtinput"
 	"github.com/unxed/vtui"
@@ -179,6 +180,121 @@ func TestPanelsFrame_ProcessMouse_DoubleClickFile(t *testing.T) {
 	}
 	if pf.ShowPanels {
 		t.Error("Double clicking a runnable file should hide the panels")
+	}
+}
+
+func setupArchiveEntryPanel(t *testing.T) (*panel.PanelsFrame, *panel.FileSystemPanel, string) {
+	t.Helper()
+	t.Cleanup(paneltest.SwapFrameManager(t))
+
+	pf := paneltest.SetupMockPanelsFrame(t)
+	pf.ResizeConsole(80, 25)
+
+	tmp := t.TempDir()
+	archivePath := filepath.Join(tmp, "payload.zip")
+	if err := os.WriteFile(archivePath, []byte("not opened by this regression test"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fsp := pf.Panels[0].(*panel.FileSystemPanel)
+	fsp.SetViewMode(panel.ViewModeDetailed)
+	if err := fsp.Vfs.SetPath(tmp); err != nil {
+		t.Fatal(err)
+	}
+	fsp.Entries = []*panel.FileEntry{
+		{VFSItem: vfs.VFSItem{Name: "..", IsDir: true}},
+		{VFSItem: vfs.VFSItem{Name: "payload.zip", IsDir: false}},
+	}
+	fsp.Refresh()
+	fsp.SetCursorIndex(1)
+	pf.ActiveIdx = 0
+
+	archiveProvider := &archive.ArchiveProvider{}
+	vfs.RegisterProvider(archiveProvider)
+	t.Cleanup(func() {
+		if !vfs.UnregisterProvider(archiveProvider) {
+			t.Errorf("archive provider was not registered")
+		}
+	})
+
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	vtui.FrameManager.Push(pf)
+	return pf, fsp, tmp
+}
+
+func TestPanelsFrame_EnterArchiveFileRequiresExplicitAction(t *testing.T) {
+	pf, fsp, tmp := setupArchiveEntryPanel(t)
+	defer pf.Close()
+
+	if !pressKey(pf, &vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_RETURN,
+	}) {
+		t.Fatal("plain Enter on an archive file must be handled")
+	}
+	if fsp.ProviderOpenTask != nil {
+		t.Fatal("plain Enter on an archive file must not start a provider transition")
+	}
+	if got := fsp.Vfs.GetPath(); filepath.Clean(got) != filepath.Clean(tmp) {
+		t.Fatalf("plain Enter changed the panel path to %q", got)
+	}
+	if !pf.ShowPanels {
+		t.Fatal("plain Enter on an archive file must not launch it")
+	}
+}
+
+func TestPanelsFrame_ProcessMouse_DoubleClickArchiveFileRequiresExplicitAction(t *testing.T) {
+	pf, fsp, tmp := setupArchiveEntryPanel(t)
+	defer pf.Close()
+
+	handled := pf.ProcessMouse(&vtinput.InputEvent{
+		Type:            vtinput.MouseEventType,
+		KeyDown:         true,
+		MouseX:          checkedMouseCoordinate(t, fsp.Table.X1),
+		MouseY:          checkedMouseCoordinate(t, fsp.Table.Y1+fsp.Table.MarginTop+1),
+		ButtonState:     vtinput.FromLeft1stButtonPressed,
+		MouseEventFlags: vtinput.DoubleClick,
+	})
+	if !handled {
+		t.Fatal("double click on an archive file must be handled")
+	}
+	if got := fsp.GetRawSelectedName(); got != "payload.zip" {
+		t.Fatalf("double click selected %q, want payload.zip", got)
+	}
+	if fsp.ProviderOpenTask != nil {
+		t.Fatal("double click on an archive file must not start a provider transition")
+	}
+	if got := fsp.Vfs.GetPath(); filepath.Clean(got) != filepath.Clean(tmp) {
+		t.Fatalf("double click changed the panel path to %q", got)
+	}
+	if !pf.ShowPanels {
+		t.Fatal("double click on an archive file must not launch it")
+	}
+}
+
+func TestPanelsFrame_ProcessMouse_MiddleClickArchiveFileRequiresExplicitAction(t *testing.T) {
+	pf, fsp, tmp := setupArchiveEntryPanel(t)
+	defer pf.Close()
+
+	handled := pf.ProcessMouse(&vtinput.InputEvent{
+		Type:        vtinput.MouseEventType,
+		KeyDown:     true,
+		MouseX:      checkedMouseCoordinate(t, fsp.Table.X1),
+		MouseY:      checkedMouseCoordinate(t, fsp.Table.Y1+fsp.Table.MarginTop+1),
+		ButtonState: vtinput.FromLeft2ndButtonPressed,
+	})
+	if !handled {
+		t.Fatal("middle click on an archive file must be handled")
+	}
+	if fsp.ProviderOpenTask != nil {
+		t.Fatal("middle click on an archive file must not start a provider transition")
+	}
+	if got := fsp.Vfs.GetPath(); filepath.Clean(got) != filepath.Clean(tmp) {
+		t.Fatalf("middle click changed the panel path to %q", got)
+	}
+	if !pf.ShowPanels {
+		t.Fatal("middle click on an archive file must not launch it")
 	}
 }
 

--- a/internal/panel/list.go
+++ b/internal/panel/list.go
@@ -676,6 +676,12 @@ func isNilVFS(v vfs.VFS) bool {
 	return false
 }
 
+// PanelEnterDirectoryInputSource marks the explicit Ctrl+PgDn action. Plain
+// Enter and mouse double-click must not silently enter archive files: users
+// asked for archive entry to be an intentional action, while ordinary
+// directories and executable files retain their existing Enter behaviour.
+const PanelEnterDirectoryInputSource = "panel-enter-directory"
+
 // isArchiveProvider reports whether p is the archive/zip plugin's provider,
 // so archive open failures get an "Open Error" dialog instead of the
 // network-oriented "Connection Error" used by remote VFS plugins.
@@ -3422,6 +3428,12 @@ func (fp *FileSystemPanel) ProcessKey(e *vtinput.InputEvent) bool {
 				}
 			}
 			if provider != nil {
+				if !selected.IsDir && isArchiveProvider(provider) && e.InputSource != PanelEnterDirectoryInputSource {
+					// Archive entry is deliberately explicit. In particular, the
+					// synthetic Enter emitted for a mouse double-click must not
+					// turn an archive into a directory or launch an archive reader.
+					return true
+				}
 				sourceVFS := fp.Vfs
 				selectedName := selected.Name
 				return fp.openVFSAsync(


### PR DESCRIPTION
Atomic slice for #915. Archive files are no longer entered through plain Enter, left-button double-click, or middle-click. The explicit Panel.EnterDirectory action (Ctrl+PgDn/Ctrl+Shift+PgDn) marks its synthetic Enter and keeps archive navigation available. Ordinary directories and non-archive files retain their existing behavior. Focused validation: GOCACHE=/home/unxed/.cache/go-build go test ./internal/app -run TestPanelsFrame_... -count=1; gofmt; git diff --check. Remaining multivolume and password-protected SFX reports are outside this slice.