### PR TITLE
test(gui): cover Wine path conversion helpers

### DIFF
--- a/docs/LUNOBOT/coverage-winepath-windows.md
+++ b/docs/LUNOBOT/coverage-winepath-windows.md
@@ -1,0 +1,10 @@
+# Coverage: internal/gui/winepath_windows.go
+
+Status: test coverage for the platform-independent helper paths is added in the companion Windows test.
+
+Covered behavior:
+- conversion of NUL-terminated UTF-8 and UTF-16 buffers;
+- empty paths, embedded-NUL conversion failures, and the unavailable-translation result;
+- the zero-pointer freeProcessHeap guard.
+
+Invariant: Wine path conversion remains best-effort. If Wine exports are unavailable or reject a path, callers receive ("", false) and retain their existing fallback behavior.

--- a/internal/gui/winepath_windows_test.go
+++ b/internal/gui/winepath_windows_test.go
@@ -1,0 +1,45 @@
+//go:build windows && (amd64 || arm64)
+
+package gui
+
+import (
+	"syscall"
+	"testing"
+	"unsafe"
+)
+
+func TestWinePathStringHelpers(t *testing.T) {
+	raw := []byte("unix/path\x00ignored")
+	if got := stringFromCString(uintptr(unsafe.Pointer(&raw[0]))); got != "unix/path" {
+		t.Fatalf("stringFromCString() = %q, want unix/path", got)
+	}
+
+	wide := []uint16{'D', ':', '\\', 't', 'm', 'p', 0, 'x'}
+	if got := stringFromWideCString(uintptr(unsafe.Pointer(&wide[0]))); got != "D:\\tmp" {
+		t.Fatalf("stringFromWideCString() = %q, want D:\\tmp", got)
+	}
+}
+
+func TestWinePathUnavailableInputs(t *testing.T) {
+	freeProcessHeap(0)
+
+	if got, ok := HostUnixPath(""); got != "" || ok {
+		t.Fatalf("HostUnixPath(empty) = %q, %v; want empty, false", got, ok)
+	}
+	if got, ok := HostDosPath(""); got != "" || ok {
+		t.Fatalf("HostDosPath(empty) = %q, %v; want empty, false", got, ok)
+	}
+
+	if got, ok := HostUnixPath("contains\x00nul"); got != "" || ok {
+		t.Fatalf("HostUnixPath(NUL) = %q, %v; want empty, false", got, ok)
+	}
+	if got, ok := HostDosPath("contains\x00nul"); got != "" || ok {
+		t.Fatalf("HostDosPath(NUL) = %q, %v; want empty, false", got, ok)
+	}
+}
+
+func TestWinePathUTF16Error(t *testing.T) {
+	if _, err := syscall.UTF16PtrFromString("contains\x00nul"); err == nil {
+		t.Fatal("UTF16PtrFromString accepted an embedded NUL")
+	}
+}


### PR DESCRIPTION
## Summary

Add Windows-only tests for the platform-independent helpers in internal/gui/winepath_windows.go:
- NUL-terminated UTF-8 and UTF-16 buffer decoding;
- empty and embedded-NUL inputs returning the unavailable result;
- the zero-pointer process-heap free guard.

The tests do not call Wine exports or mutate native state. The required status is documented in docs/LUNOBOT/coverage-winepath-windows.md.

## Validation

GitHub Actions only, including the Windows workflow for the build-tagged tests.