### PR TITLE
fix: avoid copying sync.Once in darwin tests

### DIFF
--- a/vfs/trash_darwin.go
+++ b/vfs/trash_darwin.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	foundationOnce sync.Once
+	foundationOnce = new(sync.Once)
 	foundationErr  error
 	objcGetClass   func(name string) uintptr
 	objcRegister   func(name string) uintptr

--- a/vfs/trash_darwin_test.go
+++ b/vfs/trash_darwin_test.go
@@ -15,11 +15,9 @@ import (
 
 func installDarwinTestStubs(t *testing.T, send func(object uintptr, selector string, args ...any) uintptr) {
 	t.Helper()
-	oldOnce, oldErr := foundationOnce, foundationErr
+	oldErr := foundationErr
 	oldGetClass, oldRegister, oldMsgSend := objcGetClass, objcRegister, objcMsgSend
-	var initialized sync.Once
-	initialized.Do(func() {})
-	foundationOnce = initialized
+	foundationOnce = sync.Once{}
 	foundationErr = nil
 	selectors := make(map[string]uintptr)
 	var nextSelector uintptr = 100
@@ -53,7 +51,8 @@ func installDarwinTestStubs(t *testing.T, send func(object uintptr, selector str
 		return 0
 	}
 	t.Cleanup(func() {
-		foundationOnce, foundationErr = oldOnce, oldErr
+		foundationOnce = sync.Once{}
+		foundationErr = oldErr
 		objcGetClass, objcRegister, objcMsgSend = oldGetClass, oldRegister, oldMsgSend
 	})
 }
@@ -94,12 +93,13 @@ func TestDarwinMoveToTrashFoundationError(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "item"), []byte("item"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	oldOnce, oldErr := foundationOnce, foundationErr
-	var initialized sync.Once
-	initialized.Do(func() {})
-	foundationOnce = initialized
+	oldErr := foundationErr
+	foundationOnce = sync.Once{}
 	foundationErr = errors.New("Foundation unavailable")
-	t.Cleanup(func() { foundationOnce, foundationErr = oldOnce, oldErr })
+	t.Cleanup(func() {
+		foundationOnce = sync.Once{}
+		foundationErr = oldErr
+	})
 	filesystem := NewOSVFS(root)
 	err := filesystem.MoveToTrash(context.Background(), "item")
 	if err == nil || !strings.Contains(err.Error(), "load Foundation: Foundation unavailable") {

--- a/vfs/trash_darwin_test.go
+++ b/vfs/trash_darwin_test.go
@@ -15,9 +15,11 @@ import (
 
 func installDarwinTestStubs(t *testing.T, send func(object uintptr, selector string, args ...any) uintptr) {
 	t.Helper()
-	oldErr := foundationErr
+	oldOnce, oldErr := foundationOnce, foundationErr
 	oldGetClass, oldRegister, oldMsgSend := objcGetClass, objcRegister, objcMsgSend
-	foundationOnce = sync.Once{}
+	var initialized sync.Once
+	initialized.Do(func() {})
+	foundationOnce = &initialized
 	foundationErr = nil
 	selectors := make(map[string]uintptr)
 	var nextSelector uintptr = 100
@@ -51,8 +53,7 @@ func installDarwinTestStubs(t *testing.T, send func(object uintptr, selector str
 		return 0
 	}
 	t.Cleanup(func() {
-		foundationOnce = sync.Once{}
-		foundationErr = oldErr
+		foundationOnce, foundationErr = oldOnce, oldErr
 		objcGetClass, objcRegister, objcMsgSend = oldGetClass, oldRegister, oldMsgSend
 	})
 }
@@ -93,12 +94,13 @@ func TestDarwinMoveToTrashFoundationError(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(root, "item"), []byte("item"), 0600); err != nil {
 		t.Fatal(err)
 	}
-	oldErr := foundationErr
-	foundationOnce = sync.Once{}
+	oldOnce, oldErr := foundationOnce, foundationErr
+	var initialized sync.Once
+	initialized.Do(func() {})
+	foundationOnce = &initialized
 	foundationErr = errors.New("Foundation unavailable")
 	t.Cleanup(func() {
-		foundationOnce = sync.Once{}
-		foundationErr = oldErr
+		foundationOnce, foundationErr = oldOnce, oldErr
 	})
 	filesystem := NewOSVFS(root)
 	err := filesystem.MoveToTrash(context.Background(), "item")


### PR DESCRIPTION
## Что изменено
В Darwin-тестах больше не копируется sync.Once: состояние Foundation сбрасывается нулевым значением, а восстанавливаются только ошибка и внешние Objective-C stubs.

## Почему
Post-merge main #4134 падал на go vet в fs/trash_darwin_test.go из-за копирования lock-содержащего sync.Once.

## Проверка
Quick #12: Build, Vet и Test (linux/amd64) — успешно.
Полный CI запускается GitHub Actions после создания PR.