### PR TITLE
test(vfs): cover Windows disk helpers

### DIFF
--- a/docs/LUNOBOT/coverage-disks-windows.md
+++ b/docs/LUNOBOT/coverage-disks-windows.md
@@ -1,0 +1,11 @@
+# Coverage: vfs/disks_windows.go
+
+Status: Windows-only tests cover the safe helper and preflight paths without opening or enumerating a physical disk.
+
+Covered behavior:
+- adding and preserving the Windows device-path prefix;
+- obtaining a size from a seekable file and restoring its offset;
+- rejecting an embedded-NUL device path before native I/O;
+- honoring a canceled context before device enumeration.
+
+Invariant: disk discovery and size probing remain best-effort and never turn a failed native probe into a fabricated device size.

--- a/vfs/disks_windows_test.go
+++ b/vfs/disks_windows_test.go
@@ -1,0 +1,66 @@
+//go:build windows
+
+package vfs
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestResolveDevicePath(t *testing.T) {
+	if got := resolveDevicePath("PhysicalDrive0"); got != "\\\\.\\PhysicalDrive0" {
+		t.Fatalf("resolveDevicePath() = %q, want \\\\.\\PhysicalDrive0", got)
+	}
+	if got := resolveDevicePath("\\\\.\\PhysicalDrive0"); got != "\\\\.\\PhysicalDrive0" {
+		t.Fatalf("resolveDevicePath(existing prefix) = %q", got)
+	}
+}
+
+func TestGetDeviceSizeUsesSeekableFile(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "device")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString("payload"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Seek(2, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := getDeviceSize("unused", f)
+	if err != nil {
+		t.Fatalf("getDeviceSize() error = %v", err)
+	}
+	if got != int64(len("payload")) {
+		t.Fatalf("getDeviceSize() = %d, want %d", got, len("payload"))
+	}
+	pos, err := f.Seek(0, io.SeekCurrent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pos != 0 {
+		t.Fatalf("size probe left file offset at %d, want 0", pos)
+	}
+}
+
+func TestGetDeviceSizeRejectsEmbeddedNUL(t *testing.T) {
+	got, err := getDeviceSize("bad\x00path", nil)
+	if err != nil {
+		t.Fatalf("getDeviceSize() error = %v, want nil", err)
+	}
+	if got != 0 {
+		t.Fatalf("getDeviceSize() = %d, want 0", got)
+	}
+}
+
+func TestGetPlatformBlockDevicesHonorsCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if got := getPlatformBlockDevices(ctx); len(got) != 0 {
+		t.Fatalf("getPlatformBlockDevices(canceled) = %#v, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

Add Windows-only tests for vfs/disks_windows.go:
- normalize and preserve Windows physical-device paths;
- probe a seekable file size while restoring its offset;
- reject embedded-NUL paths before native I/O;
- stop device enumeration when the context is already canceled.

The tests never enumerate or open a physical disk. The required status is documented in docs/LUNOBOT/coverage-disks-windows.md.

## Validation

GitHub Actions only, including the Windows test workflow.