### PR TITLE
archive: report Shift+F3 test progress

### DIFF
--- a/plugins/archive/archive.go
+++ b/plugins/archive/archive.go
@@ -266,12 +266,43 @@ func testArchiveWithPasswordPrompt(ctx context.Context, srcPath string, reporter
 	}
 }
 
+type archiveTestingReader struct {
+	io.Reader
+	read int64
+}
+
+func (r *archiveTestingReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	r.read += int64(n)
+	return n, err
+}
+
+func archiveTestingPercent(current, total int64) int {
+	if total <= 0 {
+		return -1
+	}
+	pct := int(float64(current) * 100 / float64(total))
+	if pct < 0 {
+		return 0
+	}
+	if pct > 100 {
+		return 100
+	}
+	return pct
+}
+
 func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs.TaskReporter) error {
 	f, err := os.Open(srcPath)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = f.Close() }()
+
+	archiveStat, err := f.Stat()
+	if err != nil {
+		return err
+	}
+	archiveSize := archiveStat.Size()
 
 	format, stream, err := archives.Identify(ctx, srcPath, f)
 	if err != nil {
@@ -287,22 +318,58 @@ func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs
 		return fmt.Errorf("format %T does not support testing", format)
 	}
 
+	countedStream := &archiveTestingReader{Reader: stream}
+	startTime := time.Now()
+	reportProgress := func(name string, current, size int64) {
+		archiveBytes := countedStream.read
+		elapsed := time.Since(startTime)
+		speed := int64(0)
+		if elapsed > 0 {
+			speed = int64(float64(archiveBytes) / elapsed.Seconds())
+		}
+		totalText := fmt.Sprintf("Total: %s / %s", formatSize(archiveBytes), formatSize(archiveSize))
+		reporter.UpdateTransfer("Testing", name, archiveTestingPercent(current, size), totalText, archiveTestingPercent(archiveBytes, archiveSize), formatSize(speed)+"/s")
+	}
+	reportProgress(filepath.Base(srcPath), 0, 1)
+
 	var failures []error
-	err = extractor.Extract(ctx, stream, func(ctx context.Context, info archives.FileInfo) error {
+	err = extractor.Extract(ctx, countedStream, func(ctx context.Context, info archives.FileInfo) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		reporter.UpdateTransfer("Testing", info.NameInArchive, -1, "", -1, "")
 		if info.IsDir() || !info.Mode().IsRegular() {
+			reportProgress(info.NameInArchive, -1, 0)
 			return nil
 		}
 
 		member, openErr := info.Open()
 		if openErr != nil {
+			reportProgress(info.NameInArchive, 0, info.Size())
 			failures = append(failures, fmt.Errorf("%s: %w", info.NameInArchive, openErr))
 			return nil
 		}
-		_, readErr := io.Copy(io.Discard, member)
+
+		memberSize := info.Size()
+		var memberBytes int64
+		var readErr error
+		buf := make([]byte, 128*1024)
+		for {
+			if err := ctx.Err(); err != nil {
+				readErr = err
+				break
+			}
+			n, err := member.Read(buf)
+			if n > 0 {
+				memberBytes += int64(n)
+				reportProgress(info.NameInArchive, memberBytes, memberSize)
+			}
+			if err != nil {
+				if err != io.EOF {
+					readErr = err
+				}
+				break
+			}
+		}
 		closeErr := member.Close()
 		if failure := errors.Join(readErr, closeErr); failure != nil {
 			failures = append(failures, fmt.Errorf("%s: %w", info.NameInArchive, failure))
@@ -311,6 +378,10 @@ func testArchiveOnce(ctx context.Context, srcPath, password string, reporter vfs
 	})
 	if err != nil {
 		failures = append(failures, err)
+	}
+	if len(failures) == 0 {
+		reporter.UpdateTransfer("Testing", filepath.Base(srcPath), 100,
+			fmt.Sprintf("Total: %s / %s", formatSize(archiveSize), formatSize(archiveSize)), 100, "")
 	}
 	return errors.Join(failures...)
 }

--- a/plugins/archive/archive_test.go
+++ b/plugins/archive/archive_test.go
@@ -157,6 +157,7 @@ type mockAppForProgress struct {
 	passiveVfs  vfs.VFS
 	names       []string
 	inputBoxes  int
+	currentPct  []int
 	progressPct []int
 	progressMsg []string
 	done        chan struct{}
@@ -212,9 +213,67 @@ func (r *mockReporter) UpdateScan(currentPath string, files, dirs int64) {}
 func (r *mockReporter) IsCancelled() bool                                { return false }
 func (r *mockReporter) UpdateTransfer(action, filename string, currentPct int, totalText string, totalPct int, speedText string) {
 	r.m.mu.Lock()
+	r.m.currentPct = append(r.m.currentPct, currentPct)
 	r.m.progressPct = append(r.m.progressPct, totalPct)
 	r.m.progressMsg = append(r.m.progressMsg, fmt.Sprintf("%s: %s | %s | %s", action, filename, totalText, speedText))
 	r.m.mu.Unlock()
+}
+
+func TestTestArchiveOnce_ReportsCurrentAndTotalProgress(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "progress.zip")
+	f, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(f)
+	fw, err := zw.Create("large.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := fw.Write([]byte(strings.Repeat("payload", 64*1024))); err != nil {
+		t.Fatal(err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &mockAppForProgress{}
+	if err := testArchiveOnce(context.Background(), archivePath, "", &mockReporter{m: app}); err != nil {
+		t.Fatalf("testArchiveOnce() error = %v", err)
+	}
+
+	app.mu.Lock()
+	defer app.mu.Unlock()
+	hasCurrentProgress := false
+	for _, pct := range app.currentPct {
+		if pct >= 0 {
+			hasCurrentProgress = true
+			break
+		}
+	}
+	if !hasCurrentProgress {
+		t.Fatalf("current archive-member progress was never reported: %v", app.currentPct)
+	}
+	if app.currentPct[len(app.currentPct)-1] != 100 {
+		t.Fatalf("final current archive-member progress = %d, want 100", app.currentPct[len(app.currentPct)-1])
+	}
+	hasTotalProgress := false
+	for _, pct := range app.progressPct {
+		if pct >= 0 {
+			hasTotalProgress = true
+			break
+		}
+	}
+	if !hasTotalProgress {
+		t.Fatalf("total archive progress was never reported: %v", app.progressPct)
+	}
+	if app.progressPct[len(app.progressPct)-1] != 100 {
+		t.Fatalf("final total archive progress = %d, want 100", app.progressPct[len(app.progressPct)-1])
+	}
 }
 
 func (m *mockAppForProgress) RunAdvancedProgressTask(title string, forked bool, worker func(ctx context.Context, reporter vfs.TaskReporter) error, onComplete func(err error)) {


### PR DESCRIPTION
## Summary
- report current member progress and overall archive progress during Shift+F3 archive testing
- keep the archive test UI responsive by updating progress while reading members
- add coverage for current and total progress reaching 100%

Part 2 of 3 for #900.

Tests were not run locally, per repository instructions; GitHub CI is the verification path.

Closes #900 (part 2 of 3).