### PR TITLE
fix: keep restored session on plain startup (#823)

### DIFF
--- a/internal/app/bootstrap.go
+++ b/internal/app/bootstrap.go
@@ -65,6 +65,17 @@ func startupDirsFor(cwd string, args []string) (left, right string) {
 	}
 }
 
+// startupDirsOverride distinguishes an explicit directory argument from a
+// plain launch. With no directory argument the restored session must win over
+// the process cwd.
+func startupDirsOverride(cwd string, args []string) (left, right string, ok bool) {
+	if len(args) == 0 {
+		return "", "", false
+	}
+	left, right = startupDirsFor(cwd, args)
+	return left, right, true
+}
+
 // startupDirArgs picks the panel directories out of a command line: the words
 // before the first switch, plus everything after a "--" separator. --gui and
 // --tty take their backend as a separate word, so a word after a switch could
@@ -100,7 +111,10 @@ func rememberStartupDirs(args []string) {
 	if err != nil {
 		return
 	}
-	left, right := startupDirsFor(cwd, args)
+	left, right, ok := startupDirsOverride(cwd, args)
+	if !ok {
+		return
+	}
 	_ = os.Setenv(startupDirEnv, left)
 	if right != "" {
 		_ = os.Setenv(startupDirRightEnv, right)

--- a/internal/app/bootstrap_startupdir_test.go
+++ b/internal/app/bootstrap_startupdir_test.go
@@ -66,6 +66,12 @@ func TestStartupDirsForCommandLine(t *testing.T) {
 	}
 }
 
+func TestStartupDirsOverrideIgnoresPlainLaunch(t *testing.T) {
+	if left, right, ok := startupDirsOverride(t.TempDir(), nil); ok || left != "" || right != "" {
+		t.Fatalf("startupDirsOverride(no args) = (%q, %q, %t), want (empty, empty, false)", left, right, ok)
+	}
+}
+
 func TestStartupDirArgs(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
Часть 1 из 1 по #823.\n\nПосле PR #921 plain startup без каталогов вызывал startupDirsFor с пустым списком и записывал cwd в F4_STARTUP_DIR; этот override затем перекрывал пути, восстановленные из session.ini.\n\nИзменение отделяет явный directory override от обычного запуска. Явные один/два каталога сохраняют прежнее поведение, а запуск без каталогов оставляет восстановленную сессию. Добавлен regression test на отсутствие override.\n\nПроверены форматирование и git diff --check; проектные Go-тесты по текущей LUNOBOT.md отправлены в hosted CI.