### PR TITLE
fix: test local archives from archive panels (#900)

### DIFF
--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -96,12 +96,15 @@ func actionArchiveCommands(app vfs.App) {
 	})
 }
 
-// resolveLocalArchivePath returns the absolute path of the selected archive
-// when the active panel is a local filesystem.
+// resolveLocalArchivePath returns the absolute path of the archive to operate
+// on when the active panel is a local filesystem or a local ArchiveVFS.
 func resolveLocalArchivePath(app vfs.App) (string, bool) {
 	srcVfs := app.GetActivePanelVFS()
 	if srcVfs == nil {
 		return "", false
+	}
+	if archiveVFS, ok := srcVfs.(*ArchiveVFS); ok {
+		return archiveVFS.LocalArchivePath()
 	}
 	name := app.GetSelectedName()
 	if name == "" || name == ".." {

--- a/plugins/archive/archive_test.go
+++ b/plugins/archive/archive_test.go
@@ -163,6 +163,25 @@ type mockAppForProgress struct {
 	mu          sync.Mutex
 }
 
+func TestResolveLocalArchivePathFromInsideLocalArchive(t *testing.T) {
+	root := t.TempDir()
+	archiveVFS := &ArchiveVFS{
+		parent:    vfs.NewOSVFS(root),
+		arcPath:   filepath.Join("archives", "bundle.zip"),
+		innerPath: "folder",
+	}
+	app := &mockAppForProgress{
+		activeVfs: archiveVFS,
+		names:     []string{"file.txt"},
+	}
+
+	got, ok := resolveLocalArchivePath(app)
+	want := filepath.Join(root, "archives", "bundle.zip")
+	if !ok || got != want {
+		t.Fatalf("resolveLocalArchivePath() = (%q, %t), want (%q, true)", got, ok, want)
+	}
+}
+
 func (m *mockAppForProgress) GetActivePanelVFS() vfs.VFS      { return m.activeVfs }
 func (m *mockAppForProgress) GetPassivePanelVFS() vfs.VFS     { return m.passiveVfs }
 func (m *mockAppForProgress) GetSelectedNames() []string      { return m.names }

--- a/plugins/archive/vfs.go
+++ b/plugins/archive/vfs.go
@@ -443,6 +443,23 @@ func (v *ArchiveVFS) GetPath() string {
 	// Мы возвращаем нативный путь ОС, объединяя путь к архиву и внутренний путь
 	return archivePathJoin(v.arcPath, v.innerPath)
 }
+
+// LocalArchivePath returns the original archive path when this VFS was opened
+// from the local filesystem. A materialized remote or nested archive is not
+// exposed as local here: testing it through this action belongs to a separate
+// operation with different lifecycle and error-reporting rules.
+func (v *ArchiveVFS) LocalArchivePath() (string, bool) {
+	osvfs, ok := v.parent.(*vfs.OSVFS)
+	if !ok {
+		return "", false
+	}
+	path, err := osvfs.Abs(v.arcPath)
+	if err != nil || path == "" {
+		return "", false
+	}
+	return path, true
+}
+
 func (v *ArchiveVFS) IsAbs(candidate string) bool {
 	return archivePathHasPrefix(candidate, v.arcPath) || (!vfs.IsURIPath(candidate) && (filepath.IsAbs(candidate) || path.IsAbs(candidate)))
 }

--- a/plugins/archive/vfs_test.go
+++ b/plugins/archive/vfs_test.go
@@ -34,6 +34,28 @@ func TestArchiveVFS_PathSlashes(t *testing.T) {
 	}
 }
 
+func TestArchiveVFS_LocalArchivePath(t *testing.T) {
+	root := t.TempDir()
+	v := &ArchiveVFS{
+		parent:    vfs.NewOSVFS(root),
+		arcPath:   filepath.Join("archives", "bundle.zip"),
+		innerPath: "folder",
+	}
+
+	got, ok := v.LocalArchivePath()
+	want := filepath.Join(root, "archives", "bundle.zip")
+	if !ok || got != want {
+		t.Fatalf("LocalArchivePath() = (%q, %t), want (%q, true)", got, ok, want)
+	}
+}
+
+func TestArchiveVFS_LocalArchivePathRejectsNonLocalParent(t *testing.T) {
+	v := &ArchiveVFS{arcPath: "remote.zip"}
+	if got, ok := v.LocalArchivePath(); ok || got != "" {
+		t.Fatalf("LocalArchivePath() = (%q, %t), want (empty, false)", got, ok)
+	}
+}
+
 func TestArchiveVFS_SkipsExplicitRootEntryDuringScan(t *testing.T) {
 	tmpDir := t.TempDir()
 	tarPath := filepath.Join(tmpDir, "root-entry.tar")


### PR DESCRIPTION
Часть 1 из 3 по #900.\n\nЧто изменено:\n- Shift+F3 теперь находит исходный локальный архив, если активная панель уже открыта внутри ArchiveVFS.\n- Используется существующий integrity-test pipeline с его текущими progress/error/password сценариями.\n- Удалённые и вложенные архивы не объявляются локальными.\n- Добавлены регрессионные тесты для локального источника из подпапки и нелокального родителя.\n\nПодробный список ошибок, отсутствующие тома и расширенные password-сценарии остаются отдельными частями задачи.