### PR TITLE
fix: launch SFX files on ordinary Enter (#915)

### DIFF
--- a/internal/panel/list.go
+++ b/internal/panel/list.go
@@ -3440,7 +3440,11 @@ func (fp *FileSystemPanel) processKey(e *vtinput.InputEvent, allowProviderPanelE
 			if provider != nil && !allowProviderPanelEnter {
 				if policy, ok := provider.(vfs.PanelEnterPolicyProvider); ok &&
 					!policy.PanelEnterAllowed(context.Background(), fp.Vfs, fullPath) {
-					return true
+					// The provider reserves ordinary Enter for another
+					// action (for example, running an SFX executable).
+					// Decline the panel key so PanelsFrame can dispatch
+					// that action instead of swallowing the key.
+					provider = nil
 				}
 			}
 			if provider != nil {

--- a/internal/panel/panels_frame_test.go
+++ b/internal/panel/panels_frame_test.go
@@ -3295,7 +3295,7 @@ func TestPanelsFrame_NavigateToPath(t *testing.T) {
 	}
 }
 
-func TestFileSystemPanel_SFXRequiresCtrlPgDn(t *testing.T) {
+func TestFileSystemPanel_SFXEnterFallsThroughToExecute(t *testing.T) {
 	vfs.RegisterProvider(&archive.ArchiveProvider{})
 	vtui.FrameManager.Init(vtui.NewSilentScreenBuf())
 
@@ -3324,14 +3324,27 @@ func TestFileSystemPanel_SFXRequiresCtrlPgDn(t *testing.T) {
 	fp.SetCursorIndex(0)
 
 	enter := &vtinput.InputEvent{Type: vtinput.KeyEventType, KeyDown: true, VirtualKeyCode: vtinput.VK_RETURN}
-	if !fp.ProcessKey(enter) {
-		t.Fatal("ordinary Enter on an SFX row was not consumed")
+	if fp.ProcessKey(enter) {
+		t.Fatal("ordinary Enter on an SFX row was consumed instead of falling through to Execute")
 	}
 	if _, ok := fp.Vfs.(*vfs.OSVFS); !ok {
 		t.Fatalf("ordinary Enter changed VFS to %T", fp.Vfs)
 	}
 	if fp.ProviderOpenTask != nil {
 		t.Fatal("ordinary Enter started an SFX provider open")
+	}
+
+	pf := &PanelsFrame{ActiveIdx: 0, ShowPanels: true, CmdLine: cmdline.NewCommandLine(">")}
+	pf.Panels[0] = fp
+	called := 0
+	oldExecute := Execute
+	Execute = func(*PanelsFrame, vfs.VFS, string, string, string) { called++ }
+	t.Cleanup(func() { Execute = oldExecute })
+	if !pf.ProcessKey(enter) {
+		t.Fatal("PanelsFrame did not handle ordinary Enter")
+	}
+	if called != 1 {
+		t.Fatalf("ordinary Enter executed SFX %d times, want once", called)
 	}
 
 	if !fp.EnterSelectedFromAction() {


### PR DESCRIPTION
Issue #915 follow-up: when the archive provider reserves ordinary panel Enter for another action, let the panel decline the key so PanelsFrame dispatches the normal Execute path. This makes Enter and the existing double-click-to-Enter route launch an SFX executable instead of silently swallowing the key. Explicit Ctrl+PgDn still opens the SFX as an archive. Added regression coverage for the provider fall-through, Execute dispatch, and preserved Ctrl+PgDn entry. Local builds/tests were intentionally not run; please validate with hosted CI.