### PR TITLE
fix: restore main menu in additional workspaces

### DIFF
--- a/internal/panel/frame.go
+++ b/internal/panel/frame.go
@@ -1757,12 +1757,21 @@ func (pf *PanelsFrame) Show(scr *vtui.ScreenBuf) {
 		pf.TermView.Show(scr)
 	}
 
-	if config.App.AlwaysShowMenuBar && pf.ShowPanels {
+	showMenuBar := pf.ShowPanels && (config.App.AlwaysShowMenuBar || pf.MenuBar.Active)
+	if showMenuBar {
+		// A contextual menu bar is kept off-screen while inactive so it does not
+		// intercept terminal/panel mouse events. F9 can activate it without a
+		// resize, though (notably after a second workspace made the top inset
+		// appear), so restore its live geometry at render time before the global
+		// FrameManager draws the active bar and its submenu.
+		menuY := vtui.FrameManager.WorkspaceTopInset()
+		pf.MenuBar.SetPosition(0, menuY, pf.LastW-1, menuY)
 		pf.MenuBar.SetVisible(true)
 		pf.MenuBar.Show(scr)
 	} else {
 		// MenuBar.HitTest is geometry-only in vtui, so visibility alone is not
 		// enough to keep the hidden bar from intercepting terminal row 0.
+		pf.MenuBar.SetPosition(0, -2, pf.LastW-1, -2)
 		pf.MenuBar.SetVisible(false)
 	}
 

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -1004,6 +1004,39 @@ func TestPanelsFrame_AlwaysShowMenuBar(t *testing.T) {
 	}
 }
 
+func TestPanelsFrame_ActiveMenuBarAppearsAfterWorkspaceInset(t *testing.T) {
+	t.Cleanup(swapFrameManager(t))
+	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
+	theme.SetDefaultF4Palette()
+	oldAlways := config.App.AlwaysShowMenuBar
+	config.App.AlwaysShowMenuBar = false
+	t.Cleanup(func() { config.App.AlwaysShowMenuBar = oldAlways })
+
+	pf := NewPanelsFrame()
+	defer pf.Close()
+	pf.ResizeConsole(80, 25)
+	vtui.FrameManager.Push(pf)
+	vtui.FrameManager.AddScreenBackground(vtui.NewDesktop())
+
+	if inset := vtui.FrameManager.WorkspaceTopInset(); inset != 1 {
+		t.Fatalf("workspace top inset = %d, want 1 with multiple workspaces", inset)
+	}
+	pf.MenuBar.Active = true
+	pf.Show(vtui.FrameManager.Screen())
+
+	_, menuY, _, _ := pf.MenuBar.GetPosition()
+	if menuY != 1 || !pf.MenuBar.IsVisible() {
+		t.Fatalf("active menu bar position/visibility = (%d, %v), want (1, true)", menuY, pf.MenuBar.IsVisible())
+	}
+
+	pf.MenuBar.Active = false
+	pf.Show(vtui.FrameManager.Screen())
+	_, menuY, _, _ = pf.MenuBar.GetPosition()
+	if menuY >= 0 || pf.MenuBar.IsVisible() {
+		t.Fatalf("inactive menu bar position/visibility = (%d, %v), want off-screen and hidden", menuY, pf.MenuBar.IsVisible())
+	}
+}
+
 // TestPanelsFrame_HiddenTerminalFirstRowDoesNotOpenMenu covers issue #1093:
 // a click on the first line of micro (or far2l started from f4) used to hit
 // f4's stale menu-bar geometry and open the f4 menu over the terminal app.

--- a/internal/terminal/kitty_coverage_test.go
+++ b/internal/terminal/kitty_coverage_test.go
@@ -111,7 +111,6 @@ func TestKittyCoverageFileSafetyAndRanges(t *testing.T) {
 		t.Fatalf("offset and size read = %v, %v", got, err)
 	}
 
-
 	for _, bad := range []string{"", "/proc/self/status", "/sys/kernel", "/dev/null", filepath.Join(dir, "missing")} {
 		if _, err := kittyReadFile(bad, 'f', 0, 0); err == nil {
 			t.Errorf("%q was accepted", bad)


### PR DESCRIPTION
## Что изменено

При открытии главного меню в дополнительном Workspace строка главного меню больше не остаётся за пределами экрана: её позиция синхронизируется с верхним отступом Workspace. После закрытия меню полоса снова скрывается, поэтому она не перехватывает клики по терминалу или панели.

Добавлен регрессионный тест для нескольких Workspace.

## Как проверить

1. Откройте второй Workspace.
2. Нажмите F9.
3. Убедитесь, что видны строка главного меню и выпадающее подменю.
4. Закройте меню и проверьте, что обычная раскладка не изменилась.

Quick CI прошёл; локальные сборка и тесты не запускались по правилам проекта.

Closes #1129.