### PR TITLE
f4 #904: keep help zoom controls visible

### DIFF
--- a/internal/dialog/help_search.go
+++ b/internal/dialog/help_search.go
@@ -344,7 +344,9 @@ func ToggleHelpZoom(frame vtui.Frame) bool {
 	} else {
 		currentHelpZoom = &helpZoomState{frame: frame, saved: helpWindowBounds{x1, y1, x2, y2}}
 		width, height := vtui.FrameManager.GetScreenSize(), vtui.FrameManager.GetScreenHeight()
-		target = helpWindowBounds{0, 0, width - 1, height - 3}
+		// Leave one extra row below the maximized help window so its top
+		// border and controls remain inside the visible frame.
+		target = helpWindowBounds{0, 0, width - 1, height - 4}
 	}
 	lastW, okW := nestedHelpInt(reflect.ValueOf(frame), "lastW")
 	lastH, okH := nestedHelpInt(reflect.ValueOf(frame), "lastH")

--- a/internal/dialog/help_search_test.go
+++ b/internal/dialog/help_search_test.go
@@ -276,8 +276,8 @@ func TestHelpShowsZoomButtonAndRestoresPreviousBounds(t *testing.T) {
 		t.Fatal("zoom button click was not handled")
 	}
 	maxX1, maxY1, maxX2, maxY2 := view.GetPosition()
-	if maxX1 != 0 || maxY1 != 0 || maxX2 != 79 || maxY2 != 37 || currentHelpZoom == nil {
-		t.Fatalf("zoomed Help bounds=(%d,%d)-(%d,%d), zoom state=%v, want (0,0)-(79,37)", maxX1, maxY1, maxX2, maxY2, currentHelpZoom)
+	if maxX1 != 0 || maxY1 != 0 || maxX2 != 79 || maxY2 != 36 || currentHelpZoom == nil {
+		t.Fatalf("zoomed Help bounds=(%d,%d)-(%d,%d), zoom state=%v, want (0,0)-(79,36)", maxX1, maxY1, maxX2, maxY2, currentHelpZoom)
 	}
 	_, _, zoomedX2, _ := view.GetPosition()
 	if !HandleHelpSearchHotkey(&vtinput.InputEvent{


### PR DESCRIPTION
Refs #904

## Criteria
- Keep one additional row below maximized main and contextual help windows.
- Preserve the upper border and collapse control inside the visible frame.

## Change
- Set the help zoom target height to screen height minus four rows.
- Update the focused zoom-bounds regression test.

## Validation
- `gofmt`
- `git diff --check`
- Full validation is delegated to GitHub Actions; no local build or test was run.