### PR TITLE
archive: report detailed test failures

### DIFF
--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -13,10 +13,10 @@ import (
 	"time"
 
 	"github.com/unxed/archives"
-	"github.com/unxed/f4/internal/terminal"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/sevenzip"
 	"github.com/unxed/vtinput"
+	"github.com/unxed/vtui"
 	"github.com/unxed/zipper/archive"
 )
 
@@ -315,7 +315,7 @@ func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs
 func showArchiveTestFailure(app vfs.App, srcPath string, err error) {
 	report := formatArchiveTestFailure(srcPath, err)
 	if app.Message(" Test archive ", report, []string{"&Copy list", "&Close"}) == 0 {
-		terminal.SetClipboardAsync(report)
+		go vtui.SetClipboard(report)
 	}
 }
 

--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -2,6 +2,7 @@ package archive
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"hash/crc32"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"github.com/unxed/archives"
+	"github.com/unxed/f4/internal/terminal"
 	"github.com/unxed/f4/vfs"
 	"github.com/unxed/sevenzip"
 	"github.com/unxed/vtinput"
@@ -211,9 +213,9 @@ func extractArchiveWithPasswordPrompt(ctx context.Context, srcPath, destDir stri
 	}
 }
 
-// actionTestArchive verifies that every member of the selected archive can
-// be extracted and passes its size/CRC checks, without writing anything to
-// the panels. Password prompts behave like everywhere else in the plugin.
+// actionTestArchive verifies every regular member of the selected archive by
+// reading it to completion, without writing anything to the panels. Password
+// prompts behave like everywhere else in the plugin.
 func actionTestArchive(app vfs.App) {
 	srcPath, ok := resolveLocalArchivePath(app)
 	if !ok {
@@ -223,23 +225,102 @@ func actionTestArchive(app vfs.App) {
 		return
 	}
 	go func() {
-		tempDir, err := os.MkdirTemp("", "f4arc-test-*")
-		if err != nil {
-			app.Message(" Error ", fmt.Sprintf("Test failed:\n%v", err), []string{"&Ok"})
-			return
-		}
 		app.RunAdvancedProgressTask(" Testing... ", false, func(ctx context.Context, reporter vfs.TaskReporter) error {
 			reporter.UpdateTransfer("Testing", filepath.Base(srcPath), -1, "", -1, "")
-			return extractArchiveWithPasswordPrompt(ctx, srcPath, tempDir, reporter)
+			return testArchiveWithPasswordPrompt(ctx, srcPath, reporter)
 		}, func(err error) {
-			_ = os.RemoveAll(tempDir)
 			if err == nil {
 				go app.Message(" Test archive ", fmt.Sprintf("%s\nNo errors found.", filepath.Base(srcPath)), []string{"&Ok"})
 			} else if err != context.Canceled {
-				go app.Message(" Error ", fmt.Sprintf("Test failed:\n%v", err), []string{"&Ok"})
+				go showArchiveTestFailure(app, srcPath, err)
 			}
 		})
 	}()
+}
+
+func testArchiveWithPasswordPrompt(ctx context.Context, srcPath string, reporter vfs.TaskReporter) error {
+	var password string
+	var release func()
+	defer func() {
+		if release != nil {
+			release()
+		}
+	}()
+
+	for {
+		err := testArchiveOnce(ctx, srcPath, password, reporter)
+		if err == nil || !isArchivePasswordRetryError(err) {
+			return err
+		}
+
+		if release == nil {
+			release = vfs.HoldInteractivePrompt()
+		}
+		password, err = promptArchivePasswordUntilProvided(ctx, filepath.Base(srcPath))
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs.TaskReporter) error {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	format, stream, err := archives.Identify(ctx, srcPath, f)
+	if err != nil {
+		return err
+	}
+	if configured, ok := configureRARArchiveFormat(format, srcPath, password); ok {
+		format = configured
+	} else {
+		format, _ = archivePasswordFormat(format, password)
+	}
+	extractor, ok := format.(archives.Extractor)
+	if !ok {
+		return fmt.Errorf("format %T does not support testing", format)
+	}
+
+	var failures []error
+	err = extractor.Extract(ctx, stream, func(ctx context.Context, info archives.FileInfo) error {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		reporter.UpdateTransfer("Testing", info.NameInArchive, -1, "", -1, "")
+		if info.IsDir() || !info.Mode().IsRegular() {
+			return nil
+		}
+
+		member, openErr := info.Open()
+		if openErr != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", info.NameInArchive, openErr))
+			return nil
+		}
+		_, readErr := io.Copy(io.Discard, member)
+		closeErr := member.Close()
+		if failure := errors.Join(readErr, closeErr); failure != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", info.NameInArchive, failure))
+		}
+		return nil
+	})
+	if err != nil {
+		failures = append(failures, err)
+	}
+	return errors.Join(failures...)
+}
+
+func showArchiveTestFailure(app vfs.App, srcPath string, err error) {
+	report := formatArchiveTestFailure(srcPath, err)
+	if app.Message(" Test archive ", report, []string{"&Copy list", "&Close"}) == 0 {
+		terminal.SetClipboardAsync(report)
+	}
+}
+
+func formatArchiveTestFailure(srcPath string, err error) string {
+	return fmt.Sprintf("Test failed for %s:\n%s", filepath.Base(srcPath), err)
 }
 
 func extractArchiveOnce(ctx context.Context, srcPath, destDir, password string, reporter vfs.TaskReporter) error {

--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -268,7 +268,7 @@ func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	format, stream, err := archives.Identify(ctx, srcPath, f)
 	if err != nil {

--- a/plugins/archive/archive_plugin_test.go
+++ b/plugins/archive/archive_plugin_test.go
@@ -3,6 +3,7 @@ package archive
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -207,5 +208,18 @@ func TestArchivePluginRegistersFar2lFileShortcutsWithoutContributionHost(t *test
 		if app.items[index] != wantItems[index] {
 			t.Errorf("legacy menu item %d = %q, want %q", index, app.items[index], wantItems[index])
 		}
+	}
+}
+
+func TestFormatArchiveTestFailureIncludesArchiveAndMemberErrors(t *testing.T) {
+	err := errors.Join(
+		errors.New("broken.txt: checksum mismatch"),
+		errors.New("missing.bin: read failed"),
+	)
+
+	got := formatArchiveTestFailure(filepath.Join("/tmp", "sample.zip"), err)
+	want := "Test failed for sample.zip:\nbroken.txt: checksum mismatch\nmissing.bin: read failed"
+	if got != want {
+		t.Fatalf("formatArchiveTestFailure() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Refs #900

This PR makes Shift+F3 archive testing read each regular member through the archives API, collects member-specific read/checksum failures, and offers copying the full report to the clipboard. Existing password retry behaviour is preserved.

Validation: gofmt and git diff --check. Hosted CI is authoritative; no local Go build/test was run.