### PR TITLE
fix: restore session paths in console mode and support startup dirs in GUI

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -85,15 +85,22 @@ func startupDirArgs(args []string) []string {
 	return dirs
 }
 
-// rememberStartupDirs records those directories, but only for a start from a
-// terminal. It must run before checkAndDetach and before the daemon is spawned:
-// both hand the next process /dev/null on stdin. Values inherited from the
-// parent win, they are the answer that process already worked out.
+// rememberStartupDirs records the directories the user explicitly named on
+// the command line (or, for a terminal start without arguments, the current
+// working directory). The environment carries the values to the process that
+// draws the panels — the GUI's detached copy, or the session daemon — neither
+// of which can work them out on its own.
+//
+// Without explicit arguments, CWD is only captured when stdin is a terminal.
+// A GUI started from Explorer/Dock arrives with a working directory inside the
+// application bundle, which is not a place anyone asked to see. Explicit
+// directory arguments are always honoured regardless of stdin type so that
+// `f4-gui.exe C:\dir` works the same as `f4 C:\dir` from a terminal.
 func rememberStartupDirs(args []string) {
 	if os.Getenv(startupDirEnv) != "" {
 		return
 	}
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
+	if len(args) == 0 && !term.IsTerminal(int(os.Stdin.Fd())) {
 		return
 	}
 	cwd, err := os.Getwd()


### PR DESCRIPTION
## Problem

Two bugs introduced by [PR #921](https://github.com/unxed/f4/pull/921) (commits [652a14f0](https://github.com/unxed/f4/commit/652a14f0) and [4bb404fe](https://github.com/unxed/f4/commit/4bb404fe)):

1. **Console mode loses session paths.** \ememberStartupDirs()\ unconditionally captures the current working directory whenever \stdin\ is a terminal. \ApplyStartupDirs()\ then overwrites the paths that \LoadSession()\ just restored from \session.ini\. Result: \4\ launched from a terminal always opens in the CWD, ignoring saved panel paths.

2. **GUI ignores directory arguments.** The same function bails out when \stdin\ is NOT a terminal, so \4-gui.exe C:\\dir\ launched from Explorer silently ignores the directory argument.

## Fix

Change one condition in \ememberStartupDirs()\:

\\\go
// Before (broken):
if !term.IsTerminal(int(os.Stdin.Fd())) {
    return
}

// After (fixed):
if len(args) == 0 && !term.IsTerminal(int(os.Stdin.Fd())) {
    return
}
\\\

| Scenario | Before | After |
|---|---|---|
| \4\ (no args, terminal) | CWD overrides session | CWD overrides session (unchanged) |
| \4\ (no args, GUI from Explorer) | N/A (GUI goes through detach) | session restored |
| \4 dir\ (terminal) | opens in dir | opens in dir (unchanged) |
| \4-gui.exe dir\ (Explorer) | **dir ignored** | opens in dir |

## Why this is safe

- When no args are given and stdin is a terminal: behavior is unchanged (mc-compatible CWD open).
- When no args are given and stdin is not a terminal: session paths are now properly restored instead of being silently lost.
- When explicit directory args are given: always captured, regardless of stdin type. This is the new behavior that fixes the GUI case.
- The \	erm.IsTerminal\ check is still used for the no-args case to prevent a GUI start from Explorer from capturing the application bundle's working directory.