### PR TITLE
fix: consume failed Arkanoid hotkey (#983)

### DIFF
--- a/internal/app/panels_frame_app_test.go
+++ b/internal/app/panels_frame_app_test.go
@@ -71,6 +71,31 @@ func TestPanelsFrame_ArkanoidHotkey(t *testing.T) {
 	t.Cleanup(arkFrame.Close)
 }
 
+func TestPanelsFrame_FailedArkanoidHotkeyStillConsumesEvent_Issue983(t *testing.T) {
+	previous := panel.Arkanoid
+	t.Cleanup(func() { panel.Arkanoid = previous })
+
+	calls := 0
+	panel.Arkanoid = func() bool {
+		calls++
+		return false
+	}
+
+	pf := &panel.PanelsFrame{ShowPanels: true}
+	e := &vtinput.InputEvent{
+		Type:            vtinput.KeyEventType,
+		KeyDown:         true,
+		VirtualKeyCode:  'A',
+		ControlKeyState: vtinput.LeftCtrlPressed | vtinput.LeftAltPressed,
+	}
+	if !pf.InterceptPluginKey(e) {
+		t.Fatal("failed Arkanoid launch passed the matched hotkey to the frame dispatcher")
+	}
+	if calls != 1 {
+		t.Fatalf("Arkanoid handler calls = %d, want 1", calls)
+	}
+}
+
 func TestPanelsFrame_ProcessMouse_DoubleClick(t *testing.T) {
 	oldNavigationMode := config.App.NavigationMode
 	config.App.NavigationMode = config.NavigationClassic

--- a/internal/panel/frame.go
+++ b/internal/panel/frame.go
@@ -1817,7 +1817,12 @@ func (pf *PanelsFrame) InterceptPluginKey(e *vtinput.InputEvent) bool {
 
 	// Arkanoid easter egg: Ctrl+Alt+A
 	if e.VirtualKeyCode == 'A' && alt && ctrl {
-		return Arkanoid()
+		// The matching plugin gesture owns the event even when its handler
+		// cannot open the game. Letting a failed launch fall through exposes
+		// the same key to the frame dispatcher and can leave a stale overlay
+		// behind (#983).
+		Arkanoid()
+		return true
 	}
 
 	// Check global hotkeys (ignoring Lock and Enhanced keys)


### PR DESCRIPTION
Issue #983

A matched Ctrl+Alt+A Arkanoid gesture now consumes the event even when the handler cannot open the game, preventing the failed shortcut from reaching the frame dispatcher and leaving an invisible overlay. Added a regression test for the failed-handler path.

Validation: gofmt and git diff --check; full validation is delegated to GitHub Actions.