### PR TITLE
f4: avoid copying sync.Once in Darwin tests

### DIFF
--- a/vfs/trash_darwin.go
+++ b/vfs/trash_darwin.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	foundationOnce sync.Once
+	foundationOnce = new(sync.Once)
 	foundationErr  error
 	objcGetClass   func(name string) uintptr
 	objcRegister   func(name string) uintptr

--- a/vfs/trash_darwin_test.go
+++ b/vfs/trash_darwin_test.go
@@ -19,7 +19,7 @@ func installDarwinTestStubs(t *testing.T, send func(object uintptr, selector str
 	oldGetClass, oldRegister, oldMsgSend := objcGetClass, objcRegister, objcMsgSend
 	var initialized sync.Once
 	initialized.Do(func() {})
-	foundationOnce = initialized
+	foundationOnce = &initialized
 	foundationErr = nil
 	selectors := make(map[string]uintptr)
 	var nextSelector uintptr = 100
@@ -97,7 +97,7 @@ func TestDarwinMoveToTrashFoundationError(t *testing.T) {
 	oldOnce, oldErr := foundationOnce, foundationErr
 	var initialized sync.Once
 	initialized.Do(func() {})
-	foundationOnce = initialized
+	foundationOnce = &initialized
 	foundationErr = errors.New("Foundation unavailable")
 	t.Cleanup(func() { foundationOnce, foundationErr = oldOnce, oldErr })
 	filesystem := NewOSVFS(root)


### PR DESCRIPTION
Причина красного main: go vet на darwin/freebsd/dragonfly находил копирование sync.Once в vfs/trash_darwin_test.go.

Изменение: foundationOnce хранится через указатель; тестовые заглушки сохраняют и восстанавливают указатель, не копируя sync.Once.

Что проверить: дождаться CI и убедиться, что Vet (darwin/arm64, freebsd/amd64, dragonfly/amd64) проходит.