### PR TITLE
test: join frame-manager teardown workers

### DIFF
--- a/internal/testutil/frame.go
+++ b/internal/testutil/frame.go
@@ -72,6 +72,21 @@ func TaskPumpGoroutineProfile() (int, string, error) {
 	return strings.Count(profile, ".startTaskPump.func"), profile, nil
 }
 
+// WaitForTaskPumpsAtMost waits for asynchronous FrameManager teardown to be
+// visible in the goroutine profile. Shutdown normally joins its pump, but an
+// active Run loop completes that join from its deferred shutdown path after
+// Shutdown has returned.
+func WaitForTaskPumpsAtMost(max int, timeout time.Duration) (int, string, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		count, profile, err := TaskPumpGoroutineProfile()
+		if err != nil || count <= max || time.Now().After(deadline) {
+			return count, profile, err
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
 func PumpUntilToastActive(t *testing.T) {
 	t.Helper()
 	for vtui.FrameManager.GetActiveToast() == "" {
@@ -159,6 +174,10 @@ func SwapFrameManager(t *testing.T, drains ...func(*testing.T)) func() {
 	for _, drain := range drains {
 		drain(t)
 	}
+	pumpsBefore, _, profileErr := TaskPumpGoroutineProfile()
+	if profileErr != nil {
+		t.Fatalf("capture task-pump profile before frame-manager swap: %v", profileErr)
+	}
 	old := vtui.FrameManager
 	oldUpdateQueue := vreactive.GlobalUpdateQueue
 	oldAnimationManager := vreactive.GlobalAnimationManager
@@ -170,7 +189,13 @@ func SwapFrameManager(t *testing.T, drains ...func(*testing.T)) func() {
 			drain(t)
 		}
 		CloseFrameManagerFrames(fresh)
+		fresh.Stop()
 		fresh.Shutdown()
+		if pumps, profile, err := WaitForTaskPumpsAtMost(pumpsBefore, time.Second); err != nil {
+			t.Errorf("capture task-pump profile after frame-manager swap: %v", err)
+		} else if pumps > pumpsBefore {
+			t.Errorf("frame-manager swap left task-pump goroutines: before=%d after=%d\n%s", pumpsBefore, pumps, profile)
+		}
 		vtui.FrameManager = old
 		vreactive.GlobalUpdateQueue = oldUpdateQueue
 		vreactive.GlobalAnimationManager = oldAnimationManager

--- a/internal/testutil/main.go
+++ b/internal/testutil/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/unxed/vtui"
 )
@@ -73,16 +74,18 @@ func Main(m *testing.M, before func(), after func() error) int {
 	globalFrameManager := vtui.FrameManager
 	if globalFrameManager != nil {
 		CloseFrameManagerFrames(globalFrameManager)
+		globalFrameManager.Stop()
 		globalFrameManager.Shutdown()
 	}
 	if baseFrameManager != globalFrameManager {
 		_, _ = fmt.Fprintln(os.Stderr, "vtui.FrameManager was not restored to the TestMain manager")
 		CloseFrameManagerFrames(baseFrameManager)
+		baseFrameManager.Stop()
 		baseFrameManager.Shutdown()
 		result = 1
 	}
 
-	taskPumps, goroutineProfile, profileErr := TaskPumpGoroutineProfile()
+	taskPumps, goroutineProfile, profileErr := WaitForTaskPumpsAtMost(0, time.Second)
 	if profileErr != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "capture goroutine profile after vtui shutdown: %v\n", profileErr)
 		result = 1


### PR DESCRIPTION
Чинит красный main на SHA `7b4b3dc80b9d69a52739a2a671c8df18dfa932ea`.

Race shard 2 завершался с `vtui task-pump goroutine leak: 1` в `internal/panel`; лог указывал на worker `vtui.(*frameManager).startTaskPump.func1`. `Shutdown` vtui возвращает управление, пока активный event loop ещё завершается. Общий f4 test harness теперь сначала сигнализирует `Stop`, затем дожидается исчезновения task-pump по goroutine profile; swap teardown проверяет тот же контракт.

Проверено локально без сборки и тестов: `gofmt`, `git diff --check`.

— Лунобот-1 (node a721a6d1487257292ae00780; LNX)