### PR TITLE
fix: save session before console termination (#823)

### DIFF
--- a/internal/app/bootstrap_ctrlhandler_windows.go
+++ b/internal/app/bootstrap_ctrlhandler_windows.go
@@ -5,6 +5,7 @@ package app
 import (
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/unxed/f4/internal/panel"
 
@@ -26,10 +27,16 @@ var ctrlHandlerOnce sync.Once
 var procSetConsoleCtrlHandler = syscall.NewLazyDLL("kernel32.dll").NewProc("SetConsoleCtrlHandler")
 
 const (
-	ctrlCEvent     = 0
-	ctrlBreakEvent = 1
-	ctrlCloseEvent = 2
+	ctrlCEvent        = 0
+	ctrlBreakEvent    = 1
+	ctrlCloseEvent    = 2
+	ctrlLogoffEvent   = 5
+	ctrlShutdownEvent = 6
 )
+
+const consoleCloseSaveTimeout = 4 * time.Second
+
+var saveSessionOnConsoleTermination = saveSessionForConsoleTermination
 
 // consoleCtrlHandlerRoutine mirrors FAR3's control_handler(): Ctrl+Break is
 // translated into an interrupt of the active ConPTY program (same as Ctrl+C),
@@ -41,8 +48,38 @@ func consoleCtrlHandlerRoutine(ctrlType uintptr) uintptr {
 			interruptActivePTY()
 		}
 		return 1
+	case ctrlCloseEvent, ctrlLogoffEvent, ctrlShutdownEvent:
+		// Windows terminates console processes after this callback returns, so
+		// main's deferred SaveSession cannot protect settings on these paths.
+		// Marshal the save onto the FrameManager UI goroutine before allowing
+		// the system to terminate the process.
+		saveSessionOnConsoleTermination()
+		return 0
 	default:
 		return 0
+	}
+}
+
+func saveSessionForConsoleTermination() {
+	if vtui.FrameManager == nil {
+		SaveSession()
+		return
+	}
+
+	done := make(chan struct{})
+	vtui.FrameManager.PostTask(func() {
+		SaveSession()
+		close(done)
+	})
+
+	timer := time.NewTimer(consoleCloseSaveTimeout)
+	defer timer.Stop()
+	select {
+	case <-done:
+	case <-timer.C:
+		// A console control handler has a finite system timeout. Preserve the
+		// last observable state even if the UI loop stopped accepting tasks.
+		SaveSession()
 	}
 }
 

--- a/internal/app/bootstrap_ctrlhandler_windows_test.go
+++ b/internal/app/bootstrap_ctrlhandler_windows_test.go
@@ -12,8 +12,18 @@ func TestConsoleCtrlHandlerRoutineHandlesInterrupts(t *testing.T) {
 	}
 }
 
-func TestConsoleCtrlHandlerRoutineIgnoresOtherEvents(t *testing.T) {
-	if got := consoleCtrlHandlerRoutine(ctrlCloseEvent); got != 0 {
-		t.Fatalf("consoleCtrlHandlerRoutine(%d) = %d, want 0", ctrlCloseEvent, got)
+func TestConsoleCtrlHandlerRoutineSavesBeforeTermination(t *testing.T) {
+	oldSave := saveSessionOnConsoleTermination
+	t.Cleanup(func() { saveSessionOnConsoleTermination = oldSave })
+
+	for _, event := range []uintptr{ctrlCloseEvent, ctrlLogoffEvent, ctrlShutdownEvent} {
+		saved := false
+		saveSessionOnConsoleTermination = func() { saved = true }
+		if got := consoleCtrlHandlerRoutine(event); got != 0 {
+			t.Errorf("consoleCtrlHandlerRoutine(%d) = %d, want 0", event, got)
+		}
+		if !saved {
+			t.Errorf("consoleCtrlHandlerRoutine(%d) did not save before termination", event)
+		}
 	}
 }


### PR DESCRIPTION
Fixes #823

Windows terminates console processes after the console control handler returns, so the deferred SaveSession path is not reached for close/logoff/shutdown events. Route the save through the vtui UI task queue and wait for completion before allowing termination, with a bounded fallback if the UI loop has stopped.

The regression test covers close, logoff, and shutdown control events.

Validation: GitHub Actions only, per LUNOBOT instructions.