### PR TITLE
docs: explain highlight rule precedence (#420)

### DIFF
--- a/docs/HIGHLIGHTING.md
+++ b/docs/HIGHLIGHTING.md
@@ -117,6 +117,32 @@ Dates can be evaluated either absolutely or relatively:
 
 Color expressions match the standard f4 format: `foreground:<color> | background:<color>`, where `<color>` is a hex RGB value (e.g. `#8AE234` or `#0000FF`).
 
+### Theme rules and `highlight.ini`
+
+The active Color Style and the user's `highlight.ini` contribute separate
+rule lists; sections with the same number are not merged key by key. By
+default the user's list is placed first, so a matching user rule wins before
+the theme is considered. `Appearance.HighlightPriority = 0` in `settings.ini`
+selects this order. Set it to `1` when the theme should be tried first.
+
+A rule that matches an item normally ends the search, even if it does not set
+a colour for the current state. Use `ContinueProcessing = 1` when a later
+matching rule should fill in or blend the remaining colour components. This is
+also how a user rule can override only the foreground while retaining a
+background supplied by a later theme rule:
+
+```ini
+[Highlight_100]
+Mask = *.log
+NormalColor = foreground:#FF5555
+ContinueProcessing = 1
+```
+
+Conversely, a broad user rule without a mask or attribute filter can stop all
+theme rules below it. For a folder-only override include
+`IncludeAttributes = Directory`; for a file-only override exclude that
+attribute.
+
 ### Cascade Blending (`ContinueProcessing = 1`)
 
 Normally, `f4` evaluates rules from top to bottom and stops on the first match. However, if `ContinueProcessing = 1` is specified, `f4` merges the colors of this rule with subsequent matches.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1449,6 +1449,12 @@ func CreateDefaultHighlightIni(path string) {
 #
 # f4 applies file highlighting rules from both the active Color Style (Theme)
 # and this file. By default, rules in this file have higher priority.
+# The two sources are not merged field by field: f4 puts one complete rule
+# list before the other. Change Appearance.HighlightPriority in settings.ini
+# to 0 (user rules first, the default) or 1 (theme rules first).
+# A matching rule normally stops processing even when it has no colour for
+# the current state. Add ContinueProcessing = 1 when a later rule should be
+# allowed to supply or merge the remaining colour components.
 #
 # You can add your custom highlight groups here (e.g. Mask = *.mp3).
 # Default groups (Hidden, Executables, Directories) are already defined

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -402,6 +402,9 @@ func TestCreateDefaultHighlightIniDocumentsColorOptions(t *testing.T) {
 	content := string(data)
 	for _, key := range []string{
 		"# [Highlight_100]",
+		"Appearance.HighlightPriority",
+		"user rules first, the default",
+		"ContinueProcessing = 1 when a later rule",
 		"# NormalColor =",
 		"# SelectedColor =",
 		"# CursorColor =",


### PR DESCRIPTION
Issue: #420

The generated highlight.ini now explains that user and theme rules are separate ordered lists, how Appearance.HighlightPriority changes precedence, and when ContinueProcessing is required. The HIGHLIGHTING.md reference documents the same behavior with a concrete override example. The existing generator test asserts the new guidance.

No local Go build/test was run per LUNOBOT.md; git diff --check passed and hosted CI is authoritative.