### PR TITLE
fix: preserve Shift in hotkey configurator (#1127)

### DIFF
--- a/internal/app/hotkeys_ui_test.go
+++ b/internal/app/hotkeys_ui_test.go
@@ -88,6 +88,30 @@ func TestHotkeyAssignFramePreservesRightCtrl(t *testing.T) {
 	}
 }
 
+func TestHotkeyAssignFramePreservesShiftFromModifierEvent(t *testing.T) {
+	hm := keymap.NewHotkeyManager("")
+	f := dialog.NewHotkeyAssignFrame(hm, "File.Attributes", "Shell", nil)
+
+	if !f.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_LSHIFT,
+	}) {
+		t.Fatal("Shift keydown was not consumed by the assignment dialog")
+	}
+	if !f.ProcessKey(&vtinput.InputEvent{
+		Type:           vtinput.KeyEventType,
+		KeyDown:        true,
+		VirtualKeyCode: vtinput.VK_K,
+	}) {
+		t.Fatal("Shift+K was not consumed by the assignment dialog")
+	}
+
+	if got := hm.Bindings["Shell"]["ShiftK"]; got != "File.Attributes" {
+		t.Fatalf("captured Shift+K = %q, want File.Attributes under ShiftK", got)
+	}
+}
+
 func TestHotkeyDialogSizeForScreen(t *testing.T) {
 	if gotW, gotH := hotkeyDialogSizeForScreen(200, 60); gotW != 196 || gotH != 58 {
 		t.Fatalf("large screen size = %dx%d, want 196x58", gotW, gotH)

--- a/internal/dialog/hotkey_capture.go
+++ b/internal/dialog/hotkey_capture.go
@@ -16,6 +16,7 @@ type HotkeyAssignFrame struct {
 	actionName string
 	area       string
 	onComplete func()
+	shiftHeld  bool
 }
 
 func NewHotkeyAssignFrame(hm *keymap.HotkeyManager, actionName, area string, onComplete func()) *HotkeyAssignFrame {
@@ -58,7 +59,19 @@ func NewHotkeyAssignFrame(hm *keymap.HotkeyManager, actionName, area string, onC
 
 func (f *HotkeyAssignFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	if e.Type == vtinput.FocusEventType {
+		if !e.SetFocus {
+			f.shiftHeld = false
+		}
 		return f.Window.ProcessKey(e)
+	}
+
+	switch e.VirtualKeyCode {
+	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT:
+		// Some GUI hosts omit ShiftPressed from the following key event. Keep
+		// the modifier state across the two events while the assignment dialog
+		// owns the keyboard (the same rule used by the grabber).
+		f.shiftHeld = e.KeyDown
+		return true
 	}
 
 	if !e.KeyDown {
@@ -72,14 +85,17 @@ func (f *HotkeyAssignFrame) ProcessKey(e *vtinput.InputEvent) bool {
 	}
 
 	switch e.VirtualKeyCode {
-	case vtinput.VK_SHIFT, vtinput.VK_LSHIFT, vtinput.VK_RSHIFT,
-		vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
+	case vtinput.VK_CONTROL, vtinput.VK_LCONTROL, vtinput.VK_RCONTROL,
 		vtinput.VK_MENU, vtinput.VK_LMENU, vtinput.VK_RMENU,
 		vtinput.VK_CAPITAL, vtinput.VK_NUMLOCK, vtinput.VK_SCROLL:
-		return false
+		return true
 	}
 
-	keyStr := keymap.EventToHotkeyString(e)
+	keyEvent := *e
+	if f.shiftHeld {
+		keyEvent.ControlKeyState |= vtinput.ShiftPressed
+	}
+	keyStr := keymap.EventToHotkeyString(&keyEvent)
 
 	if f.hm != nil {
 		f.hm.Bind(f.area, keyStr, f.actionName)


### PR DESCRIPTION
Fixes #1127.

Some GUI hosts deliver the modifier key as a separate event and omit ShiftPressed from the following key event. The assignment dialog now tracks Shift while it owns the keyboard, consumes modifier events, resets on focus loss, and folds the held state into the captured hotkey. Added a regression test for Shift+K.

Validation: gofmt and git diff --check locally; quick workflow is running for the exact commit.